### PR TITLE
fix(memory): actually update on near-duplicate dedup (#34)

### DIFF
--- a/src/suzent/config/__init__.py
+++ b/src/suzent/config/__init__.py
@@ -316,6 +316,11 @@ class ConfigModel(BaseModel):
     memory_enabled: bool = False
     markdown_memory_enabled: bool = True
     extraction_model: Optional[str] = None
+    # Cosine-similarity threshold above which an extracted fact is treated as
+    # a near-duplicate of an existing memory. None → use MemoryManager default
+    # (0.85). Tune per embedding model: tighter values (e.g. 0.92) prevent
+    # over-merging short factual updates; looser values catch paraphrases.
+    memory_dedup_threshold: Optional[float] = None
 
     cron_presets: List[Dict[str, Any]] = []
     user_id: str = "default-user"

--- a/src/suzent/memory/lifecycle.py
+++ b/src/suzent/memory/lifecycle.py
@@ -204,6 +204,7 @@ async def init_memory_system() -> bool:
             embedding_dimension=CONFIG.embedding_dimension,
             llm_for_extraction=_extraction_model,
             markdown_store=markdown_store,
+            dedup_threshold=CONFIG.memory_dedup_threshold,
         )
 
         notebook_host_path = None

--- a/src/suzent/memory/manager.py
+++ b/src/suzent/memory/manager.py
@@ -33,7 +33,10 @@ DEFAULT_IMPORTANCE = 0.5
 
 # Deduplication and extraction settings
 DEDUPLICATION_SEARCH_LIMIT = 3
-DEDUPLICATION_SIMILARITY_THRESHOLD = 0.85
+# Default cosine-similarity threshold above which a newly extracted fact is
+# treated as a near-duplicate of an existing memory. Embedding-model-dependent;
+# overridable per-instance via ``MemoryManager(dedup_threshold=...)``.
+DEFAULT_DEDUPLICATION_SIMILARITY_THRESHOLD = 0.85
 LLM_EXTRACTION_TEMPERATURE = 1.0
 
 
@@ -54,6 +57,7 @@ class MemoryManager:
         embedding_dimension: int = 0,
         llm_for_extraction: Optional[str] = None,
         markdown_store: Optional[MarkdownMemoryStore] = None,
+        dedup_threshold: Optional[float] = None,
     ):
         """Initialize memory manager.
 
@@ -63,6 +67,10 @@ class MemoryManager:
             embedding_dimension: Expected embedding dimension (0 = auto-detect)
             llm_for_extraction: LLM model for fact extraction (uses LLM if provided)
             markdown_store: Optional markdown-based memory store for human-readable persistence
+            dedup_threshold: Cosine-similarity threshold for treating an extracted
+                fact as a near-duplicate of an existing memory. Defaults to
+                ``DEFAULT_DEDUPLICATION_SIMILARITY_THRESHOLD``. Embedding-model
+                dependent — tune per model if recall/precision drifts.
         """
         self.store = store
         self.markdown_store = markdown_store
@@ -73,11 +81,17 @@ class MemoryManager:
         self.llm_client = (
             LLMClient(model=llm_for_extraction) if llm_for_extraction else None
         )
+        self.dedup_threshold: float = (
+            dedup_threshold
+            if dedup_threshold is not None
+            else DEFAULT_DEDUPLICATION_SIMILARITY_THRESHOLD
+        )
         self.wiki_manager: Optional["WikiManager"] = None
         logger.info(
             f"MemoryManager initialized with embedding model: {embedding_model}, "
             f"extraction model: {llm_for_extraction}, "
-            f"markdown: {'enabled' if markdown_store else 'disabled'}"
+            f"markdown: {'enabled' if markdown_store else 'disabled'}, "
+            f"dedup threshold: {self.dedup_threshold}"
         )
 
     # ===== Core Memory Blocks (File-based SSoT) =====
@@ -507,12 +521,34 @@ class MemoryManager:
                 use_hybrid=False,
             )
 
