### PR TITLE
Feat/notification rework

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@tauri-apps/api": "^2.9.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "@tauri-apps/plugin-fs": "^2.4.5",
+        "@tauri-apps/plugin-shell": "^2.3.5",
         "@types/marked": "^5.0.2",
         "clsx": "^2.1.1",
         "marked": "^16.4.0",
@@ -1190,9 +1191,9 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.1.tgz",
-      "integrity": "sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
+      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -1215,6 +1216,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-shell": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz",
+      "integrity": "sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@types/babel__core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@tauri-apps/api": "^2.9.1",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-fs": "^2.4.5",
+    "@tauri-apps/plugin-shell": "^2.3.5",
     "@types/marked": "^5.0.2",
     "clsx": "^2.1.1",
     "marked": "^16.4.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,8 @@ import { ChatProvider, useChatStore } from './hooks/useChatStore.js';
 import { PlanProvider, usePlan } from './hooks/usePlan';
 import { useStatusStore } from './hooks/useStatusStore';
 import { useTheme } from './hooks/useTheme';
-import { drainCronNotifications } from './lib/api';
+import { drainCronNotifications, fetchHeartbeatStatus } from './lib/api';
+import { useHeartbeatRunning } from './hooks/useHeartbeatRunning';
 import {
   DESKTOP_BREAKPOINT_PX,
   LEFT_SIDEBAR_WIDTH_PX,
@@ -99,6 +100,7 @@ function AppInner(): React.ReactElement {
   const { refresh } = usePlan();
   const { currentChatId, setViewSwitcher, refreshChatList, chats, loadChat } = useChatStore();
   const setStatusMsg = useStatusStore(s => s.setStatus);
+  const setHeartbeatStatus = useHeartbeatRunning(s => s.setStatus);
   const { theme, toggleTheme } = useTheme();
   const { t } = useI18n();
 
@@ -112,23 +114,31 @@ function AppInner(): React.ReactElement {
   React.useEffect(() => { currentChatIdRef.current = currentChatId; }, [currentChatId]);
   React.useEffect(() => { chatsRef.current = chats; }, [chats]);
 
-  // Poll every 5 s: drain cron notifications + refresh sidebar + reload open social chat.
+  // Poll every 5 s: drain cron notifications + heartbeat status + refresh sidebar + reload open chat.
   React.useEffect(() => {
     const interval = setInterval(async () => {
-      const notifications = await drainCronNotifications();
-      for (const n of notifications) {
-        setStatusMsg(`[${n.job_name}] ${n.result}`, 'info', 8000);
+      // Heartbeat status runs in parallel with notification drain.
+      const [notifications] = await Promise.all([
+        drainCronNotifications(),
+        fetchHeartbeatStatus().then(setHeartbeatStatus).catch(() => {}),
+      ]);
+      if (notifications.length === 1) {
+        setStatusMsg(`[${notifications[0].job_name}] finished — view in Social`, 'info', 4000);
+      } else if (notifications.length > 1) {
+        setStatusMsg(`${notifications.length} tasks finished — view in Social`, 'info', 4000);
       }
       refreshChatListRef.current();
 
-      // If a social chat is open, reload its messages (social brain writes silently to DB).
+      // If a platform chat (cron/social) is open, reload its messages from DB.
+      // Skip if a live background stream is active — the SSE connection already delivers events.
       const chatId = currentChatIdRef.current;
-      if (chatId && chatsRef.current.some(c => c.id === chatId && !!c.platform)) {
+      const openChat = chatsRef.current.find(c => c.id === chatId);
+      if (chatId && (openChat?.platform || openChat?.heartbeatEnabled) && !openChat?.isRunning) {
         loadChatRef.current(chatId);
       }
     }, 5000);
     return () => clearInterval(interval);
-  }, [setStatusMsg]); // stable: only depends on setStatusMsg
+  }, [setStatusMsg, setHeartbeatStatus]); // stable Zustand actions
 
   function handleRightSidebarToggle(isOpen: boolean): void {
     setIsRightSidebarOpen(isOpen);

--- a/frontend/src/components/ChatInputPanel.tsx
+++ b/frontend/src/components/ChatInputPanel.tsx
@@ -29,6 +29,7 @@ interface ChatInputPanelProps {
     stopStreaming?: () => void; // Optional because only used in footer sometimes
     stopInFlight?: boolean;
     modelSelectDropUp?: boolean;
+    hideConfigSelector?: boolean;
     onPaste?: (files: File[]) => void;
     onImageClick?: (src: string) => void;
 }
@@ -82,6 +83,7 @@ export const ChatInputPanel: React.FC<ChatInputPanelProps> = ({
     stopStreaming,
     stopInFlight = false,
     modelSelectDropUp = true,
+    hideConfigSelector = false,
     onPaste,
     onImageClick,
 }) => {
@@ -332,7 +334,7 @@ export const ChatInputPanel: React.FC<ChatInputPanelProps> = ({
                 </div>
 
                 <div className="flex flex-nowrap gap-2 items-center justify-end flex-1 min-w-0">
-                    {configReady && (
+                    {configReady && !hideConfigSelector && (
                         <div className="relative shrink-0">
                             <BrutalSelect
                                 value={config.model}

--- a/frontend/src/components/ChatList.tsx
+++ b/frontend/src/components/ChatList.tsx
@@ -65,10 +65,11 @@ export const ChatList: React.FC = () => {
     return Math.max(0, chat.messageCount - (lastViewed[chat.id]?.count ?? 0));
   };
 
-  // Mark current chat read when it changes (e.g. opened from notification toast)
+  // Mark current chat read when it becomes active, and re-mark whenever the
+  // chat list refreshes (new messages arrive) while the user is viewing it.
   useEffect(() => {
     if (currentChatId) markRead(currentChatId);
-  }, [currentChatId, markRead]);
+  }, [currentChatId, chats, markRead]);
 
   // Sync local search with global search on mount
   useEffect(() => {
@@ -323,9 +324,15 @@ export const ChatList: React.FC = () => {
 
                     <div className={`flex items-center justify-between mt-3 pt-2 border-t-2 ${currentChatId === chat.id ? 'border-brutal-black/20' : 'border-neutral-200/50'}`}>
                       <div className="flex items-center gap-1.5">
-                        <span className={`text-[10px] font-bold uppercase px-1.5 py-0.5 border ${currentChatId === chat.id ? 'bg-white text-brutal-black border-brutal-black' : 'bg-neutral-100 dark:bg-zinc-700 text-neutral-500 dark:text-neutral-400 border-neutral-300 dark:border-zinc-600'}`}>
-                          {chat.messageCount} MSG
-                        </span>
+                        {(() => {
+                          const count = currentChatId === chat.id ? 0 : unreadMessages(chat);
+                          if (count <= 0) return null;
+                          return (
+                            <span className="text-[10px] font-bold uppercase px-1.5 py-0.5 border bg-brutal-yellow text-brutal-black border-brutal-black">
+                              {count} NEW
+                            </span>
+                          );
+                        })()}
                         
                         {/* Heartbeat Status Icon */}
                         {chat.heartbeatEnabled && (

--- a/frontend/src/components/ChatList.tsx
+++ b/frontend/src/components/ChatList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useChatStore } from '../hooks/useChatStore';
 import { ChatSummary } from '../types/api';
 import { RobotAvatar } from './chat/RobotAvatar';
@@ -26,7 +26,49 @@ export const ChatList: React.FC = () => {
   const [showRefreshIndicator, setShowRefreshIndicator] = useState(false);
   const [localSearchQuery, setLocalSearchQuery] = useState<string>('');
   const [viewMode, setViewMode] = useState<'personal' | 'social'>('personal');
+  const [lastViewed, setLastViewed] = useState<Record<string, { at: string; count: number }>>(() => {
+    try {
+      const raw = JSON.parse(localStorage.getItem('chat_last_viewed') || '{}');
+      // Migrate old format (plain string timestamps) to new { at, count } format
+      const result: Record<string, { at: string; count: number }> = {};
+      for (const [id, val] of Object.entries(raw)) {
+        if (typeof val === 'string') result[id] = { at: val, count: 0 };
+        else if (val && typeof val === 'object' && 'at' in val) result[id] = val as { at: string; count: number };
+      }
+      return result;
+    } catch { return {}; }
+  });
   const { t } = useI18n();
+
+  // Keep a ref so markRead always reads the latest chats without going stale.
+  const chatsRef = useRef(chats);
+  useEffect(() => { chatsRef.current = chats; }, [chats]);
+
+  const markRead = useCallback((chatId: string) => {
+    const count = chatsRef.current.find(c => c.id === chatId)?.messageCount ?? 0;
+    setLastViewed(prev => {
+      const next = { ...prev, [chatId]: { at: new Date().toISOString(), count } };
+      try { localStorage.setItem('chat_last_viewed', JSON.stringify(next)); } catch { }
+      return next;
+    });
+  }, []);
+
+  const isUnread = (chat: ChatSummary) => {
+    if (!chat.lastResultAt) return false;
+    const viewed = lastViewed[chat.id];
+    if (!viewed) return true;
+    return new Date(chat.lastResultAt) > new Date(viewed.at);
+  };
+
+  const unreadMessages = (chat: ChatSummary) => {
+    if (!isUnread(chat)) return 0;
+    return Math.max(0, chat.messageCount - (lastViewed[chat.id]?.count ?? 0));
+  };
+
+  // Mark current chat read when it changes (e.g. opened from notification toast)
+  useEffect(() => {
+    if (currentChatId) markRead(currentChatId);
+  }, [currentChatId, markRead]);
 
   // Sync local search with global search on mount
   useEffect(() => {
@@ -99,6 +141,10 @@ export const ChatList: React.FC = () => {
     }
     return !chat.platform;
   });
+
+  const socialUnreadCount = chats
+    .filter(c => !!c.platform)
+    .reduce((sum, c) => sum + unreadMessages(c), 0);
 
   if (loadingChats) {
     return (
@@ -185,7 +231,14 @@ export const ChatList: React.FC = () => {
                     : 'bg-white dark:bg-zinc-700 text-neutral-500 dark:text-neutral-400 hover:bg-neutral-50 dark:hover:bg-zinc-600 hover:text-brutal-black dark:hover:text-white'
                   }`}
               >
-                {mode === 'personal' ? t('chatList.view.desktop') : t('chatList.view.social')}
+                <span className="flex items-center justify-center gap-1">
+                  {mode === 'personal' ? t('chatList.view.desktop') : t('chatList.view.social')}
+                  {mode === 'social' && socialUnreadCount > 0 && (
+                    <span className="inline-flex items-center justify-center min-w-[14px] h-[14px] px-0.5 bg-brutal-yellow text-brutal-black dark:bg-brutal-yellow dark:text-brutal-black text-[9px] font-bold leading-none">
+                      {socialUnreadCount}
+                    </span>
+                  )}
+                </span>
               </button>
             ))}
           </div>
@@ -212,6 +265,7 @@ export const ChatList: React.FC = () => {
               <div
                 key={chat.id}
                 onClick={() => {
+                  markRead(chat.id);
                   loadChat(chat.id);
                   // Switch back to chat view when loading a chat
                   if (switchToView) {
@@ -243,13 +297,19 @@ export const ChatList: React.FC = () => {
                 <div className="flex items-start justify-between pl-2">
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-1.5 overflow-hidden">
+                      {/* Unread dot */}
+                      {isUnread(chat) && (
+                        (!!chat.platform || (chat.heartbeatEnabled && !chat.platform))
+                      ) && currentChatId !== chat.id && (
+                        <span className="w-2 h-2 rounded-full bg-brutal-red shrink-0" aria-label="Unread" />
+                      )}
                       {/* Platform Badge */}
                       {chat.platform && (
                         <span className="text-[10px] font-bold uppercase px-1 py-0.5 bg-neutral-200 dark:bg-zinc-700 dark:text-white border border-brutal-black shrink-0">
                           {chat.platform}
                         </span>
                       )}
-                      
+
                       <h3 className={`font-bold text-sm truncate uppercase ${currentChatId === chat.id ? 'text-brutal-black' : 'text-neutral-800 dark:text-white'}`}>
                         {chat.title || t('chatList.untitled')}
                       </h3>

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -523,7 +523,8 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       setIsStreaming(false, chatId);
       streamingChatIdRef.current = null;
       stopInFlightRef.current = false;
-      if (!wasHeartbeat && !isLiveStreamRef.current) {
+      const isNetworkError = error.message === 'Failed to fetch' || error instanceof TypeError;
+      if (!wasHeartbeat && !isLiveStreamRef.current && !isNetworkError) {
         addMessage({ role: 'assistant', content: `\u26a0\ufe0f Error: ${error.message}` }, chatId);
       }
       isLiveStreamRef.current = false;
@@ -716,6 +717,9 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
 
     const tryConnect = async () => {
       if (isLiveStreamRef.current) return; // already streaming
+      // Don't probe while a user-initiated stream is active — it shares the same
+      // AbortController ref and probing would overwrite the real stream's controller.
+      if (activeStreamingChatId === currentChatId) return;
       const liveUrl = `${getApiBase()}/chat/live`;
       const chatIdAtStart = currentChatId;
 
@@ -888,7 +892,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       role: 'user',
       content: prompt,
       timestamp: new Date().toISOString(),
-      images: imagePreviews,
+      images: uploadedFileMetadata ? undefined : imagePreviews,
       files: uploadedFileMetadata
     }, chatIdForSend);
     setIsStreaming(true, chatIdForSend);

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -719,7 +719,8 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       if (isLiveStreamRef.current) return; // already streaming
       // Don't probe while a user-initiated stream is active — it shares the same
       // AbortController ref and probing would overwrite the real stream's controller.
-      if (activeStreamingChatId === currentChatId) return;
+      // Use the ref (not the closed-over state) so this is never stale.
+      if (streamingChatIdRef.current === currentChatId) return;
       const liveUrl = `${getApiBase()}/chat/live`;
       const chatIdAtStart = currentChatId;
 

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -10,6 +10,7 @@ import { useCanvas } from '../hooks/useCanvas';
 import type { A2UISurface } from '../types/a2ui';
 import { useAutoScroll } from '../hooks/useAutoScroll';
 import { useUnifiedFileUpload } from '../hooks/useUnifiedFileUpload';
+import { useToolApproval } from '../hooks/chat/useToolApproval';
 import { PlanProgress } from './PlanProgress';
 import { NewChatView } from './NewChatView';
 import { ChatInputPanel } from './ChatInputPanel';
@@ -432,6 +433,11 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
         }
         heartbeatInFlightRef.current = false;
         setCurrentUsage(null);
+        // For live background streams (social/cron), save the parts so tryConnect's
+        // cleanup can detect the pending-approval state and skip clearParts().
+        if (isLiveStreamRef.current) {
+          liveStreamPartsRef.current = parts;
+        }
         return;
       }
 
@@ -540,131 +546,23 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     return () => window.removeEventListener('agui:send-message', handler);
   }, [sendAGUI, currentChatId, setHeartbeatRunning]);
 
-  // HITL: tool approval handler (Stateless Resume)
-  // Batches multiple approval decisions and only sends to backend when all are decided.
-  const handleToolApproval = useCallback(async (
-    approvalId: string,
-    toolCallId: string,
-    approved: boolean,
-    remember?: 'session' | null,
-    toolName?: string
-  ) => {
-    const targetChatId = activeChatIdRef.current || currentChatId;
-    if (!targetChatId) return;
-
-    const updateApprovalStateInHistory = (id: string, state: 'approved' | 'denied') => {
-      messages.forEach((m, idx) => {
-        if (m.role === 'assistant' && m.content.includes(`data-approval-id="${id}"`)) {
-          const finalContent = m.content.replace(
-            new RegExp(`(<details[^>]*data-approval-id="${id}"[^>]*data-approval-state=")pending(")`),
-            `$1${state}$2`
-          );
-
-          if (finalContent !== m.content) {
-            updateMessage(idx, { content: finalContent }, targetChatId);
-          }
-        }
-      });
-    };
-
-    // Optimistic UI: instantly hide buttons before the backend responds
-    resolveApproval(approvalId, approved);
-
-    // Also update historical messages in the store if they contain this approval
-    const newState = approved ? 'approved' : 'denied';
-    updateApprovalStateInHistory(approvalId, newState);
-
-    // Accumulate decision; only send when all pending approvals are decided
-    let allDecided = addApprovalDecision(approvalId, toolCallId, approved, remember, toolName);
-
-    // If user chose session policy on this tool, apply that same decision to all
-    // currently pending approvals of the same tool in this paused stream.
-    if (remember === 'session' && toolName) {
-      const linkedPending = streamingParts
-        .filter(
-          p =>
-            p.type === 'tool' &&
-            p.state === 'approval-requested' &&
-            p.toolName === toolName &&
-            p.approvalId &&
-            p.approvalId !== approvalId &&
-            p.toolCallId
-        )
-        .map(p => ({ approvalId: p.approvalId as string, toolCallId: p.toolCallId as string }));
-
-      for (const linked of linkedPending) {
-        resolveApproval(linked.approvalId, approved);
-        updateApprovalStateInHistory(linked.approvalId, newState);
-        allDecided = addApprovalDecision(
-          linked.approvalId,
-          linked.toolCallId,
-          approved,
-          null,
-          toolName
-        ) || allDecided;
-      }
-    }
-
-    if (!allDecided) return; // Still waiting for more decisions
-
-    // All approvals decided — batch and send
-    const decisions = consumeApprovalDecisions();
-
-    // If any decision had "remember: session", update the UI config.
-    // The backend gets the new config immediately via the payload.
-    let currentConfig = config || { model: '', agent: '', tools: [] };
-    let hasPolicyUpdate = false;
-    const policyUpdates: Record<string, string> = {};
-
-    decisions.forEach(d => {
-      if (d.remember === 'session' && d.toolName) {
-        policyUpdates[d.toolName] = d.approved ? 'always_allow' : 'always_deny';
-        hasPolicyUpdate = true;
-      }
-    });
-
-    if (hasPolicyUpdate) {
-      currentConfig = {
-        ...currentConfig,
-        tool_approval_policy: {
-          ...(currentConfig.tool_approval_policy || {}),
-          ...policyUpdates
-        }
-      };
-      setConfig(currentConfig);
-    }
-
-    const resumeApprovals = decisions.map(d => ({
-      request_id: d.approvalId,
-      tool_call_id: d.toolCallId,
-      approved: d.approved,
-      remember: d.remember,
-      tool_name: d.toolName,
-    }));
-
-    try {
-      const payload: Record<string, unknown> = {
-        message: "",
-        config: currentConfig,
-        chat_id: targetChatId,
-        reset: false,
-        resume_approvals: resumeApprovals,
-      };
-
-      setIsStreaming(true, targetChatId);
-      streamingChatIdRef.current = targetChatId;
-      stopInFlightRef.current = false;
-      // Use resumeStream to preserve existing tool parts in the UI
-      await resumeStream(payload);
-    } catch (error) {
-      console.error('Failed to resume with tool approval:', error);
-    } finally {
-      setIsStreaming(false, targetChatId);
-      stopInFlightRef.current = false;
-      // resumeStream's onFinish() callback handles cleanup (optimistic append, loadChat, clearParts).
-      // Don't call clearParts here—it races with onFinish and wipes the streamed response.
-    }
-  }, [currentChatId, config, resumeStream, resolveApproval, addApprovalDecision, consumeApprovalDecisions, updateMessage, setIsStreaming, loadChat, clearParts, setConfig, messages, streamingParts]);
+  const { handleToolApproval } = useToolApproval({
+    currentChatId,
+    activeStreamingChatId,
+    config,
+    messages,
+    streamingParts,
+    streamingChatIdRef,
+    activeChatIdRef,
+    stopInFlightRef,
+    setConfig,
+    updateMessage,
+    setIsStreaming,
+    resumeStream,
+    resolveApproval,
+    addApprovalDecision,
+    consumeApprovalDecisions,
+  });
 
   // Remove a tool from the approval policy
   const handleRemoveApprovalPolicy = useCallback((toolName: string) => {
@@ -835,6 +733,18 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
 
       if (!streamed || cancelled) return;
 
+      // If the stream paused for tool approval, onFinish saved the parts to
+      // liveStreamPartsRef. Keep the approval UI visible and let the 2-second
+      // poll re-subscribe when the resume stream starts; don't clearParts.
+      const pendingApproval = liveStreamPartsRef.current.some(
+        p => p.type === 'tool' && p.state === 'approval-requested'
+      );
+      if (pendingApproval) {
+        isLiveStreamRef.current = false;
+        liveStreamPartsRef.current = [];
+        return;
+      }
+
       // Convert the captured streaming parts to a rich message (includes tool-step HTML).
       // This must happen before clearParts so the parts are still populated.
       const richMsg = aguiPartsToStoreMessage(liveStreamPartsRef.current, null);
@@ -900,12 +810,17 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     const prompt = input.trim();
     if (!prompt || !configReady || isUploading) return;
 
-    // If currently streaming for this chat, steer instead of sending new message
-    if (streamingForCurrentChat && currentChatId) {
+    // If currently streaming (or paused on pending approvals) for this chat,
+    // steer instead of starting a brand-new turn.
+    if ((streamingForCurrentChat || hasPendingTransientApprovals) && currentChatId) {
       setInput('');
       addMessage({ role: 'user', content: prompt, timestamp: new Date().toISOString() }, currentChatId);
 
       steeringRef.current = true;
+      setIsStreaming(true, currentChatId);
+      streamingChatIdRef.current = currentChatId;
+      activeChatIdRef.current = currentChatId;
+      stopInFlightRef.current = false;
       try {
         await steerStream({
           chat_id: currentChatId,

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -460,6 +460,9 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       }
       heartbeatInFlightRef.current = false;
       streamingChatIdRef.current = null;
+      // Clear any stale live-stream parts from a previous background turn so
+      // tryConnect's cleanup path doesn't convert them to a redundant message.
+      liveStreamPartsRef.current = [];
 
       // Optimistic append: convert parts to HTML and store locally, preventing
       // a blank flash while loadChat waits for the backend to finish DB writes.
@@ -523,6 +526,8 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       if (!wasHeartbeat && !isLiveStreamRef.current) {
         addMessage({ role: 'assistant', content: `\u26a0\ufe0f Error: ${error.message}` }, chatId);
       }
+      isLiveStreamRef.current = false;
+      liveStreamPartsRef.current = [];
     },
   });
 
@@ -960,7 +965,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   };
 
   // Handle file click from chat messages
-  const handleFileClick = async (path: string, name: string, shiftKey?: boolean) => {
+  const handleFileClick = useCallback(async (path: string, name: string, shiftKey?: boolean) => {
     // Let the click animation finish first
     await new Promise(resolve => setTimeout(resolve, 150));
 
@@ -990,7 +995,11 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     } catch (error) {
       // Error checking file - do nothing (animation already played)
     }
-  };
+  }, [currentChatId, config.sandbox_volumes, isRightSidebarOpen, onRightSidebarToggle]);
+
+  const handleInlineAction = useCallback((surfaceId: string, action: string, context: Record<string, unknown>) => {
+    handleCanvasDispatch(action, context, surfaceId);
+  }, [handleCanvasDispatch]);
 
   // Handle maximize button from sidebar
   const handleMaximizeFile = (path: string, name: string) => {
@@ -1065,7 +1074,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
                     onToolApproval={handleToolApproval}
                     toolApprovalPolicy={safeConfig.tool_approval_policy}
                     onRemoveApprovalPolicy={handleRemoveApprovalPolicy}
-                    onInlineAction={(surfaceId, action, context) => handleCanvasDispatch(action, context, surfaceId)}
+                    onInlineAction={handleInlineAction}
                   />
                 )}
                 {/* Streaming/transient assistant message from AG-UI */}
@@ -1084,7 +1093,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
                           usage={currentUsage}
                           toolApprovalPolicy={safeConfig.tool_approval_policy}
                           onRemoveApprovalPolicy={handleRemoveApprovalPolicy}
-                          onInlineAction={(surfaceId, action, context) => handleCanvasDispatch(action, context, surfaceId)}
+                          onInlineAction={handleInlineAction}
                         />
                       </div>
                     </div>

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -17,6 +17,8 @@ import { ImageViewer } from './ImageViewer';
 import { FileViewer } from './FileViewer';
 import { UserMessage, AssistantMessage, ToolCallBlock, RightSidebar } from './chat';
 import { useI18n } from '../i18n';
+import { useHeartbeatRunning } from '../hooks/useHeartbeatRunning';
+
 
 // ── AGUIPart[] → Store Message conversion ────────────────────────────
 function escapeHtmlForStore(unsafe: string): string {
@@ -122,7 +124,6 @@ const LoadingIndicator: React.FC = () => {
 // Message list component (renders historical / store messages only)
 const MessageList: React.FC<{
   messages: Message[];
-  isStreaming: boolean;
   streamingForCurrentChat: boolean;
   chatId?: string;
   onImageClick?: (src: string) => void;
@@ -207,7 +208,7 @@ const MessageList: React.FC<{
         // Intermediate step group representative: render merged pills (no badge here — shows after final answer)
         if (group) {
           return (
-            <div key={idx} className="w-full flex flex-col group/message">
+            <div key={idx} className="chat-msg-row w-full flex flex-col group/message">
               <div className="flex justify-start w-full">
                 <div className="w-full max-w-4xl text-sm leading-relaxed pl-2">
                   {group.mergedBlocks.map((b, bi) => {
@@ -270,7 +271,7 @@ const MessageList: React.FC<{
         // Canvas action message — lightweight dashed pill
         if (m.role === 'canvas_action') {
           return (
-            <div key={idx} className="w-full flex justify-start pl-2">
+            <div key={idx} className="chat-msg-row w-full flex justify-start pl-2">
               <div className="border-2 border-dashed border-brutal-black px-4 py-2 text-sm font-mono text-neutral-500 dark:text-neutral-400 italic bg-white dark:bg-zinc-800">
                 {m.content}
               </div>
@@ -279,7 +280,7 @@ const MessageList: React.FC<{
         }
 
         return (
-          <div key={idx} className="w-full flex flex-col group/message">
+          <div key={idx} className="chat-msg-row w-full flex flex-col group/message">
             <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} w-full`}>
               {isUser ? (
                 <UserMessage message={m} chatId={chatId} onImageClick={onImageClick} onFileClick={onFileClick} />
@@ -312,6 +313,10 @@ const MessageList: React.FC<{
   </div>
 );
 
+// Memoised so scroll-driven setShowScrollButton re-renders in ChatWindow don't
+// retrigger the O(n) message grouping logic.
+const MessageListMemo = React.memo(MessageList);
+
 interface ChatWindowProps {
   isRightSidebarOpen?: boolean;
   onRightSidebarToggle?: (isOpen: boolean) => void;
@@ -329,28 +334,6 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   viewportWidthPx,
   rightSidebarForceFullView = false,
 }) => {
-  const HEARTBEAT_HEALTHY_WINDOW_MS = 18_000;
-
-  const formatRelativeHeartbeatTime = (iso?: string): string | null => {
-    if (!iso) return null;
-    const timestamp = new Date(iso).getTime();
-    if (Number.isNaN(timestamp)) return null;
-    const deltaMs = Date.now() - timestamp;
-    if (deltaMs < 0) return null;
-
-    const deltaSec = Math.floor(deltaMs / 1000);
-    if (deltaSec < 10) return 'just now';
-    if (deltaSec < 60) return `${deltaSec}s ago`;
-
-    const deltaMin = Math.floor(deltaSec / 60);
-    if (deltaMin < 60) return `${deltaMin}m ago`;
-
-    const deltaHours = Math.floor(deltaMin / 60);
-    if (deltaHours < 24) return `${deltaHours}h ago`;
-
-    const deltaDays = Math.floor(deltaHours / 24);
-    return `${deltaDays}d ago`;
-  };
 
   // Store hooks
   const {
@@ -369,12 +352,14 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     loadChat,
     isStreaming,
     activeStreamingChatId,
+    chats,
   } = useChatStore();
 
   const { refresh: refreshPlan, applySnapshot: applyPlanSnapshot, plan } = usePlan();
   const { loadCoreMemory, loadStats } = useMemory();
   const canvas = useCanvas(currentChatId);
   const { t } = useI18n();
+  const setHeartbeatRunning = useHeartbeatRunning(s => s.setRunning);
 
   // Local state
   const [input, setInput] = useState('');
@@ -398,7 +383,8 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   // Set to true when the backend signals HEARTBEAT_OK — onFinish should discard the message.
   const heartbeatOkRef = useRef(false);
   const heartbeatInFlightRef = useRef(false);
-  const [heartbeatLastOkAt, setHeartbeatLastOkAt] = useState<string | null>(null);
+  // Set to true while a live background stream is active — onFinish should skip addMessage/forceSaveNow.
+  const isLiveStreamRef = useRef(false);
 
   // ── AG-UI streaming hook ─────────────────────────────────────────────
   const {
@@ -423,8 +409,8 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
 
       if (heartbeatOkRef.current) {
         // HEARTBEAT_OK: backend rolled back the messages; discard streamed content and reload.
+        setHeartbeatRunning(false, null);
         heartbeatInFlightRef.current = false;
-        setHeartbeatLastOkAt(new Date().toISOString());
         heartbeatOkRef.current = false;
         setIsStreaming(false, chatId);
         streamingChatIdRef.current = null;
@@ -440,9 +426,18 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       if (hasPendingApprovals) {
         setIsStreaming(false, chatId);
         if (heartbeatInFlightRef.current) {
-          setHeartbeatLastOkAt(new Date().toISOString());
         }
         heartbeatInFlightRef.current = false;
+        setCurrentUsage(null);
+        return;
+      }
+
+      if (isLiveStreamRef.current) {
+        // Live background stream: backend already persisted the message.
+        // Do NOT call addMessage, forceSaveNow, setIsStreaming(false), or clearParts here.
+        // The live stream effect's finally() handles all cleanup AFTER loadChat resolves,
+        // so streaming parts stay visible until the DB reload completes — no blank flash.
+        streamingChatIdRef.current = null;
         setCurrentUsage(null);
         return;
       }
@@ -454,7 +449,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       setIsStreaming(false, chatId);
       if (heartbeatInFlightRef.current) {
         // Heartbeat ran but no heartbeat_ok signal — still record last run time.
-        setHeartbeatLastOkAt(new Date().toISOString());
+        setHeartbeatRunning(false, null);
       }
       heartbeatInFlightRef.current = false;
       streamingChatIdRef.current = null;
@@ -477,7 +472,6 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
         setCurrentUsage(value);
       } else if (name === 'heartbeat_ok') {
         // Backend signals that this heartbeat run was OK and messages were rolled back.
-        setHeartbeatLastOkAt(new Date().toISOString());
         heartbeatOkRef.current = true;
       } else if (name === 'a2ui.render') {
         const rawSurface = value as (A2UISurface & { chatId?: string }) | null;
@@ -502,6 +496,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       console.error('AG-UI error:', error);
       const chatId = streamingChatIdRef.current || activeChatIdRef.current;
       const wasHeartbeat = heartbeatInFlightRef.current;
+      if (wasHeartbeat) setHeartbeatRunning(false, null);
       heartbeatInFlightRef.current = false;
       heartbeatOkRef.current = false;
       setIsStreaming(false, chatId);
@@ -517,17 +512,21 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   useEffect(() => {
     const handler = (e: any) => {
       const { body, options } = e.detail || {};
-      heartbeatInFlightRef.current = Boolean(body?.is_heartbeat);
+      const isHeartbeat = Boolean(body?.is_heartbeat);
+      heartbeatInFlightRef.current = isHeartbeat;
       if (body) {
+        const chatId = body.chat_id || currentChatId;
+        if (isHeartbeat) setHeartbeatRunning(true, chatId);
         sendAGUI(body, options).catch(err => {
           heartbeatInFlightRef.current = false;
+          if (isHeartbeat) setHeartbeatRunning(false, null);
           console.error('[ChatWindow] External sendAGUI failed:', err);
         });
       }
     };
     window.addEventListener('agui:send-message', handler);
     return () => window.removeEventListener('agui:send-message', handler);
-  }, [sendAGUI]);
+  }, [sendAGUI, currentChatId, setHeartbeatRunning]);
 
   // HITL: tool approval handler (Stateless Resume)
   // Batches multiple approval decisions and only sends to backend when all are decided.
@@ -691,7 +690,17 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
 
   // Safe values
   const safeMessages = messages || [];
-  const safeConfig = config || { model: '', agent: '', tools: [] };
+  const _prefs = backendConfig?.userPreferences;
+  const _base = config || { model: '', agent: '', tools: [] as string[] };
+  // Platform chats (cron, social) have no model/agent — fall back to user prefs.
+  // The config selector is hidden for these chats so users can't override the managed config.
+  const _isPlatformChat = !!(config as any)?.platform;
+  const safeConfig = {
+    ..._base,
+    model: _base.model || (_isPlatformChat ? (_prefs?.model || backendConfig?.models?.[0] || '') : ''),
+    agent: _base.agent || (_isPlatformChat ? (_prefs?.agent || backendConfig?.agents?.[0] || '') : ''),
+    tools: _base.tools?.length ? _base.tools : (_isPlatformChat ? (_prefs?.tools ?? []) : []),
+  };
 
   // Unified canvas action dispatcher — used by both the canvas sidebar panel and inline surfaces.
   // Adds a decorative canvas_action pill to the chat, then starts a real AG-UI stream so the
@@ -766,58 +775,6 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   const showTransientAssistant = streamingForCurrentChat || hasPendingTransientApprovals;
   const configReady = !!(safeBackendConfig && safeConfig.model && safeConfig.agent);
 
-  const heartbeatEnabled = !!safeConfig.heartbeat_enabled;
-  const heartbeatIsRunning = heartbeatEnabled && heartbeatInFlightRef.current && streamingForCurrentChat;
-  const heartbeatLastSeen = heartbeatLastOkAt || safeConfig.heartbeat_last_run_at || null;
-  const heartbeatLastSeenTs = heartbeatLastSeen ? new Date(heartbeatLastSeen).getTime() : 0;
-  const heartbeatFresh = heartbeatEnabled && heartbeatLastSeenTs > 0 && (Date.now() - heartbeatLastSeenTs) <= HEARTBEAT_HEALTHY_WINDOW_MS;
-  const heartbeatRelative = formatRelativeHeartbeatTime(heartbeatLastSeen || undefined);
-
-  const heartbeatBadge = (() => {
-    if (!heartbeatEnabled) {
-      return {
-        signClass: 'bg-neutral-200 dark:bg-zinc-700 text-neutral-500 dark:text-neutral-400',
-        containerClass: 'bg-neutral-50 dark:bg-zinc-800 text-neutral-500 dark:text-neutral-400',
-        text: t('chatWindow.heartbeatOff'),
-        isBeating: false,
-        fast: false,
-        ekg: 'flat',
-      };
-    }
-
-    if (heartbeatIsRunning) {
-      return {
-        signClass: 'bg-brutal-black text-white dark:bg-white dark:text-brutal-black',
-        containerClass: 'bg-white dark:bg-zinc-800 text-brutal-black dark:text-white bg-dot-pattern',
-        text: t('chatWindow.heartbeatRunning'),
-        isBeating: true,
-        fast: true,
-        ekg: 'active',
-      };
-    }
-
-    if (heartbeatFresh) {
-      return {
-        signClass: 'bg-brutal-black text-white dark:bg-white dark:text-brutal-black',
-        containerClass: 'bg-white dark:bg-zinc-800 text-brutal-black dark:text-white',
-        text: t('chatWindow.heartbeatHealthy'),
-        isBeating: true,
-        fast: false,
-        ekg: 'active',
-      };
-    }
-
-    return {
-      signClass: 'bg-white dark:bg-zinc-800 text-brutal-black dark:text-white',
-      containerClass: 'bg-white dark:bg-zinc-800 text-brutal-black dark:text-white',
-      text: heartbeatRelative
-        ? t('chatWindow.heartbeatLastRun', { time: heartbeatRelative })
-        : t('chatWindow.heartbeatEnabled'),
-      isBeating: false,
-      fast: false,
-      ekg: 'slow',
-    };
-  })();
 
   // Auto-scroll
   const { scrollContainerRef, bottomRef, showScrollButton, scrollToBottom } = useAutoScroll(
@@ -828,6 +785,59 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   useEffect(() => {
     refreshPlan(currentChatId);
   }, [currentChatId, refreshPlan]);
+
+  // Live background stream: when a background platform chat (cron/heartbeat/social) is open,
+  // poll /chat/live/{chat_id} on a tight 2s interval. As soon as a stream is active (non-204),
+  // subscribe and render events live. This avoids the 5s chat-list poll delay that would
+  // otherwise cause late joins or missed fast streams.
+  const currentChatSummary = chats.find(c => c.id === currentChatId);
+  const isBackgroundChat = !!currentChatSummary?.platform || !!currentChatSummary?.heartbeatEnabled;
+  useEffect(() => {
+    if (!currentChatId || !isBackgroundChat) return;
+
+    let cancelled = false;
+
+    const tryConnect = async () => {
+      if (isLiveStreamRef.current) return; // already streaming
+      const liveUrl = `${getApiBase()}/chat/live`;
+      const chatIdAtStart = currentChatId;
+
+      // Single fetch: connectToLiveStream handles 204 (no stream) returning false,
+      // or streams and returns true. onStreamStart fires only when a real stream is found.
+      const streamed = await sendAGUI({ chat_id: currentChatId }, {
+        urlOverride: liveUrl,
+        onStreamStart: () => {
+          isLiveStreamRef.current = true;
+          setIsStreaming(true, chatIdAtStart);
+        },
+      });
+
+      if (!streamed || cancelled) return;
+
+      // Keep isLiveStreamRef = true during cleanup so the 2s poll guard
+      // (above) prevents a new probe from clearing parts while loadChat is pending.
+      try { await loadChat(chatIdAtStart); } catch { /* ignore */ }
+      setIsStreaming(false, chatIdAtStart);
+      clearParts();
+      isLiveStreamRef.current = false; // Only release after full cleanup
+    };
+
+    // Poll every 2s
+    const id = setInterval(() => {
+      if (!cancelled) tryConnect();
+    }, 2000);
+
+    // Also try immediately
+    tryConnect();
+
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+      stopAGUIStream();
+      isLiveStreamRef.current = false;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentChatId, isBackgroundChat]);
 
   // Auto-resize textarea
   useEffect(() => {
@@ -1049,56 +1059,14 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
               <span>{((currentUsage.total_tokens ?? currentUsage.total ?? 0) / 1000).toFixed(0)}k / {(safeBackendConfig.maxContextTokens / 1000).toFixed(0)}k</span>
             </div>
           )}
-          <div
-            className={`inline-flex items-center shadow-[2px_2px_0_0_#000] border-2 border-brutal-black font-bold uppercase tracking-wide pointer-events-auto cursor-default group transition-transform hover:-translate-y-0.5`}
-            aria-live="polite"
-            title={heartbeatBadge.text}
-          >
-            <div className={`flex items-center justify-center px-1.5 py-1 h-full border-r-2 border-brutal-black ${heartbeatBadge.signClass}`}>
-              <svg 
-                className={`w-3.5 h-3.5 sm:w-4 sm:h-4 ${heartbeatBadge.isBeating ? (heartbeatBadge.fast ? 'pixel-heart-beat-fast' : 'pixel-heart-beat') : ''}`}
-                viewBox="0 0 24 24" 
-                fill="currentColor"
-              >
-                <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-              </svg>
-            </div>
-            
-            <div className={`px-2 py-1 flex items-center gap-1.5 ${heartbeatBadge.containerClass}`}>
-              <div className="w-8 h-4 sm:w-10 sm:h-5 relative border-r-2 border-current pr-1 flex-shrink-0 opacity-80">
-                <svg viewBox="0 0 100 50" preserveAspectRatio="none" className="w-full h-full">
-                  {heartbeatBadge.ekg !== 'flat' ? (
-                    <path
-                      className={`ekg-active-wave ${heartbeatBadge.ekg === 'active' ? (heartbeatBadge.fast ? '[animation-duration:1.5s]' : '[animation-duration:3s]') : '[animation-duration:6s] opacity-50'}`}
-                      pathLength="100"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="6"
-                      d={heartbeatBadge.ekg === 'slow' ? "M 0 25 L 30 25 L 34 30 L 38 15 L 44 35 L 50 25 L 100 25" : "M 0 25 L 10 25 L 14 30 L 22 5 L 28 45 L 34 25 L 100 25"}
-                    />
-                  ) : (
-                    <path
-                      className="ekg-flatline"
-                      pathLength="100"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="6"
-                      d="M 0 25 L 100 25"
-                    />
-                  )}
-                </svg>
-              </div>
-              <span className="text-[10px] sm:text-xs max-w-[120px] sm:max-w-[180px] truncate">{heartbeatBadge.text}</span>
-            </div>
-          </div>
         </div>
 
         <div className="relative flex-1 min-h-0">
           <div
             ref={scrollContainerRef}
             className={safeMessages.length === 0
-              ? "h-full overflow-hidden p-4 md:p-6 pb-2"
-              : "h-full overflow-y-auto overflow-x-hidden px-4 md:px-6 pt-3 pb-6 scrollbar-thin"
+              ? "h-full overflow-hidden p-4 md:p-6 pb-2 bg-neutral-50 dark:bg-zinc-900"
+              : "h-full overflow-y-auto overflow-x-hidden px-4 md:px-6 pt-3 pb-6 scrollbar-thin bg-neutral-50 dark:bg-zinc-900"
             }
           >
             {safeMessages.length === 0 ? (
@@ -1125,9 +1093,8 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
               />
             ) : (
               <>
-                <MessageList
+                <MessageListMemo
                   messages={safeMessages}
-                  isStreaming={isStreaming}
                   streamingForCurrentChat={streamingForCurrentChat}
                   chatId={currentChatId ?? undefined}
                   onImageClick={setViewingImage}
@@ -1204,6 +1171,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
               stopStreaming={stopStreaming}
               stopInFlight={stopInFlightRef.current}
               modelSelectDropUp={true}
+              hideConfigSelector={_isPlatformChat}
               onPaste={handlePaste}
               onImageClick={setViewingImage}
             />

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -385,6 +385,9 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   const heartbeatInFlightRef = useRef(false);
   // Set to true while a live background stream is active — onFinish should skip addMessage/forceSaveNow.
   const isLiveStreamRef = useRef(false);
+  // Captures the final AGUI parts from a live background stream so the cleanup path can
+  // convert them to a persisted rich message (with tool-step HTML) after clearParts.
+  const liveStreamPartsRef = useRef<AGUIPart[]>([]);
 
   // ── AG-UI streaming hook ─────────────────────────────────────────────
   const {
@@ -434,30 +437,39 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
 
       if (isLiveStreamRef.current) {
         // Live background stream: backend already persisted the message.
+        // Capture final parts so the cleanup path can persist the rich (tool-step) version.
         // Do NOT call addMessage, forceSaveNow, setIsStreaming(false), or clearParts here.
         // The live stream effect's finally() handles all cleanup AFTER loadChat resolves,
         // so streaming parts stay visible until the DB reload completes — no blank flash.
+        liveStreamPartsRef.current = parts;
         streamingChatIdRef.current = null;
         setCurrentUsage(null);
         return;
       }
 
-      const storeMsg = aguiPartsToStoreMessage(parts, currentUsage);
-      if (storeMsg.content.trim()) {
-        addMessage(storeMsg, chatId);
-      }
-      setIsStreaming(false, chatId);
+      // 100% Backend Authored: instead of pushing frontend-assembled HTML,
+      // load the official JSON-based chat history from the backend.
       if (heartbeatInFlightRef.current) {
-        // Heartbeat ran but no heartbeat_ok signal — still record last run time.
         setHeartbeatRunning(false, null);
       }
       heartbeatInFlightRef.current = false;
       streamingChatIdRef.current = null;
-      clearParts();
+
+      // Optimistic append: convert parts to HTML and store locally, preventing
+      // a blank flash while loadChat waits for the backend to finish DB writes.
+      const storeMsg = aguiPartsToStoreMessage(parts, currentUsage);
+      if (storeMsg.content.trim()) {
+        addMessage(storeMsg, chatId!);
+      }
+
       setCurrentUsage(null);
-      setTimeout(async () => {
-        try { await forceSaveNow(chatId); } catch { }
-      }, 200);
+
+      // Load official chat history to ensure we have exact DB state (with JSON tools & reasoning mapped to HTML)
+      loadChat(chatId!).finally(() => {
+        setIsStreaming(false, chatId);
+        clearParts();
+      });
+
       try { loadCoreMemory(); loadStats(); } catch { }
     },
     onMarkDeferred: (surfaceId) => {
@@ -502,7 +514,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       setIsStreaming(false, chatId);
       streamingChatIdRef.current = null;
       stopInFlightRef.current = false;
-      if (!wasHeartbeat) {
+      if (!wasHeartbeat && !isLiveStreamRef.current) {
         addMessage({ role: 'assistant', content: `\u26a0\ufe0f Error: ${error.message}` }, chatId);
       }
     },
@@ -649,11 +661,10 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     } finally {
       setIsStreaming(false, targetChatId);
       stopInFlightRef.current = false;
-      setTimeout(async () => {
-        try { await forceSaveNow(targetChatId); } catch { }
-      }, 600);
+      // resumeStream's onFinish() callback handles cleanup (optimistic append, loadChat, clearParts).
+      // Don't call clearParts here—it races with onFinish and wipes the streamed response.
     }
-  }, [currentChatId, config, resumeStream, resolveApproval, addApprovalDecision, consumeApprovalDecisions, updateMessage, setIsStreaming, forceSaveNow, setConfig, messages, streamingParts]);
+  }, [currentChatId, config, resumeStream, resolveApproval, addApprovalDecision, consumeApprovalDecisions, updateMessage, setIsStreaming, loadChat, clearParts, setConfig, messages, streamingParts]);
 
   // Remove a tool from the approval policy
   const handleRemoveApprovalPolicy = useCallback((toolName: string) => {
@@ -797,6 +808,9 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
 
     let cancelled = false;
 
+    // On re-entry: reload from DB so any stream that completed while away is visible.
+    loadChat(currentChatId).catch(() => {});
+
     const tryConnect = async () => {
       if (isLiveStreamRef.current) return; // already streaming
       const liveUrl = `${getApiBase()}/chat/live`;
@@ -808,18 +822,51 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
         urlOverride: liveUrl,
         onStreamStart: () => {
           isLiveStreamRef.current = true;
+          // Pin the streaming chat ID so onFinish uses the correct chat even if
+          // the user navigates away (causing activeChatIdRef to point elsewhere).
+          streamingChatIdRef.current = chatIdAtStart;
           setIsStreaming(true, chatIdAtStart);
+          // Reload messages now that the stream has confirmed active: the backend
+          // pre-saves the user message to DB before yielding the first SSE event,
+          // so this loadChat will pick it up and show it alongside the stream.
+          loadChat(chatIdAtStart).catch(() => {});
         },
       });
 
       if (!streamed || cancelled) return;
 
-      // Keep isLiveStreamRef = true during cleanup so the 2s poll guard
-      // (above) prevents a new probe from clearing parts while loadChat is pending.
-      try { await loadChat(chatIdAtStart); } catch { /* ignore */ }
+      // Convert the captured streaming parts to a rich message (includes tool-step HTML).
+      // This must happen before clearParts so the parts are still populated.
+      const richMsg = aguiPartsToStoreMessage(liveStreamPartsRef.current, null);
+
+      const isSocialStream = chatIdAtStart.startsWith('social-');
+
+      // Stop streaming indicator before any async work so transient parts stop
+      // rendering while we wait for the DB reload.
       setIsStreaming(false, chatIdAtStart);
+
+      if (isSocialStream) {
+        // Social chats: backend rebuilds the full message log asynchronously after the
+        // stream, so loadChat may return stale (pre-rebuild) data if called immediately.
+        // Add the optimistic rich message first — the loadChat length guard will then
+        // block any stale DB state from overwriting it, preventing a blank flash.
+        if (richMsg.content.trim()) {
+          addMessage(richMsg, chatIdAtStart);
+        }
+        try { await loadChat(chatIdAtStart); } catch { /* ignore */ }
+      }
+
       clearParts();
-      isLiveStreamRef.current = false; // Only release after full cleanup
+      liveStreamPartsRef.current = [];
+      isLiveStreamRef.current = false;
+
+      // Desktop/heartbeat/cron: add the rich message (tool-step HTML) to the store.
+      // addMessage schedules an 800ms autosave, which is faster than the 5-s polling
+      // loadChat, so the store guard (existing.length >= serverMessages.length) will
+      // preserve the rich message through polling reloads until the autosave fires.
+      if (!isSocialStream && richMsg.content.trim()) {
+        addMessage(richMsg, chatIdAtStart);
+      }
     };
 
     // Poll every 2s
@@ -1069,7 +1116,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
               : "h-full overflow-y-auto overflow-x-hidden px-4 md:px-6 pt-3 pb-6 scrollbar-thin bg-neutral-50 dark:bg-zinc-900"
             }
           >
-            {safeMessages.length === 0 ? (
+            {safeMessages.length === 0 && !showTransientAssistant ? (
               <NewChatView
                 input={input}
                 setInput={setInput}
@@ -1093,17 +1140,19 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
               />
             ) : (
               <>
-                <MessageListMemo
-                  messages={safeMessages}
-                  streamingForCurrentChat={streamingForCurrentChat}
-                  chatId={currentChatId ?? undefined}
-                  onImageClick={setViewingImage}
-                  onFileClick={handleFileClick}
-                  onToolApproval={handleToolApproval}
-                  toolApprovalPolicy={safeConfig.tool_approval_policy}
-                  onRemoveApprovalPolicy={handleRemoveApprovalPolicy}
-                  onInlineAction={(surfaceId, action, context) => handleCanvasDispatch(action, context, surfaceId)}
-                />
+                {safeMessages.length > 0 && (
+                  <MessageListMemo
+                    messages={safeMessages}
+                    streamingForCurrentChat={false}
+                    chatId={currentChatId ?? undefined}
+                    onImageClick={setViewingImage}
+                    onFileClick={handleFileClick}
+                    onToolApproval={handleToolApproval}
+                    toolApprovalPolicy={safeConfig.tool_approval_policy}
+                    onRemoveApprovalPolicy={handleRemoveApprovalPolicy}
+                    onInlineAction={(surfaceId, action, context) => handleCanvasDispatch(action, context, surfaceId)}
+                  />
+                )}
                 {/* Streaming/transient assistant message from AG-UI */}
                 {showTransientAssistant && (
                   <div className="space-y-6 mt-6">

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { useStatusStore, StatusType } from '../hooks/useStatusStore';
+import { useChatStore } from '../hooks/useChatStore';
+import { useI18n } from '../i18n';
+import { useHeartbeatRunning } from '../hooks/useHeartbeatRunning';
 
 const getStatusStyles = (type: StatusType) => {
   switch (type) {
@@ -28,24 +31,114 @@ const getStatusIcon = (type: StatusType) => {
   }
 };
 
+const HEARTBEAT_HEALTHY_WINDOW_MS = 90_000; // 90s — runner ticks every 1 min
+
+function formatRelativeTime(iso: string | null): string | null {
+  if (!iso) return null;
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return null;
+  const deltaMs = Date.now() - ts;
+  if (deltaMs < 0) return null;
+  const deltaSec = Math.floor(deltaMs / 1000);
+  if (deltaSec < 10) return 'just now';
+  if (deltaSec < 60) return `${deltaSec}s ago`;
+  const deltaMin = Math.floor(deltaSec / 60);
+  if (deltaMin < 60) return `${deltaMin}m ago`;
+  const deltaHours = Math.floor(deltaMin / 60);
+  if (deltaHours < 24) return `${deltaHours}h ago`;
+  return `${Math.floor(deltaHours / 24)}d ago`;
+}
+
+function HeartbeatWidget() {
+  const { currentChatId, config } = useChatStore();
+  const { t } = useI18n();
+  const { inFlight, inFlightChatId, loopRunning, lastPingAt, statusError } = useHeartbeatRunning();
+
+  const enabled = !!(currentChatId && config?.heartbeat_enabled);
+  const inFlightForChat = enabled && inFlight && inFlightChatId === currentChatId;
+
+  const lastPingMs = lastPingAt ? new Date(lastPingAt).getTime() : 0;
+  const fresh = enabled && lastPingMs > 0 && (Date.now() - lastPingMs) <= HEARTBEAT_HEALTHY_WINDOW_MS;
+  const relative = formatRelativeTime(lastPingAt);
+
+  type EkgMode = 'fast' | 'active' | 'slow' | 'flat';
+  let ekg: EkgMode;
+  let heartClass: string;
+  let text: string;
+
+  if (!enabled) {
+    ekg = 'flat'; heartClass = ''; text = t('chatWindow.heartbeatOff');
+  } else if (inFlightForChat) {
+    ekg = 'fast'; heartClass = 'pixel-heart-beat-fast'; text = t('chatWindow.heartbeatRunning');
+  } else if (statusError) {
+    ekg = 'slow'; heartClass = ''; text = statusError.slice(0, 32);
+  } else if (fresh) {
+    ekg = 'active'; heartClass = 'pixel-heart-beat'; text = t('chatWindow.heartbeatHealthy');
+  } else if (relative) {
+    ekg = 'slow'; heartClass = ''; text = t('chatWindow.heartbeatLastRun', { time: relative });
+  } else {
+    ekg = 'slow'; heartClass = ''; text = t('chatWindow.heartbeatEnabled');
+  }
+
+  const ekgClass = ekg === 'fast'
+    ? 'ekg-active-wave [animation-duration:1.5s]'
+    : ekg === 'active'
+    ? 'ekg-active-wave [animation-duration:3s]'
+    : ekg === 'slow'
+    ? 'ekg-active-wave [animation-duration:6s] opacity-50'
+    : 'ekg-flatline';
+  const ekgPath = ekg !== 'flat'
+    ? "M 0 25 L 10 25 L 14 30 L 22 5 L 28 45 L 34 25 L 100 25"
+    : "M 0 25 L 100 25";
+
+  return (
+    <div className={`flex items-center gap-1 flex-shrink-0 ml-3 ${!enabled ? 'opacity-40' : ''}`} title={loopRunning ? undefined : 'Heartbeat loop stopped'}>
+      <svg
+        className={`w-3 h-3 flex-shrink-0 ${heartClass}`}
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+      </svg>
+      <div className="hidden md:block w-8 h-3 flex-shrink-0">
+        <svg viewBox="0 0 100 50" preserveAspectRatio="none" className="w-full h-full">
+          <path
+            className={ekgClass}
+            pathLength="100"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="6"
+            d={ekgPath}
+          />
+        </svg>
+      </div>
+      <span className="hidden md:inline text-[10px] font-bold uppercase tracking-wider">{text}</span>
+    </div>
+  );
+}
+
 export const StatusBar: React.FC = () => {
   const { message, type } = useStatusStore();
 
   return (
     <div className={`
-      w-full h-7 flex items-center px-4 md:px-6 
-      border-b-3 border-brutal-black 
+      w-full h-7 flex items-center px-4 md:px-6
+      border-b-3 border-brutal-black
       font-mono text-[10px] md:text-xs font-bold uppercase tracking-wider
       transition-colors duration-200
       ${getStatusStyles(type)}
     `}>
-      <div className="flex items-center gap-3 w-full">
+      {/* Left: transient toast area */}
+      <div className="flex items-center gap-3 flex-1 min-w-0">
         <span className="flex-shrink-0 w-4 text-center">{getStatusIcon(type)}</span>
-        <span className="truncate flex-1">{message}</span>
-        <span className="hidden md:inline opacity-50">
+        <span className="truncate">{message}</span>
+        <span className="hidden md:inline opacity-50 flex-shrink-0">
           {new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
         </span>
       </div>
+      {/* Right: persistent heartbeat widget */}
+      <HeartbeatWidget />
     </div>
   );
 };

--- a/frontend/src/components/chat/AssistantMessage.tsx
+++ b/frontend/src/components/chat/AssistantMessage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import type { Message } from '../../types/api';
 import type { AGUIPart } from '../../hooks/useAGUI';
-import { splitAssistantContent, generateBlockKey, ContentBlock } from '../../lib/chatUtils';
+import { splitAssistantContent, generateBlockKey, ContentBlock, formatMessageTime } from '../../lib/chatUtils';
 import { useTypewriter } from '../../hooks/useTypewriter';
 import { ThinkingAnimation, AgentBadge } from './ThinkingAnimation';
 import { MarkdownRenderer } from './MarkdownRenderer';
@@ -338,15 +338,6 @@ const MetricsBadge: React.FC<{ usage?: any; stepInfo?: string }> = ({ usage, ste
   );
 };
 
-function formatMessageTime(iso: string): string {
-  const date = new Date(iso);
-  const now = new Date();
-  const isToday = date.toDateString() === now.toDateString();
-  if (isToday) {
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  }
-  return date.toLocaleDateString([], { month: 'short', day: 'numeric' }) + ' ' + date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-}
 
 // Helper to extract the first line of reasoning for the header
 const getReasoningHeader = (text: string) => {

--- a/frontend/src/components/chat/MarkdownRenderer.tsx
+++ b/frontend/src/components/chat/MarkdownRenderer.tsx
@@ -55,6 +55,41 @@ const FileButton: React.FC<{
 
 export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({ content, onFileClick }) => {
   const RM: any = ReactMarkdown;
+  const openingLinksRef = React.useRef(new Map<string, number>());
+
+  const isExternalLink = React.useCallback((href: string): boolean => {
+    return /^(https?:|mailto:|tel:)/i.test(href.trim());
+  }, []);
+
+  const openExternalLink = React.useCallback(async (href: string) => {
+    const link = href.trim();
+    if (!link) return;
+
+    // Guard against duplicate click events firing close together.
+    const now = Date.now();
+    const lastOpen = openingLinksRef.current.get(link);
+    if (lastOpen && now - lastOpen < 750) {
+      return;
+    }
+    openingLinksRef.current.set(link, now);
+
+    try {
+      if (window.__TAURI__) {
+        const { open } = await import('@tauri-apps/plugin-shell');
+        await open(link);
+        return;
+      }
+
+      window.open(link, '_blank', 'noopener,noreferrer');
+    } catch (err) {
+      console.warn('Failed to open external link', err);
+    } finally {
+      // Keep a short cooldown to suppress accidental double opens.
+      window.setTimeout(() => {
+        openingLinksRef.current.delete(link);
+      }, 750);
+    }
+  }, []);
 
   // Normalize content
   const normalized = String(content)
@@ -179,8 +214,13 @@ export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({ content, on
             return (
               <a
                 href={hrefStr}
-                target="_blank"
                 rel="noopener noreferrer"
+                onClick={(e) => {
+                  if (!isExternalLink(hrefStr)) return;
+                  e.preventDefault();
+                  e.stopPropagation();
+                  void openExternalLink(hrefStr);
+                }}
                 className="text-brutal-blue hover:bg-brutal-yellow font-bold underline break-words transition-colors duration-100"
               >
                 {children}

--- a/frontend/src/components/chat/UserMessage.tsx
+++ b/frontend/src/components/chat/UserMessage.tsx
@@ -4,6 +4,7 @@ import { FileIcon } from '../FileIcon';
 import { ClickableContent } from '../ClickableContent';
 import { ArrowDownTrayIcon, EyeIcon } from '@heroicons/react/24/outline';
 import { getApiBase, getSandboxParams } from '../../lib/api';
+import { formatMessageTime } from '../../lib/chatUtils';
 import { useChatStore } from '../../hooks/useChatStore';
 import { useI18n } from '../../i18n';
 
@@ -89,15 +90,30 @@ function LazyImage({
   );
 }
 
-function formatMessageTime(iso: string): string {
-  const date = new Date(iso);
-  const now = new Date();
-  const isToday = date.toDateString() === now.toDateString();
-  if (isToday) {
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+/**
+ * Sanitizes message content that was accidentally stored as a Python list repr,
+ * e.g. "['user text', BinaryContent(data=b'\\x89PNG...')]".
+ * Extracts only the human-readable text segments and discards binary blobs.
+ */
+function sanitizeContent(content: string): string {
+  if (!content.includes('BinaryContent(data=')) return content;
+  // Truncate at the first BinaryContent object
+  let cleaned = content;
+  const binaryIdx = cleaned.indexOf(', BinaryContent(');
+  if (binaryIdx !== -1) {
+    cleaned = cleaned.slice(0, binaryIdx);
   }
-  return date.toLocaleDateString([], { month: 'short', day: 'numeric' }) + ' ' + date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  // Strip leading Python list bracket + opening quote: [' or ["
+  if (cleaned.startsWith("['") || cleaned.startsWith('["')) {
+    cleaned = cleaned.slice(2);
+  }
+  // Strip trailing quote
+  if (cleaned.endsWith("'") || cleaned.endsWith('"')) {
+    cleaned = cleaned.slice(0, -1);
+  }
+  return cleaned;
 }
+
 
 interface UserMessageProps {
   message: Message;
@@ -110,10 +126,10 @@ export const UserMessage: React.FC<UserMessageProps> = ({ message, chatId, onIma
   const { config } = useChatStore();
   const { t } = useI18n();
 
-  // Don't render empty messages (no content, no images, and no files)
-  if (!message.content?.trim() &&
-    (!message.images || message.images.length === 0) &&
-    (!message.files || message.files.length === 0)) {
+  const imageFiles = message.files?.filter(f => f.mime_type.startsWith('image/')) ?? [];
+  const otherFiles = message.files?.filter(f => !f.mime_type.startsWith('image/')) ?? [];
+
+  if (!message.content?.trim() && !message.images?.length && !message.files?.length) {
     return null;
   }
 
@@ -141,21 +157,44 @@ export const UserMessage: React.FC<UserMessageProps> = ({ message, chatId, onIma
         </div>
       )}
 
-      {/* File attachments */}
-      {message.files && message.files.length > 0 && (
-        <div className="flex flex-col gap-2 items-end">
-          {message.files.map((file, fileIdx) => {
-            // Generate download URL with volumes
-            const downloadParams = getSandboxParams(chatId || '', file.path, config.sandbox_volumes);
-            const downloadUrl = `${getApiBase()}/sandbox/serve?${downloadParams}`;
+      {/* Image files — render inline via sandbox serve URL */}
+      {imageFiles.length > 0 && (
+        <div className="flex flex-wrap gap-3 justify-end">
+          {imageFiles.map((file, idx) => {
+            const serveUrl = `${getApiBase()}/sandbox/serve?${getSandboxParams(chatId || '', file.path, config.sandbox_volumes)}`;
+            return (
+              <div key={idx} className="relative group animate-brutal-pop">
+                <img
+                  src={serveUrl}
+                  alt={file.filename}
+                  className="max-w-sm max-h-64 border-4 border-brutal-black shadow-brutal-lg object-contain bg-white"
+                  title={file.filename}
+                  onClick={() => onImageClick?.(serveUrl)}
+                  style={{ cursor: onImageClick ? 'pointer' : 'default' }}
+                  loading="lazy"
+                  decoding="async"
+                />
+                <div className="absolute bottom-0 left-0 right-0 bg-brutal-black text-brutal-white text-xs px-2 py-1 font-bold opacity-0 group-hover:opacity-100 transition-opacity duration-100">
+                  {file.filename}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
 
+      {/* Non-image file attachments — download cards */}
+      {otherFiles.length > 0 && (
+        <div className="flex flex-col gap-2 items-end">
+          {otherFiles.map((file, fileIdx) => {
+            const downloadUrl = `${getApiBase()}/sandbox/serve?${getSandboxParams(chatId || '', file.path, config.sandbox_volumes)}`;
             return (
               <div key={fileIdx} className="bg-white dark:bg-zinc-800 border-3 border-brutal-black shadow-brutal px-4 py-3 flex items-center gap-3 max-w-md w-full animate-brutal-pop">
                 <FileIcon mimeType={file.mime_type} className="w-6 h-6 shrink-0" />
                 <div className="flex-1 min-w-0">
                   <div className="text-sm font-bold text-brutal-black dark:text-white truncate">{file.filename}</div>
                   <div className="text-xs text-neutral-500 dark:text-neutral-400">
-                    {(file.size / 1024).toFixed(1)} KB
+                    {file.size > 0 ? `${(file.size / 1024).toFixed(1)} KB` : file.mime_type}
                   </div>
                 </div>
                 {chatId && (
@@ -188,7 +227,7 @@ export const UserMessage: React.FC<UserMessageProps> = ({ message, chatId, onIma
         <div className="flex justify-end">
           <div className="bg-brutal-yellow border-3 border-brutal-black shadow-brutal-lg px-5 py-4 max-w-full font-medium relative select-text">
             <div className="prose prose-sm max-w-none break-words text-brutal-black font-sans whitespace-pre-wrap">
-              <ClickableContent content={message.content} onFileClick={onFileClick} />
+              <ClickableContent content={sanitizeContent(message.content)} onFileClick={onFileClick} />
             </div>
           </div>
         </div>

--- a/frontend/src/components/chat/UserMessage.tsx
+++ b/frontend/src/components/chat/UserMessage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import type { Message } from '../../types/api';
 import { FileIcon } from '../FileIcon';
 import { ClickableContent } from '../ClickableContent';
@@ -6,6 +6,88 @@ import { ArrowDownTrayIcon, EyeIcon } from '@heroicons/react/24/outline';
 import { getApiBase, getSandboxParams } from '../../lib/api';
 import { useChatStore } from '../../hooks/useChatStore';
 import { useI18n } from '../../i18n';
+
+// Must match the CSS max-w-sm / max-h-64 constraints on the rendered <img>.
+const IMG_MAX_W = 384;
+const IMG_MAX_H = 256;
+
+/**
+ * Downsamples a base64 image to display size via canvas before creating an object URL.
+ * Caps the GPU texture to ≤384×256 and enables loading="lazy" (a no-op on data: URLs).
+ */
+function LazyImage({
+  data,
+  mimeType,
+  alt,
+  className,
+  title,
+  onClick,
+  style,
+}: {
+  data: string;
+  mimeType: string;
+  alt?: string;
+  className?: string;
+  title?: string;
+  onClick?: () => void;
+  style?: React.CSSProperties;
+}) {
+  const [src, setSrc] = useState<string | null>(null);
+  const blobUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const img = new window.Image();
+    img.onload = () => {
+      if (cancelled) return;
+      const scale = Math.min(1, IMG_MAX_W / img.naturalWidth, IMG_MAX_H / img.naturalHeight);
+      const w = Math.round(img.naturalWidth * scale);
+      const h = Math.round(img.naturalHeight * scale);
+
+      const canvas = document.createElement('canvas');
+      canvas.width = w;
+      canvas.height = h;
+      canvas.getContext('2d')!.drawImage(img, 0, 0, w, h);
+
+      canvas.toBlob(blob => {
+        if (cancelled || !blob) return;
+        const url = URL.createObjectURL(blob);
+        blobUrlRef.current = url;
+        setSrc(url);
+      }, 'image/jpeg', 0.88);
+    };
+    img.onerror = () => {
+      if (!cancelled) setSrc(`data:${mimeType};base64,${data}`);
+    };
+    img.src = `data:${mimeType};base64,${data}`;
+
+    return () => {
+      cancelled = true;
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
+        blobUrlRef.current = null;
+      }
+    };
+  }, [data, mimeType]);
+
+  if (!src) {
+    return <div className="w-24 h-16 bg-neutral-200 dark:bg-zinc-700 border-2 border-brutal-black animate-pulse" />;
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={className}
+      title={title}
+      onClick={onClick}
+      style={style}
+      loading="lazy"
+      decoding="async"
+    />
+  );
+}
 
 function formatMessageTime(iso: string): string {
   const date = new Date(iso);
@@ -42,8 +124,9 @@ export const UserMessage: React.FC<UserMessageProps> = ({ message, chatId, onIma
         <div className="flex flex-wrap gap-3 justify-end">
           {message.images.map((img, imgIdx) => (
             <div key={imgIdx} className="relative group animate-brutal-pop">
-              <img
-                src={`data:${img.mime_type};base64,${img.data}`}
+              <LazyImage
+                data={img.data}
+                mimeType={img.mime_type}
                 alt={img.filename}
                 className="max-w-sm max-h-64 border-4 border-brutal-black shadow-brutal-lg object-contain bg-white"
                 title={img.filename}

--- a/frontend/src/components/chat/UserMessage.tsx
+++ b/frontend/src/components/chat/UserMessage.tsx
@@ -49,14 +49,22 @@ function LazyImage({
       const canvas = document.createElement('canvas');
       canvas.width = w;
       canvas.height = h;
-      canvas.getContext('2d')!.drawImage(img, 0, 0, w, h);
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        if (!cancelled) setSrc(`data:${mimeType};base64,${data}`);
+        return;
+      }
+      ctx.drawImage(img, 0, 0, w, h);
 
+      const outputMime = (mimeType === 'image/png' || mimeType === 'image/webp' || mimeType === 'image/jpeg')
+        ? mimeType
+        : 'image/jpeg';
       canvas.toBlob(blob => {
         if (cancelled || !blob) return;
         const url = URL.createObjectURL(blob);
         blobUrlRef.current = url;
         setSrc(url);
-      }, 'image/jpeg', 0.88);
+      }, outputMime, outputMime === 'image/jpeg' ? 0.88 : undefined);
     };
     img.onerror = () => {
       if (!cancelled) setSrc(`data:${mimeType};base64,${data}`);

--- a/frontend/src/hooks/chat/useToolApproval.ts
+++ b/frontend/src/hooks/chat/useToolApproval.ts
@@ -1,4 +1,4 @@
-import { useCallback, type MutableRefObject } from 'react';
+import { useCallback, useRef, type MutableRefObject } from 'react';
 import type { ChatConfig, Message } from '../../types/api';
 import type { AGUIPart } from '../useAGUI';
 
@@ -63,6 +63,12 @@ export function useToolApproval(options: UseToolApprovalOptions): UseToolApprova
     consumeApprovalDecisions,
   } = options;
 
+  // Keep refs so the callback never needs to re-create just because messages/parts changed.
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+  const streamingPartsRef = useRef(streamingParts);
+  streamingPartsRef.current = streamingParts;
+
   const handleToolApproval = useCallback(async (
     approvalId: string,
     toolCallId: string,
@@ -79,7 +85,7 @@ export function useToolApproval(options: UseToolApprovalOptions): UseToolApprova
     if (!targetChatId) return;
 
     const updateApprovalStateInHistory = (id: string, state: 'approved' | 'denied') => {
-      messages.forEach((m, idx) => {
+      messagesRef.current.forEach((m, idx) => {
         if (m.role === 'assistant' && m.content.includes(`data-approval-id="${id}"`)) {
           const finalContent = m.content.replace(
             new RegExp(`(<details[^>]*data-approval-id="${id}"[^>]*data-approval-state=")pending(")`),
@@ -101,7 +107,7 @@ export function useToolApproval(options: UseToolApprovalOptions): UseToolApprova
     let allDecided = addApprovalDecision(approvalId, toolCallId, approved, remember, toolName);
 
     if (remember === 'session' && toolName) {
-      const linkedPending = streamingParts
+      const linkedPending = streamingPartsRef.current
         .filter(
           p =>
             p.type === 'tool' &&
@@ -179,11 +185,9 @@ export function useToolApproval(options: UseToolApprovalOptions): UseToolApprova
     activeStreamingChatId,
     activeChatIdRef,
     currentChatId,
-    messages,
     updateMessage,
     resolveApproval,
     addApprovalDecision,
-    streamingParts,
     consumeApprovalDecisions,
     config,
     setConfig,

--- a/frontend/src/hooks/chat/useToolApproval.ts
+++ b/frontend/src/hooks/chat/useToolApproval.ts
@@ -1,0 +1,196 @@
+import { useCallback, type MutableRefObject } from 'react';
+import type { ChatConfig, Message } from '../../types/api';
+import type { AGUIPart } from '../useAGUI';
+
+interface ToolApprovalDecision {
+  approvalId: string;
+  toolCallId: string;
+  approved: boolean;
+  remember?: 'session' | null;
+  toolName?: string;
+}
+
+interface UseToolApprovalOptions {
+  currentChatId: string | null;
+  activeStreamingChatId: string | null;
+  config: ChatConfig;
+  messages: Message[];
+  streamingParts: AGUIPart[];
+  streamingChatIdRef: MutableRefObject<string | null>;
+  activeChatIdRef: MutableRefObject<string | null>;
+  stopInFlightRef: MutableRefObject<boolean>;
+  setConfig: (c: ChatConfig | ((prev: ChatConfig) => ChatConfig)) => void;
+  updateMessage: (index: number, update: Partial<Message>, chatId?: string | null) => void;
+  setIsStreaming: (streaming: boolean, chatId?: string | null) => void;
+  resumeStream: (body: Record<string, unknown>) => Promise<void>;
+  resolveApproval: (approvalId: string, approved: boolean) => void;
+  addApprovalDecision: (
+    approvalId: string,
+    toolCallId: string,
+    approved: boolean,
+    remember?: 'session' | null,
+    toolName?: string,
+  ) => boolean;
+  consumeApprovalDecisions: () => ToolApprovalDecision[];
+}
+
+interface UseToolApprovalReturn {
+  handleToolApproval: (
+    approvalId: string,
+    toolCallId: string,
+    approved: boolean,
+    remember?: 'session' | null,
+    toolName?: string,
+  ) => Promise<void>;
+}
+
+export function useToolApproval(options: UseToolApprovalOptions): UseToolApprovalReturn {
+  const {
+    currentChatId,
+    activeStreamingChatId,
+    config,
+    messages,
+    streamingParts,
+    streamingChatIdRef,
+    activeChatIdRef,
+    stopInFlightRef,
+    setConfig,
+    updateMessage,
+    setIsStreaming,
+    resumeStream,
+    resolveApproval,
+    addApprovalDecision,
+    consumeApprovalDecisions,
+  } = options;
+
+  const handleToolApproval = useCallback(async (
+    approvalId: string,
+    toolCallId: string,
+    approved: boolean,
+    remember?: 'session' | null,
+    toolName?: string,
+  ) => {
+    const targetChatId =
+      streamingChatIdRef.current ||
+      activeStreamingChatId ||
+      activeChatIdRef.current ||
+      currentChatId;
+
+    if (!targetChatId) return;
+
+    const updateApprovalStateInHistory = (id: string, state: 'approved' | 'denied') => {
+      messages.forEach((m, idx) => {
+        if (m.role === 'assistant' && m.content.includes(`data-approval-id="${id}"`)) {
+          const finalContent = m.content.replace(
+            new RegExp(`(<details[^>]*data-approval-id="${id}"[^>]*data-approval-state=")pending(")`),
+            `$1${state}$2`,
+          );
+
+          if (finalContent !== m.content) {
+            updateMessage(idx, { content: finalContent }, targetChatId);
+          }
+        }
+      });
+    };
+
+    resolveApproval(approvalId, approved);
+
+    const newState = approved ? 'approved' : 'denied';
+    updateApprovalStateInHistory(approvalId, newState);
+
+    let allDecided = addApprovalDecision(approvalId, toolCallId, approved, remember, toolName);
+
+    if (remember === 'session' && toolName) {
+      const linkedPending = streamingParts
+        .filter(
+          p =>
+            p.type === 'tool' &&
+            p.state === 'approval-requested' &&
+            p.toolName === toolName &&
+            p.approvalId &&
+            p.approvalId !== approvalId &&
+            p.toolCallId,
+        )
+        .map(p => ({ approvalId: p.approvalId as string, toolCallId: p.toolCallId as string }));
+
+      for (const linked of linkedPending) {
+        resolveApproval(linked.approvalId, approved);
+        updateApprovalStateInHistory(linked.approvalId, newState);
+        allDecided =
+          addApprovalDecision(linked.approvalId, linked.toolCallId, approved, null, toolName) ||
+          allDecided;
+      }
+    }
+
+    if (!allDecided) return;
+
+    const decisions = consumeApprovalDecisions();
+
+    let currentConfig = config || { model: '', agent: '', tools: [] };
+    let hasPolicyUpdate = false;
+    const policyUpdates: Record<string, string> = {};
+
+    decisions.forEach(d => {
+      if (d.remember === 'session' && d.toolName) {
+        policyUpdates[d.toolName] = d.approved ? 'always_allow' : 'always_deny';
+        hasPolicyUpdate = true;
+      }
+    });
+
+    if (hasPolicyUpdate) {
+      currentConfig = {
+        ...currentConfig,
+        tool_approval_policy: {
+          ...(currentConfig.tool_approval_policy || {}),
+          ...policyUpdates,
+        },
+      };
+      setConfig(currentConfig);
+    }
+
+    const resumeApprovals = decisions.map(d => ({
+      request_id: d.approvalId,
+      tool_call_id: d.toolCallId,
+      approved: d.approved,
+      remember: d.remember,
+      tool_name: d.toolName,
+    }));
+
+    try {
+      const payload: Record<string, unknown> = {
+        message: '',
+        config: currentConfig,
+        chat_id: targetChatId,
+        reset: false,
+        resume_approvals: resumeApprovals,
+      };
+
+      setIsStreaming(true, targetChatId);
+      streamingChatIdRef.current = targetChatId;
+      stopInFlightRef.current = false;
+      await resumeStream(payload);
+    } catch (error) {
+      console.error('Failed to resume with tool approval:', error);
+      setIsStreaming(false, targetChatId);
+      stopInFlightRef.current = false;
+    }
+  }, [
+    streamingChatIdRef,
+    activeStreamingChatId,
+    activeChatIdRef,
+    currentChatId,
+    messages,
+    updateMessage,
+    resolveApproval,
+    addApprovalDecision,
+    streamingParts,
+    consumeApprovalDecisions,
+    config,
+    setConfig,
+    setIsStreaming,
+    stopInFlightRef,
+    resumeStream,
+  ]);
+
+  return { handleToolApproval };
+}

--- a/frontend/src/hooks/useAGUI.ts
+++ b/frontend/src/hooks/useAGUI.ts
@@ -403,6 +403,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
 
   // Pending approval tracking
   const [pendingApprovalCount, setPendingApprovalCount] = useState(0);
+  const pendingApprovalCountRef = useRef(0);
   const approvalDecisionsRef = useRef<Array<{ approvalId: string; toolCallId: string; approved: boolean; remember?: 'session' | null; toolName?: string }>>([]);
 
   // Stable refs for callbacks to avoid re-creating sendMessage
@@ -413,6 +414,16 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
     setParts([]);
     partsRef.current = [];
   }, []);
+
+  const setPendingApprovalCountSync = useCallback((count: number) => {
+    pendingApprovalCountRef.current = count;
+    setPendingApprovalCount(prev => (prev === count ? prev : count));
+  }, []);
+
+  const resetApprovalTracking = useCallback(() => {
+    setPendingApprovalCountSync(0);
+    approvalDecisionsRef.current = [];
+  }, [setPendingApprovalCountSync]);
 
   const removeInlineSurface = useCallback((surfaceId: string) => {
     setParts(prev => {
@@ -464,16 +475,15 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
     } else {
       approvalDecisionsRef.current.push(nextDecision);
     }
-    const remaining = pendingApprovalCount - approvalDecisionsRef.current.length;
-    return remaining <= 0;
-  }, [pendingApprovalCount]);
+    const requiredDecisions = pendingApprovalCountRef.current;
+    return requiredDecisions > 0 && approvalDecisionsRef.current.length >= requiredDecisions;
+  }, []);
 
   const consumeApprovalDecisions = useCallback(() => {
     const decisions = [...approvalDecisionsRef.current];
-    approvalDecisionsRef.current = [];
-    setPendingApprovalCount(0);
+    resetApprovalTracking();
     return decisions;
-  }, []);
+  }, [resetApprovalTracking]);
 
   /**
    * Resume a stream after tool approval without clearing existing parts.
@@ -484,9 +494,8 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
 
     // DON'T clear parts — keep existing tool parts from first stream
     setError(undefined);
-    setStatus('submitted');
-    setPendingApprovalCount(0);
-    approvalDecisionsRef.current = [];
+    setStatus('streaming');
+    resetApprovalTracking();
 
     const controller = new AbortController();
     abortRef.current = controller;
@@ -508,14 +517,12 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
         throw new Error('Response body is null');
       }
 
-      setStatus('streaming');
-
       const reader = response.body.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
       // Start from existing parts instead of empty array
       let currentParts = [...partsRef.current];
-      let newApprovalCount = 0;
+      const pendingApprovalIds = new Set<string>();
 
       while (true) {
         const { done, value } = await reader.read();
@@ -529,9 +536,13 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
         buffer = remainder;
 
         for (const event of events) {
-          // Track new approval requests
+          // Track unique approval requests in this paused stream segment.
           if (event.type === 'CUSTOM' && (event.data.name as string) === 'tool_approval_request') {
-            newApprovalCount++;
+            const approval = event.data.value as Record<string, unknown> | undefined;
+            const approvalId = approval?.approvalId;
+            if (typeof approvalId === 'string' && approvalId.length > 0) {
+              pendingApprovalIds.add(approvalId);
+            }
           }
           const result = processEvent(event, currentParts, onCustomEvent, onMarkDeferred);
           currentParts = result.parts;
@@ -549,9 +560,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
         if (events.length > 0) {
           setParts(currentParts);
           partsRef.current = currentParts;
-          if (newApprovalCount > 0) {
-            setPendingApprovalCount(newApprovalCount);
-          }
+          setPendingApprovalCountSync(pendingApprovalIds.size);
         }
       }
 
@@ -584,6 +593,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
     const { onFinish, onCustomEvent, onMarkDeferred, onError } = optionsRef.current;
     // Derive steer URL from the base chat URL
     const steerUrl = optionsRef.current.url.replace(/\/chat$/, '/chat/steer');
+    const previousParts = [...partsRef.current];
 
     // Mark any pending approvals as cancelled before aborting,
     // so they won't show approval buttons after being saved to the store
@@ -604,13 +614,11 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
     isSteeringRef.current = true;
     abortRef.current?.abort();
 
-    // Clear existing parts so the steer stream starts fresh
-    setParts([]);
-    partsRef.current = [];
+    // Keep existing parts visible until the steer response is confirmed.
+    // This prevents a blank UI when steering fails before the first chunk.
     setError(undefined);
     setStatus('submitted');
-    setPendingApprovalCount(0);
-    approvalDecisionsRef.current = [];
+    resetApprovalTracking();
 
     const controller = new AbortController();
     abortRef.current = controller;
@@ -632,13 +640,16 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
         throw new Error('Response body is null');
       }
 
+      // Steer stream is confirmed active; start with a fresh transient message.
+      setParts([]);
+      partsRef.current = [];
       setStatus('streaming');
 
       const reader = response.body.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
       let currentParts = [...partsRef.current];
-      let newApprovalCount = 0;
+      const pendingApprovalIds = new Set<string>();
 
       while (true) {
         const { done, value } = await reader.read();
@@ -653,7 +664,11 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
 
         for (const event of events) {
           if (event.type === 'CUSTOM' && (event.data.name as string) === 'tool_approval_request') {
-            newApprovalCount++;
+            const approval = event.data.value as Record<string, unknown> | undefined;
+            const approvalId = approval?.approvalId;
+            if (typeof approvalId === 'string' && approvalId.length > 0) {
+              pendingApprovalIds.add(approvalId);
+            }
           }
           const result = processEvent(event, currentParts, onCustomEvent, onMarkDeferred);
           currentParts = result.parts;
@@ -672,9 +687,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
         if (events.length > 0) {
           setParts(currentParts);
           partsRef.current = currentParts;
-          if (newApprovalCount > 0) {
-            setPendingApprovalCount(newApprovalCount);
-          }
+          setPendingApprovalCountSync(pendingApprovalIds.size);
         }
       }
 
@@ -688,6 +701,11 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
         setStatus('idle');
         onFinish?.(partsRef.current);
       } else {
+        // Restore previous parts if steer failed before the replacement stream started.
+        if (partsRef.current.length === 0 && previousParts.length > 0) {
+          partsRef.current = previousParts;
+          setParts(previousParts);
+        }
         const errorMsg = (err as Error).message;
         setError(errorMsg);
         setStatus('error');
@@ -713,8 +731,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
       partsRef.current = [];
       setError(undefined);
       setStatus('submitted');
-      setPendingApprovalCount(0);
-      approvalDecisionsRef.current = [];
+      resetApprovalTracking();
     }
 
     const controller = new AbortController();
@@ -754,8 +771,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
         partsRef.current = [];
         setError(undefined);
         setStatus('submitted');
-        setPendingApprovalCount(0);
-        approvalDecisionsRef.current = [];
+        resetApprovalTracking();
       }
 
       // Notify caller (e.g. set isLiveStreamRef) before entering the read loop.
@@ -766,7 +782,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
       const decoder = new TextDecoder();
       let buffer = '';
       let currentParts: AGUIPart[] = [];
-      let newApprovalCount = 0;
+      const pendingApprovalIds = new Set<string>();
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
@@ -782,7 +798,11 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
         for (const event of events) {
           // Track approval requests
           if (event.type === 'CUSTOM' && (event.data.name as string) === 'tool_approval_request') {
-            newApprovalCount++;
+            const approval = event.data.value as Record<string, unknown> | undefined;
+            const approvalId = approval?.approvalId;
+            if (typeof approvalId === 'string' && approvalId.length > 0) {
+              pendingApprovalIds.add(approvalId);
+            }
           }
           const result = processEvent(event, currentParts, onCustomEvent, onMarkDeferred);
           currentParts = result.parts;
@@ -800,9 +820,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
         if (events.length > 0) {
           setParts(currentParts);
           partsRef.current = currentParts;
-          if (newApprovalCount > 0) {
-            setPendingApprovalCount(newApprovalCount);
-          }
+          setPendingApprovalCountSync(pendingApprovalIds.size);
         }
       }
 
@@ -826,7 +844,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
       }
       return false;
     }
-  }, []);
+  }, [resetApprovalTracking, setPendingApprovalCountSync]);
 
   return { parts, status, error, sendMessage, resumeStream, steerStream, stop, clearParts, removeInlineSurface, resolveApproval, pendingApprovalCount, addApprovalDecision, consumeApprovalDecisions };
 }

--- a/frontend/src/hooks/useAGUI.ts
+++ b/frontend/src/hooks/useAGUI.ts
@@ -5,6 +5,7 @@
  * that parses AG-UI events and builds up parts-based state.
  */
 import { useState, useCallback, useRef } from 'react';
+import type { A2UISurface } from '../types/a2ui';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -29,7 +30,7 @@ export interface AGUIPart {
   /** Rich display data from CustomEvent (for future use) */
   displayData?: unknown;
   /** Inline A2UI surface (type === 'a2ui') */
-  surface?: unknown;
+  surface?: A2UISurface & { target?: string };
 }
 
 export type AGUIStatus = 'idle' | 'submitted' | 'streaming' | 'error';
@@ -46,7 +47,7 @@ interface UseAGUIReturn {
   parts: AGUIPart[];
   status: AGUIStatus;
   error: string | undefined;
-  sendMessage: (body: Record<string, unknown>, opts?: { formData?: FormData }) => Promise<void>;
+  sendMessage: (body: Record<string, unknown>, opts?: { formData?: FormData; urlOverride?: string; onStreamStart?: () => void }) => Promise<boolean>;
   /** Resume a stream after approval without clearing existing parts */
   resumeStream: (body: Record<string, unknown>) => Promise<void>;
   /** Interrupt the current stream and redirect the agent with a new message */
@@ -697,17 +698,24 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
 
   const sendMessage = useCallback(async (
     body: Record<string, unknown>,
-    opts?: { formData?: FormData },
-  ) => {
+    opts?: { formData?: FormData; urlOverride?: string; onStreamStart?: () => void },
+  ): Promise<boolean> => {
     const { url, onFinish, onCustomEvent, onMarkDeferred, onError } = optionsRef.current;
+    const targetUrl = opts?.urlOverride ?? url;
+    // For live-stream probes (urlOverride) we defer the state reset until we know
+    // there is actually an active stream — this prevents every 204 probe from
+    // clearing streaming parts that should stay visible.
+    const isProbe = !!opts?.urlOverride;
 
-    // Reset state
-    setParts([]);
-    partsRef.current = [];
-    setError(undefined);
-    setStatus('submitted');
-    setPendingApprovalCount(0);
-    approvalDecisionsRef.current = [];
+    if (!isProbe) {
+      // Normal send: reset immediately so the UI shows "submitted" while waiting.
+      setParts([]);
+      partsRef.current = [];
+      setError(undefined);
+      setStatus('submitted');
+      setPendingApprovalCount(0);
+      approvalDecisionsRef.current = [];
+    }
 
     const controller = new AbortController();
     abortRef.current = controller;
@@ -718,12 +726,18 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
         ? {} // Let browser set Content-Type for FormData
         : { 'Content-Type': 'application/json' };
 
-      const response = await fetch(url, {
+      const response = await fetch(targetUrl, {
         method: 'POST',
         headers,
         body: fetchBody,
         signal: controller.signal,
       });
+
+      // 204: no active stream (e.g. /chat/live when no background run is in progress)
+      if (response.status === 204) {
+        if (!isProbe) setStatus('idle');
+        return false;
+      }
 
       if (!response.ok) {
         const text = await response.text().catch(() => response.statusText);
@@ -734,6 +748,18 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
         throw new Error('Response body is null');
       }
 
+      if (isProbe) {
+        // Stream confirmed active — reset state now (not on every silent 204 probe).
+        setParts([]);
+        partsRef.current = [];
+        setError(undefined);
+        setStatus('submitted');
+        setPendingApprovalCount(0);
+        approvalDecisionsRef.current = [];
+      }
+
+      // Notify caller (e.g. set isLiveStreamRef) before entering the read loop.
+      opts?.onStreamStart?.();
       setStatus('streaming');
 
       const reader = response.body.getReader();
@@ -741,7 +767,6 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
       let buffer = '';
       let currentParts: AGUIPart[] = [];
       let newApprovalCount = 0;
-
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
@@ -768,7 +793,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
             setParts(currentParts);
             partsRef.current = currentParts;
             onError?.(new Error(result.error));
-            return;
+            return true;
           }
         }
 
@@ -783,6 +808,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
 
       setStatus('idle');
       onFinish?.(currentParts);
+      return true;
 
     } catch (err) {
       if ((err as Error).name === 'AbortError') {
@@ -798,6 +824,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
         setStatus('error');
         onError?.(err as Error);
       }
+      return false;
     }
   }, []);
 

--- a/frontend/src/hooks/useAGUI.ts
+++ b/frontend/src/hooks/useAGUI.ts
@@ -353,7 +353,7 @@ function processEvent(
           }
         }
       } else if (name === 'a2ui.render') {
-        const surface = value as Record<string, unknown>;
+        const surface = value as A2UISurface & { target?: string; deferred?: boolean };
         if (surface?.target === 'inline') {
           // Inline: embed as a part inside the current message
           next.push({ type: 'a2ui', surface });
@@ -417,7 +417,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
   const removeInlineSurface = useCallback((surfaceId: string) => {
     setParts(prev => {
       const next = prev.filter(
-        p => !(p.type === 'a2ui' && (p.surface as Record<string, unknown>)?.id === surfaceId)
+        p => !(p.type === 'a2ui' && (p.surface as A2UISurface)?.id === surfaceId)
       );
       partsRef.current = next;
       return next;

--- a/frontend/src/hooks/useChatStore.tsx
+++ b/frontend/src/hooks/useChatStore.tsx
@@ -2,6 +2,10 @@ import React, { createContext, useContext, useState, useEffect, useCallback, use
 import { Message, ChatConfig, ConfigOptions, Chat, ChatSummary } from '../types/api';
 import { getApiBase } from '../lib/api';
 
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
 interface ChatContextValue {
   messages: Message[];
   config: ChatConfig;
@@ -949,17 +953,17 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
               }
               if (msg.tool_calls && Array.isArray(msg.tool_calls)) {
                 msg.tool_calls.forEach((tc: any) => {
-                  const args = typeof tc.function.arguments === 'string' ? tc.function.arguments : JSON.stringify(tc.function.arguments);
+                  const args = escapeHtml(typeof tc.function.arguments === 'string' ? tc.function.arguments : JSON.stringify(tc.function.arguments));
                   const stateAttr = tc.state === 'approval-requested' ? ' data-approval-state="pending"' : '';
-                  const idAttr = tc.id ? ` data-approval-id="${tc.id}"` : '';
-                  currentAssistant!.content += `\n<details data-tool-call-id="${tc.id}"${idAttr}${stateAttr}><summary>🔧 ${tc.function.name}</summary>\n<pre><code class="language-json">${args}</code></pre>\n</details>\n`;
+                  const idAttr = tc.id ? ` data-approval-id="${escapeHtml(tc.id)}"` : '';
+                  currentAssistant!.content += `\n<details data-tool-call-id="${escapeHtml(tc.id ?? '')}"${idAttr}${stateAttr}><summary>🔧 ${escapeHtml(tc.function.name)}</summary>\n<pre><code class="language-json">${args}</code></pre>\n</details>\n`;
                 });
               }
             } else if (msg.role === 'tool') {
               if (!currentAssistant) {
                 currentAssistant = { role: 'assistant', content: '' };
               }
-              currentAssistant.content += `\n<details data-tool-call-id="${msg.tool_call_id}"><summary>📦 ${msg.name}</summary>\n<pre><code class="language-text">${msg.content}</code></pre>\n</details>\n`;
+              currentAssistant.content += `\n<details data-tool-call-id="${escapeHtml(msg.tool_call_id ?? '')}"><summary>📦 ${escapeHtml(msg.name ?? '')}</summary>\n<pre><code class="language-text">${escapeHtml(msg.content ?? '')}</code></pre>\n</details>\n`;
             } else {
               if (currentAssistant) { mappedMessages.push(currentAssistant as Message); currentAssistant = null; }
               mappedMessages.push(msg);

--- a/frontend/src/hooks/useChatStore.tsx
+++ b/frontend/src/hooks/useChatStore.tsx
@@ -522,7 +522,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
         }
       }
 
-      const payload: any = { config: chatConfig, messages: chatMessages };
+      const payload: any = { config: chatConfig };
       if (updateTitle) payload.title = updateTitle;
 
       const res = await fetch(`${getApiBase()}/chats/${chatId}`, {
@@ -927,15 +927,65 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
           console.warn('Failed to save config to localStorage:', e);
         }
         setMessagesByChat(prev => {
-          const existing = prev[key] ?? [];
-          const serverMessages = chat.messages ?? [];
-          // Social chats: backend is always the source of truth, always replace.
-          // Desktop chats: guard against overwriting frontend-streamed messages with a stale snapshot.
-          const isSocialChat = chatId.startsWith('social-');
-          if (!isSocialChat && existing.length >= serverMessages.length) {
+          // 100% Backend Authored: backend is ALWAYS the source of truth for ALL chats.
+          // Map backend JSON (which includes strict tool_calls arrays and 'tool' roles)
+          // into the legacy HTML `<details>` string blocks that the UI parser expects.
+          const serverMessages: any[] = chat.messages || [];
+          const mappedMessages: Message[] = [];
+          
+          let currentAssistant: Partial<Message> | null = null;
+          
+          for (const msg of serverMessages) {
+            if (msg.role === 'user') {
+              if (currentAssistant) { mappedMessages.push(currentAssistant as Message); currentAssistant = null; }
+              mappedMessages.push(msg);
+            } else if (msg.role === 'assistant') {
+              if (!currentAssistant) {
+                currentAssistant = { ...msg, content: msg.content || '' };
+              } else {
+                if (msg.content) {
+                  currentAssistant.content = (currentAssistant.content ? currentAssistant.content + '\n\n' : '') + msg.content;
+                }
+              }
+              if (msg.tool_calls && Array.isArray(msg.tool_calls)) {
+                msg.tool_calls.forEach((tc: any) => {
+                  const args = typeof tc.function.arguments === 'string' ? tc.function.arguments : JSON.stringify(tc.function.arguments);
+                  const stateAttr = tc.state === 'approval-requested' ? ' data-approval-state="pending"' : '';
+                  const idAttr = tc.id ? ` data-approval-id="${tc.id}"` : '';
+                  currentAssistant!.content += `\n<details data-tool-call-id="${tc.id}"${idAttr}${stateAttr}><summary>🔧 ${tc.function.name}</summary>\n<pre><code class="language-json">${args}</code></pre>\n</details>\n`;
+                });
+              }
+            } else if (msg.role === 'tool') {
+              if (!currentAssistant) {
+                currentAssistant = { role: 'assistant', content: '' };
+              }
+              currentAssistant.content += `\n<details data-tool-call-id="${msg.tool_call_id}"><summary>📦 ${msg.name}</summary>\n<pre><code class="language-text">${msg.content}</code></pre>\n</details>\n`;
+            } else {
+              if (currentAssistant) { mappedMessages.push(currentAssistant as Message); currentAssistant = null; }
+              mappedMessages.push(msg);
+            }
+          }
+          if (currentAssistant) { mappedMessages.push(currentAssistant as Message); }
+
+          // Prevent UI flicker: if local store has more messages (e.g. optimistic append right after stream),
+          // don't let stale backend DB state overwrite it. Wait until DB catches up.
+          const existing = prev[key] || [];
+          if (existing.length > mappedMessages.length) {
             return prev;
           }
-          return { ...prev, [key]: serverMessages };
+          // Guard against replacing locally-resolved content with a stale pending-approval
+          // DB state. This race occurs when loadChat is called immediately after a resume
+          // stream ends but before the backend persists the final resolved state.
+          const serverHasPendingApproval = mappedMessages.some(
+            (m: Message) => typeof m.content === 'string' && m.content.includes('data-approval-state="pending"')
+          );
+          const localHasNoPendingApproval = existing.length > 0 && !existing.some(
+            (m: Message) => typeof m.content === 'string' && m.content.includes('data-approval-state="pending"')
+          );
+          if (serverHasPendingApproval && localHasNoPendingApproval) {
+            return prev;
+          }
+          return { ...prev, [key]: mappedMessages };
         });
         setShouldResetNext(false);
       } else {

--- a/frontend/src/hooks/useHeartbeatRunning.ts
+++ b/frontend/src/hooks/useHeartbeatRunning.ts
@@ -22,6 +22,12 @@ export const useHeartbeatRunning = create<HeartbeatRunningState>((set) => ({
   lastPingAt: null,
   statusError: null,
   setRunning: (running, chatId) => set({ inFlight: running, inFlightChatId: chatId }),
-  setStatus: (status) =>
-    set({ loopRunning: status.running, lastPingAt: status.last_run_at, statusError: status.last_error }),
+  setStatus: (status) => {
+    const s = status as any;
+    set({
+      loopRunning: status.running,
+      lastPingAt: s.last_run_at ?? s.last_ping_at ?? null,
+      statusError: s.last_error ?? s.error ?? null,
+    });
+  },
 }));

--- a/frontend/src/hooks/useHeartbeatRunning.ts
+++ b/frontend/src/hooks/useHeartbeatRunning.ts
@@ -12,7 +12,7 @@ interface HeartbeatRunningState {
   statusError: string | null;
 
   setRunning: (running: boolean, chatId: string | null) => void;
-  setStatus: (status: { running: boolean; last_ping_at: string | null; error: string | null }) => void;
+  setStatus: (status: import('../lib/api').HeartbeatStatus) => void;
 }
 
 export const useHeartbeatRunning = create<HeartbeatRunningState>((set) => ({
@@ -22,6 +22,6 @@ export const useHeartbeatRunning = create<HeartbeatRunningState>((set) => ({
   lastPingAt: null,
   statusError: null,
   setRunning: (running, chatId) => set({ inFlight: running, inFlightChatId: chatId }),
-  setStatus: ({ running, last_ping_at, error }) =>
-    set({ loopRunning: running, lastPingAt: last_ping_at, statusError: error }),
+  setStatus: (status) =>
+    set({ loopRunning: status.running, lastPingAt: status.last_run_at, statusError: status.last_error }),
 }));

--- a/frontend/src/hooks/useHeartbeatRunning.ts
+++ b/frontend/src/hooks/useHeartbeatRunning.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+interface HeartbeatRunningState {
+  // In-flight LLM turn: a heartbeat turn is actively streaming for a specific chat.
+  // Set by ChatWindow event handlers via setRunning().
+  inFlight: boolean;
+  inFlightChatId: string | null;
+
+  // Global runner status: polled from /heartbeat/status every 5 s via App.tsx.
+  loopRunning: boolean;
+  lastPingAt: string | null;
+  statusError: string | null;
+
+  setRunning: (running: boolean, chatId: string | null) => void;
+  setStatus: (status: { running: boolean; last_ping_at: string | null; error: string | null }) => void;
+}
+
+export const useHeartbeatRunning = create<HeartbeatRunningState>((set) => ({
+  inFlight: false,
+  inFlightChatId: null,
+  loopRunning: false,
+  lastPingAt: null,
+  statusError: null,
+  setRunning: (running, chatId) => set({ inFlight: running, inFlightChatId: chatId }),
+  setStatus: ({ running, last_ping_at, error }) =>
+    set({ loopRunning: running, lastPingAt: last_ping_at, statusError: error }),
+}));

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -417,6 +417,7 @@ export async function drainCronNotifications(): Promise<CronNotification[]> {
   }
 }
 
+
 export interface CronRun {
   id: number;
   job_id: number;

--- a/frontend/src/lib/chatUtils.ts
+++ b/frontend/src/lib/chatUtils.ts
@@ -1,4 +1,13 @@
 
+export function formatMessageTime(iso: string): string {
+  const date = new Date(iso);
+  const now = new Date();
+  if (date.toDateString() === now.toDateString()) {
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+  return date.toLocaleDateString([], { month: 'short', day: 'numeric' }) + ' ' + date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
 export interface ContentBlock {
   type: 'markdown' | 'code' | 'log' | 'toolCall' | 'codeStep' | 'reasoning' | 'a2ui';
   content: string;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -6,6 +6,12 @@
   .brutal-btn {
     @apply hover:-translate-y-[1px] hover:shadow-[4px_4px_0_0_#000] active:translate-y-[2px] active:shadow-none transition-all;
   }
+
+  /* Skips paint/composite for off-screen message rows, preventing GPU layer exhaustion on long histories. */
+  .chat-msg-row {
+    content-visibility: auto;
+    contain-intrinsic-block-size: auto 120px;
+  }
 }
 
 html,

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -58,6 +58,8 @@ export interface ChatSummary {
   lastMessage?: string;
   platform?: string;
   heartbeatEnabled?: boolean;
+  lastResultAt?: string;
+  isRunning?: boolean;
 }
 
 export type PlanPhaseStatus = 'pending' | 'in_progress' | 'completed';

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
         "dialog:default",
         "core:window:default",
         "shell:allow-execute",
+        "shell:allow-open",
         "core:window:allow-start-dragging",
         "core:window:allow-close",
         "core:window:allow-minimize",

--- a/src/suzent/cli/main.py
+++ b/src/suzent/cli/main.py
@@ -446,12 +446,11 @@ def register_commands(app: typer.Typer):
             cmd.append("--debug")
 
         try:
-            creationflags = 0
-            if IS_WINDOWS:
-                creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-
             # Keep a process handle so Ctrl+C can shut down the child reliably.
-            process = subprocess.Popen(cmd, env=env, creationflags=creationflags)
+            # NOTE: Do NOT use CREATE_NEW_PROCESS_GROUP on Windows here.
+            # It can prevent Ctrl+C from propagating naturally from the console,
+            # leaving the backend process alive after the CLI is interrupted.
+            process = subprocess.Popen(cmd, env=env)
             return_code = process.wait()
 
             # 130 = terminated via SIGINT/Ctrl+C on many platforms.

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -507,8 +507,14 @@ class ChatProcessor:
         steer_message: str,
         config_override: Dict = None,
         on_event: Any = None,
+        _stream_queue=None,
     ) -> str:
-        """Run a steer and return only the final response text."""
+        """Run a steer and return only the final response text.
+
+        If `_stream_queue` is an asyncio.Queue, each raw SSE chunk is also put
+        on that queue so live subscribers can receive events in real time.
+        A None sentinel is put at the end to signal completion.
+        """
         full_response = ""
         parser = StreamParser()
 
@@ -518,6 +524,8 @@ class ChatProcessor:
             steer_message=steer_message,
             config_override=config_override,
         ):
+            if _stream_queue is not None:
+                await _stream_queue.put(chunk)
             for event in parser.parse([chunk]):
                 if on_event:
                     await on_event(event)
@@ -525,6 +533,9 @@ class ChatProcessor:
                     full_response += event.content
                 elif isinstance(event, ErrorEvent):
                     raise RuntimeError(event.message)
+
+        if _stream_queue is not None:
+            await _stream_queue.put(None)  # sentinel: stream finished
 
         return full_response.strip()
 
@@ -539,11 +550,16 @@ class ChatProcessor:
         resume_approvals: List[Dict] = None,
         is_social: bool = False,
         is_heartbeat: bool = False,
+        _stream_queue=None,
     ) -> str:
         """Run a conversation turn and return only the final response text.
 
         Allows for an optional async 'on_event' callback to handle intermediate
         events (like tool approval requests) while draining the stream.
+
+        If `_stream_queue` is an asyncio.Queue, each raw SSE chunk is also put
+        on that queue so live subscribers can receive events in real time.
+        A None sentinel is put at the end to signal completion.
         """
         full_response = ""
         parser = StreamParser()
@@ -558,6 +574,9 @@ class ChatProcessor:
             is_social=is_social,
             is_heartbeat=is_heartbeat,
         ):
+            if _stream_queue is not None:
+                await _stream_queue.put(chunk)
+
             # Use the shared parser to turn raw SSE chunks into events
             for event in parser.parse([chunk]):
                 if on_event:
@@ -567,6 +586,9 @@ class ChatProcessor:
                     full_response += event.content
                 elif isinstance(event, ErrorEvent):
                     raise RuntimeError(event.message)
+
+        if _stream_queue is not None:
+            await _stream_queue.put(None)  # sentinel: stream finished
 
         return full_response.strip()
 

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -235,6 +235,25 @@ class ChatProcessor:
             new_request = ModelRequest(parts=parts)
             message_history.append(new_request)
 
+            # Pre-save the user message to the DB display log for social chats so the
+            # frontend can show it as soon as the stream starts, without waiting for the
+            # background post-processing task that normally persists the full history.
+            if (
+                chat_id
+                and chat_id.startswith("social-")
+                and isinstance(full_prompt, str)
+                and full_prompt.strip()
+            ):
+                try:
+                    _db = get_database()
+                    _chat = _db.get_chat(chat_id)
+                    if _chat is not None:
+                        _existing = list(_chat.messages or [])
+                        _user_entry: dict = {"role": "user", "content": full_prompt}
+                        _db.update_chat(chat_id, messages=_existing + [_user_entry])
+                except Exception:
+                    pass  # Non-fatal; post-processing will persist the full history anyway
+
         # Handle stateless resume
         deferred_tool_results = None
         if resume_approvals:
@@ -247,9 +266,9 @@ class ChatProcessor:
             if cached_auto:
                 approvals_dict.update(cached_auto)
             for app in resume_approvals:
-                req_id = app.get("request_id")
-                if req_id:
-                    approvals_dict[req_id] = bool(app.get("approved"))
+                tool_call_id = app.get("tool_call_id") or app.get("request_id")
+                if tool_call_id:
+                    approvals_dict[tool_call_id] = bool(app.get("approved"))
 
             if approvals_dict:
                 deferred_tool_results = DeferredToolResults(approvals=approvals_dict)
@@ -716,46 +735,13 @@ class ChatProcessor:
             if skip_messages:
                 # Heartbeat: rollback already owns message state; only save agent_state.
                 db.update_chat(chat_id, agent_state=agent_state)
-            elif chat_id.startswith("social-"):
-                # Social chats: rebuild the complete display log from the full agent history
-                # so chat.messages is always a faithful log of all exchanges — including any
-                # that were missed while the old incremental-append logic was in use.
+            else:
+                # 100% Backend Authored: rebuild the complete display log from the full agent history
+                # so chat.messages is always a faithful log of all exchanges, including tools and reasoning.
                 rebuilt = _rebuild_display_messages(messages)
                 db.update_chat(
                     chat_id, agent_state=agent_state, messages=rebuilt or chat_messages
                 )
-            else:
-                # Desktop chats: frontend pushes messages via forceSaveNow ~200ms after stream.
-                # Only append here when the frontend hasn't already saved this turn.
-                last_msg_role = chat_messages[-1].get("role") if chat_messages else None
-                if last_msg_role != "assistant":
-                    if user_content:
-                        last_msg = chat_messages[-1] if chat_messages else None
-                        is_duplicate_user = (
-                            last_msg
-                            and last_msg.get("role") == "user"
-                            and last_msg.get("content") == user_content
-                        )
-                        if not is_duplicate_user:
-                            chat_messages.append(
-                                {
-                                    "role": "user",
-                                    "content": user_content,
-                                    "timestamp": datetime.now().isoformat(),
-                                }
-                            )
-                    chat_messages.append(
-                        {
-                            "role": "assistant",
-                            "content": agent_content,
-                            "timestamp": datetime.now().isoformat(),
-                        }
-                    )
-                    db.update_chat(
-                        chat_id, agent_state=agent_state, messages=chat_messages
-                    )
-                else:
-                    db.update_chat(chat_id, agent_state=agent_state)
 
             # Update session lifecycle fields
             try:
@@ -831,15 +817,26 @@ def _extract_tool_calls(messages: list) -> List[AgentAction]:
 
 def _rebuild_display_messages(messages: list) -> list:
     """
-    Reconstruct a flat [{role, content}] display log from pydantic-ai message history.
-    Used for social chats so chat.messages is always a complete, faithful log.
+    Reconstruct an OpenAI-like JSON display log from pydantic-ai message history.
+    This ensures that tool calls and tool results are preserved in the database.
     """
     from pydantic_ai.messages import (
         ModelRequest,
         ModelResponse,
         UserPromptPart,
         TextPart,
+        ToolCallPart,
+        ToolReturnPart,
     )
+    import json
+
+    # First pass: find all tool calls that have a corresponding return
+    executed_tool_calls = set()
+    for msg in messages:
+        if isinstance(msg, ModelRequest):
+            for part in msg.parts:
+                if isinstance(part, ToolReturnPart):
+                    executed_tool_calls.add(part.tool_call_id)
 
     result = []
     for msg in messages:
@@ -851,28 +848,61 @@ def _rebuild_display_messages(messages: list) -> list:
                         if isinstance(part.content, str)
                         else str(part.content)
                     )
-                    if content.strip():
-                        ts = (
-                            part.timestamp.isoformat()
-                            if getattr(part, "timestamp", None)
-                            else None
-                        )
-                        entry: dict = {"role": "user", "content": content}
-                        if ts:
-                            entry["timestamp"] = ts
-                        result.append(entry)
+                    ts = (
+                        part.timestamp.isoformat()
+                        if getattr(part, "timestamp", None)
+                        else None
+                    )
+                    entry: dict = {"role": "user", "content": content}
+                    if ts:
+                        entry["timestamp"] = ts
+                    result.append(entry)
+                elif isinstance(part, ToolReturnPart):
+                    ts = (
+                        part.timestamp.isoformat()
+                        if getattr(part, "timestamp", None)
+                        else None
+                    )
+                    entry = {
+                        "role": "tool",
+                        "tool_call_id": part.tool_call_id,
+                        "name": part.tool_name,
+                        "content": str(part.content),
+                    }
+                    if ts:
+                        entry["timestamp"] = ts
+                    result.append(entry)
         elif isinstance(msg, ModelResponse):
-            text = "".join(
-                part.content for part in msg.parts if isinstance(part, TextPart)
-            )
-            if text.strip():
-                ts = (
-                    msg.timestamp.isoformat()
-                    if getattr(msg, "timestamp", None)
-                    else None
-                )
-                entry = {"role": "assistant", "content": text}
-                if ts:
-                    entry["timestamp"] = ts
-                result.append(entry)
+            text_parts = []
+            tool_calls = []
+            for part in msg.parts:
+                if isinstance(part, TextPart):
+                    text_parts.append(part.content)
+                elif isinstance(part, ToolCallPart):
+                    args_str = (
+                        json.dumps(part.args)
+                        if isinstance(part.args, dict)
+                        else str(part.args)
+                    )
+                    tc_dict = {
+                        "id": part.tool_call_id,
+                        "type": "function",
+                        "function": {"name": part.tool_name, "arguments": args_str},
+                    }
+                    if part.tool_call_id not in executed_tool_calls:
+                        tc_dict["state"] = "approval-requested"
+                    tool_calls.append(tc_dict)
+
+            text_content = "".join(text_parts) if text_parts else None
+            # Only skip if there's no text AND no tool calls
+            if not text_content and not tool_calls:
+                continue
+
+            ts = msg.timestamp.isoformat() if getattr(msg, "timestamp", None) else None
+            entry = {"role": "assistant", "content": text_content}
+            if tool_calls:
+                entry["tool_calls"] = tool_calls
+            if ts:
+                entry["timestamp"] = ts
+            result.append(entry)
     return result

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -559,24 +559,25 @@ class ChatProcessor:
         full_response = ""
         parser = StreamParser()
 
-        async for chunk in self.process_steer(
-            chat_id=chat_id,
-            user_id=user_id,
-            steer_message=steer_message,
-            config_override=config_override,
-        ):
+        try:
+            async for chunk in self.process_steer(
+                chat_id=chat_id,
+                user_id=user_id,
+                steer_message=steer_message,
+                config_override=config_override,
+            ):
+                if _stream_queue is not None:
+                    await _stream_queue.put(chunk)
+                for event in parser.parse([chunk]):
+                    if on_event:
+                        await on_event(event)
+                    if isinstance(event, TextChunk):
+                        full_response += event.content
+                    elif isinstance(event, ErrorEvent):
+                        raise RuntimeError(event.message)
+        finally:
             if _stream_queue is not None:
-                await _stream_queue.put(chunk)
-            for event in parser.parse([chunk]):
-                if on_event:
-                    await on_event(event)
-                if isinstance(event, TextChunk):
-                    full_response += event.content
-                elif isinstance(event, ErrorEvent):
-                    raise RuntimeError(event.message)
-
-        if _stream_queue is not None:
-            await _stream_queue.put(None)  # sentinel: stream finished
+                await _stream_queue.put(None)  # sentinel: stream finished (or errored)
 
         return full_response.strip()
 
@@ -605,31 +606,32 @@ class ChatProcessor:
         full_response = ""
         parser = StreamParser()
 
-        async for chunk in self.process_turn(
-            chat_id=chat_id,
-            user_id=user_id,
-            message_content=message_content,
-            files=files,
-            config_override=config_override,
-            resume_approvals=resume_approvals,
-            is_social=is_social,
-            is_heartbeat=is_heartbeat,
-        ):
+        try:
+            async for chunk in self.process_turn(
+                chat_id=chat_id,
+                user_id=user_id,
+                message_content=message_content,
+                files=files,
+                config_override=config_override,
+                resume_approvals=resume_approvals,
+                is_social=is_social,
+                is_heartbeat=is_heartbeat,
+            ):
+                if _stream_queue is not None:
+                    await _stream_queue.put(chunk)
+
+                # Use the shared parser to turn raw SSE chunks into events
+                for event in parser.parse([chunk]):
+                    if on_event:
+                        await on_event(event)
+
+                    if isinstance(event, TextChunk):
+                        full_response += event.content
+                    elif isinstance(event, ErrorEvent):
+                        raise RuntimeError(event.message)
+        finally:
             if _stream_queue is not None:
-                await _stream_queue.put(chunk)
-
-            # Use the shared parser to turn raw SSE chunks into events
-            for event in parser.parse([chunk]):
-                if on_event:
-                    await on_event(event)
-
-                if isinstance(event, TextChunk):
-                    full_response += event.content
-                elif isinstance(event, ErrorEvent):
-                    raise RuntimeError(event.message)
-
-        if _stream_queue is not None:
-            await _stream_queue.put(None)  # sentinel: stream finished
+                await _stream_queue.put(None)  # sentinel: stream finished (or errored)
 
         return full_response.strip()
 

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -6,7 +6,9 @@ AgentDeps, and message-history-based state persistence.
 """
 
 import json
+import mimetypes
 import os
+import re
 import shutil
 import time
 from pathlib import Path
@@ -759,6 +761,23 @@ class ChatProcessor:
                 # 100% Backend Authored: rebuild the complete display log from the full agent history
                 # so chat.messages is always a faithful log of all exchanges, including tools and reasoning.
                 rebuilt = _rebuild_display_messages(messages)
+
+                # Guard: if the agent produced no output and this is a social chat, the
+                # pre-save at turn start left an orphaned user message in chat_messages.
+                # Roll it back so the history doesn't show a user turn with no reply.
+                if (
+                    not agent_content.strip()
+                    and chat_id.startswith("social-")
+                    and not rebuilt
+                ):
+                    chat_messages = [
+                        m
+                        for m in chat_messages
+                        if not (
+                            m.get("role") == "user" and m.get("content") == user_content
+                        )
+                    ]
+
                 db.update_chat(
                     chat_id, agent_state=agent_state, messages=rebuilt or chat_messages
                 )
@@ -798,6 +817,35 @@ class ChatProcessor:
 
 
 # ─── Utility ───────────────────────────────────────────────────────────
+
+
+_ATTACHMENT_PATTERN = re.compile(r"\n?\[User attached (?:an image|a file): ([^\]]+)\]")
+
+
+def _extract_attachment_files(text: str) -> list:
+    """Parse [User attached …] annotations into FileAttachment-like dicts."""
+    from pathlib import PurePosixPath
+
+    files = []
+    for m in _ATTACHMENT_PATTERN.finditer(text):
+        vpath = m.group(1).strip()
+        name = PurePosixPath(vpath).name
+        files.append(
+            {
+                "id": vpath,
+                "filename": name,
+                "path": vpath,
+                "size": 0,
+                "mime_type": mimetypes.guess_type(name)[0]
+                or "application/octet-stream",
+            }
+        )
+    return files
+
+
+def _strip_attachment_annotations(text: str) -> str:
+    """Remove [User attached …] annotations from display text."""
+    return _ATTACHMENT_PATTERN.sub("", text).strip()
 
 
 def _extract_tool_calls(messages: list) -> List[AgentAction]:
@@ -863,17 +911,34 @@ def _rebuild_display_messages(messages: list) -> list:
         if isinstance(msg, ModelRequest):
             for part in msg.parts:
                 if isinstance(part, UserPromptPart):
-                    content = (
-                        part.content
-                        if isinstance(part.content, str)
-                        else str(part.content)
-                    )
+                    if isinstance(part.content, str):
+                        raw_text = part.content
+                    elif isinstance(part.content, list):
+                        # Mixed list of strings + BinaryContent/ImageUrl objects.
+                        # Take only the first string segment (the user's actual text +
+                        # any attachment annotations injected by process_turn).
+                        raw_text = next(
+                            (item for item in part.content if isinstance(item, str)), ""
+                        )
+                    else:
+                        raw_text = str(part.content)
+
+                    # Parse attachment annotations injected by process_turn and convert
+                    # them to structured FileAttachment entries so the frontend renders
+                    # the proper file/image card rather than raw path text.
+                    files = _extract_attachment_files(raw_text)
+                    # Strip the annotations from the displayed text since the cards
+                    # already communicate the same information.
+                    clean_text = _strip_attachment_annotations(raw_text)
+
                     ts = (
                         part.timestamp.isoformat()
                         if getattr(part, "timestamp", None)
                         else None
                     )
-                    entry: dict = {"role": "user", "content": content}
+                    entry: dict = {"role": "user", "content": clean_text}
+                    if files:
+                        entry["files"] = files
                     if ts:
                         entry["timestamp"] = ts
                     result.append(entry)

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -65,6 +65,18 @@ class ChatProcessor:
         4. Background Tasks (Memory, Compression, Persistence)
         """
 
+        # 0. Wait for any pending post-processing from the previous turn to finish.
+        # This prevents resuming with a stale message history from the DB if the user
+        # approves/denies a tool call (or steers) very quickly.
+        try:
+            from suzent.core.task_registry import wait_for_background_task_prefix
+
+            await wait_for_background_task_prefix(
+                f"post_process_{chat_id}_", timeout=10.0
+            )
+        except Exception as e:
+            logger.warning(f"Error waiting for previous post-processing: {e}")
+
         # 1. Configuration
         logger.debug(f"[ChatProcessor] Starting process_turn for chat_id={chat_id}")
         config = {
@@ -442,9 +454,17 @@ class ChatProcessor:
         5. Start new agent run
         """
         from suzent.core.run_state import cancel_and_wait
+        from suzent.core.task_registry import wait_for_background_task_prefix
 
         # 1. Cancel and wait for cleanup
         await cancel_and_wait(chat_id)
+
+        try:
+            await wait_for_background_task_prefix(
+                f"post_process_{chat_id}_", timeout=10.0
+            )
+        except Exception as e:
+            logger.warning(f"Error waiting for previous post-processing in steer: {e}")
 
         # 2. Load persisted state from DB
         message_history = None

--- a/src/suzent/core/heartbeat.py
+++ b/src/suzent/core/heartbeat.py
@@ -168,10 +168,8 @@ class HeartbeatRunner(BaseBrain):
             "running": self._running,
             "polling_interval": self.polling_interval_minutes,
             "active_sessions": sessions,
-            "last_ping_at": self._last_run_at.isoformat()
-            if self._last_run_at
-            else None,
-            "error": self._last_error,
+            "last_run_at": self._last_run_at.isoformat() if self._last_run_at else None,
+            "last_error": self._last_error,
         }
 
     async def _tick(self):

--- a/src/suzent/core/heartbeat.py
+++ b/src/suzent/core/heartbeat.py
@@ -16,7 +16,11 @@ from suzent.config import CONFIG
 from suzent.core.base_brain import BaseBrain, get_active
 from suzent.database import get_database
 from suzent.logger import get_logger
-from suzent.core.stream_registry import stream_controls
+from suzent.core.stream_registry import (
+    stream_controls,
+    register_background_stream,
+    unregister_background_stream,
+)
 from suzent.core.chat_processor import ChatProcessor
 
 logger = get_logger(__name__)
@@ -164,6 +168,10 @@ class HeartbeatRunner(BaseBrain):
             "running": self._running,
             "polling_interval": self.polling_interval_minutes,
             "active_sessions": sessions,
+            "last_ping_at": self._last_run_at.isoformat()
+            if self._last_run_at
+            else None,
+            "error": self._last_error,
         }
 
     async def _tick(self):
@@ -327,6 +335,8 @@ class HeartbeatRunner(BaseBrain):
             except Exception as _e:
                 logger.warning(f"Failed to persist heartbeat_last_result: {_e}")
 
+            db.set_last_result_at(chat_id)
+
             if self._notification_callback and response_text:
                 self._notification_callback(f"Chat {chat_id[:8]}: {response_text}")
 
@@ -354,6 +364,7 @@ class HeartbeatRunner(BaseBrain):
 
         config_override = self._build_config_override(heartbeat_allowed_tools)
 
+        stream_queue = register_background_stream(chat_id)
         try:
             return await processor.process_turn_text(
                 chat_id=chat_id,
@@ -361,10 +372,13 @@ class HeartbeatRunner(BaseBrain):
                 message_content=prompt,
                 config_override=config_override,
                 is_heartbeat=True,
+                _stream_queue=stream_queue,
             )
         except RuntimeError as e:
             self._last_error = str(e)
             return ""
+        finally:
+            unregister_background_stream(chat_id)
 
     def _rollback_heartbeat_messages(self, chat_id: str, original_count: int, db):
         """Remove the heartbeat prompt and Ok response if no action was needed."""

--- a/src/suzent/core/scheduler.py
+++ b/src/suzent/core/scheduler.py
@@ -16,7 +16,11 @@ from suzent.config import CONFIG
 from suzent.core.base_brain import BaseBrain, get_active
 from suzent.database import get_database
 from suzent.logger import get_logger
-from suzent.core.stream_registry import stream_controls
+from suzent.core.stream_registry import (
+    stream_controls,
+    register_background_stream,
+    unregister_background_stream,
+)
 
 logger = get_logger(__name__)
 
@@ -131,6 +135,7 @@ class SchedulerBrain(BaseBrain):
 
             db.update_cron_job_run_state(job_id, last_result=response_text)
             db.finish_cron_run(run_id, "success", result=response_text)
+            db.set_last_result_at(chat_id)
 
             if job.delivery_mode == "announce" and response_text:
                 self._pending_notifications.append(
@@ -158,18 +163,22 @@ class SchedulerBrain(BaseBrain):
             db, model_override=job.model_override
         )
 
+        stream_queue = register_background_stream(chat_id)
         try:
             return await processor.process_turn_text(
                 chat_id=chat_id,
                 user_id=CONFIG.user_id,
                 message_content=job.prompt,
                 config_override=config_override,
+                _stream_queue=stream_queue,
             )
         except RuntimeError as e:
             logger.error(f"Cron job {job_id} error: {e}")
             db.update_cron_job_run_state(job_id, last_error=str(e))
             db.finish_cron_run(run_id, "error", error=str(e))
             return ""
+        finally:
+            unregister_background_stream(chat_id)
 
     def _build_config_override(
         self, db, *, model_override: Optional[str] = None

--- a/src/suzent/core/social_brain.py
+++ b/src/suzent/core/social_brain.py
@@ -13,6 +13,10 @@ from suzent.core.approval_manager import PendingApprovalSession
 from suzent.core.stream_parser import ApprovalRequest
 from suzent.core.run_state import ChatRunState
 from suzent.database import get_database
+from suzent.core.stream_registry import (
+    register_background_stream,
+    unregister_background_stream,
+)
 
 logger = get_logger(__name__)
 
@@ -405,23 +409,34 @@ class SocialBrain(BaseBrain):
                     )
                     collected_approvals.append(event)
 
-            if is_steer:
-                full_response = await processor.process_steer_text(
-                    chat_id=social_chat_id,
-                    user_id=CONFIG.user_id,
-                    steer_message=enriched_content,
-                    config_override=config_override,
-                    on_event=on_event,
-                )
-            else:
-                full_response = await processor.process_turn_text(
-                    chat_id=social_chat_id,
-                    user_id=CONFIG.user_id,
-                    message_content=enriched_content,
-                    files=message.attachments,
-                    config_override=config_override,
-                    on_event=on_event,
-                )
+            stream_queue = register_background_stream(social_chat_id)
+            try:
+                if is_steer:
+                    full_response = await processor.process_steer_text(
+                        chat_id=social_chat_id,
+                        user_id=CONFIG.user_id,
+                        steer_message=enriched_content,
+                        config_override=config_override,
+                        on_event=on_event,
+                        _stream_queue=stream_queue,
+                    )
+                else:
+                    full_response = await processor.process_turn_text(
+                        chat_id=social_chat_id,
+                        user_id=CONFIG.user_id,
+                        message_content=enriched_content,
+                        files=message.attachments,
+                        config_override=config_override,
+                        on_event=on_event,
+                        _stream_queue=stream_queue,
+                    )
+            finally:
+                unregister_background_stream(social_chat_id)
+
+            try:
+                get_database().set_last_result_at(social_chat_id)
+            except Exception:
+                pass
 
             # If tools need approval, store the session and prompt the first one
             if collected_approvals:

--- a/src/suzent/core/stream_registry.py
+++ b/src/suzent/core/stream_registry.py
@@ -62,10 +62,6 @@ def pop_pending_auto_approvals(chat_id: str) -> Dict[str, bool]:
 
 background_queues: Dict[str, asyncio.Queue] = {}
 
-# Per-chat events set when a background stream is registered.
-# Allows /chat/live to block efficiently instead of polling with asyncio.sleep.
-_stream_start_events: Dict[str, asyncio.Event] = {}
-
 
 def register_background_stream(chat_id: str) -> asyncio.Queue:
     """Create and register a background SSE queue for a chat. Returns the queue."""
@@ -79,24 +75,12 @@ def register_background_stream(chat_id: str) -> asyncio.Queue:
             pass
     q: asyncio.Queue = asyncio.Queue(maxsize=2000)
     background_queues[chat_id] = q
-    # Wake any /chat/live waiters that are blocking on this chat's start event.
-    event = _stream_start_events.get(chat_id)
-    if event is not None:
-        event.set()
     return q
 
 
 def unregister_background_stream(chat_id: str) -> None:
     """Remove the background queue for a chat (signals no active stream)."""
     background_queues.pop(chat_id, None)
-    _stream_start_events.pop(chat_id, None)
-
-
-def get_or_create_stream_start_event(chat_id: str) -> asyncio.Event:
-    """Return (creating if needed) the stream-start event for a chat."""
-    if chat_id not in _stream_start_events:
-        _stream_start_events[chat_id] = asyncio.Event()
-    return _stream_start_events[chat_id]
 
 
 def get_background_queue(chat_id: str) -> Optional[asyncio.Queue]:

--- a/src/suzent/core/stream_registry.py
+++ b/src/suzent/core/stream_registry.py
@@ -62,17 +62,41 @@ def pop_pending_auto_approvals(chat_id: str) -> Dict[str, bool]:
 
 background_queues: Dict[str, asyncio.Queue] = {}
 
+# Per-chat events set when a background stream is registered.
+# Allows /chat/live to block efficiently instead of polling with asyncio.sleep.
+_stream_start_events: Dict[str, asyncio.Event] = {}
+
 
 def register_background_stream(chat_id: str) -> asyncio.Queue:
     """Create and register a background SSE queue for a chat. Returns the queue."""
+    existing = background_queues.get(chat_id)
+    if existing is not None:
+        # Signal any live subscriber on the old queue to terminate gracefully
+        # so it doesn't hang on a dead queue for up to 60 seconds.
+        try:
+            existing.put_nowait(None)
+        except asyncio.QueueFull:
+            pass
     q: asyncio.Queue = asyncio.Queue()
     background_queues[chat_id] = q
+    # Wake any /chat/live waiters that are blocking on this chat's start event.
+    event = _stream_start_events.get(chat_id)
+    if event is not None:
+        event.set()
     return q
 
 
 def unregister_background_stream(chat_id: str) -> None:
     """Remove the background queue for a chat (signals no active stream)."""
     background_queues.pop(chat_id, None)
+    _stream_start_events.pop(chat_id, None)
+
+
+def get_or_create_stream_start_event(chat_id: str) -> asyncio.Event:
+    """Return (creating if needed) the stream-start event for a chat."""
+    if chat_id not in _stream_start_events:
+        _stream_start_events[chat_id] = asyncio.Event()
+    return _stream_start_events[chat_id]
 
 
 def get_background_queue(chat_id: str) -> Optional[asyncio.Queue]:

--- a/src/suzent/core/stream_registry.py
+++ b/src/suzent/core/stream_registry.py
@@ -77,7 +77,7 @@ def register_background_stream(chat_id: str) -> asyncio.Queue:
             existing.put_nowait(None)
         except asyncio.QueueFull:
             pass
-    q: asyncio.Queue = asyncio.Queue()
+    q: asyncio.Queue = asyncio.Queue(maxsize=2000)
     background_queues[chat_id] = q
     # Wake any /chat/live waiters that are blocking on this chat's start event.
     event = _stream_start_events.get(chat_id)

--- a/src/suzent/core/stream_registry.py
+++ b/src/suzent/core/stream_registry.py
@@ -6,7 +6,7 @@ can check for active streams without importing the full streaming module.
 """
 
 import asyncio
-from typing import Dict
+from typing import Dict, Optional
 
 
 class StreamControl:
@@ -52,3 +52,34 @@ def pop_pending_auto_approvals(chat_id: str) -> Dict[str, bool]:
     if not chat_id:
         return {}
     return pending_auto_approvals.pop(chat_id, {})
+
+
+# ---------------------------------------------------------------------------
+# Background stream queues
+# Maps chat_id → asyncio.Queue of raw SSE chunks from background executors.
+# A None sentinel in the queue signals end-of-stream.
+# ---------------------------------------------------------------------------
+
+background_queues: Dict[str, asyncio.Queue] = {}
+
+
+def register_background_stream(chat_id: str) -> asyncio.Queue:
+    """Create and register a background SSE queue for a chat. Returns the queue."""
+    q: asyncio.Queue = asyncio.Queue()
+    background_queues[chat_id] = q
+    return q
+
+
+def unregister_background_stream(chat_id: str) -> None:
+    """Remove the background queue for a chat (signals no active stream)."""
+    background_queues.pop(chat_id, None)
+
+
+def get_background_queue(chat_id: str) -> Optional[asyncio.Queue]:
+    """Return the active background queue for a chat, or None if not streaming."""
+    return background_queues.get(chat_id)
+
+
+def is_background_streaming(chat_id: str) -> bool:
+    """Return True if a background stream is currently active for this chat."""
+    return chat_id in background_queues

--- a/src/suzent/core/task_registry.py
+++ b/src/suzent/core/task_registry.py
@@ -161,6 +161,9 @@ class BackgroundTaskRegistry:
         """
         Wait for all registered tasks with IDs starting with a prefix to complete.
 
+        Uses a retry loop so newly registered tasks with the same prefix that
+        arrive between lock release and gather are not missed.
+
         Args:
             prefix: The task_id prefix to wait for
             timeout: Maximum time to wait in seconds (None = wait forever)
@@ -168,28 +171,39 @@ class BackgroundTaskRegistry:
         Raises:
             asyncio.TimeoutError: If timeout is exceeded
         """
-        async with self._lock:
-            tasks = [
-                info.task
-                for task_id, info in self._tasks.items()
-                if task_id.startswith(prefix) and not info.task.done()
-            ]
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout if timeout is not None else None
 
-        if not tasks:
-            return
+        while True:
+            async with self._lock:
+                tasks = [
+                    info.task
+                    for task_id, info in self._tasks.items()
+                    if task_id.startswith(prefix) and not info.task.done()
+                ]
 
-        logger.info(
-            f"Waiting for {len(tasks)} background tasks with prefix '{prefix}' to complete..."
-        )
+            if not tasks:
+                return
 
-        if timeout:
-            await asyncio.wait_for(
-                asyncio.gather(*tasks, return_exceptions=True), timeout
+            logger.info(
+                f"Waiting for {len(tasks)} background tasks with prefix '{prefix}' to complete..."
             )
-        else:
-            await asyncio.gather(*tasks, return_exceptions=True)
 
-        logger.info(f"All background tasks with prefix '{prefix}' completed")
+            remaining = (deadline - loop.time()) if deadline is not None else None
+            if remaining is not None and remaining <= 0:
+                raise asyncio.TimeoutError()
+
+            # Wait up to 1 s at a time so we can re-check for newly added tasks.
+            slice_timeout = min(remaining, 1.0) if remaining is not None else 1.0
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*tasks, return_exceptions=True),
+                    timeout=slice_timeout,
+                )
+            except asyncio.TimeoutError:
+                if deadline is not None and loop.time() >= deadline:
+                    raise
+                # Re-check: new tasks may have been added under this prefix.
 
     async def cancel_all(self):
         """Cancel all registered tasks."""

--- a/src/suzent/core/task_registry.py
+++ b/src/suzent/core/task_registry.py
@@ -157,6 +157,40 @@ class BackgroundTaskRegistry:
 
         logger.info("All background tasks completed")
 
+    async def wait_for_task_prefix(self, prefix: str, timeout: Optional[float] = None):
+        """
+        Wait for all registered tasks with IDs starting with a prefix to complete.
+
+        Args:
+            prefix: The task_id prefix to wait for
+            timeout: Maximum time to wait in seconds (None = wait forever)
+
+        Raises:
+            asyncio.TimeoutError: If timeout is exceeded
+        """
+        async with self._lock:
+            tasks = [
+                info.task
+                for task_id, info in self._tasks.items()
+                if task_id.startswith(prefix) and not info.task.done()
+            ]
+
+        if not tasks:
+            return
+
+        logger.info(
+            f"Waiting for {len(tasks)} background tasks with prefix '{prefix}' to complete..."
+        )
+
+        if timeout:
+            await asyncio.wait_for(
+                asyncio.gather(*tasks, return_exceptions=True), timeout
+            )
+        else:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        logger.info(f"All background tasks with prefix '{prefix}' completed")
+
     async def cancel_all(self):
         """Cancel all registered tasks."""
         async with self._lock:
@@ -264,3 +298,15 @@ async def register_background_task(
     """
     registry = get_task_registry()
     return await registry.register(coro, task_id, description)
+
+
+async def wait_for_background_task_prefix(prefix: str, timeout: Optional[float] = None):
+    """Wait for all tasks with a specific prefix to complete."""
+    registry = get_task_registry()
+    await registry.wait_for_task_prefix(prefix, timeout)
+
+
+async def wait_for_all_background_tasks(timeout: Optional[float] = None):
+    """Wait for all background tasks to complete."""
+    registry = get_task_registry()
+    await registry.wait_for_all(timeout)

--- a/src/suzent/core/task_registry.py
+++ b/src/suzent/core/task_registry.py
@@ -194,16 +194,13 @@ class BackgroundTaskRegistry:
                 raise asyncio.TimeoutError()
 
             # Wait up to 1 s at a time so we can re-check for newly added tasks.
+            # Use asyncio.wait (not wait_for+gather) so slice timeouts don't cancel
+            # the underlying tasks — they just stop waiting for this slice.
             slice_timeout = min(remaining, 1.0) if remaining is not None else 1.0
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(*tasks, return_exceptions=True),
-                    timeout=slice_timeout,
-                )
-            except asyncio.TimeoutError:
-                if deadline is not None and loop.time() >= deadline:
-                    raise
-                # Re-check: new tasks may have been added under this prefix.
+            await asyncio.wait(tasks, timeout=slice_timeout)
+            if deadline is not None and loop.time() >= deadline:
+                raise asyncio.TimeoutError()
+            # Re-check: tasks may have completed or new ones may have been added.
 
     async def cancel_all(self):
         """Cancel all registered tasks."""

--- a/src/suzent/core/task_registry.py
+++ b/src/suzent/core/task_registry.py
@@ -183,7 +183,23 @@ class BackgroundTaskRegistry:
                 ]
 
             if not tasks:
-                return
+                # No matching tasks right now, but a new one could be registered
+                # just after this snapshot. Wait briefly and re-check once before
+                # returning so callers get a stronger "truly empty" guarantee.
+                remaining = (deadline - loop.time()) if deadline is not None else None
+                if remaining is not None and remaining <= 0:
+                    return
+                await asyncio.sleep(
+                    min(remaining, 0.1) if remaining is not None else 0.1
+                )
+                async with self._lock:
+                    still_none = not any(
+                        task_id.startswith(prefix) and not info.task.done()
+                        for task_id, info in self._tasks.items()
+                    )
+                if still_none:
+                    return
+                continue
 
             logger.info(
                 f"Waiting for {len(tasks)} background tasks with prefix '{prefix}' to complete..."

--- a/src/suzent/database.py
+++ b/src/suzent/database.py
@@ -6,7 +6,7 @@ Provides a clean, type-safe interface for all database operations.
 
 import os
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from pydantic import BaseModel
@@ -377,7 +377,7 @@ class ChatDatabase:
         with self._session() as session:
             chat = session.get(ChatModel, chat_id)
             if chat:
-                chat.last_result_at = datetime.now()
+                chat.last_result_at = datetime.now(timezone.utc)
                 session.add(chat)
                 session.commit()
 

--- a/src/suzent/database.py
+++ b/src/suzent/database.py
@@ -40,6 +40,7 @@ class ChatSummaryModel(BaseModel):
     lastMessage: Optional[str] = None
     platform: Optional[str] = None
     heartbeatEnabled: bool = False
+    lastResultAt: Optional[str] = None
 
 
 class ChatModel(SQLModel, table=True):
@@ -58,6 +59,9 @@ class ChatModel(SQLModel, table=True):
     # Session lifecycle fields
     last_active_at: Optional[datetime] = None
     turn_count: int = Field(default=0)
+
+    # Background execution tracking — written only by background executors
+    last_result_at: Optional[datetime] = None
 
     plans: List["PlanModel"] = Relationship(
         back_populates="chat",
@@ -273,6 +277,10 @@ class ChatDatabase:
                             "ALTER TABLE chats ADD COLUMN turn_count INTEGER DEFAULT 0"
                         )
                     )
+                if "last_result_at" not in columns:
+                    conn.execute(
+                        text("ALTER TABLE chats ADD COLUMN last_result_at DATETIME")
+                    )
                 conn.commit()
 
     def _session(self) -> Session:
@@ -364,6 +372,15 @@ class ChatDatabase:
             session.commit()
             return True
 
+    def set_last_result_at(self, chat_id: str) -> None:
+        """Mark that a background executor just completed a turn for this chat."""
+        with self._session() as session:
+            chat = session.get(ChatModel, chat_id)
+            if chat:
+                chat.last_result_at = datetime.now()
+                session.add(chat)
+                session.commit()
+
     def list_chats(
         self,
         limit: int = 50,
@@ -410,6 +427,9 @@ class ChatDatabase:
                         lastMessage=last_message,
                         platform=chat.config.get("platform"),
                         heartbeatEnabled=chat.config.get("heartbeat_enabled", False),
+                        lastResultAt=chat.last_result_at.isoformat()
+                        if chat.last_result_at
+                        else None,
                     )
                 )
 

--- a/src/suzent/database.py
+++ b/src/suzent/database.py
@@ -404,7 +404,23 @@ class ChatDatabase:
                 messages = chat.messages or []
                 last_message = None
                 if messages:
-                    content = messages[-1].get("content", "")
+                    last_msg = messages[-1]
+                    if isinstance(last_msg, dict):
+                        content = last_msg.get("content") or ""
+                    else:
+                        content = str(last_msg)
+
+                    if isinstance(content, list):
+                        # Extract text from list of dicts (e.g. OpenAI vision)
+                        text_parts = []
+                        for part in content:
+                            if isinstance(part, dict) and part.get("type") == "text":
+                                text_parts.append(part.get("text", ""))
+                            elif isinstance(part, str):
+                                text_parts.append(part)
+                        content = " ".join(text_parts)
+                    elif not isinstance(content, str):
+                        content = str(content)
 
                     # 1. completely eradicate any <details> tool blocks (including inner text)
                     clean_content = re.sub(
@@ -417,6 +433,7 @@ class ChatDatabase:
                     if len(clean_content) > 100:
                         last_message += "..."
 
+                config = chat.config or {}
                 results.append(
                     ChatSummaryModel(
                         id=chat.id,
@@ -425,8 +442,8 @@ class ChatDatabase:
                         updatedAt=chat.updated_at.isoformat(),
                         messageCount=len(messages),
                         lastMessage=last_message,
-                        platform=chat.config.get("platform"),
-                        heartbeatEnabled=chat.config.get("heartbeat_enabled", False),
+                        platform=config.get("platform"),
+                        heartbeatEnabled=config.get("heartbeat_enabled", False),
                         lastResultAt=chat.last_result_at.isoformat()
                         if chat.last_result_at
                         else None,

--- a/src/suzent/routes/chat_routes.py
+++ b/src/suzent/routes/chat_routes.py
@@ -19,11 +19,7 @@ from suzent.config import CONFIG
 from suzent.database import get_database
 from suzent.logger import get_logger
 from suzent.streaming import stop_stream
-from suzent.core.stream_registry import (
-    get_background_queue,
-    is_background_streaming,
-    get_or_create_stream_start_event,
-)
+from suzent.core.stream_registry import get_background_queue, is_background_streaming
 
 logger = get_logger(__name__)
 
@@ -256,17 +252,13 @@ async def live_stream(request: Request) -> StreamingResponse:
 
     q = get_background_queue(chat_id)
     if q is None and wait_ms > 0:
-        event = get_or_create_stream_start_event(chat_id)
-        event.clear()
-        # Re-check after clearing: stream may have started between the first
-        # get_background_queue call and the event.clear().
-        q = get_background_queue(chat_id)
-        if q is None:
-            try:
-                await asyncio.wait_for(event.wait(), timeout=wait_ms / 1000.0)
-            except asyncio.TimeoutError:
-                pass
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + (wait_ms / 1000.0)
+        while loop.time() < deadline:
+            await asyncio.sleep(0.15)
             q = get_background_queue(chat_id)
+            if q is not None:
+                break
 
     if q is None:
         return Response(status_code=204)

--- a/src/suzent/routes/chat_routes.py
+++ b/src/suzent/routes/chat_routes.py
@@ -18,6 +18,7 @@ from suzent.config import CONFIG
 from suzent.database import get_database
 from suzent.logger import get_logger
 from suzent.streaming import stop_stream
+from suzent.core.stream_registry import get_background_queue, is_background_streaming
 
 logger = get_logger(__name__)
 
@@ -224,6 +225,68 @@ async def stop_chat(request: Request) -> JSONResponse:
     return JSONResponse({"status": "stopping", "reason": reason})
 
 
+async def live_stream(request: Request) -> StreamingResponse:
+    """Subscribe to a live background stream for a chat (cron, heartbeat, social).
+
+    Accepts POST with JSON body: {"chat_id": "...", "wait_ms": 25000}
+    Returns text/event-stream SSE (same format as /chat) if active, 204 if not.
+    If `wait_ms` is provided (>0), waits up to that long for a stream to appear.
+    """
+    import asyncio
+    from starlette.responses import Response
+
+    try:
+        data = await request.json()
+    except Exception:
+        return Response(status_code=400)
+
+    chat_id = data.get("chat_id", "")
+    wait_ms_raw = data.get("wait_ms", 0)
+    try:
+        wait_ms = max(0, int(wait_ms_raw or 0))
+    except Exception:
+        wait_ms = 0
+
+    if not chat_id:
+        return Response(status_code=400)
+
+    q = get_background_queue(chat_id)
+    if q is None and wait_ms > 0:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + (wait_ms / 1000.0)
+        while loop.time() < deadline:
+            await asyncio.sleep(0.15)
+            q = get_background_queue(chat_id)
+            if q is not None:
+                break
+
+    if q is None:
+        return Response(status_code=204)
+
+    async def generate():
+        while True:
+            try:
+                chunk = await asyncio.wait_for(q.get(), timeout=60.0)
+            except asyncio.TimeoutError:
+                # Heartbeat to keep connection alive
+                yield ": keep-alive\n\n"
+                continue
+            if chunk is None:
+                return
+            yield chunk
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
 async def get_chats(request: Request) -> JSONResponse:
     """Return list of chat summaries with pagination and optional search."""
     try:
@@ -237,8 +300,14 @@ async def get_chats(request: Request) -> JSONResponse:
         chats = db.list_chats(limit=limit, offset=offset, search=search)
         total = db.get_chat_count(search=search)
 
-        # Convert Pydantic models to dicts
-        chats_data = [c.model_dump(mode="json", by_alias=True) for c in chats]
+        # Convert Pydantic models to dicts, annotating live background streams
+        chats_data = [
+            {
+                **c.model_dump(mode="json", by_alias=True),
+                "isRunning": is_background_streaming(c.id),
+            }
+            for c in chats
+        ]
 
         return JSONResponse(
             {

--- a/src/suzent/routes/chat_routes.py
+++ b/src/suzent/routes/chat_routes.py
@@ -7,6 +7,7 @@ This module handles all chat endpoints including:
 - Stopping active streams
 """
 
+import asyncio
 import json
 import traceback
 
@@ -18,7 +19,11 @@ from suzent.config import CONFIG
 from suzent.database import get_database
 from suzent.logger import get_logger
 from suzent.streaming import stop_stream
-from suzent.core.stream_registry import get_background_queue, is_background_streaming
+from suzent.core.stream_registry import (
+    get_background_queue,
+    is_background_streaming,
+    get_or_create_stream_start_event,
+)
 
 logger = get_logger(__name__)
 
@@ -232,7 +237,6 @@ async def live_stream(request: Request) -> StreamingResponse:
     Returns text/event-stream SSE (same format as /chat) if active, 204 if not.
     If `wait_ms` is provided (>0), waits up to that long for a stream to appear.
     """
-    import asyncio
     from starlette.responses import Response
 
     try:
@@ -252,13 +256,17 @@ async def live_stream(request: Request) -> StreamingResponse:
 
     q = get_background_queue(chat_id)
     if q is None and wait_ms > 0:
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + (wait_ms / 1000.0)
-        while loop.time() < deadline:
-            await asyncio.sleep(0.15)
+        event = get_or_create_stream_start_event(chat_id)
+        event.clear()
+        # Re-check after clearing: stream may have started between the first
+        # get_background_queue call and the event.clear().
+        q = get_background_queue(chat_id)
+        if q is None:
+            try:
+                await asyncio.wait_for(event.wait(), timeout=wait_ms / 1000.0)
+            except asyncio.TimeoutError:
+                pass
             q = get_background_queue(chat_id)
-            if q is not None:
-                break
 
     if q is None:
         return Response(status_code=204)

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -28,6 +28,7 @@ from suzent.routes.chat_routes import (
     delete_chat,
     get_chat,
     get_chats,
+    live_stream,
     steer_chat,
     stop_chat,
     update_chat,
@@ -203,20 +204,6 @@ async def startup():
         global heartbeat_runner
         try:
             heartbeat_runner = HeartbeatRunner(interval_minutes=1)
-            # Route heartbeat alerts through the scheduler notification deque
-            if scheduler_brain:
-                heartbeat_runner.set_notification_callback(
-                    lambda msg: scheduler_brain._pending_notifications.append(
-                        {
-                            "job_id": 0,
-                            "job_name": "Heartbeat",
-                            "result": msg[:500],
-                            "timestamp": __import__("datetime")
-                            .datetime.now()
-                            .isoformat(),
-                        }
-                    )
-                )
             app.state.heartbeat_runner = heartbeat_runner
             await heartbeat_runner.start()
         except Exception as e:
@@ -401,6 +388,7 @@ app = Starlette(
     debug=True,
     routes=[
         Route("/chat", chat, methods=["POST"]),
+        Route("/chat/live", live_stream, methods=["POST"]),
         Route("/chat/stop", stop_chat, methods=["POST"]),
         Route("/chat/steer", steer_chat, methods=["POST"]),
         Route("/chat/approve-tool", approve_tool, methods=["POST"]),

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -4,8 +4,11 @@ import importlib
 import subprocess
 
 import pytest
+import typer
+from typer.testing import CliRunner
 
 cli_main = importlib.import_module("suzent.cli.main")
+runner = CliRunner()
 
 
 class _DummyProcess:
@@ -94,3 +97,71 @@ def test_terminate_process_fallback_to_kill(monkeypatch):
     assert process.signal_calls == [cli_main.signal.SIGINT]
     assert process.terminate_calls == 1
     assert process.kill_calls == 1
+
+
+class _ServeProcessSuccess:
+    """Process double that exits successfully."""
+
+    def __init__(self):
+        self.wait_calls = 0
+
+    def wait(self):
+        self.wait_calls += 1
+        return 0
+
+
+class _ServeProcessKeyboardInterrupt:
+    """Process double that simulates Ctrl+C during wait."""
+
+    def wait(self):
+        raise KeyboardInterrupt()
+
+
+def test_serve_uses_default_windows_process_group(monkeypatch):
+    """Regression: `suzent serve` should not create a new process group on Windows."""
+    app = typer.Typer()
+    cli_main.register_commands(app)
+
+    popen_calls = {}
+
+    def fake_popen(cmd, env=None, **kwargs):
+        popen_calls["cmd"] = cmd
+        popen_calls["env"] = env
+        popen_calls["kwargs"] = kwargs
+        return _ServeProcessSuccess()
+
+    monkeypatch.setattr(cli_main, "IS_WINDOWS", True)
+    monkeypatch.setattr(cli_main.subprocess, "Popen", fake_popen)
+
+    result = runner.invoke(app, ["serve", "--host", "127.0.0.1", "--port", "25314"])
+
+    assert result.exit_code == 0
+    assert popen_calls["cmd"][:3] == [cli_main.sys.executable, "-m", "suzent.server"]
+    assert popen_calls["env"]["SUZENT_HOST"] == "127.0.0.1"
+    assert popen_calls["env"]["SUZENT_PORT"] == "25314"
+    # Important assertion: no CREATE_NEW_PROCESS_GROUP is passed.
+    assert "creationflags" not in popen_calls["kwargs"]
+
+
+def test_serve_ctrl_c_calls_graceful_terminator(monkeypatch):
+    """Regression: Ctrl+C during `serve` must attempt child shutdown."""
+    app = typer.Typer()
+    cli_main.register_commands(app)
+
+    process = _ServeProcessKeyboardInterrupt()
+    terminate_calls = []
+
+    def fake_popen(cmd, env=None, **kwargs):
+        return process
+
+    def fake_terminate(proc):
+        terminate_calls.append(proc)
+
+    monkeypatch.setattr(cli_main.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(cli_main, "_terminate_process_gracefully", fake_terminate)
+
+    result = runner.invoke(app, ["serve"])
+
+    assert result.exit_code == 0
+    assert len(terminate_calls) == 1
+    assert terminate_calls[0] is process

--- a/tests/test_task_registry.py
+++ b/tests/test_task_registry.py
@@ -114,6 +114,32 @@ class TestBackgroundTaskRegistry:
         # All tasks should be done
         assert registry.active_count == 0
 
+    async def test_wait_for_task_prefix(self):
+        """Test waiting only for tasks matching a task_id prefix."""
+        from suzent.core.task_registry import BackgroundTaskRegistry
+
+        registry = BackgroundTaskRegistry()
+
+        async def task_with_delay(delay):
+            await asyncio.sleep(delay)
+            return delay
+
+        await registry.register(
+            task_with_delay(0.05), task_id="post_process_chat1_1", description="A"
+        )
+        await registry.register(
+            task_with_delay(0.05), task_id="post_process_chat1_2", description="B"
+        )
+        await registry.register(
+            task_with_delay(0.2), task_id="other_chat_1", description="C"
+        )
+
+        # Should wait for the post_process tasks only.
+        await registry.wait_for_task_prefix("post_process_chat1_", timeout=1.0)
+
+        # The unrelated task should still be active at this point.
+        assert registry.active_count == 1
+
     async def test_cancel_all(self):
         """Test cancelling all tasks."""
         from suzent.core.task_registry import BackgroundTaskRegistry
@@ -181,6 +207,34 @@ class TestBackgroundTaskRegistry:
         task = await register_background_task(test_task(), description="Global test")
         result = await task
         assert result == "test"
+
+    async def test_wait_for_background_task_prefix(self):
+        """Test module-level prefix wait helper."""
+        from suzent.core.task_registry import (
+            register_background_task,
+            wait_for_background_task_prefix,
+            wait_for_all_background_tasks,
+        )
+
+        async def task_with_delay(delay):
+            await asyncio.sleep(delay)
+            return delay
+
+        await register_background_task(
+            task_with_delay(0.05),
+            task_id="post_process_test_chat_1",
+            description="Prefix wait target",
+        )
+        await register_background_task(
+            task_with_delay(0.2),
+            task_id="unrelated_task_1",
+            description="Unrelated task",
+        )
+
+        await wait_for_background_task_prefix("post_process_test_chat_", timeout=1.0)
+
+        # Cleanup remaining global tasks for test isolation.
+        await wait_for_all_background_tasks(timeout=1.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_task_registry.py
+++ b/tests/test_task_registry.py
@@ -124,21 +124,27 @@ class TestBackgroundTaskRegistry:
             await asyncio.sleep(delay)
             return delay
 
+        # Use an event so the unrelated task is guaranteed still active after the
+        # prefix wait completes, regardless of CI timing jitter.
+        release_event = asyncio.Event()
+
+        async def blocked_task():
+            await release_event.wait()
+
         await registry.register(
             task_with_delay(0.05), task_id="post_process_chat1_1", description="A"
         )
         await registry.register(
             task_with_delay(0.05), task_id="post_process_chat1_2", description="B"
         )
-        await registry.register(
-            task_with_delay(0.2), task_id="other_chat_1", description="C"
-        )
+        await registry.register(blocked_task(), task_id="other_chat_1", description="C")
 
         # Should wait for the post_process tasks only.
         await registry.wait_for_task_prefix("post_process_chat1_", timeout=1.0)
 
-        # The unrelated task should still be active at this point.
+        # The unrelated task must still be active — it's blocked on release_event.
         assert registry.active_count == 1
+        release_event.set()
 
     async def test_cancel_all(self):
         """Test cancelling all tasks."""

--- a/tests/test_task_registry.py
+++ b/tests/test_task_registry.py
@@ -144,7 +144,10 @@ class TestBackgroundTaskRegistry:
 
         # The unrelated task must still be active — it's blocked on release_event.
         assert registry.active_count == 1
+
+        # Release and await so the task doesn't leak into subsequent tests.
         release_event.set()
+        await registry.wait_for_all(timeout=1.0)
 
     async def test_cancel_all(self):
         """Test cancelling all tasks."""


### PR DESCRIPTION
## Summary

- **Unread / notification system** — Chat list now tracks which chats have new background-generated messages. Social and heartbeat chats show an unread dot, a "N NEW" badge, and the Social tab shows a total unread count. Read state is persisted per-session in \`localStorage\`.

- **Live background stream subscriptions** — Background turns (heartbeat, social, cron) now emit SSE through a per-chat queue in \`stream_registry\`. A new \`/chat/live\` endpoint lets the frontend subscribe mid-turn so background responses stream in real-time without a page reload. \`ChatWindow\` handles the live-stream lifecycle separately from user-initiated turns to avoid blank flashes on completion.

- **Heartbeat status bar widget** — \`StatusBar\` shows a live EKG-style indicator with last-ping time and loop health, backed by a new \`useHeartbeatRunning\` Zustand store polled from \`/heartbeat/status\`.

- **Tool approval streaming fix** — Tool approval logic extracted from \`ChatWindow\` into \`useToolApproval\` hook; fixes a race where approval responses could be lost when multiple tools requested approval in the same turn.

- **Links open in default browser** — Markdown links now open in the OS default browser via \`@tauri-apps/plugin-shell\` instead of within the webview.

- **Image rendering improvements** — User-uploaded images are downsampled to display size via canvas before rendering (\`LazyImage\`) to avoid large GPU textures from high-res base64 payloads.

- **Backend: \`last_result_at\` tracking** — DB tracks when a chat last received a background-generated result; exposed as \`isRunning\` in the chat list API so the frontend can distinguish actively-streaming chats.

## Test plan

- [ ] Open a social/heartbeat chat while it is actively processing — response should stream in live without a manual refresh
- [ ] Switch away from a chat mid-heartbeat, then switch back — unread dot and NEW badge appear; clicking the chat clears them
- [ ] Social tab badge shows correct aggregate unread count across all social chats
- [ ] Approve / deny a tool call — stream resumes correctly; approving "always for this session" auto-approves subsequent calls of the same tool
- [ ] Click a Markdown link — opens in default OS browser
- [ ] Send a message with a high-res image — thumbnail renders without lag; memory is released on unmount
- [ ] StatusBar heartbeat widget shows correct last-ping time and healthy/error state