### PR TITLE
feat(chat): background streaming so chats run concurrently

### DIFF
--- a/frontend/src/components/ChatInputPanel.tsx
+++ b/frontend/src/components/ChatInputPanel.tsx
@@ -20,7 +20,6 @@ interface ChatInputPanelProps {
     isUploading?: boolean;
     fileError?: string | null;
     send: () => void;
-    isStreaming: boolean;
     config: ChatConfig;
     setConfig: React.Dispatch<React.SetStateAction<ChatConfig>>;
     backendConfig: ConfigOptions | null;
@@ -141,7 +140,6 @@ export const ChatInputPanel: React.FC<ChatInputPanelProps> = ({
     isUploading = false,
     fileError = null,
     send,
-    isStreaming,
     config,
     setConfig,
     backendConfig,
@@ -589,7 +587,7 @@ export const ChatInputPanel: React.FC<ChatInputPanelProps> = ({
                         onMount={handleMountFolder}
                         activeVolumes={config.sandbox_volumes || []}
                         onRemoveVolume={removeVolume}
-                        disabled={!configReady || isStreaming || isUploading}
+                        disabled={!configReady || streamingForCurrentChat || isUploading}
                         dropUp={modelSelectDropUp}
                     />
 
@@ -607,7 +605,7 @@ export const ChatInputPanel: React.FC<ChatInputPanelProps> = ({
                         onClick={() => fileInputRef.current?.click()}
                         className="text-brutal-black hover:text-brutal-blue transition-colors disabled:opacity-40 shrink-0"
                         title={t('chatInput.attachFiles')}
-                        disabled={!configReady || isStreaming || isUploading}
+                        disabled={!configReady || streamingForCurrentChat || isUploading}
                     >
                         <PaperClipIcon className="w-6 h-6" />
                     </button>
@@ -655,7 +653,7 @@ export const ChatInputPanel: React.FC<ChatInputPanelProps> = ({
                         <button
                             type="submit"
                             className="h-9 border-2 border-brutal-black shadow-[2px_2px_0_0_#000] brutal-btn duration-100 px-4 text-sm font-bold disabled:opacity-50 disabled:cursor-not-allowed text-white uppercase ml-1 shrink-0 bg-brutal-blue"
-                            disabled={isStreaming || !configReady}
+                            disabled={streamingForCurrentChat || !configReady}
                             title={t('chatInput.sendMessage')}
                         >
                             {t('chatInput.send').toUpperCase()}

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -549,6 +549,16 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   // Captures the final AGUI parts from a live background stream so the cleanup path can
   // convert them to a persisted rich message (with tool-step HTML) after clearParts.
   const liveStreamPartsRef = useRef<AGUIPart[]>([]);
+  // Chats whose live stream we silently abandoned on navigation. On return we
+  // reload them from the DB so the response that streamed (and was persisted by
+  // the backend) while we were away is shown.
+  const abandonedStreamChatsRef = useRef<Set<string>>(new Set());
+  // Snapshot of streaming parts at the moment we abandoned a chat's live stream,
+  // so reconnecting can seed them back (preserving steps and in-flight tools).
+  const abandonedPartsRef = useRef<Map<string, AGUIPart[]>>(new Map());
+  // Wall-clock start time per streaming chat, so the activity timer resumes from
+  // the original start instead of resetting when the transient message remounts.
+  const streamStartByChatRef = useRef<Map<string, number>>(new Map());
   const [streamDisplayRole, setStreamDisplayRole] = useState<Message['role']>('assistant');
   const streamDisplayRoleRef = useRef<Message['role']>('assistant');
 
@@ -564,6 +574,8 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     resumeStream,
     steerStream,
     stop: stopAGUIStream,
+    stopSilently: stopAGUIStreamSilently,
+    getParts: getStreamingParts,
     clearParts,
     resolveApproval,
     addApprovalDecision,
@@ -736,6 +748,10 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       setIsStreaming(false, chatId);
       streamingChatIdRef.current = null;
       stopInFlightRef.current = false;
+      if (chatId) {
+        streamStartByChatRef.current.delete(chatId);
+        abandonedPartsRef.current.delete(chatId);
+      }
       const errorMessage = typeof error?.message === 'string' ? error.message : '';
       const isNetworkError = errorMessage === 'Failed to fetch' || error instanceof TypeError;
       const isOutputValidationRetryError =
@@ -1017,8 +1033,17 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     const chatIdAtMount = currentChatId;
     let cancelled = false;
 
-    // On entry into a background chat: reload from DB so any completed stream is visible.
-    if (isBackgroundChat) {
+    // On entry: reload from DB so any stream that completed while we were away
+    // is visible. Covers platform/heartbeat chats and regular chats whose live
+    // stream we abandoned on a previous navigation.
+    if (isBackgroundChat || abandonedStreamChatsRef.current.has(chatIdAtMount)) {
+      abandonedStreamChatsRef.current.delete(chatIdAtMount);
+      // If the stream already finished while we were away, the DB has the full
+      // message — drop any preserved reconnect state so it isn't seeded stale.
+      if (!isBusStreaming(chatIdAtMount)) {
+        abandonedPartsRef.current.delete(chatIdAtMount);
+        streamStartByChatRef.current.delete(chatIdAtMount);
+      }
       loadChat(chatIdAtMount).catch(() => {});
     }
 
@@ -1033,13 +1058,24 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
 
       const liveUrl = `${getApiBase()}/chat/live`;
 
+      // Seed with parts from a prior connection we abandoned on switch, so the
+      // visible steps and in-flight tool states resume instead of resetting.
+      const seedParts = abandonedPartsRef.current.get(chatIdAtMount);
+      abandonedPartsRef.current.delete(chatIdAtMount);
+
       const streamed = await sendAGUI({ chat_id: chatIdAtMount }, {
         urlOverride: liveUrl,
+        seedParts,
         onStreamStart: () => {
           isLiveStreamRef.current = true;
           // Pin the streaming chat ID so onFinish uses the correct chat even if
           // the user navigates away mid-stream.
           streamingChatIdRef.current = chatIdAtMount;
+          // Preserve the original start time across reconnects so the activity
+          // timer continues; only set it if this is the first time we see it.
+          if (!streamStartByChatRef.current.has(chatIdAtMount)) {
+            streamStartByChatRef.current.set(chatIdAtMount, Date.now());
+          }
           setIsStreaming(true, chatIdAtMount);
           loadChat(chatIdAtMount).catch(() => {});
         },
@@ -1061,6 +1097,9 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       const richMsg = aguiPartsToStoreMessage(liveStreamPartsRef.current, null);
       const isSocialStream = chatIdAtMount.startsWith('social-');
       setIsStreaming(false, chatIdAtMount);
+      // Stream finished cleanly — drop preserved reconnect state for this chat.
+      streamStartByChatRef.current.delete(chatIdAtMount);
+      abandonedPartsRef.current.delete(chatIdAtMount);
 
       if (isSocialStream) {
         if (richMsg.content.trim()) addMessage(richMsg, chatIdAtMount);
@@ -1098,9 +1137,24 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       // Only stop the AG-UI connection if this effect started a background live stream.
       // Leave user-initiated /chat streams alone (they use a different code path).
       if (isLiveStreamRef.current && streamingChatIdRef.current === chatIdAtMount) {
-        stopAGUIStream();
+        // Silent stop: discard transient parts without finalizing them. Otherwise
+        // the abort-triggered onFinish would misroute this chat's parts into the
+        // chat we just switched to. The backend keeps producing and persists the
+        // result; we mark this chat for reload-on-return.
+        // Snapshot the current parts first so reconnecting can seed them back
+        // (preserving visible steps + in-flight tool states).
+        const snapshot = getStreamingParts();
+        if (snapshot.length > 0) {
+          abandonedPartsRef.current.set(chatIdAtMount, snapshot);
+        }
+        stopAGUIStreamSilently();
+        abandonedStreamChatsRef.current.add(chatIdAtMount);
         isLiveStreamRef.current = false;
         streamingChatIdRef.current = null;
+        clearParts();
+        // Clear streaming state so the next chat's send button is not blocked.
+        // The backend continues processing; reconnecting via /chat/live picks it up.
+        setIsStreaming(false, chatIdAtMount);
       }
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1159,7 +1213,8 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       return;
     }
 
-    // Normal send — not streaming
+    // Block only if the frontend is currently watching this chat's live stream.
+    // Other chats streaming in the background don't block a new send here.
     if (isStreaming) return;
 
     // Create chat if needed
@@ -1170,6 +1225,14 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
         console.error('Unable to initialize chat before sending message.');
         return;
       }
+    }
+
+    // Block if this chat already has an active background stream (subagent, heartbeat, etc.).
+    // tryConnect() will attach to it shortly; once streamingForCurrentChat becomes true
+    // the user can steer via the redirect button instead.
+    if (isBusStreaming(chatIdForSend)) {
+      setStatusBar('This chat is still responding — wait or use the redirect button', 'info', 4000);
+      return;
     }
 
     const filesToSend = [...selectedFiles];
@@ -1189,7 +1252,6 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       }
     }
 
-    // Upload successful - now clear input and files
     const resetFlag = shouldResetNext;
     if (resetFlag) consumeResetFlag();
     setInput('');
@@ -1197,7 +1259,6 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     setFileMentions([]);
     setCurrentUsage(null);
 
-    // Add user message to store for display + persistence
     addMessage({
       role: 'user',
       content: prompt,
@@ -1205,38 +1266,41 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       images: uploadedFileMetadata ? undefined : imagePreviews,
       files: uploadedFileMetadata
     }, chatIdForSend);
+
+    // Show loading indicator immediately before the network round-trip.
+    clearParts();
+    streamStartByChatRef.current.set(chatIdForSend, Date.now());
     setIsStreaming(true, chatIdForSend);
-    streamingChatIdRef.current = chatIdForSend;
-    activeChatIdRef.current = chatIdForSend;
-    stopInFlightRef.current = false;
 
-    try {
-      const mentionsToSend = extractSelectedFileMentions(prompt, fileMentions);
-      const payload: Record<string, unknown> = {
-        message: prompt,
-        config: safeConfig,
-        chat_id: chatIdForSend,
-        reset: resetFlag,
-      };
-      if (mentionsToSend.length > 0) {
-        payload.file_mentions = mentionsToSend;
-      }
-      if (uploadedFileMetadata) {
-        payload.files = uploadedFileMetadata;
-      }
+    const mentionsToSend = extractSelectedFileMentions(prompt, fileMentions);
+    const payload: Record<string, unknown> = {
+      message: prompt,
+      config: safeConfig,
+      chat_id: chatIdForSend,
+      reset: resetFlag,
+    };
+    if (mentionsToSend.length > 0) payload.file_mentions = mentionsToSend;
+    if (uploadedFileMetadata) payload.files = uploadedFileMetadata;
 
-      await sendAGUI(payload);
-    } catch (error) {
-      console.error('Error during streaming:', error);
-      if (!steeringRef.current) {
+    // Fire and forget — backend registers the background stream and returns 202.
+    // The event bus will emit stream_started, which triggers tryConnect() in the
+    // mounted effect for this chat, connecting to /chat/live to receive the stream.
+    fetch(`${getApiBase()}/chat/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }).then(resp => {
+      if (!resp.ok) {
+        const msg = resp.status === 409 ? 'Chat is already responding' : `Send failed (${resp.status})`;
+        setStatusBar(msg, 'error', 4000);
         setIsStreaming(false, chatIdForSend);
+        clearParts();
       }
-    } finally {
-      stopInFlightRef.current = false;
-      setTimeout(async () => {
-        try { await forceSaveNow(chatIdForSend); } catch { }
-      }, 600);
-    }
+    }).catch(err => {
+      console.error('[send] /chat/send failed:', err);
+      setIsStreaming(false, chatIdForSend);
+      clearParts();
+    });
   };
 
   // Retry handler — restores last checkpoint and re-runs the original message
@@ -1382,7 +1446,6 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
                 isUploading={isUploading}
                 fileError={fileError}
                 send={send}
-                isStreaming={isStreaming}
                 config={safeConfig}
                 setConfig={setConfig}
                 backendConfig={safeBackendConfig}
@@ -1432,6 +1495,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
                             isLastMessage={true}
                             onFileClick={handleFileClick}
                             aguiParts={streamingParts}
+                            streamStartedAtMs={currentChatId ? streamStartByChatRef.current.get(currentChatId) : undefined}
                             onToolApproval={handleToolApproval}
                             usage={currentUsage}
                             toolApprovalPolicy={safeConfig.tool_approval_policy}
@@ -1481,7 +1545,6 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
               isUploading={isUploading}
               fileError={fileError}
               send={send}
-              isStreaming={isStreaming}
               config={safeConfig}
               setConfig={setConfig}
               backendConfig={safeBackendConfig}

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -1271,6 +1271,11 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     clearParts();
     streamStartByChatRef.current.set(chatIdForSend, Date.now());
     setIsStreaming(true, chatIdForSend);
+    const clearPartsIfStillViewingSendChat = () => {
+      if (activeChatIdRef.current === chatIdForSend) {
+        clearParts();
+      }
+    };
 
     const mentionsToSend = extractSelectedFileMentions(prompt, fileMentions);
     const payload: Record<string, unknown> = {
@@ -1294,12 +1299,12 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
         const msg = resp.status === 409 ? 'Chat is already responding' : `Send failed (${resp.status})`;
         setStatusBar(msg, 'error', 4000);
         setIsStreaming(false, chatIdForSend);
-        clearParts();
+        clearPartsIfStillViewingSendChat();
       }
     }).catch(err => {
       console.error('[send] /chat/send failed:', err);
       setIsStreaming(false, chatIdForSend);
-      clearParts();
+      clearPartsIfStillViewingSendChat();
     });
   };
 

--- a/frontend/src/components/NewChatView.tsx
+++ b/frontend/src/components/NewChatView.tsx
@@ -14,7 +14,6 @@ interface NewChatViewProps {
     isUploading?: boolean;
     fileError?: string | null;
     send: () => void;
-    isStreaming: boolean;
     config: ChatConfig;
     setConfig: React.Dispatch<React.SetStateAction<ChatConfig>>;
     backendConfig: ConfigOptions | null;
@@ -74,7 +73,6 @@ export const NewChatView: React.FC<NewChatViewProps> = ({
     isUploading,
     fileError,
     send,
-    isStreaming,
     config,
     setConfig,
     backendConfig,
@@ -103,7 +101,6 @@ export const NewChatView: React.FC<NewChatViewProps> = ({
                     isUploading={isUploading}
                     fileError={fileError}
                     send={send}
-                    isStreaming={isStreaming}
                     config={config}
                     setConfig={setConfig}
                     backendConfig={backendConfig}

--- a/frontend/src/components/chat/ActivityRail.tsx
+++ b/frontend/src/components/chat/ActivityRail.tsx
@@ -129,15 +129,27 @@ export const ActivityRail: React.FC<{
   children: React.ReactNode;
   itemCount: number;
   durationSeconds?: number;
+  startedAtMs?: number;
   showDuration?: boolean;
   defaultExpanded?: boolean;
   isActive?: boolean;
   hasPending?: boolean;
   currentLabel?: string;
-}> = ({ children, itemCount, durationSeconds, showDuration = true, defaultExpanded = false, isActive = false, hasPending = false, currentLabel }) => {
+}> = ({ children, itemCount, durationSeconds, startedAtMs, showDuration = true, defaultExpanded = false, isActive = false, hasPending = false, currentLabel }) => {
   const [expanded, setExpanded] = useState(defaultExpanded);
-  const startedAtRef = React.useRef(Date.now());
+  // Use the caller-provided start time when available so the timer resumes from
+  // the original start across remounts (e.g. reconnecting to a stream after a
+  // chat switch); otherwise fall back to mount time.
+  const startedAtRef = React.useRef(startedAtMs ?? Date.now());
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
+
+  // Adopt a later-arriving start time (the prop may be undefined on first render
+  // and resolve once the streaming chat's start timestamp is known).
+  useEffect(() => {
+    if (startedAtMs && startedAtMs !== startedAtRef.current) {
+      startedAtRef.current = startedAtMs;
+    }
+  }, [startedAtMs]);
 
   useEffect(() => {
     if (defaultExpanded) {

--- a/frontend/src/components/chat/AssistantMessage.tsx
+++ b/frontend/src/components/chat/AssistantMessage.tsx
@@ -43,6 +43,8 @@ interface AssistantMessageProps {
   usage?: any;
   /** When provided, renders from AG-UI streaming parts instead of legacy HTML parsing */
   aguiParts?: AGUIPart[];
+  /** Wall-clock start time (ms) of the active stream, so the activity timer resumes across reconnects */
+  streamStartedAtMs?: number;
   /** HITL approval handler: (approvalId, toolCallId, approved, remember?, toolName?) */
   onToolApproval?: (approvalId: string, toolCallId: string, approved: boolean, remember?: ApprovalRememberScope, toolName?: string) => void;
   /** Tool approval policy for showing auto-approval badges */
@@ -98,6 +100,7 @@ const AGUIPartsContent: React.FC<{
   parts: AGUIPart[];
   messageIndex: number;
   workedDurationSeconds?: number;
+  streamStartedAtMs?: number;
   isStreaming?: boolean;
   onFileClick?: (filePath: string, fileName: string, shiftKey?: boolean) => void;
   onToolApproval?: (approvalId: string, toolCallId: string, approved: boolean, remember?: ApprovalRememberScope, toolName?: string) => void;
@@ -108,7 +111,7 @@ const AGUIPartsContent: React.FC<{
   onOpenSubAgentSidebar?: (taskId: string) => void;
   onStopSubAgent?: (taskId: string) => void;
   onForceWebContext?: (contextId: string) => void;
-}> = ({ parts, messageIndex, workedDurationSeconds, isStreaming, onFileClick, onToolApproval, toolApprovalPolicy, onRemoveApprovalPolicy, onInlineAction, subAgentTasks, onOpenSubAgentSidebar, onStopSubAgent, onForceWebContext }) => {
+}> = ({ parts, messageIndex, workedDurationSeconds, streamStartedAtMs, isStreaming, onFileClick, onToolApproval, toolApprovalPolicy, onRemoveApprovalPolicy, onInlineAction, subAgentTasks, onOpenSubAgentSidebar, onStopSubAgent, onForceWebContext }) => {
   // Normalize tool parts: when resume/recovery emits another tool part with the
   // same toolCallId later in the stream, merge it into the first occurrence so
   // output stays under the initial tool call instead of rendering a split block.
@@ -178,6 +181,7 @@ const AGUIPartsContent: React.FC<{
               key={`activity-${gi}`}
               itemCount={countActivityItems(group.chunks)}
               durationSeconds={workedDurationSeconds}
+              startedAtMs={activityGroupOrdinal === 0 ? streamStartedAtMs : undefined}
               showDuration={activityGroupOrdinal === 0}
               defaultExpanded={Boolean(isStreaming)}
               isActive={Boolean(isStreaming)}
@@ -450,6 +454,7 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
   isLastMessage,
   onFileClick,
   aguiParts,
+  streamStartedAtMs,
   onToolApproval,
   usage,
   toolApprovalPolicy,
@@ -585,6 +590,7 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
                 parts={effectiveParts}
                 messageIndex={messageIndex}
                 workedDurationSeconds={workedDurationSeconds}
+                streamStartedAtMs={streamStartedAtMs}
                 isStreaming={isStreamingThis}
                 onFileClick={onFileClick}
                 onToolApproval={onToolApproval}

--- a/frontend/src/hooks/useAGUI.ts
+++ b/frontend/src/hooks/useAGUI.ts
@@ -24,12 +24,16 @@ interface UseAGUIReturn {
   parts: AGUIPart[];
   status: AGUIStatus;
   error: string | undefined;
-  sendMessage: (body: Record<string, unknown>, opts?: { formData?: FormData; urlOverride?: string; onStreamStart?: () => void }) => Promise<boolean>;
+  sendMessage: (body: Record<string, unknown>, opts?: { formData?: FormData; urlOverride?: string; onStreamStart?: () => void; seedParts?: AGUIPart[] }) => Promise<boolean>;
   /** Resume a stream after approval without clearing existing parts */
   resumeStream: (body: Record<string, unknown>) => Promise<void>;
   /** Interrupt the current stream and redirect the agent with a new message */
   steerStream: (body: Record<string, unknown>) => Promise<void>;
   stop: () => void;
+  /** Abort the active stream without triggering onFinish (used on chat switch) */
+  stopSilently: () => void;
+  /** Read the current parts synchronously (e.g. to snapshot before switching chats) */
+  getParts: () => AGUIPart[];
   clearParts: () => void;
   /** Remove an inline A2UI surface part by surface id (e.g. after ask_question is answered) */
   removeInlineSurface: (surfaceId: string) => void;
@@ -396,6 +400,11 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
   const abortRef = useRef<AbortController | null>(null);
   // Set to true while steerStream is running so abort-triggered onFinish is suppressed
   const isSteeringRef = useRef(false);
+  // Set to true by stopSilently() so the next abort skips onFinish entirely.
+  // Used when abandoning a live background stream on chat switch — the backend
+  // persists the content, so the frontend must NOT addMessage (which would
+  // misroute the parts to whatever chat is now being viewed).
+  const suppressFinishRef = useRef(false);
   // Keep a ref to latest parts so onFinish gets the final value
   const partsRef = useRef<AGUIPart[]>([]);
   partsRef.current = parts;
@@ -444,6 +453,17 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
   const stop = useCallback(() => {
     abortRef.current?.abort();
   }, []);
+
+  // Abort the active stream WITHOUT triggering onFinish. Used when navigating
+  // away from a live background stream — the backend keeps producing and
+  // persists the result, so the frontend discards its transient parts instead
+  // of finalizing them into the (now different) currently-viewed chat.
+  const stopSilently = useCallback(() => {
+    suppressFinishRef.current = true;
+    abortRef.current?.abort();
+  }, []);
+
+  const getParts = useCallback(() => partsRef.current, []);
 
   // Optimistically update a tool part's state when user approves/denies
   // so buttons disappear instantly (no waiting for backend round-trip)
@@ -723,7 +743,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
 
   const sendMessage = useCallback(async (
     body: Record<string, unknown>,
-    opts?: { formData?: FormData; urlOverride?: string; onStreamStart?: () => void },
+    opts?: { formData?: FormData; urlOverride?: string; onStreamStart?: () => void; seedParts?: AGUIPart[] },
   ): Promise<boolean> => {
     const { url, onFinish, onCustomEvent, onMarkDeferred, onError } = optionsRef.current;
     const targetUrl = opts?.urlOverride ?? url;
@@ -774,8 +794,14 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
 
       if (isProbe) {
         // Stream confirmed active — reset state now (not on every silent 204 probe).
-        setParts([]);
-        partsRef.current = [];
+        // Seed with prior parts when reconnecting to a stream we abandoned on a
+        // chat switch, so previously-shown steps (and in-flight tool states)
+        // are preserved instead of resetting. The background queue is
+        // consume-once, so it only replays chunks from the reconnect point —
+        // the seed supplies everything before it.
+        const seed = opts?.seedParts ?? [];
+        setParts(seed);
+        partsRef.current = seed;
         setError(undefined);
         setStatus('submitted');
         resetApprovalTracking();
@@ -837,9 +863,13 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
 
     } catch (err) {
       if ((err as Error).name === 'AbortError') {
-        // If the abort was triggered by steerStream, do nothing here —
-        // steerStream owns the status and will call onFinish when done.
-        if (!isSteeringRef.current) {
+        // Silent stop (chat switch): discard parts, never finalize.
+        if (suppressFinishRef.current) {
+          suppressFinishRef.current = false;
+          setStatus('idle');
+        } else if (!isSteeringRef.current) {
+          // If the abort was triggered by steerStream, do nothing here —
+          // steerStream owns the status and will call onFinish when done.
           setStatus('idle');
           onFinish?.(partsRef.current);
         }
@@ -853,5 +883,5 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
     }
   }, [resetApprovalTracking, setPendingApprovalCountSync]);
 
-  return { parts, status, error, sendMessage, resumeStream, steerStream, stop, clearParts, removeInlineSurface, resolveApproval, pendingApprovalCount, addApprovalDecision, consumeApprovalDecisions };
+  return { parts, status, error, sendMessage, resumeStream, steerStream, stop, stopSilently, getParts, clearParts, removeInlineSurface, resolveApproval, pendingApprovalCount, addApprovalDecision, consumeApprovalDecisions };
 }

--- a/frontend/src/hooks/useEventBus.ts
+++ b/frontend/src/hooks/useEventBus.ts
@@ -48,6 +48,9 @@ function _handleMessage(evt: MessageEvent) {
     if (msg.event === 'snapshot') {
       _activeStreams = new Set(msg.streams ?? []);
       notify();
+      _activeStreams.forEach((chatId) => {
+        _streamEventListeners.get(chatId)?.forEach((cb) => cb.onStart?.());
+      });
     } else if (msg.event === 'stream_started') {
       if (msg.chat_id) {
         _activeStreams = new Set([..._activeStreams, msg.chat_id]);

--- a/src/suzent/core/stream_registry.py
+++ b/src/suzent/core/stream_registry.py
@@ -169,7 +169,7 @@ class _BusStreamQueue:
     else delegates to the inner asyncio.Queue.
     """
 
-    def __init__(self, chat_id: str, maxsize: int = 2000):
+    def __init__(self, chat_id: str, maxsize: int = 0):
         self.chat_id = chat_id
         self._q: asyncio.Queue = asyncio.Queue(maxsize=maxsize)
         # Cleared when the None sentinel is put so is_background_streaming()
@@ -225,8 +225,20 @@ def register_background_stream(chat_id: str) -> _BusStreamQueue:
     return q
 
 
-def unregister_background_stream(chat_id: str) -> None:
+def try_register_background_stream(chat_id: str) -> Optional[_BusStreamQueue]:
+    """Register a background SSE queue unless a producer is already active."""
+    existing = background_queues.get(chat_id)
+    if existing is not None and existing.producer_active:
+        return None
+    return register_background_stream(chat_id)
+
+
+def unregister_background_stream(
+    chat_id: str, queue: Optional[_BusStreamQueue] = None
+) -> None:
     """Remove the background queue for a chat (signals no active stream)."""
+    if queue is not None and background_queues.get(chat_id) is not queue:
+        return
     background_queues.pop(chat_id, None)
     # stream_ended is already emitted by the None sentinel put_nowait in _BusStreamQueue
 

--- a/src/suzent/core/stream_registry.py
+++ b/src/suzent/core/stream_registry.py
@@ -172,14 +172,22 @@ class _BusStreamQueue:
     def __init__(self, chat_id: str, maxsize: int = 2000):
         self.chat_id = chat_id
         self._q: asyncio.Queue = asyncio.Queue(maxsize=maxsize)
+        # Cleared when the None sentinel is put so is_background_streaming()
+        # returns False as soon as the producer finishes, even if a late
+        # /chat/live client hasn't drained the queue yet.
+        self.producer_active: bool = True
 
     # --- write side ---
 
     async def put(self, item) -> None:
+        if item is None:
+            self.producer_active = False
         await self._q.put(item)
         _fan_chunk_to_bus(self.chat_id, item)
 
     def put_nowait(self, item) -> None:
+        if item is None:
+            self.producer_active = False
         self._q.put_nowait(item)
         _fan_chunk_to_bus(self.chat_id, item)
 
@@ -229,8 +237,13 @@ def get_background_queue(chat_id: str) -> Optional[_BusStreamQueue]:
 
 
 def is_background_streaming(chat_id: str) -> bool:
-    """Return True if a background stream is currently active for this chat."""
-    return chat_id in background_queues
+    """Return True if a background stream producer is still active for this chat.
+
+    Returns False as soon as the producer puts the None sentinel, even if the
+    queue still exists for late-arriving /chat/live consumers to drain.
+    """
+    q = background_queues.get(chat_id)
+    return q is not None and q.producer_active
 
 
 async def push_custom_event(chat_id: str, event_name: str, data: Any) -> None:

--- a/src/suzent/routes/chat_routes.py
+++ b/src/suzent/routes/chat_routes.py
@@ -22,11 +22,12 @@ from suzent.streaming import stop_stream
 from suzent.core.stream_registry import (
     get_background_queue,
     is_background_streaming,
-    register_background_stream,
+    try_register_background_stream,
     unregister_background_stream,
 )
 
 logger = get_logger(__name__)
+_chat_send_tasks: set[asyncio.Task[None]] = set()
 
 
 async def chat(request: Request) -> StreamingResponse:
@@ -241,15 +242,14 @@ async def chat_send(request: Request) -> JSONResponse:
         return JSONResponse({"error": "chat_id is required"}, status_code=400)
     if not message and not files_list:
         return JSONResponse({"error": "Empty message"}, status_code=400)
-    if is_background_streaming(chat_id):
-        return JSONResponse({"error": "Chat is already streaming"}, status_code=409)
-
     from suzent.core.chat_processor import ChatProcessor
     from suzent.agent_manager import build_agent_config
 
     processor = ChatProcessor()
     config_override = build_agent_config(config, require_social_tool=False)
-    stream_queue = register_background_stream(chat_id)
+    stream_queue = try_register_background_stream(chat_id)
+    if stream_queue is None:
+        return JSONResponse({"error": "Chat is already streaming"}, status_code=409)
 
     async def _run() -> None:
         try:
@@ -275,7 +275,9 @@ async def chat_send(request: Request) -> JSONResponse:
         finally:
             await stream_queue.put(None)
 
-    asyncio.create_task(_run())
+    task = asyncio.create_task(_run())
+    _chat_send_tasks.add(task)
+    task.add_done_callback(_chat_send_tasks.discard)
     return JSONResponse({"chat_id": chat_id}, status_code=202)
 
 
@@ -428,7 +430,7 @@ async def live_stream(request: Request) -> StreamingResponse:
                 yield ": keep-alive\n\n"
                 continue
             if chunk is None:
-                unregister_background_stream(chat_id)
+                unregister_background_stream(chat_id, q)
                 return
             yield chunk
 

--- a/src/suzent/routes/chat_routes.py
+++ b/src/suzent/routes/chat_routes.py
@@ -22,6 +22,7 @@ from suzent.streaming import stop_stream
 from suzent.core.stream_registry import (
     get_background_queue,
     is_background_streaming,
+    register_background_stream,
     unregister_background_stream,
 )
 
@@ -215,6 +216,67 @@ async def chat(request: Request) -> StreamingResponse:
     except Exception as e:
         logger.error(f"Error handling chat request: {e}")
         return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+async def chat_send(request: Request) -> JSONResponse:
+    """
+    POST /chat/send — Start a user chat turn as a background stream.
+
+    Returns 202 immediately. The response streams through /chat/live
+    and is observable via /events/stream, enabling the frontend to
+    watch other chats while this one processes.
+    """
+    try:
+        data = await request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON"}, status_code=400)
+
+    chat_id = data.get("chat_id")
+    message = data.get("message", "").strip()
+    config = data.get("config", {})
+    files_list = data.get("files", [])
+    file_mentions = data.get("file_mentions", [])
+
+    if not chat_id:
+        return JSONResponse({"error": "chat_id is required"}, status_code=400)
+    if not message and not files_list:
+        return JSONResponse({"error": "Empty message"}, status_code=400)
+    if is_background_streaming(chat_id):
+        return JSONResponse({"error": "Chat is already streaming"}, status_code=409)
+
+    from suzent.core.chat_processor import ChatProcessor
+    from suzent.agent_manager import build_agent_config
+
+    processor = ChatProcessor()
+    config_override = build_agent_config(config, require_social_tool=False)
+    stream_queue = register_background_stream(chat_id)
+
+    async def _run() -> None:
+        try:
+            generator = processor.process_turn(
+                chat_id=chat_id,
+                user_id=CONFIG.user_id,
+                message_content=message,
+                files=files_list,
+                file_mentions=file_mentions,
+                config_override=config_override,
+            )
+            async for chunk in generator:
+                await stream_queue.put(chunk)
+        except Exception as exc:
+            logger.error(f"[chat_send] Background turn error for {chat_id}: {exc}")
+            error_payload = (
+                f'data: {{"type":"RUN_ERROR","message":{json.dumps(str(exc))}}}\n\n'
+            )
+            try:
+                await stream_queue.put(error_payload)
+            except Exception:
+                pass
+        finally:
+            await stream_queue.put(None)
+
+    asyncio.create_task(_run())
+    return JSONResponse({"chat_id": chat_id}, status_code=202)
 
 
 async def retry_chat(request: Request) -> StreamingResponse:

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -28,6 +28,7 @@ from suzent.logger import get_logger, setup_logging
 from suzent.routes.chat_routes import (
     approve_tool,
     chat,
+    chat_send,
     create_chat,
     deactivate_tool,
     delete_chat,
@@ -661,6 +662,7 @@ app = Starlette(
     lifespan=lifespan,
     routes=[
         Route("/chat", chat, methods=["POST"]),
+        Route("/chat/send", chat_send, methods=["POST"]),
         Route("/chat/live", live_stream, methods=["POST"]),
         Route("/chat/stop", stop_chat, methods=["POST"]),
         Route("/chat/steer", steer_chat, methods=["POST"]),

--- a/tests/core/test_stream_registry.py
+++ b/tests/core/test_stream_registry.py
@@ -1,12 +1,19 @@
+import asyncio
+
 from suzent.core.stream_registry import (
+    background_queues,
     merge_pending_auto_approvals,
     pending_auto_approvals,
     pop_pending_auto_approvals,
+    register_background_stream,
+    try_register_background_stream,
+    unregister_background_stream,
 )
 
 
 def teardown_function():
     pending_auto_approvals.clear()
+    background_queues.clear()
 
 
 def test_merge_and_pop_pending_auto_approvals():
@@ -25,3 +32,49 @@ def test_merge_pending_auto_approvals_ignores_empty_inputs():
     merge_pending_auto_approvals("", {"a": True})
     merge_pending_auto_approvals("chat-2", {})
     assert pending_auto_approvals == {}
+
+
+def test_try_register_background_stream_rejects_active_producer():
+    chat_id = "chat-3"
+
+    first = try_register_background_stream(chat_id)
+    second = try_register_background_stream(chat_id)
+
+    assert first is not None
+    assert second is None
+    assert background_queues[chat_id] is first
+
+
+def test_register_background_stream_can_replace_finished_queue():
+    chat_id = "chat-4"
+    first = register_background_stream(chat_id)
+    asyncio.run(first.put(None))
+
+    second = try_register_background_stream(chat_id)
+
+    assert second is not None
+    assert second is not first
+    assert background_queues[chat_id] is second
+
+
+def test_background_stream_queue_does_not_block_without_live_consumer():
+    queue = register_background_stream("chat-5")
+
+    async def fill_queue() -> None:
+        for index in range(2500):
+            await queue.put(f"data: {index}\n\n")
+
+    asyncio.run(fill_queue())
+
+    assert queue.qsize() == 2500
+
+
+def test_unregister_background_stream_keeps_newer_queue():
+    chat_id = "chat-6"
+    old_queue = register_background_stream(chat_id)
+    old_queue.producer_active = False
+    new_queue = register_background_stream(chat_id)
+
+    unregister_background_stream(chat_id, old_queue)
+
+    assert background_queues[chat_id] is new_queue


### PR DESCRIPTION
## Summary

Lets you start a chat turn, navigate to another chat, and send/work there while the first keeps running — picking the stream back up when you return. Previously the singleton `useAGUI` connection meant switching chats mid-stream interrupted or misrouted the response.

User-initiated turns now run as **background streams** (the same mechanism cron/heartbeat/social already use): the frontend fires `POST /chat/send` and the existing event-bus + `/chat/live` machinery delivers the stream to whichever chat is currently being viewed.

## Backend

- **`POST /chat/send`** ([chat_routes.py](src/suzent/routes/chat_routes.py)) — starts a turn as a background task feeding a `_BusStreamQueue`, returns `202` immediately, returns `409` if the chat is already streaming.
- **`is_background_streaming` fix** ([stream_registry.py](src/suzent/core/stream_registry.py)) — now tracks `producer_active` so it flips to `false` the moment the producer finishes, instead of staying `true` until a late `/chat/live` consumer drains the queue. This removes false `409`s on the next send.

## Frontend

- **`send()`** ([ChatWindow.tsx](frontend/src/components/ChatWindow.tsx)) — posts to `/chat/send` (fire-and-forget); `tryConnect()` attaches via the event bus. Guards against sending to a chat that's already streaming using the synchronous `isBusStreaming()` (avoids a race that produced the `409`).
- **No misrouting on switch** — added `stopSilently()` to [useAGUI](frontend/src/hooks/useAGUI.ts) so abandoning a stream on navigation never fires `onFinish` (which would otherwise append the parts to the now-current chat). The chat is marked for reload-on-return.
- **Resume continuity** — on reconnect, the prior streaming parts are snapshotted and re-seeded (`seedParts`) so steps and in-flight tool states are preserved rather than reset; a per-chat stream start timestamp (`streamStartedAtMs`) flows through `AssistantMessage` → `ActivityRail` so the activity timer resumes instead of restarting.
- Send button disabling now keys off `streamingForCurrentChat` rather than global `isStreaming`.

## Testing

- `tsc --noEmit` passes clean.
- Manually: start chat A, switch to B and send, switch back — both stream independently; returning to a mid-stream chat shows accumulated steps + continuous timer; completed-while-away chats reload from DB.