### PR TITLE
feat: search chat message content and add load-more pagination

### DIFF
--- a/frontend/src/components/ChatList.tsx
+++ b/frontend/src/components/ChatList.tsx
@@ -239,16 +239,30 @@ export const ChatList: React.FC = () => {
       {/* Chat List - Scrollable Content */}
       <div className="flex-1 overflow-y-auto scrollbar-thin min-h-0">
         {displayedChats.length === 0 ? (
-          <div className="p-8 text-center bg-white dark:bg-zinc-800">
-            <div className="w-16 h-16 mx-auto mb-3">
-              <RobotAvatar variant={searchQuery ? "ghost" : "portal"} />
+          <div className="flex flex-col bg-white dark:bg-zinc-800">
+            <div className="p-8 text-center">
+              <div className="w-16 h-16 mx-auto mb-3">
+                <RobotAvatar variant={searchQuery ? "ghost" : "portal"} />
+              </div>
+              <p className="text-brutal-black dark:text-white text-sm font-bold uppercase">
+                {searchQuery ? t('chatList.empty.noResultsTitle') : (viewMode === 'social' ? t('chatList.empty.noSocialTitle') : t('chatList.empty.noChatsTitle'))}
+              </p>
+              <p className="text-neutral-500 dark:text-neutral-400 text-xs mt-1">
+                {searchQuery ? t('chatList.empty.noResultsDesc') : (viewMode === 'social' ? t('chatList.empty.noSocialDesc') : t('chatList.empty.noChatsDesc'))}
+              </p>
             </div>
-            <p className="text-brutal-black dark:text-white text-sm font-bold uppercase">
-              {searchQuery ? t('chatList.empty.noResultsTitle') : (viewMode === 'social' ? t('chatList.empty.noSocialTitle') : t('chatList.empty.noChatsTitle'))}
-            </p>
-            <p className="text-neutral-500 dark:text-neutral-400 text-xs mt-1">
-              {searchQuery ? t('chatList.empty.noResultsDesc') : (viewMode === 'social' ? t('chatList.empty.noSocialDesc') : t('chatList.empty.noChatsDesc'))}
-            </p>
+            {/* Load more even when current view is empty (e.g. social tab but chats beyond first page) */}
+            {chats.length < chatTotal && (
+              <button
+                onClick={loadMoreChats}
+                disabled={loadingMoreChats}
+                className="w-full py-2.5 text-[10px] font-bold uppercase border-t-2 border-brutal-black bg-white dark:bg-zinc-800 hover:bg-neutral-100 dark:hover:bg-zinc-700 text-neutral-500 dark:text-neutral-400 hover:text-brutal-black dark:hover:text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {loadingMoreChats
+                  ? t('chatList.loadingMore')
+                  : t('chatList.loadMore', { count: Math.max(0, chatTotal - chats.length) })}
+              </button>
+            )}
           </div>
         ) : (
           <div className="flex flex-col bg-white dark:bg-zinc-800 pt-[3px]">
@@ -367,7 +381,7 @@ export const ChatList: React.FC = () => {
               >
                 {loadingMoreChats
                   ? t('chatList.loadingMore')
-                  : t('chatList.loadMore').replace('{count}', String(chatTotal - chats.length))}
+                  : t('chatList.loadMore', { count: Math.max(0, chatTotal - chats.length) })}
               </button>
             )}
           </div>

