### PR TITLE
fix: Ignore Enter keypress while IME composition is active

### DIFF
--- a/frontend/src/components/ChatInputPanel.tsx
+++ b/frontend/src/components/ChatInputPanel.tsx
@@ -166,6 +166,7 @@ export const ChatInputPanel: React.FC<ChatInputPanelProps> = ({
     const [mentionRange, setMentionRange] = React.useState<{ start: number; end: number; query: string } | null>(null);
     const [isMentionLoading, setIsMentionLoading] = React.useState(false);
     const highlightRef = React.useRef<HTMLPreElement | null>(null);
+    const isComposingRef = React.useRef(false);
     const shouldHighlightFileMentions = hasFileMentionHighlight(input);
     const suggestions = useSlashCommands(input);
     React.useEffect(() => { setSelectedSuggestion(0); }, [suggestions.length]);
@@ -449,6 +450,14 @@ export const ChatInputPanel: React.FC<ChatInputPanelProps> = ({
                         setInput(e.target.value);
                         updateMentionRange(e.target.value, e.target.selectionStart);
                     }}
+                    onCompositionStart={() => {
+                        isComposingRef.current = true;
+                    }}
+                    onCompositionEnd={() => {
+                        window.setTimeout(() => {
+                            isComposingRef.current = false;
+                        }, 0);
+                    }}
                     onClick={(e) => updateMentionRange(input, e.currentTarget.selectionStart)}
                     onKeyUp={(e) => {
                         if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(e.key)) {
@@ -456,6 +465,12 @@ export const ChatInputPanel: React.FC<ChatInputPanelProps> = ({
                         }
                     }}
                     onKeyDown={(e) => {
+                    // Always ignore Enter if IME composition is active to allow selecting characters
+                    // Including e.keyCode === 229 for broad cross-browser compatibility
+                    if (e.key === 'Enter' && (isComposingRef.current || e.nativeEvent.isComposing || e.keyCode === 229)) {
+                        return;
+                    }
+
                     if (mentionRange && mentionSuggestions.length > 0) {
                         if (e.key === 'ArrowUp') {
                             e.preventDefault();
@@ -526,10 +541,6 @@ export const ChatInputPanel: React.FC<ChatInputPanelProps> = ({
                     }
                     
                     if (e.key === 'Enter' && !e.shiftKey) {
-                        // e.nativeEvent.isComposing prevents sending when pressing Enter in an IME (like Chinese/Japanese input method)
-                        if (e.nativeEvent.isComposing) {
-                            return;
-                        }
                         e.preventDefault();
                         if (configReady && input.trim()) {
                             send();

--- a/frontend/src/components/ChatInputPanel.tsx
+++ b/frontend/src/components/ChatInputPanel.tsx
@@ -526,6 +526,10 @@ export const ChatInputPanel: React.FC<ChatInputPanelProps> = ({
                     }
                     
                     if (e.key === 'Enter' && !e.shiftKey) {
+                        // e.nativeEvent.isComposing prevents sending when pressing Enter in an IME (like Chinese/Japanese input method)
+                        if (e.nativeEvent.isComposing) {
+                            return;
+                        }
                         e.preventDefault();
                         if (configReady && input.trim()) {
                             send();

--- a/src/suzent/routes/compact_routes.py
+++ b/src/suzent/routes/compact_routes.py
@@ -50,17 +50,16 @@ async def compact_chat(request: Request) -> StreamingResponse:
 
 async def _compact_stream(chat_id: str, focus: str | None):
     from suzent.config import CONFIG
-    from suzent.core.commands.base import CommandContext
-    from suzent.core.commands.compact import handle_compact
+    from suzent.core.commands.base import CommandContext, dispatch
 
     try:
         yield _sse(
             "compaction_progress",
             {"stage": "summarizing", "message": "Compacting context..."},
         )
-        args = focus.split() if focus else []
         ctx = CommandContext(chat_id=chat_id, user_id=CONFIG.user_id)
-        result = await handle_compact(ctx, "/compact", args)
+        command_str = f"/compact {focus}" if focus else "/compact"
+        result = await dispatch(ctx, command_str)
         yield _sse("compaction_complete", {"skipped": False, "message": result})
     except Exception as e:
         logger.error(f"Compact route failed for {chat_id}: {e}")

--- a/src/suzent/routes/compact_routes.py
+++ b/src/suzent/routes/compact_routes.py
@@ -50,16 +50,17 @@ async def compact_chat(request: Request) -> StreamingResponse:
 
 async def _compact_stream(chat_id: str, focus: str | None):
     from suzent.config import CONFIG
-    from suzent.core.commands.base import CommandContext, dispatch
+    from suzent.core.commands.base import CommandContext
+    from suzent.core.commands.compact import handle_compact
 
     try:
         yield _sse(
             "compaction_progress",
             {"stage": "summarizing", "message": "Compacting context..."},
         )
+        args = focus.split() if focus else []
         ctx = CommandContext(chat_id=chat_id, user_id=CONFIG.user_id)
-        command_str = f"/compact {focus}" if focus else "/compact"
-        result = await dispatch(ctx, command_str)
+        result = await handle_compact(ctx, "/compact", args)
         yield _sse("compaction_complete", {"skipped": False, "message": result})
     except Exception as e:
         logger.error(f"Compact route failed for {chat_id}: {e}")


### PR DESCRIPTION
Fixes an issue where pressing Enter to confirm IME input (e.g. Chinese/Japanese) prematurely sends the message. Added a check for `e.nativeEvent.isComposing` to prevent `preventDefault()` and message submission during an active composition session.