### PR TITLE
fix: Use dispatch for compact command to avoid TypeError

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -98,6 +98,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1427,6 +1428,7 @@
       "integrity": "sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1448,6 +1450,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1468,8 +1471,7 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -1783,6 +1785,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001733",
         "electron-to-chromium": "^1.5.199",
@@ -2119,7 +2122,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
       "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -3876,7 +3878,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -3887,7 +3888,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -4132,6 +4132,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4304,6 +4305,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4316,6 +4318,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4900,6 +4903,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -5261,6 +5265,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/suzent/routes/compact_routes.py
+++ b/src/suzent/routes/compact_routes.py
@@ -50,17 +50,16 @@ async def compact_chat(request: Request) -> StreamingResponse:
 
 async def _compact_stream(chat_id: str, focus: str | None):
     from suzent.config import CONFIG
-    from suzent.core.commands.base import CommandContext
-    from suzent.core.commands.compact import handle_compact
+    from suzent.core.commands.base import CommandContext, dispatch
 
     try:
         yield _sse(
             "compaction_progress",
             {"stage": "summarizing", "message": "Compacting context..."},
         )
-        args = focus.split() if focus else []
         ctx = CommandContext(chat_id=chat_id, user_id=CONFIG.user_id)
-        result = await handle_compact(ctx, "/compact", args)
+        command_str = f"/compact {focus}" if focus else "/compact"
+        result = await dispatch(ctx, command_str)
         yield _sse("compaction_complete", {"skipped": False, "message": result})
     except Exception as e:
         logger.error(f"Compact route failed for {chat_id}: {e}")

--- a/src/suzent/routes/compact_routes.py
+++ b/src/suzent/routes/compact_routes.py
@@ -58,9 +58,15 @@ async def _compact_stream(chat_id: str, focus: str | None):
             {"stage": "summarizing", "message": "Compacting context..."},
         )
         ctx = CommandContext(chat_id=chat_id, user_id=CONFIG.user_id)
-        command_str = f"/compact {focus}" if focus else "/compact"
+        command_str = f"/compact -- {focus}" if focus else "/compact"
         result = await dispatch(ctx, command_str)
-        yield _sse("compaction_complete", {"skipped": False, "message": result})
+        if result is None:
+            yield _sse(
+                "compaction_error",
+                {"message": "Command dispatch failed or returned no result."},
+            )
+        else:
+            yield _sse("compaction_complete", {"skipped": False, "message": result})
     except Exception as e:
         logger.error(f"Compact route failed for {chat_id}: {e}")
         yield _sse("compaction_error", {"message": str(e)})


### PR DESCRIPTION
Fixes a bug where clicking the compact button in frontend crashed with `COMPACTION FAILED: HANDLE_COMPACT() TAKES FROM 1 TO 2 POSITIONAL ARGUMENTS BUT 3 WERE GIVEN`.