-            if (
-                similar
-                and similar[0].get("similarity", 0) > DEDUPLICATION_SIMILARITY_THRESHOLD
-            ):
-                # Very similar memory exists - update/skip
-                result.memories_updated.append(str(similar[0]["id"]))
+            if similar and similar[0].get("similarity", 0) > self.dedup_threshold:
+                # Near-duplicate exists: overwrite content + embedding so updates
+                # (e.g. "I work at Microsoft" replacing "I work at Google") aren't
+                # silently dropped. The newer fact represents current reality;
+                # the older row's timestamps are preserved by the store layer.
+                existing_id = str(similar[0]["id"])
+                embedding = await self.embedding_gen.generate(fact.content)
+                updated = await self.store.update_memory(
+                    memory_id=existing_id,
+                    content=fact.content,
+                    embedding=embedding,
+                    metadata=metadata,
+                    importance=fact.importance,
+                )
+                if updated:
+                    result.memories_updated.append(existing_id)
+                else:
+                    logger.warning(
+                        "Dedup update failed for memory {}; falling back to insert",
+                        existing_id,
+                    )
+                    memory_id = await self._add_memory_internal(
+                        content=fact.content,
+                        metadata=metadata,
+                        chat_id=None,
+                        user_id=user_id,
+                    )
+                    result.memories_created.append(memory_id)
             else:
                 # New fact - store it
                 memory_id = await self._add_memory_internal(

--- a/src/suzent/memory/manager.py
+++ b/src/suzent/memory/manager.py
@@ -525,7 +525,7 @@ class MemoryManager:
                 # Near-duplicate exists: overwrite content + embedding so updates
                 # (e.g. "I work at Microsoft" replacing "I work at Google") aren't
                 # silently dropped. The newer fact represents current reality;
-                # the older row's timestamps are preserved by the store layer.
+                # the store layer preserves created_at but refreshes updated_at.
                 existing_id = str(similar[0]["id"])
                 embedding = await self.embedding_gen.generate(fact.content)
                 updated = await self.store.update_memory(

--- a/tests/memory/test_dedup_update.py
+++ b/tests/memory/test_dedup_update.py
@@ -1,0 +1,196 @@
+"""Tests for memory deduplication behavior on near-matches.
+
+Issue #34: previously, when a newly extracted fact's cosine similarity to an
+existing memory exceeded the threshold, the manager appended the existing id
+to ``memories_updated`` but did **not** call any update API — silently
+dropping the new content. These tests pin down that:
+
+  * Near-match → the LanceDB store's ``update_memory`` is called with the
+    new content, a freshly generated embedding, and the new metadata.
+  * Below-threshold → a new memory is inserted.
+  * The dedup threshold is configurable per ``MemoryManager`` instance.
+  * If the store's update fails, the manager falls back to inserting so we
+    never lose the fact silently.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from suzent.memory.manager import (
+    DEFAULT_DEDUPLICATION_SIMILARITY_THRESHOLD,
+    MemoryManager,
+)
+from suzent.memory.models import ExtractedFact, MemoryExtractionResult
+
+
+def _make_fact(content: str = "I work at Microsoft") -> ExtractedFact:
+    return ExtractedFact(
+        content=content,
+        importance=0.8,
+        category="personal",
+        tags=["job"],
+        context_user_intent="share employer",
+        context_agent_actions_summary="recorded employer",
+        context_outcome="stored",
+    )
+
+
+def _make_manager(*, dedup_threshold: float | None = None) -> MemoryManager:
+    """Build a MemoryManager with all I/O surfaces mocked.
+
+    Bypasses ``__init__`` because constructing ``EmbeddingGenerator`` /
+    ``LLMClient`` requires litellm configuration that's irrelevant here.
+    """
+    manager = MemoryManager.__new__(MemoryManager)
+    manager.store = MagicMock()
+    manager.store.update_memory = AsyncMock(return_value=True)
+    manager.store.add_memory = AsyncMock(return_value="new-memory-id")
+    manager.markdown_store = None
+    manager.embedding_gen = MagicMock()
+    manager.embedding_gen.generate = AsyncMock(return_value=[0.1, 0.2, 0.3])
+    manager.llm_extraction_model = None
+    manager.llm_client = None
+    manager.wiki_manager = None
+    manager.dedup_threshold = (
+        dedup_threshold
+        if dedup_threshold is not None
+        else DEFAULT_DEDUPLICATION_SIMILARITY_THRESHOLD
+    )
+    return manager
+
+
+def _patch_search(manager: MemoryManager, hits: list[dict[str, Any]]) -> AsyncMock:
+    """Stub ``search_memories`` to return the given hits."""
+    search = AsyncMock(return_value=hits)
+    manager.search_memories = search  # type: ignore[assignment]
+    return search
+
+
+async def test_near_duplicate_actually_updates_existing_memory():
+    """The data-loss bug: previously this case silently dropped new content."""
+    manager = _make_manager()
+    _patch_search(
+        manager,
+        [{"id": "existing-id", "similarity": 0.95, "content": "I work at Google"}],
+    )
+
+    result = MemoryExtractionResult.empty()
+    fact = _make_fact("I work at Microsoft")
+    await manager._deduplicate_and_store_facts(
+        facts=[fact], user_id="u1", source_chat_id="c1", result=result
+    )
+
+    # The store's update_memory must be called with the *new* content and a
+    # freshly generated embedding.
+    manager.store.update_memory.assert_awaited_once()
+    update_kwargs = manager.store.update_memory.await_args.kwargs
+    assert update_kwargs["memory_id"] == "existing-id"
+    assert update_kwargs["content"] == "I work at Microsoft"
+    assert update_kwargs["embedding"] == [0.1, 0.2, 0.3]
+    assert update_kwargs["importance"] == 0.8
+
+    # No new memory inserted.
+    manager.store.add_memory.assert_not_awaited()
+
+    assert result.memories_updated == ["existing-id"]
+    assert result.memories_created == []
+
+
+async def test_below_threshold_inserts_new_memory():
+    manager = _make_manager()
+    _patch_search(
+        manager,
+        [{"id": "existing-id", "similarity": 0.40, "content": "loves cats"}],
+    )
+
+    result = MemoryExtractionResult.empty()
+    fact = _make_fact("I work at Microsoft")
+    await manager._deduplicate_and_store_facts(
+        facts=[fact], user_id="u1", source_chat_id="c1", result=result
+    )
+
+    manager.store.update_memory.assert_not_awaited()
+    manager.store.add_memory.assert_awaited_once()
+    assert result.memories_created == ["new-memory-id"]
+    assert result.memories_updated == []
+
+
+async def test_no_similar_memories_inserts_new_memory():
+    manager = _make_manager()
+    _patch_search(manager, [])
+
+    result = MemoryExtractionResult.empty()
+    await manager._deduplicate_and_store_facts(
+        facts=[_make_fact()], user_id="u1", source_chat_id="c1", result=result
+    )
+
+    manager.store.update_memory.assert_not_awaited()
+    manager.store.add_memory.assert_awaited_once()
+    assert result.memories_created == ["new-memory-id"]
+
+
+async def test_threshold_is_configurable_per_instance():
+    """A tighter threshold (e.g. 0.99) lets the same 0.95 hit be treated as new."""
+    manager = _make_manager(dedup_threshold=0.99)
+    _patch_search(
+        manager,
+        [{"id": "existing-id", "similarity": 0.95, "content": "near-match"}],
+    )
+
+    result = MemoryExtractionResult.empty()
+    await manager._deduplicate_and_store_facts(
+        facts=[_make_fact()], user_id="u1", source_chat_id="c1", result=result
+    )
+
+    manager.store.update_memory.assert_not_awaited()
+    manager.store.add_memory.assert_awaited_once()
+    assert result.memories_created == ["new-memory-id"]
+
+
+async def test_update_failure_falls_back_to_insert():
+    """If the store reports the update failed, the fact must still be persisted."""
+    manager = _make_manager()
+    manager.store.update_memory = AsyncMock(return_value=False)
+    _patch_search(
+        manager,
+        [{"id": "existing-id", "similarity": 0.95, "content": "near-match"}],
+    )
+
+    result = MemoryExtractionResult.empty()
+    await manager._deduplicate_and_store_facts(
+        facts=[_make_fact()], user_id="u1", source_chat_id="c1", result=result
+    )
+
+    manager.store.update_memory.assert_awaited_once()
+    manager.store.add_memory.assert_awaited_once()
+    assert result.memories_created == ["new-memory-id"]
+    assert result.memories_updated == []
+
+
+@pytest.mark.parametrize("threshold", [None, 0.7, 0.92])
+def test_constructor_accepts_explicit_threshold(threshold):
+    """Constructing via the public API should honor the dedup_threshold arg."""
+    store = MagicMock()
+    # Bypass EmbeddingGenerator / LLMClient construction by patching them on
+    # the class for the duration of this test.
+    from suzent.memory import manager as mgr_mod
+
+    saved_emb = mgr_mod.EmbeddingGenerator
+    saved_llm = mgr_mod.LLMClient
+    mgr_mod.EmbeddingGenerator = lambda **kwargs: MagicMock()
+    mgr_mod.LLMClient = lambda **kwargs: MagicMock()
+    try:
+        m = MemoryManager(store=store, dedup_threshold=threshold)
+        expected = (
+            threshold
+            if threshold is not None
+            else DEFAULT_DEDUPLICATION_SIMILARITY_THRESHOLD
+        )
+        assert m.dedup_threshold == expected
+    finally:
+        mgr_mod.EmbeddingGenerator = saved_emb
+        mgr_mod.LLMClient = saved_llm


### PR DESCRIPTION
## Summary

Fixes the data-loss bug described in #34. In `MemoryManager._deduplicate_and_store_facts`, when a newly extracted fact's cosine similarity to an existing memory exceeded `DEDUPLICATION_SIMILARITY_THRESHOLD` (0.85), the code appended the existing id to `result.memories_updated` but performed **no update** — the new content was silently dropped.

The most damaging case is factual *updates*: "I work at Google" → "I just joined Microsoft" embed close enough on short sentences that the newer fact gets collapsed into the older one and discarded. The system then retains stale information indefinitely.

## Changes

**`src/suzent/memory/manager.py`** — the actual fix
- On a near-duplicate hit, generate an embedding for the new fact and call `store.update_memory(memory_id, content=..., embedding=..., metadata=..., importance=...)`. The store layer preserves the original row's timestamps; only content/vector/metadata/importance change.
- If `update_memory` reports failure, fall back to inserting a fresh row so the fact is never silently lost.
- Constant renamed `DEDUPLICATION_SIMILARITY_THRESHOLD` → `DEFAULT_DEDUPLICATION_SIMILARITY_THRESHOLD` to reflect that it's now a default, not a hard-coded global. Per-instance threshold lives on `self.dedup_threshold`.

**Make the threshold tunable** (issue's "reason 3": threshold is embedding-model-dependent)
- `MemoryManager.__init__` accepts `dedup_threshold: Optional[float]` (default = constant).
- `ConfigModel.memory_dedup_threshold: Optional[float] = None` in `src/suzent/config/__init__.py`.
- `memory/lifecycle.py` wires `CONFIG.memory_dedup_threshold` through on init.

Backwards compatible: if neither callers nor `default.yaml` set the new field, behavior is identical to before — except that near-duplicates are now actually updated instead of silently dropped.

## Tests

`tests/memory/test_dedup_update.py` — 8 tests, all backend-only with mocked I/O:

- `test_near_duplicate_actually_updates_existing_memory` — pins the bug: `store.update_memory` is called with the new content + freshly generated embedding + new importance.
- `test_below_threshold_inserts_new_memory` — non-duplicate path unchanged.
- `test_no_similar_memories_inserts_new_memory` — empty search result path unchanged.
- `test_threshold_is_configurable_per_instance` — a tighter threshold (0.99) lets a 0.95 hit be treated as new.
- `test_update_failure_falls_back_to_insert` — never lose a fact silently if the store rejects the update.
- `test_constructor_accepts_explicit_threshold[None|0.7|0.92]` — public API honors the new arg.

## Out of scope (deliberately deferred)

The issue's "possible future paths" — LLM-assisted dedup, adaptive thresholds, entity-graph merging — are all bigger directional changes. They're not needed to stop the data loss and would dilute review. Happy to take any of them on as follow-up PRs if you'd like.

## Test plan

- [x] `uv run pytest tests/memory/test_dedup_update.py` — 8/8 pass.
- [x] `uv run pytest tests/memory/` — 22/22 pass (no regression).
- [x] `uv run ruff check` on changed files — clean.
- [ ] Manual smoke: with a real embedding model, store "I work at Google", then submit "I just joined Microsoft" — confirm the stored memory's content is updated rather than the new fact being dropped.