--- a/frontend/src/components/ChatList.tsx
+++ b/frontend/src/components/ChatList.tsx
@@ -10,7 +10,9 @@ import { markChatRead } from '../lib/api';
 export const ChatList: React.FC = () => {
   const {
     chats,
+    chatTotal,
     loadingChats,
+    loadingMoreChats,
     refreshingChats,
     currentChatId,
     searchQuery,
@@ -19,7 +21,8 @@ export const ChatList: React.FC = () => {
     beginNewChat,
     deleteChat,
     switchToView,
-    refreshChatList
+    refreshChatList,
+    loadMoreChats,
   } = useChatStore();
 
   const [deletingChatId, setDeletingChatId] = useState<string | null>(null);
@@ -62,11 +65,12 @@ export const ChatList: React.FC = () => {
     setLocalSearchQuery(searchQuery);
   }, []);
 
-  // Debounce search to avoid too many API calls
+  // Debounce search — force=true bypasses the 3500ms throttle so every keystroke
+  // (after the 300ms debounce) actually fires a new request.
   useEffect(() => {
     const timeout = setTimeout(() => {
       setSearchQuery(localSearchQuery);
-      refreshChatList(localSearchQuery);
+      refreshChatList(localSearchQuery, true);
     }, 300);
     return () => clearTimeout(timeout);
   }, [localSearchQuery]);
@@ -248,7 +252,7 @@ export const ChatList: React.FC = () => {
           </div>
         ) : (
           <div className="flex flex-col bg-white dark:bg-zinc-800 pt-[3px]">
-            {displayedChats.map((chat: ChatSummary, idx: number) => (
+            {displayedChats.map((chat: ChatSummary, _idx: number) => (
               <div
                 key={chat.id}
                 onClick={() => {
@@ -354,6 +358,18 @@ export const ChatList: React.FC = () => {
                 </div>
               </div>
             ))}
+            {/* Load more button — shown when server has more chats than currently loaded */}
+            {chats.length < chatTotal && (
+              <button
+                onClick={loadMoreChats}
+                disabled={loadingMoreChats}
+                className="w-full py-2.5 text-[10px] font-bold uppercase border-t-2 border-brutal-black bg-white dark:bg-zinc-800 hover:bg-neutral-100 dark:hover:bg-zinc-700 text-neutral-500 dark:text-neutral-400 hover:text-brutal-black dark:hover:text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {loadingMoreChats
+                  ? t('chatList.loadingMore')
+                  : t('chatList.loadMore').replace('{count}', String(chatTotal - chats.length))}
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/hooks/useChatStore.tsx
+++ b/frontend/src/hooks/useChatStore.tsx
@@ -42,8 +42,11 @@ interface ChatCoreContextValue {
   finalSave: (chatId?: string | null) => Promise<void>;
   forceSaveNow: (chatId?: string | null) => Promise<void>;
   deleteChat: (chatId: string) => Promise<void>;
-  refreshChatList: (searchQuery?: string) => Promise<void>;
+  chatTotal: number;
+  loadingMoreChats: boolean;
+  refreshChatList: (searchQuery?: string, force?: boolean) => Promise<void>;
   refreshChatListSilently: (searchQuery?: string) => Promise<void>;
+  loadMoreChats: () => Promise<void>;
   updateChatTitleLocally: (chatId: string, title: string) => void;
   updateMessage: (index: number, update: Partial<Message>, chatId?: string | null) => void;
   truncateMessagesFrom: (fromIndex: number, chatId?: string | null) => void;
@@ -195,7 +198,10 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [currentChatId, setCurrentChatId] = useState<string | null>(null);
   const [currentChatTitle, setCurrentChatTitle] = useState<string>('New Chat');
   const [chats, setChats] = useState<ChatSummary[]>([]);
+  const [chatTotal, setChatTotal] = useState<number>(0);
+  const [chatOffset, setChatOffset] = useState<number>(0);
   const [loadingChats, setLoadingChats] = useState(false);
+  const [loadingMoreChats, setLoadingMoreChats] = useState(false);
   const [refreshingChats, setRefreshingChats] = useState(false);
   const [searchQuery, setSearchQuery] = useState<string>('');
   const chatsLoadedRef = useRef(false);
@@ -394,20 +400,25 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const refreshChatListInternal = useCallback(async (
     search?: string,
-    options?: { silent?: boolean },
+    options?: { silent?: boolean; force?: boolean },
     attempt = 1,
     maxAttempts = 5,
   ) => {
     const silent = !!options?.silent;
+    const force = !!options?.force;
     const isFirstLoad = !chatsLoadedRef.current;
 
     // Deduplicate overlapping non-initial refreshes to reduce repeated /chats traffic.
-    if (!isFirstLoad) {
+    // Skip throttle when force=true (e.g. search queries must always go through).
+    if (!isFirstLoad && !force) {
       const now = Date.now();
       if (refreshInFlightRef.current) return;
       if (now - lastRefreshAtRef.current < 3500) return;
       refreshInFlightRef.current = true;
       lastRefreshAtRef.current = now;
+    } else if (!isFirstLoad && force) {
+      // For forced requests, still update timestamp to reset the throttle window
+      lastRefreshAtRef.current = Date.now();
     }
 
     if (isFirstLoad) {
@@ -425,6 +436,8 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
       if (res.ok) {
         const data = await res.json();
         const serverList: ChatSummary[] = data.chats || [];
+        setChatTotal(data.total ?? serverList.length);
+        setChatOffset(0);
 
         // Merge server list with local state, preserving local updates
         setChats(prev => {
@@ -493,13 +506,41 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   }, [currentChatId, currentChatTitle, getMessagesForChat, searchQuery]);
 
-  const refreshChatList = useCallback(async (search?: string) => {
-    await refreshChatListInternal(search, { silent: false });
+  const refreshChatList = useCallback(async (search?: string, force?: boolean) => {
+    await refreshChatListInternal(search, { silent: false, force });
   }, [refreshChatListInternal]);
 
   const refreshChatListSilently = useCallback(async (search?: string) => {
     await refreshChatListInternal(search, { silent: true });
   }, [refreshChatListInternal]);
+
+  const loadMoreChats = useCallback(async () => {
+    if (loadingMoreChats) return;
+    setLoadingMoreChats(true);
+    try {
+      const apiBase = getApiBase();
+      const nextOffset = chatOffset + 50;
+      const searchParam = searchQuery;
+      let url = `${apiBase}/chats?limit=50&offset=${nextOffset}`;
+      if (searchParam) url += `&search=${encodeURIComponent(searchParam)}`;
+      const res = await fetch(url);
+      if (res.ok) {
+        const data = await res.json();
+        const newChats: ChatSummary[] = data.chats || [];
+        setChatTotal(data.total ?? 0);
+        setChatOffset(nextOffset);
+        setChats(prev => {
+          const existingIds = new Set(prev.map(c => c.id));
+          const appended = newChats.filter(c => !existingIds.has(c.id));
+          return [...prev, ...appended];
+        });
+      }
+    } catch (error) {
+      console.error('Error loading more chats:', error);
+    } finally {
+      setLoadingMoreChats(false);
+    }
+  }, [chatOffset, loadingMoreChats, searchQuery]);
 
   const updateChatTitleLocally = useCallback((chatId: string, title: string) => {
     setChats(prev => prev.map(c => c.id === chatId ? { ...c, title } : c));
@@ -1176,7 +1217,9 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
       removeEmptyAssistantMessage,
       currentChatId,
       chats,
+      chatTotal,
       loadingChats,
+      loadingMoreChats,
       refreshingChats,
       searchQuery,
       setSearchQuery,
@@ -1189,6 +1232,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
       deleteChat,
       refreshChatList,
       refreshChatListSilently,
+      loadMoreChats,
       updateChatTitleLocally,
       updateMessage,
       truncateMessagesFrom,
@@ -1213,7 +1257,9 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
     removeEmptyAssistantMessage,
     currentChatId,
     chats,
+    chatTotal,
     loadingChats,
+    loadingMoreChats,
     refreshingChats,
     searchQuery,
     setSearchQuery,
@@ -1226,6 +1272,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
     deleteChat,
     refreshChatList,
     refreshChatListSilently,
+    loadMoreChats,
     updateChatTitleLocally,
     updateMessage,
     truncateMessagesFrom,

--- a/frontend/src/hooks/useChatStore.tsx
+++ b/frontend/src/hooks/useChatStore.tsx
@@ -207,6 +207,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const chatsLoadedRef = useRef(false);
   const refreshInFlightRef = useRef(false);
   const lastRefreshAtRef = useRef(0);
+  const searchRequestIdRef = useRef(0);
   const chatCreationPromiseRef = useRef<Promise<string | null> | null>(null);
   const saveTimeoutsRef = useRef<Record<string, NodeJS.Timeout>>({});
   const messagesByChatRef = useRef(messagesByChat);
@@ -410,6 +411,9 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
     // Deduplicate overlapping non-initial refreshes to reduce repeated /chats traffic.
     // Skip throttle when force=true (e.g. search queries must always go through).
+    // Do NOT update lastRefreshAtRef for forced requests so background consistency
+    // refreshes (e.g. after deleteChat) are not accidentally suppressed.
+    let requestId = 0;
     if (!isFirstLoad && !force) {
       const now = Date.now();
       if (refreshInFlightRef.current) return;
@@ -417,8 +421,9 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
       refreshInFlightRef.current = true;
       lastRefreshAtRef.current = now;
     } else if (!isFirstLoad && force) {
-      // For forced requests, still update timestamp to reset the throttle window
-      lastRefreshAtRef.current = Date.now();
+      // Assign a monotonically increasing ID; only apply the response if it's still latest.
+      searchRequestIdRef.current += 1;
+      requestId = searchRequestIdRef.current;
     }
 
     if (isFirstLoad) {
@@ -434,6 +439,9 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const url = searchParam ? `${apiBase}/chats?search=${encodeURIComponent(searchParam)}` : `${apiBase}/chats`;
       const res = await fetch(url);
       if (res.ok) {
+        // Discard stale forced-search responses that arrived out of order.
+        if (force && requestId !== searchRequestIdRef.current) return;
+
         const data = await res.json();
         const serverList: ChatSummary[] = data.chats || [];
         setChatTotal(data.total ?? serverList.length);
@@ -527,7 +535,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
       if (res.ok) {
         const data = await res.json();
         const newChats: ChatSummary[] = data.chats || [];
-        setChatTotal(data.total ?? 0);
+        if (data.total != null) setChatTotal(data.total);
         setChatOffset(nextOffset);
         setChats(prev => {
           const existingIds = new Set(prev.map(c => c.id));

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -385,6 +385,8 @@ export const en = {
     },
     untitled: 'Untitled chat',
     messagesCount: '{count} MSG',
+    loadMore: 'Load more ({count} remaining)',
+    loadingMore: 'Loading...',
   },
   chatInput: {
     removeFile: 'Remove file',

--- a/frontend/src/i18n/messages/zh-CN.ts
+++ b/frontend/src/i18n/messages/zh-CN.ts
@@ -312,6 +312,8 @@ export const zhCN = {
     },
     untitled: '未命名对话',
     messagesCount: '{count} 条消息',
+    loadMore: '加载更多（还有 {count} 条）',
+    loadingMore: '加载中...',
   },
   chatInput: {
     removeFile: '移除文件',

--- a/src/suzent/database.py
+++ b/src/suzent/database.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from pydantic import BaseModel
 from sqlalchemy.orm import selectinload
-from sqlalchemy import text, inspect
+from sqlalchemy import cast, Text, or_, text, inspect
 from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import (
     Column,
@@ -791,7 +791,12 @@ class ChatDatabase:
             statement = select(ChatModel).order_by(ChatModel.updated_at.desc())
 
             if search:
-                statement = statement.where(ChatModel.title.contains(search))
+                statement = statement.where(
+                    or_(
+                        ChatModel.title.contains(search),
+                        cast(ChatModel.messages, Text).contains(search),
+                    )
+                )
 
             statement = statement.offset(offset).limit(limit)
             chats = session.exec(statement).all()
@@ -868,8 +873,12 @@ class ChatDatabase:
         with self._session() as session:
             statement = select(ChatModel)
             if search:
-                # Simplified search logic matching list_chats
-                statement = statement.where(ChatModel.title.contains(search))
+                statement = statement.where(
+                    or_(
+                        ChatModel.title.contains(search),
+                        cast(ChatModel.messages, Text).contains(search),
+                    )
+                )
             return len(session.exec(statement).all())
 
     def reassign_plan_chat(self, old_chat_id: str, new_chat_id: str) -> int:

--- a/src/suzent/database.py
+++ b/src/suzent/database.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from pydantic import BaseModel
 from sqlalchemy.orm import selectinload
-from sqlalchemy import cast, Text, or_, text, inspect
+from sqlalchemy import cast, Text, or_, text, inspect, func
 from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import (
     Column,
@@ -871,7 +871,7 @@ class ChatDatabase:
     def get_chat_count(self, search: str = None) -> int:
         """Get total number of chats."""
         with self._session() as session:
-            statement = select(ChatModel)
+            statement = select(func.count()).select_from(ChatModel)
             if search:
                 statement = statement.where(
                     or_(
@@ -879,7 +879,7 @@ class ChatDatabase:
                         cast(ChatModel.messages, Text).contains(search),
                     )
                 )
-            return len(session.exec(statement).all())
+            return session.exec(statement).one()
 
     def reassign_plan_chat(self, old_chat_id: str, new_chat_id: str) -> int:
         """Reassign all plans from one chat_id to another."""

--- a/src/suzent/database.py
+++ b/src/suzent/database.py
@@ -26,6 +26,38 @@ from sqlmodel import (
 )
 
 
+def _json_escape_for_like(s: str) -> str:
+    """Return the \\uXXXX form of any non-ASCII chars in s.
+
+    SQLAlchemy's JSON column stores non-ASCII characters as \\uXXXX escape
+    sequences (ensure_ascii=True default). A plain LIKE '%中文%' therefore
+    never matches; we must search for '\\u4e2d\\u6587' instead.
+    ASCII characters are left unchanged so English searches still work.
+    """
+    result = []
+    for ch in s:
+        if ord(ch) > 127:
+            result.append(f"\\u{ord(ch):04x}")
+        else:
+            result.append(ch)
+    return "".join(result)
+
+
+def _messages_search_filter(search: str):
+    """Build an OR filter that matches search in the messages JSON column.
+
+    Searches both the raw text (for any future ensure_ascii=False storage)
+    and the \\uXXXX-escaped form (for current ensure_ascii=True storage).
+    """
+    escaped = _json_escape_for_like(search)
+    if escaped == search:
+        return cast(ChatModel.messages, Text).contains(search)
+    return or_(
+        cast(ChatModel.messages, Text).contains(search),
+        cast(ChatModel.messages, Text).contains(escaped),
+    )
+
+
 # -----------------------------------------------------------------------------
 # SQLModel Table Definitions
 # -----------------------------------------------------------------------------
@@ -794,7 +826,7 @@ class ChatDatabase:
                 statement = statement.where(
                     or_(
                         ChatModel.title.contains(search),
-                        cast(ChatModel.messages, Text).contains(search),
+                        _messages_search_filter(search),
                     )
                 )
 
@@ -876,7 +908,7 @@ class ChatDatabase:
                 statement = statement.where(
                     or_(
                         ChatModel.title.contains(search),
-                        cast(ChatModel.messages, Text).contains(search),
+                        _messages_search_filter(search),
                     )
                 )
             return session.exec(statement).one()


### PR DESCRIPTION
## Summary

- **Message content search**: search now matches message content in addition to title, by casting the JSON messages column to Text and using LIKE in SQLite
- **Load more**: the `total` field returned by the API was previously ignored; a load-more button now appears when there are more than 50 chats on the server
- **Search throttle fix**: search requests were being dropped by the 3500ms refresh cooldown; search calls now pass `force=true` to bypass the throttle so every debounced keystroke fires a real request

## Test plan

- [ ] Search for a keyword that appears in message content (not the title) and confirm the matching chat appears
- [ ] Search by title keyword and confirm it still works
- [ ] With more than 50 chats, confirm a "load more" button appears at the bottom of the list
- [ ] Type quickly in the search box and confirm results update with each keystroke