### PR TITLE
Add goal mode: persistent self-continuing objectives

### DIFF
--- a/docs/02-concepts/automation/automation.md
+++ b/docs/02-concepts/automation/automation.md
@@ -212,8 +212,11 @@ error in `src/` and verify `ruff check` passes"*.
 
 Goals are stored in the project `GoalModel` (project + chat scoped) — the same
 record the agent's `manage_goal` tool writes and the **right-sidebar Goal tab**
-displays (objective, status, turn progress, sub-goals). Setting a goal lights up
-the sidebar automatically, and state survives restarts and resumes. The per-turn
+displays (objective, status, turn progress, sub-goals). The sidebar also exposes
+**Pause / Resume / Clear** buttons (via `POST /project/goal/action`) so you can
+control the loop without typing a command — Resume re-enters the continuation
+loop exactly like `/goal resume`. Setting a goal lights up the sidebar
+automatically, and state survives restarts and resumes. The per-turn
 `plan_reminder_hook` injects the active goal into context and advances the turn
 counter; this judge loop layers automatic continuation on top of that.
 

--- a/docs/02-concepts/automation/automation.md
+++ b/docs/02-concepts/automation/automation.md
@@ -210,7 +210,13 @@ error in `src/` and verify `ruff check` passes"*.
 4. When the judge says the goal is met, you see `✓ Goal achieved: <reason>`. When the budget runs out, you see `⏸ Goal paused — N/max turns used`.
 5. **Any real message you send preempts the loop** — your turn runs first, then the judge re-evaluates from there.
 
-Goal state lives in the chat's config, so it survives restarts and resumes.
+Goals are stored in the project `GoalModel` (project + chat scoped) — the same
+record the agent's `manage_goal` tool writes and the **right-sidebar Goal tab**
+displays (objective, status, turn progress, sub-goals). Setting a goal lights up
+the sidebar automatically, and state survives restarts and resumes. The per-turn
+`plan_reminder_hook` injects the active goal into context and advances the turn
+counter; this judge loop layers automatic continuation on top of that.
+
 The judge **fails open**: if the judge call errors or returns something
 unparseable, the loop continues (the turn budget is the real safety backstop).
 After 3 consecutive unparseable verdicts the goal auto-pauses and asks you to

--- a/docs/02-concepts/automation/automation.md
+++ b/docs/02-concepts/automation/automation.md
@@ -195,6 +195,52 @@ suzent heartbeat run -c <chat-id>
 | PUT | `/heartbeat/md` | Update HEARTBEAT.md content |
 | PUT | `/heartbeat/interval` | Set interval (`{"interval_minutes": N}`) |
 
+## Goal Mode
+
+Goal mode lets the agent pursue a standing objective across many turns without
+you re-prompting each step — our take on the "Ralph loop". Use it for tasks
+where "done" is well-defined and you want to walk away, e.g. *"Fix every lint
+error in `src/` and verify `ruff check` passes"*.
+
+### How It Works
+
+1. You set a goal with `/goal <objective>`. The agent immediately starts working on it (turn 1).
+2. After each turn, an auxiliary **judge** model (a single, cheap, stateless LLM call — not a full agent) decides whether the goal is fully satisfied.
+3. If not, and the turn budget isn't exhausted, the agent is automatically run again with a continuation prompt — you'll see `↻ Continuing toward goal (N/max)` in the status bar.
+4. When the judge says the goal is met, you see `✓ Goal achieved: <reason>`. When the budget runs out, you see `⏸ Goal paused — N/max turns used`.
+5. **Any real message you send preempts the loop** — your turn runs first, then the judge re-evaluates from there.
+
+Goal state lives in the chat's config, so it survives restarts and resumes.
+The judge **fails open**: if the judge call errors or returns something
+unparseable, the loop continues (the turn budget is the real safety backstop).
+After 3 consecutive unparseable verdicts the goal auto-pauses and asks you to
+configure a stronger `cheap` role model.
+
+Autonomous goal turns auto-approve tools so the agent can act unattended.
+
+### Commands
+
+| Command | Action |
+|---|---|
+| `/goal <objective>` | Set a goal and start working toward it |
+| `/goal` or `/goal status` | Show the current goal, status, and turn progress |
+| `/goal pause` | Stop the auto-continuation loop |
+| `/goal resume` | Resume a paused goal (resets the turn counter) |
+| `/goal clear` | Remove the goal |
+| `/subgoal <text>` | Append an acceptance criterion (judge requires all sub-goals met) |
+| `/subgoal` | List current sub-goals |
+| `/subgoal remove <N>` | Remove sub-goal number `N` |
+| `/subgoal clear` | Remove all sub-goals |
+
+### Configuration
+
+| Setting | Default | Description |
+|---|---|---|
+| `goals_max_turns` | `20` | Max autonomous continuation turns before auto-pausing |
+
+The judge uses the `cheap` model role (configurable in **Settings → Model
+Roles**), falling back to the primary model if `cheap` is unset.
+
 ## Architecture
 
 ### Scheduler (Cron)

--- a/frontend/src/components/sidebar/GoalTaskView.tsx
+++ b/frontend/src/components/sidebar/GoalTaskView.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Goal, Task, GoalStatus, TaskStatus } from '../../types/api';
 import { useI18n } from '../../i18n';
+import { useGoalTasks } from '../../hooks/useGoalTasks';
 import { BrutalButton } from '../BrutalButton';
 
 interface GoalTaskViewProps {
@@ -67,7 +68,18 @@ function TaskCheck({ status }: { status: TaskStatus }) {
 
 export const GoalTaskView: React.FC<GoalTaskViewProps> = ({ goal, tasks, onOpenBoard, projectTaskCount }) => {
   const { t } = useI18n();
+  const { goalAction } = useGoalTasks();
   const [subgoalsExpanded, setSubgoalsExpanded] = React.useState(true);
+  const [busy, setBusy] = React.useState(false);
+
+  const runGoalAction = React.useCallback(async (action: 'pause' | 'resume' | 'clear') => {
+    setBusy(true);
+    try {
+      await goalAction(action);
+    } finally {
+      setBusy(false);
+    }
+  }, [goalAction]);
 
   const activeTasks = tasks.filter(t => t.status !== 'cancelled');
   const completed = tasks.filter(t => t.status === 'completed').length;
@@ -127,6 +139,22 @@ export const GoalTaskView: React.FC<GoalTaskViewProps> = ({ goal, tasks, onOpenB
                     ))}
                   </ul>
                 )}
+              </div>
+            )}
+            {(goal.status === 'active' || goal.status === 'paused') && (
+              <div className="flex gap-1.5 pt-0.5">
+                {goal.status === 'active' ? (
+                  <BrutalButton size="sm" disabled={busy} onClick={() => runGoalAction('pause')}>
+                    ⏸ {t('goal.pause')}
+                  </BrutalButton>
+                ) : (
+                  <BrutalButton size="sm" disabled={busy} onClick={() => runGoalAction('resume')}>
+                    ▶ {t('goal.resume')}
+                  </BrutalButton>
+                )}
+                <BrutalButton size="sm" disabled={busy} onClick={() => runGoalAction('clear')}>
+                  ✕ {t('goal.clear')}
+                </BrutalButton>
               </div>
             )}
           </div>

--- a/frontend/src/hooks/useGoalTasks.ts
+++ b/frontend/src/hooks/useGoalTasks.ts
@@ -12,6 +12,7 @@ interface GoalTasksContextValue {
   goal: Goal | null;
   tasks: Task[];
   refresh: (projectId?: string | null, chatId?: string | null) => Promise<void>;
+  goalAction: (action: 'pause' | 'resume' | 'clear') => Promise<void>;
   // Project-scoped (kanban tab)
   kanban: KanbanData | null;
   refreshKanban: (projectId?: string | null) => Promise<void>;
@@ -47,6 +48,25 @@ export const GoalTasksProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       if (tasksRes.ok) setTasks(await tasksRes.json());
     } catch (err) {
       console.warn('Failed to fetch goal/tasks:', err);
+    }
+  }, []);
+
+  const goalAction = useCallback(async (action: 'pause' | 'resume' | 'clear') => {
+    const pid = currentProjectIdRef.current;
+    const cid = currentChatIdRef.current;
+    if (!pid || !cid) return;
+    try {
+      const res = await fetch(`${getApiBase()}/project/goal/action`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project_id: pid, chat_id: cid, action }),
+      });
+      if (res.ok) {
+        const updated = await res.json();
+        setGoal(updated && updated.id ? (updated as Goal) : null);
+      }
+    } catch (err) {
+      console.warn('Failed to update goal:', err);
     }
   }, []);
 
@@ -116,8 +136,8 @@ export const GoalTasksProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   }, []);
 
   const contextValue = React.useMemo(
-    () => ({ goal, tasks, refresh, kanban, refreshKanban, updateTask, createTask, deleteTask }),
-    [goal, tasks, refresh, kanban, refreshKanban, updateTask, createTask, deleteTask],
+    () => ({ goal, tasks, refresh, goalAction, kanban, refreshKanban, updateTask, createTask, deleteTask }),
+    [goal, tasks, refresh, goalAction, kanban, refreshKanban, updateTask, createTask, deleteTask],
   );
 
   return React.createElement(GoalTasksContext.Provider, { value: contextValue }, children);

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -584,6 +584,9 @@ export const en = {
     noGoal: 'No active goal.',
     turns: '{elapsed}/{max} turns',
     subgoals: 'Subgoals',
+    pause: 'Pause',
+    resume: 'Resume',
+    clear: 'Clear',
     status: {
       active: 'ACTIVE',
       paused: 'PAUSED',

--- a/frontend/src/i18n/messages/zh-CN.ts
+++ b/frontend/src/i18n/messages/zh-CN.ts
@@ -511,6 +511,9 @@ export const zhCN = {
     noGoal: '暂无目标。',
     turns: '{elapsed}/{max} 轮',
     subgoals: '子目标',
+    pause: '暂停',
+    resume: '继续',
+    clear: '清除',
     status: {
       active: '进行中',
       paused: '已暂停',

--- a/src/suzent/config/__init__.py
+++ b/src/suzent/config/__init__.py
@@ -358,6 +358,9 @@ class ConfigModel(BaseModel):
 
     plan_watcher_interval: float = 2.0
 
+    # Goal mode: max autonomous continuation turns before auto-pausing.
+    goals_max_turns: int = 20
+
     @classmethod
     def load_from_files(cls) -> "ConfigModel":
         logger = get_logger(__name__)

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -1127,10 +1127,10 @@ class ChatProcessor:
             # indexed DB read) when no goal is active; never fires for heartbeats.
             if not is_heartbeat:
                 try:
-                    from suzent.core.goals import get_goal
+                    from suzent.core.goals import resolve_goal
 
-                    goal_state = get_goal(chat_id)
-                    if goal_state and goal_state.status == "active":
+                    resolved_goal = resolve_goal(chat_id)
+                    if resolved_goal and resolved_goal[1].status == "active":
                         from suzent.core.goals import maybe_continue_goal
 
                         was_cancelled = bool(

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -1122,6 +1122,34 @@ class ChatProcessor:
                     # registration bypasses max_concurrent but still respects shutdown.
                     asyncio.create_task(_run_post_processing())
 
+            # 10. Goal-mode continuation. After a normal turn, let the judge decide
+            # whether to auto-continue toward a standing goal. Cheap no-op (one
+            # indexed DB read) when no goal is active; never fires for heartbeats.
+            if not is_heartbeat:
+                try:
+                    from suzent.core.goals import get_goal
+
+                    goal_state = get_goal(chat_id)
+                    if goal_state and goal_state.status == "active":
+                        from suzent.core.goals import maybe_continue_goal
+
+                        was_cancelled = bool(
+                            getattr(deps, "cancel_event", None)
+                            and deps.cancel_event.is_set()
+                        )
+                        await register_background_task(
+                            maybe_continue_goal(
+                                chat_id,
+                                user_id,
+                                full_response.strip(),
+                                was_cancelled,
+                            ),
+                            task_id=f"goal_continue_{chat_id}_{uuid.uuid4().hex}",
+                            description=f"Goal continuation for chat {chat_id}",
+                        )
+                except Exception as e:
+                    logger.debug(f"[goal] continuation scheduling skipped: {e}")
+
     async def process_steer(
         self,
         chat_id: str,

--- a/src/suzent/core/commands/__init__.py
+++ b/src/suzent/core/commands/__init__.py
@@ -8,6 +8,7 @@ from suzent.core.commands.model import handle_model
 from suzent.core.commands.sess import sess_command
 from suzent.core.commands.system import handle_status, handle_clear
 from suzent.core.commands.node import handle_node
+from suzent.core.commands.goal import handle_goal, handle_subgoal
 
 __all__ = [
     "dispatch",
@@ -22,4 +23,6 @@ __all__ = [
     "handle_status",
     "handle_clear",
     "handle_node",
+    "handle_goal",
+    "handle_subgoal",
 ]

--- a/src/suzent/core/commands/goal.py
+++ b/src/suzent/core/commands/goal.py
@@ -12,47 +12,11 @@ from suzent.core.commands.base import register_command, CommandContext
 
 
 def _schedule_step(chat_id: str, user_id: str) -> None:
-    """Kick off the first/next autonomous goal turn as a background task.
+    """Kick off the first/next autonomous goal turn (deferred until the
+    command-response stream finishes — see suzent.core.goals)."""
+    from suzent.core.goals import schedule_goal_step
 
-    Defers until any in-progress stream for this chat has finished so the
-    first goal turn never races with the '/goal set' or '/goal resume'
-    command-response stream that is still being emitted to the client.
-    """
-    import uuid
-    import asyncio
-    from suzent.core.goals import run_goal_step
-    from suzent.core.task_registry import register_background_task
-
-    async def _deferred() -> None:
-        from suzent.core.stream_registry import stream_controls, background_queues
-
-        ctrl = stream_controls.get(chat_id)
-        if ctrl is not None:
-            try:
-                await asyncio.wait_for(ctrl.completed_event.wait(), timeout=30.0)
-            except asyncio.TimeoutError:
-                pass
-
-        bq = background_queues.get(chat_id)
-        if bq is not None and bq.producer_active:
-            try:
-                await asyncio.wait_for(bq.done_event.wait(), timeout=30.0)
-            except asyncio.TimeoutError:
-                pass
-
-        await run_goal_step(chat_id, user_id)
-
-    coro = _deferred()
-    try:
-        asyncio.create_task(
-            register_background_task(
-                coro,
-                task_id=f"goal_step_{chat_id}_{uuid.uuid4().hex}",
-                description=f"Goal step for chat {chat_id}",
-            )
-        )
-    except Exception:
-        coro.close()
+    schedule_goal_step(chat_id, user_id)
 
 
 def _resolve_project_id(chat_id: str):

--- a/src/suzent/core/commands/goal.py
+++ b/src/suzent/core/commands/goal.py
@@ -12,13 +12,37 @@ from suzent.core.commands.base import register_command, CommandContext
 
 
 def _schedule_step(chat_id: str, user_id: str) -> None:
-    """Kick off the first/next autonomous goal turn as a background task."""
+    """Kick off the first/next autonomous goal turn as a background task.
+
+    Defers until any in-progress stream for this chat has finished so the
+    first goal turn never races with the '/goal set' or '/goal resume'
+    command-response stream that is still being emitted to the client.
+    """
     import uuid
     import asyncio
     from suzent.core.goals import run_goal_step
     from suzent.core.task_registry import register_background_task
 
-    coro = run_goal_step(chat_id, user_id)
+    async def _deferred() -> None:
+        from suzent.core.stream_registry import stream_controls, background_queues
+
+        ctrl = stream_controls.get(chat_id)
+        if ctrl is not None:
+            try:
+                await asyncio.wait_for(ctrl.completed_event.wait(), timeout=30.0)
+            except asyncio.TimeoutError:
+                pass
+
+        bq = background_queues.get(chat_id)
+        if bq is not None and bq.producer_active:
+            try:
+                await asyncio.wait_for(bq.done_event.wait(), timeout=30.0)
+            except asyncio.TimeoutError:
+                pass
+
+        await run_goal_step(chat_id, user_id)
+
+    coro = _deferred()
     try:
         asyncio.create_task(
             register_background_task(

--- a/src/suzent/core/commands/goal.py
+++ b/src/suzent/core/commands/goal.py
@@ -1,0 +1,168 @@
+"""Goal-mode slash commands: /goal and /subgoal."""
+
+import typer
+
+from suzent.core.commands.base import register_command, CommandContext
+
+_RESERVED = {"status", "pause", "resume", "clear"}
+
+
+def _schedule_step(chat_id: str, user_id: str) -> None:
+    """Kick off the first/next autonomous goal turn as a background task."""
+    import uuid
+    from suzent.core.goals import run_goal_step
+    from suzent.core.task_registry import register_background_task
+
+    coro = run_goal_step(chat_id, user_id)
+    try:
+        import asyncio
+
+        asyncio.create_task(
+            register_background_task(
+                coro,
+                task_id=f"goal_step_{chat_id}_{uuid.uuid4().hex}",
+                description=f"Goal step for chat {chat_id}",
+            )
+        )
+    except Exception:
+        coro.close()
+
+
+@register_command(
+    ["/goal"],
+    description="Set a standing goal the agent works toward across turns",
+    usage="/goal <objective> | /goal status | pause | resume | clear",
+    surfaces=["cli", "frontend", "social"],
+    category="session",
+)
+def handle_goal(
+    ctx: typer.Context,
+    args: list[str] = typer.Argument(
+        None, help="An objective, or a subcommand: status, pause, resume, clear"
+    ),
+):
+    async def _impl():
+        from suzent.config import CONFIG
+        from suzent.core.goals import (
+            GoalState,
+            STATUS_ACTIVE,
+            STATUS_DONE,
+            STATUS_PAUSED,
+            STATUS_CLEARED,
+            get_goal,
+            save_goal,
+            clear_goal,
+            format_status,
+        )
+
+        cmd_ctx: CommandContext = ctx.obj
+        chat_id = cmd_ctx.chat_id
+        user_id = cmd_ctx.user_id
+        tokens = list(args or [])
+        sub = tokens[0].lower() if tokens else "status"
+
+        if not tokens or sub == "status":
+            return format_status(get_goal(chat_id))
+
+        if sub == "pause":
+            state = get_goal(chat_id)
+            if not state or state.status not in (STATUS_ACTIVE,):
+                return "No active goal to pause."
+            state.status = STATUS_PAUSED
+            save_goal(chat_id, state)
+            return "⏸ Goal paused. Use `/goal resume` to continue."
+
+        if sub == "resume":
+            state = get_goal(chat_id)
+            if not state or state.status == STATUS_CLEARED:
+                return "No goal to resume. Set one with `/goal <objective>`."
+            if state.status == STATUS_DONE:
+                return "Goal already completed. Set a new one with `/goal <objective>`."
+            state.status = STATUS_ACTIVE
+            state.turn = 0
+            state.parse_failures = 0
+            save_goal(chat_id, state)
+            _schedule_step(chat_id, user_id)
+            return f"▶ Goal resumed (max {state.max_turns} turns):\n  {state.objective}"
+
+        if sub == "clear":
+            clear_goal(chat_id)
+            return "🗑 Goal cleared."
+
+        # Otherwise the whole argument is a new objective.
+        objective = " ".join(tokens).strip()
+        if not objective:
+            return "Usage: `/goal <objective>`"
+        state = GoalState(
+            objective=objective,
+            status=STATUS_ACTIVE,
+            turn=0,
+            max_turns=CONFIG.goals_max_turns,
+            subgoals=[],
+        )
+        save_goal(chat_id, state)
+        _schedule_step(chat_id, user_id)
+        return (
+            f"🎯 Goal set: {objective}\n"
+            f"Working autonomously toward it (max {state.max_turns} turns). "
+            "Use `/goal status` to check, `/goal pause` to stop."
+        )
+
+    return _impl
+
+
+@register_command(
+    ["/subgoal"],
+    description="Append an acceptance criterion to the active goal (no loop reset)",
+    usage="/subgoal <text> | /subgoal remove <N> | /subgoal clear",
+    surfaces=["cli", "frontend", "social"],
+    category="session",
+)
+def handle_subgoal(
+    ctx: typer.Context,
+    args: list[str] = typer.Argument(
+        None, help="A criterion, or: remove <N>, clear"
+    ),
+):
+    async def _impl():
+        from suzent.core.goals import STATUS_CLEARED, get_goal, save_goal
+
+        cmd_ctx: CommandContext = ctx.obj
+        chat_id = cmd_ctx.chat_id
+        tokens = list(args or [])
+
+        state = get_goal(chat_id)
+        if not state or state.status == STATUS_CLEARED or not state.objective:
+            return "No active goal. Set one first with `/goal <objective>`."
+
+        if not tokens:
+            if not state.subgoals:
+                return "No sub-goals. Add one with `/subgoal <text>`."
+            listing = "\n".join(
+                f"  {i + 1}. {s}" for i, s in enumerate(state.subgoals)
+            )
+            return f"Sub-goals for the active goal:\n{listing}"
+
+        sub = tokens[0].lower()
+
+        if sub == "clear":
+            state.subgoals = []
+            save_goal(chat_id, state)
+            return "🗑 All sub-goals cleared."
+
+        if sub == "remove":
+            if len(tokens) < 2 or not tokens[1].isdigit():
+                return "Usage: `/subgoal remove <N>`"
+            idx = int(tokens[1]) - 1
+            if idx < 0 or idx >= len(state.subgoals):
+                return f"No sub-goal #{tokens[1]}."
+            removed = state.subgoals.pop(idx)
+            save_goal(chat_id, state)
+            return f"🗑 Removed sub-goal: {removed}"
+
+        text = " ".join(tokens).strip()
+        state.subgoals.append(text)
+        save_goal(chat_id, state)
+        return f"➕ Sub-goal added (#{len(state.subgoals)}): {text}"
+
+    return _impl

--- a/src/suzent/core/commands/goal.py
+++ b/src/suzent/core/commands/goal.py
@@ -1,22 +1,25 @@
-"""Goal-mode slash commands: /goal and /subgoal."""
+"""User-facing goal-mode slash commands: /goal and /subgoal.
+
+Thin wrappers over the canonical GoalModel store (same data the `manage_goal`
+tool and the right-sidebar read), plus the judge-driven continuation loop in
+``suzent.core.goals``. Gives the user direct stop/start control the agent tool
+and read-only sidebar don't provide.
+"""
 
 import typer
 
 from suzent.core.commands.base import register_command, CommandContext
 
-_RESERVED = {"status", "pause", "resume", "clear"}
-
 
 def _schedule_step(chat_id: str, user_id: str) -> None:
     """Kick off the first/next autonomous goal turn as a background task."""
     import uuid
+    import asyncio
     from suzent.core.goals import run_goal_step
     from suzent.core.task_registry import register_background_task
 
     coro = run_goal_step(chat_id, user_id)
     try:
-        import asyncio
-
         asyncio.create_task(
             register_background_task(
                 coro,
@@ -26,6 +29,12 @@ def _schedule_step(chat_id: str, user_id: str) -> None:
         )
     except Exception:
         coro.close()
+
+
+def _resolve_project_id(chat_id: str):
+    from suzent.database import get_database
+
+    return get_database().get_chat_project_id(chat_id)
 
 
 @register_command(
@@ -43,15 +52,10 @@ def handle_goal(
 ):
     async def _impl():
         from suzent.config import CONFIG
+        from suzent.database import get_database
         from suzent.core.goals import (
-            GoalState,
             STATUS_ACTIVE,
-            STATUS_DONE,
             STATUS_PAUSED,
-            STATUS_CLEARED,
-            get_goal,
-            save_goal,
-            clear_goal,
             format_status,
         )
 
@@ -61,50 +65,57 @@ def handle_goal(
         tokens = list(args or [])
         sub = tokens[0].lower() if tokens else "status"
 
+        db = get_database()
+        project_id = _resolve_project_id(chat_id)
+        if not project_id:
+            return "This chat is not linked to a project, so goals are unavailable."
+
         if not tokens or sub == "status":
-            return format_status(get_goal(chat_id))
+            return format_status(db.get_goal(project_id, chat_id=chat_id))
 
         if sub == "pause":
-            state = get_goal(chat_id)
-            if not state or state.status not in (STATUS_ACTIVE,):
+            goal = db.get_goal(project_id, chat_id=chat_id)
+            if not goal or goal.status != STATUS_ACTIVE:
                 return "No active goal to pause."
-            state.status = STATUS_PAUSED
-            save_goal(chat_id, state)
+            db.update_goal(goal.id, status=STATUS_PAUSED)
             return "⏸ Goal paused. Use `/goal resume` to continue."
 
         if sub == "resume":
-            state = get_goal(chat_id)
-            if not state or state.status == STATUS_CLEARED:
+            goal = db.get_goal(project_id, chat_id=chat_id)
+            if not goal:
                 return "No goal to resume. Set one with `/goal <objective>`."
-            if state.status == STATUS_DONE:
-                return "Goal already completed. Set a new one with `/goal <objective>`."
-            state.status = STATUS_ACTIVE
-            state.turn = 0
-            state.parse_failures = 0
-            save_goal(chat_id, state)
+            db.update_goal(goal.id, status=STATUS_ACTIVE, turns_elapsed=0)
             _schedule_step(chat_id, user_id)
-            return f"▶ Goal resumed (max {state.max_turns} turns):\n  {state.objective}"
+            return f"▶ Goal resumed:\n  {goal.objective}"
 
         if sub == "clear":
-            clear_goal(chat_id)
+            if not db.get_goal(project_id, chat_id=chat_id):
+                return "No active goal to clear."
+            db.clear_goal(project_id, chat_id=chat_id)
             return "🗑 Goal cleared."
 
         # Otherwise the whole argument is a new objective.
         objective = " ".join(tokens).strip()
         if not objective:
             return "Usage: `/goal <objective>`"
-        state = GoalState(
-            objective=objective,
-            status=STATUS_ACTIVE,
-            turn=0,
-            max_turns=CONFIG.goals_max_turns,
-            subgoals=[],
-        )
-        save_goal(chat_id, state)
+        max_turns = CONFIG.goals_max_turns
+        existing = db.get_goal(project_id, chat_id=chat_id)
+        if existing:
+            db.update_goal(
+                existing.id,
+                objective=objective,
+                status=STATUS_ACTIVE,
+                turns_elapsed=0,
+                max_turns=max_turns,
+            )
+        else:
+            db.create_goal(
+                project_id, objective, chat_id=chat_id, max_turns=max_turns
+            )
         _schedule_step(chat_id, user_id)
         return (
             f"🎯 Goal set: {objective}\n"
-            f"Working autonomously toward it (max {state.max_turns} turns). "
+            f"Working autonomously toward it (max {max_turns} turns). "
             "Use `/goal status` to check, `/goal pause` to stop."
         )
 
@@ -125,44 +136,48 @@ def handle_subgoal(
     ),
 ):
     async def _impl():
-        from suzent.core.goals import STATUS_CLEARED, get_goal, save_goal
+        from suzent.database import get_database
 
         cmd_ctx: CommandContext = ctx.obj
         chat_id = cmd_ctx.chat_id
         tokens = list(args or [])
 
-        state = get_goal(chat_id)
-        if not state or state.status == STATUS_CLEARED or not state.objective:
+        db = get_database()
+        project_id = _resolve_project_id(chat_id)
+        if not project_id:
+            return "This chat is not linked to a project, so goals are unavailable."
+
+        goal = db.get_goal(project_id, chat_id=chat_id)
+        if not goal:
             return "No active goal. Set one first with `/goal <objective>`."
 
+        subgoals = list(goal.subgoals or [])
+
         if not tokens:
-            if not state.subgoals:
+            if not subgoals:
                 return "No sub-goals. Add one with `/subgoal <text>`."
-            listing = "\n".join(
-                f"  {i + 1}. {s}" for i, s in enumerate(state.subgoals)
-            )
+            listing = "\n".join(f"  {i + 1}. {s}" for i, s in enumerate(subgoals))
             return f"Sub-goals for the active goal:\n{listing}"
 
         sub = tokens[0].lower()
 
         if sub == "clear":
-            state.subgoals = []
-            save_goal(chat_id, state)
+            db.update_goal(goal.id, subgoals=[])
             return "🗑 All sub-goals cleared."
 
         if sub == "remove":
             if len(tokens) < 2 or not tokens[1].isdigit():
                 return "Usage: `/subgoal remove <N>`"
             idx = int(tokens[1]) - 1
-            if idx < 0 or idx >= len(state.subgoals):
+            if idx < 0 or idx >= len(subgoals):
                 return f"No sub-goal #{tokens[1]}."
-            removed = state.subgoals.pop(idx)
-            save_goal(chat_id, state)
+            removed = subgoals.pop(idx)
+            db.update_goal(goal.id, subgoals=subgoals)
             return f"🗑 Removed sub-goal: {removed}"
 
         text = " ".join(tokens).strip()
-        state.subgoals.append(text)
-        save_goal(chat_id, state)
-        return f"➕ Sub-goal added (#{len(state.subgoals)}): {text}"
+        subgoals.append(text)
+        db.update_goal(goal.id, subgoals=subgoals)
+        return f"➕ Sub-goal added (#{len(subgoals)}): {text}"
 
     return _impl

--- a/src/suzent/core/goals.py
+++ b/src/suzent/core/goals.py
@@ -1,50 +1,48 @@
 """
-Goal mode: persistent, self-continuing objectives ("Ralph loop").
+Goal mode: judge-driven automatic continuation on top of the project Goal system.
 
-A goal is a standing objective the agent works toward across multiple turns
-without the user re-prompting each time. After every non-heartbeat turn an
-auxiliary *judge* model (a single, stateless LLM call — never a full agent) is
-asked whether the goal is fully satisfied. If not, and the turn budget is not
-exhausted, the agent is automatically run again with a continuation prompt.
-
-State lives in ``chat.config["goal"]`` so it survives restarts and resumes,
-exactly like the heartbeat configuration. Control flow:
+The canonical goal store is ``GoalModel`` (project + chat scoped), also driven
+by the ``manage_goal`` tool, the per-turn ``plan_reminder_hook`` (which injects
+the active goal and increments ``turns_elapsed``), and surfaced in the frontend
+right sidebar. This module adds the piece that store lacks: a standing-goal
+*continuation loop* — after each non-heartbeat turn an auxiliary **judge** model
+(a single, stateless LLM call — never a full agent) decides whether the goal is
+satisfied, and if not, automatically runs the agent again until it is done or the
+turn budget is exhausted.
 
     /goal <text>            -> run_goal_step (turn 1)
     turn completes          -> maybe_continue_goal (judge)
-        verdict DONE        -> status = done
-        verdict CONTINUE    -> run_goal_step (turn N+1)
+        verdict DONE        -> status = completed
+        verdict CONTINUE    -> run_goal_step (next turn)
         budget exhausted    -> status = paused
 
-Any real user turn also passes through ``maybe_continue_goal``, so a manual
-message naturally preempts and then re-drives the loop.
+Turn counting is owned by ``plan_reminder_hook`` (it increments ``turns_elapsed``
+each turn); this module only *reads* the budget. State, status, and subgoals all
+live on ``GoalModel`` so the sidebar and the ``manage_goal`` tool stay in sync.
 """
 
 from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
 from typing import Optional
 
-from suzent.config import CONFIG
 from suzent.database import get_database
 from suzent.logger import get_logger
 
 logger = get_logger(__name__)
 
-GOAL_CONFIG_KEY = "goal"
-
-# Status values for a goal.
+# GoalModel statuses.
 STATUS_ACTIVE = "active"
 STATUS_PAUSED = "paused"
-STATUS_DONE = "done"
-STATUS_CLEARED = "cleared"
+STATUS_COMPLETED = "completed"
+STATUS_CANCELLED = "cancelled"
 
-# Consecutive judge parse failures tolerated before auto-pausing and asking the
-# user to configure a stronger judge model.
+# Consecutive judge parse failures tolerated before auto-pausing. Tracked in
+# memory (keyed by goal id) — it is a transient safety valve, not durable state.
 MAX_PARSE_FAILURES = 3
+_parse_failures: dict[int, int] = {}
 
 
 JUDGE_SYSTEM_PROMPT = (
@@ -59,71 +57,23 @@ JUDGE_SYSTEM_PROMPT = (
 )
 
 
-@dataclass
-class GoalState:
-    """Persistent state for a single chat's standing goal."""
+# ─── Goal resolution (canonical GoalModel store) ─────────────────────────────
 
-    objective: str
-    status: str = STATUS_ACTIVE
-    turn: int = 0
-    max_turns: int = 20
-    subgoals: list[str] = field(default_factory=list)
-    parse_failures: int = 0
 
-    def to_dict(self) -> dict:
-        return asdict(self)
-
-    @classmethod
-    def from_dict(cls, data: dict) -> Optional["GoalState"]:
-        if not isinstance(data, dict) or not data.get("objective"):
+def resolve_goal(chat_id: str):
+    """Return (project_id, GoalModel) for the chat's active/paused goal, or None."""
+    try:
+        db = get_database()
+        project_id = db.get_chat_project_id(chat_id)
+        if not project_id:
             return None
-        return cls(
-            objective=str(data.get("objective", "")),
-            status=str(data.get("status", STATUS_ACTIVE)),
-            turn=int(data.get("turn", 0) or 0),
-            max_turns=int(data.get("max_turns", CONFIG.goals_max_turns) or 0),
-            subgoals=[str(s) for s in (data.get("subgoals") or [])],
-            parse_failures=int(data.get("parse_failures", 0) or 0),
-        )
-
-
-# ─── Persistence ───────────────────────────────────────────────────────────
-
-
-def get_goal(chat_id: str) -> Optional[GoalState]:
-    """Load the goal state for a chat, or None if none is set."""
-    try:
-        chat = get_database().get_chat(chat_id)
+        goal = db.get_goal(project_id, chat_id=chat_id)
+        if not goal:
+            return None
+        return project_id, goal
     except Exception as e:
-        logger.debug(f"[goal] get_goal failed for {chat_id}: {e}")
+        logger.debug(f"[goal] resolve_goal failed for {chat_id}: {e}")
         return None
-    if not chat:
-        return None
-    return GoalState.from_dict((chat.config or {}).get(GOAL_CONFIG_KEY))
-
-
-def save_goal(chat_id: str, state: GoalState) -> None:
-    """Persist goal state into ``chat.config['goal']``."""
-    try:
-        get_database().merge_chat_config(chat_id, {GOAL_CONFIG_KEY: state.to_dict()})
-    except Exception as e:
-        logger.warning(f"[goal] save_goal failed for {chat_id}: {e}")
-
-
-def clear_goal(chat_id: str) -> None:
-    """Remove the goal from a chat's config."""
-    try:
-        state = get_goal(chat_id)
-        if state is None:
-            return
-        state.status = STATUS_CLEARED
-        # Keep the record but mark it cleared so /goal status reads cleanly,
-        # then drop the heavy fields by overwriting with a minimal marker.
-        get_database().merge_chat_config(
-            chat_id, {GOAL_CONFIG_KEY: {"objective": "", "status": STATUS_CLEARED}}
-        )
-    except Exception as e:
-        logger.warning(f"[goal] clear_goal failed for {chat_id}: {e}")
 
 
 # ─── Judge (single stateless LLM call) ───────────────────────────────────────
@@ -209,19 +159,17 @@ async def judge_goal(
 # ─── Continuation loop ───────────────────────────────────────────────────────
 
 
-def _build_continuation_prompt(state: GoalState) -> str:
-    parts = [
-        f"[Goal mode — step {state.turn}/{state.max_turns}] "
-        "You are autonomously working toward a standing goal. Do not ask the user "
-        "for confirmation or wait for further input — take the next concrete action "
-        "yourself. When the goal is fully achieved, state clearly that it is complete.",
-        f"GOAL:\n{state.objective}",
-    ]
-    if state.subgoals:
-        numbered = "\n".join(f"{i + 1}. {s}" for i, s in enumerate(state.subgoals))
-        parts.append("SUB-GOALS (all must be satisfied):\n" + numbered)
-    parts.append("Continue now with the next concrete step.")
-    return "\n\n".join(parts)
+CONTINUATION_PROMPT = (
+    "[Goal mode] You are autonomously continuing toward your active goal (shown "
+    "in the goal reminder above). Do not wait for the user — take the next "
+    "concrete action now. When the goal is fully achieved, call "
+    "manage_goal(action='clear'); if you cannot make progress, call "
+    "manage_goal(action='pause') and explain why."
+)
+
+
+def _budget_exhausted(goal) -> bool:
+    return bool(goal.max_turns) and goal.turns_elapsed >= goal.max_turns
 
 
 def _goal_config_override() -> dict:
@@ -249,8 +197,11 @@ async def run_goal_step(chat_id: str, user_id: str) -> None:
     """Run one autonomous turn toward the active goal, if appropriate."""
     from suzent.core.stream_registry import stream_controls
 
-    state = get_goal(chat_id)
-    if not state or state.status != STATUS_ACTIVE:
+    resolved = resolve_goal(chat_id)
+    if not resolved:
+        return
+    _project_id, goal = resolved
+    if goal.status != STATUS_ACTIVE:
         return
 
     # Another turn is already streaming for this chat (e.g. a real user message).
@@ -259,21 +210,22 @@ async def run_goal_step(chat_id: str, user_id: str) -> None:
         logger.debug(f"[goal] step skipped for {chat_id}: stream already active")
         return
 
-    if state.turn >= state.max_turns:
-        state.status = STATUS_PAUSED
-        save_goal(chat_id, state)
+    if _budget_exhausted(goal):
+        get_database().update_goal(goal.id, status=STATUS_PAUSED)
         notify_goal(
             chat_id,
-            f"⏸ Goal paused — {state.turn}/{state.max_turns} turns used. "
+            f"⏸ Goal paused — {goal.turns_elapsed}/{goal.max_turns} turns used. "
             "Use /goal resume to continue.",
         )
         return
 
-    state.turn += 1
-    save_goal(chat_id, state)
-    notify_goal(chat_id, f"↻ Continuing toward goal ({state.turn}/{state.max_turns})")
+    turns_label = (
+        f"{goal.turns_elapsed + 1}/{goal.max_turns}"
+        if goal.max_turns
+        else str(goal.turns_elapsed + 1)
+    )
+    notify_goal(chat_id, f"↻ Continuing toward goal ({turns_label})")
 
-    prompt = _build_continuation_prompt(state)
     try:
         from suzent.core.chat_processor import ChatProcessor
 
@@ -282,7 +234,7 @@ async def run_goal_step(chat_id: str, user_id: str) -> None:
             user_id=user_id,
             message_content="",
             config_override=_goal_config_override(),
-            system_reminders=[prompt],
+            system_reminders=[CONTINUATION_PROMPT],
         )
     except Exception as e:
         logger.error(f"[goal] step execution failed for {chat_id}: {e}")
@@ -295,8 +247,11 @@ async def maybe_continue_goal(
 
     Called after every non-heartbeat turn. A cheap no-op unless a goal is active.
     """
-    state = get_goal(chat_id)
-    if not state or state.status != STATUS_ACTIVE:
+    resolved = resolve_goal(chat_id)
+    if not resolved:
+        return
+    _project_id, goal = resolved
+    if goal.status != STATUS_ACTIVE:
         return
 
     # User interrupted this turn (steer / stop). Halt the loop but keep the goal
@@ -305,57 +260,67 @@ async def maybe_continue_goal(
         logger.debug(f"[goal] continuation halted for {chat_id}: turn was cancelled")
         return
 
+    db = get_database()
     verdict, reason, parse_failed = await judge_goal(
-        state.objective, state.subgoals, last_response
+        goal.objective, list(goal.subgoals or []), last_response
     )
 
     if parse_failed:
-        state.parse_failures += 1
-        if state.parse_failures >= MAX_PARSE_FAILURES:
-            state.status = STATUS_PAUSED
-            save_goal(chat_id, state)
+        count = _parse_failures.get(goal.id, 0) + 1
+        _parse_failures[goal.id] = count
+        if count >= MAX_PARSE_FAILURES:
+            _parse_failures.pop(goal.id, None)
+            db.update_goal(goal.id, status=STATUS_PAUSED)
             notify_goal(
                 chat_id,
                 "⏸ Goal paused — the judge model returned unparseable verdicts "
-                f"{state.parse_failures}× in a row. Configure a stronger 'cheap' "
-                "model, then /goal resume.",
+                f"{count}× in a row. Configure a stronger 'cheap' model, then "
+                "/goal resume.",
             )
             return
-        save_goal(chat_id, state)
         await run_goal_step(chat_id, user_id)  # fail open: keep going
         return
 
-    state.parse_failures = 0
+    _parse_failures.pop(goal.id, None)
 
     if verdict == "done":
-        state.status = STATUS_DONE
-        save_goal(chat_id, state)
+        db.update_goal(
+            goal.id,
+            status=STATUS_COMPLETED,
+            completed_at=datetime.now(timezone.utc),
+        )
         notify_goal(chat_id, f"✓ Goal achieved: {reason}")
         return
 
-    save_goal(chat_id, state)
+    if _budget_exhausted(goal):
+        db.update_goal(goal.id, status=STATUS_PAUSED)
+        notify_goal(
+            chat_id,
+            f"⏸ Goal paused — {goal.turns_elapsed}/{goal.max_turns} turns used. "
+            "Use /goal resume to continue.",
+        )
+        return
+
     await run_goal_step(chat_id, user_id)
 
 
-# ─── Display helpers ─────────────────────────────────────────────────────────
+# ─── Display helper (for /goal status) ───────────────────────────────────────
 
 
-def format_status(state: Optional[GoalState]) -> str:
-    """Render a human-readable status block for /goal status."""
-    if not state or not state.objective or state.status == STATUS_CLEARED:
+def format_status(goal) -> str:
+    """Render a human-readable status block for /goal status (takes a GoalModel)."""
+    if not goal or goal.status in (STATUS_COMPLETED, STATUS_CANCELLED):
         return "No active goal. Set one with `/goal <objective>`."
 
-    icon = {
-        STATUS_ACTIVE: "🎯",
-        STATUS_PAUSED: "⏸",
-        STATUS_DONE: "✓",
-    }.get(state.status, "🎯")
-
+    icon = {STATUS_ACTIVE: "🎯", STATUS_PAUSED: "⏸"}.get(goal.status, "🎯")
+    turns = f"{goal.turns_elapsed}/{goal.max_turns}" if goal.max_turns else str(
+        goal.turns_elapsed
+    )
     lines = [
-        f"{icon} **Goal** ({state.status}) — turn {state.turn}/{state.max_turns}",
-        f"  {state.objective}",
+        f"{icon} **Goal** ({goal.status}) — turn {turns}",
+        f"  {goal.objective}",
     ]
-    if state.subgoals:
+    if goal.subgoals:
         lines.append("  Sub-goals:")
-        lines.extend(f"    {i + 1}. {s}" for i, s in enumerate(state.subgoals))
+        lines.extend(f"    {i + 1}. {s}" for i, s in enumerate(goal.subgoals))
     return "\n".join(lines)

--- a/src/suzent/core/goals.py
+++ b/src/suzent/core/goals.py
@@ -1,0 +1,361 @@
+"""
+Goal mode: persistent, self-continuing objectives ("Ralph loop").
+
+A goal is a standing objective the agent works toward across multiple turns
+without the user re-prompting each time. After every non-heartbeat turn an
+auxiliary *judge* model (a single, stateless LLM call — never a full agent) is
+asked whether the goal is fully satisfied. If not, and the turn budget is not
+exhausted, the agent is automatically run again with a continuation prompt.
+
+State lives in ``chat.config["goal"]`` so it survives restarts and resumes,
+exactly like the heartbeat configuration. Control flow:
+
+    /goal <text>            -> run_goal_step (turn 1)
+    turn completes          -> maybe_continue_goal (judge)
+        verdict DONE        -> status = done
+        verdict CONTINUE    -> run_goal_step (turn N+1)
+        budget exhausted    -> status = paused
+
+Any real user turn also passes through ``maybe_continue_goal``, so a manual
+message naturally preempts and then re-drives the loop.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from typing import Optional
+
+from suzent.config import CONFIG
+from suzent.database import get_database
+from suzent.logger import get_logger
+
+logger = get_logger(__name__)
+
+GOAL_CONFIG_KEY = "goal"
+
+# Status values for a goal.
+STATUS_ACTIVE = "active"
+STATUS_PAUSED = "paused"
+STATUS_DONE = "done"
+STATUS_CLEARED = "cleared"
+
+# Consecutive judge parse failures tolerated before auto-pausing and asking the
+# user to configure a stronger judge model.
+MAX_PARSE_FAILURES = 3
+
+
+JUDGE_SYSTEM_PROMPT = (
+    "You are a strict goal-completion judge for an autonomous AI agent. "
+    "You are given a goal (and optional sub-goals) plus the agent's most recent "
+    "response. Your only job is to decide whether the goal is FULLY satisfied by "
+    "the work done so far. Be strict: require concrete evidence of completion, "
+    "not promises, intentions, or partial progress. When sub-goals are present, "
+    "the goal is done only when the main goal AND every sub-goal are satisfied. "
+    'Reply with a single line of minified JSON and nothing else: '
+    '{"done": <true|false>, "reason": "<one short sentence>"}.'
+)
+
+
+@dataclass
+class GoalState:
+    """Persistent state for a single chat's standing goal."""
+
+    objective: str
+    status: str = STATUS_ACTIVE
+    turn: int = 0
+    max_turns: int = 20
+    subgoals: list[str] = field(default_factory=list)
+    parse_failures: int = 0
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Optional["GoalState"]:
+        if not isinstance(data, dict) or not data.get("objective"):
+            return None
+        return cls(
+            objective=str(data.get("objective", "")),
+            status=str(data.get("status", STATUS_ACTIVE)),
+            turn=int(data.get("turn", 0) or 0),
+            max_turns=int(data.get("max_turns", CONFIG.goals_max_turns) or 0),
+            subgoals=[str(s) for s in (data.get("subgoals") or [])],
+            parse_failures=int(data.get("parse_failures", 0) or 0),
+        )
+
+
+# ─── Persistence ───────────────────────────────────────────────────────────
+
+
+def get_goal(chat_id: str) -> Optional[GoalState]:
+    """Load the goal state for a chat, or None if none is set."""
+    try:
+        chat = get_database().get_chat(chat_id)
+    except Exception as e:
+        logger.debug(f"[goal] get_goal failed for {chat_id}: {e}")
+        return None
+    if not chat:
+        return None
+    return GoalState.from_dict((chat.config or {}).get(GOAL_CONFIG_KEY))
+
+
+def save_goal(chat_id: str, state: GoalState) -> None:
+    """Persist goal state into ``chat.config['goal']``."""
+    try:
+        get_database().merge_chat_config(chat_id, {GOAL_CONFIG_KEY: state.to_dict()})
+    except Exception as e:
+        logger.warning(f"[goal] save_goal failed for {chat_id}: {e}")
+
+
+def clear_goal(chat_id: str) -> None:
+    """Remove the goal from a chat's config."""
+    try:
+        state = get_goal(chat_id)
+        if state is None:
+            return
+        state.status = STATUS_CLEARED
+        # Keep the record but mark it cleared so /goal status reads cleanly,
+        # then drop the heavy fields by overwriting with a minimal marker.
+        get_database().merge_chat_config(
+            chat_id, {GOAL_CONFIG_KEY: {"objective": "", "status": STATUS_CLEARED}}
+        )
+    except Exception as e:
+        logger.warning(f"[goal] clear_goal failed for {chat_id}: {e}")
+
+
+# ─── Judge (single stateless LLM call) ───────────────────────────────────────
+
+
+def _parse_verdict(raw: str) -> Optional[tuple[bool, str]]:
+    """Parse a judge response into (done, reason), or None if unparseable."""
+    if not raw or not raw.strip():
+        return None
+    text = raw.strip()
+    # Find the first JSON object in the response (judges sometimes add prose).
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if match:
+        text = match.group(0)
+    try:
+        data = json.loads(text)
+    except Exception:
+        return None
+    if not isinstance(data, dict) or "done" not in data:
+        return None
+    done = data.get("done")
+    if isinstance(done, str):
+        done = done.strip().lower() in {"true", "yes", "1"}
+    reason = str(data.get("reason", "")).strip()
+    return bool(done), reason
+
+
+def _build_judge_user_prompt(
+    objective: str, subgoals: list[str], last_response: str
+) -> str:
+    parts = [f"GOAL:\n{objective}"]
+    if subgoals:
+        numbered = "\n".join(f"{i + 1}. {s}" for i, s in enumerate(subgoals))
+        parts.append(
+            "SUB-GOALS (all must be satisfied, with concrete evidence):\n" + numbered
+        )
+    parts.append("AGENT'S LATEST RESPONSE:\n" + (last_response or "")[:4000])
+    parts.append(f"Current time: {datetime.now(timezone.utc).isoformat()}")
+    parts.append("Is the goal fully satisfied? Respond with JSON only.")
+    return "\n\n".join(parts)
+
+
+async def judge_goal(
+    objective: str, subgoals: list[str], last_response: str
+) -> tuple[str, str, bool]:
+    """Ask the judge model whether the goal is satisfied.
+
+    Returns ``(verdict, reason, parse_failed)`` where verdict is ``"done"`` or
+    ``"continue"``. Both parse failures and transport errors fail OPEN (continue)
+    so a flaky judge never wedges progress — the turn budget is the real backstop.
+    Only genuine parse failures set ``parse_failed`` (which drives the auto-pause
+    after repeated unparseable verdicts).
+    """
+    from suzent.core.role_router import get_role_router
+    from suzent.llm import LLMClient
+
+    model = get_role_router().get_model_id("cheap")
+    if not model:
+        logger.warning("[goal] no judge model configured; failing open (continue)")
+        return "continue", "no judge model configured", True
+
+    try:
+        raw = await LLMClient(model=model).complete(
+            prompt=_build_judge_user_prompt(objective, subgoals, last_response),
+            system=JUDGE_SYSTEM_PROMPT,
+            temperature=0.0,
+            max_tokens=200,
+            reasoning_effort="none",
+        )
+    except Exception as e:
+        logger.warning(f"[goal] judge call failed ({e}); failing open (continue)")
+        return "continue", f"judge error: {e}", False
+
+    parsed = _parse_verdict(raw)
+    if parsed is None:
+        logger.warning(f"[goal] unparseable judge verdict: {raw!r}")
+        return "continue", "unparseable judge response", True
+
+    done, reason = parsed
+    return ("done" if done else "continue"), reason, False
+
+
+# ─── Continuation loop ───────────────────────────────────────────────────────
+
+
+def _build_continuation_prompt(state: GoalState) -> str:
+    parts = [
+        f"[Goal mode — step {state.turn}/{state.max_turns}] "
+        "You are autonomously working toward a standing goal. Do not ask the user "
+        "for confirmation or wait for further input — take the next concrete action "
+        "yourself. When the goal is fully achieved, state clearly that it is complete.",
+        f"GOAL:\n{state.objective}",
+    ]
+    if state.subgoals:
+        numbered = "\n".join(f"{i + 1}. {s}" for i, s in enumerate(state.subgoals))
+        parts.append("SUB-GOALS (all must be satisfied):\n" + numbered)
+    parts.append("Continue now with the next concrete step.")
+    return "\n\n".join(parts)
+
+
+def _goal_config_override() -> dict:
+    """Config for autonomous goal turns: auto-approve tools, memory on."""
+    from suzent.agent_manager import build_agent_config
+
+    base: dict = {"memory_enabled": True, "auto_approve_tools": True}
+    return build_agent_config(base, require_social_tool=False)
+
+
+def notify_goal(chat_id: str, message: str) -> None:
+    """Surface a goal status line via the scheduler notification deque (status bar)."""
+    try:
+        from suzent.core.scheduler import get_active_scheduler
+
+        scheduler = get_active_scheduler()
+        if scheduler is not None:
+            scheduler.add_notification("goal", f"{chat_id[:8]}: {message}")
+    except Exception:
+        pass
+    logger.info(f"[goal] {chat_id}: {message}")
+
+
+async def run_goal_step(chat_id: str, user_id: str) -> None:
+    """Run one autonomous turn toward the active goal, if appropriate."""
+    from suzent.core.stream_registry import stream_controls
+
+    state = get_goal(chat_id)
+    if not state or state.status != STATUS_ACTIVE:
+        return
+
+    # Another turn is already streaming for this chat (e.g. a real user message).
+    # Let that turn drive the loop instead so we never run two turns at once.
+    if chat_id in stream_controls:
+        logger.debug(f"[goal] step skipped for {chat_id}: stream already active")
+        return
+
+    if state.turn >= state.max_turns:
+        state.status = STATUS_PAUSED
+        save_goal(chat_id, state)
+        notify_goal(
+            chat_id,
+            f"⏸ Goal paused — {state.turn}/{state.max_turns} turns used. "
+            "Use /goal resume to continue.",
+        )
+        return
+
+    state.turn += 1
+    save_goal(chat_id, state)
+    notify_goal(chat_id, f"↻ Continuing toward goal ({state.turn}/{state.max_turns})")
+
+    prompt = _build_continuation_prompt(state)
+    try:
+        from suzent.core.chat_processor import ChatProcessor
+
+        await ChatProcessor().process_background_turn(
+            chat_id=chat_id,
+            user_id=user_id,
+            message_content="",
+            config_override=_goal_config_override(),
+            system_reminders=[prompt],
+        )
+    except Exception as e:
+        logger.error(f"[goal] step execution failed for {chat_id}: {e}")
+
+
+async def maybe_continue_goal(
+    chat_id: str, user_id: str, last_response: str, was_cancelled: bool
+) -> None:
+    """Post-turn hook: judge the goal and auto-continue or finish.
+
+    Called after every non-heartbeat turn. A cheap no-op unless a goal is active.
+    """
+    state = get_goal(chat_id)
+    if not state or state.status != STATUS_ACTIVE:
+        return
+
+    # User interrupted this turn (steer / stop). Halt the loop but keep the goal
+    # active; the next real user turn (or /goal resume) re-enters the loop.
+    if was_cancelled:
+        logger.debug(f"[goal] continuation halted for {chat_id}: turn was cancelled")
+        return
+
+    verdict, reason, parse_failed = await judge_goal(
+        state.objective, state.subgoals, last_response
+    )
+
+    if parse_failed:
+        state.parse_failures += 1
+        if state.parse_failures >= MAX_PARSE_FAILURES:
+            state.status = STATUS_PAUSED
+            save_goal(chat_id, state)
+            notify_goal(
+                chat_id,
+                "⏸ Goal paused — the judge model returned unparseable verdicts "
+                f"{state.parse_failures}× in a row. Configure a stronger 'cheap' "
+                "model, then /goal resume.",
+            )
+            return
+        save_goal(chat_id, state)
+        await run_goal_step(chat_id, user_id)  # fail open: keep going
+        return
+
+    state.parse_failures = 0
+
+    if verdict == "done":
+        state.status = STATUS_DONE
+        save_goal(chat_id, state)
+        notify_goal(chat_id, f"✓ Goal achieved: {reason}")
+        return
+
+    save_goal(chat_id, state)
+    await run_goal_step(chat_id, user_id)
+
+
+# ─── Display helpers ─────────────────────────────────────────────────────────
+
+
+def format_status(state: Optional[GoalState]) -> str:
+    """Render a human-readable status block for /goal status."""
+    if not state or not state.objective or state.status == STATUS_CLEARED:
+        return "No active goal. Set one with `/goal <objective>`."
+
+    icon = {
+        STATUS_ACTIVE: "🎯",
+        STATUS_PAUSED: "⏸",
+        STATUS_DONE: "✓",
+    }.get(state.status, "🎯")
+
+    lines = [
+        f"{icon} **Goal** ({state.status}) — turn {state.turn}/{state.max_turns}",
+        f"  {state.objective}",
+    ]
+    if state.subgoals:
+        lines.append("  Sub-goals:")
+        lines.extend(f"    {i + 1}. {s}" for i, s in enumerate(state.subgoals))
+    return "\n".join(lines)

--- a/src/suzent/core/goals.py
+++ b/src/suzent/core/goals.py
@@ -240,6 +240,51 @@ async def run_goal_step(chat_id: str, user_id: str) -> None:
         logger.error(f"[goal] step execution failed for {chat_id}: {e}")
 
 
+def schedule_goal_step(chat_id: str, user_id: str) -> None:
+    """Kick off the first/next autonomous goal turn as a background task.
+
+    Defers until any in-progress stream for this chat has finished so the
+    first goal turn never races with a still-emitting command-response or
+    foreground stream (which would otherwise be terminated when this turn
+    registers its own background stream). The 30 s caps are safety valves.
+    """
+    import asyncio
+    import uuid
+
+    from suzent.core.task_registry import register_background_task
+
+    async def _deferred() -> None:
+        from suzent.core.stream_registry import background_queues, stream_controls
+
+        ctrl = stream_controls.get(chat_id)
+        if ctrl is not None:
+            try:
+                await asyncio.wait_for(ctrl.completed_event.wait(), timeout=30.0)
+            except asyncio.TimeoutError:
+                pass
+
+        bq = background_queues.get(chat_id)
+        if bq is not None and bq.producer_active:
+            try:
+                await asyncio.wait_for(bq.done_event.wait(), timeout=30.0)
+            except asyncio.TimeoutError:
+                pass
+
+        await run_goal_step(chat_id, user_id)
+
+    coro = _deferred()
+    try:
+        asyncio.create_task(
+            register_background_task(
+                coro,
+                task_id=f"goal_step_{chat_id}_{uuid.uuid4().hex}",
+                description=f"Goal step for chat {chat_id}",
+            )
+        )
+    except Exception:
+        coro.close()
+
+
 async def maybe_continue_goal(
     chat_id: str, user_id: str, last_response: str, was_cancelled: bool
 ) -> None:

--- a/src/suzent/core/scheduler.py
+++ b/src/suzent/core/scheduler.py
@@ -176,6 +176,17 @@ class SchedulerBrain(BaseBrain):
         self._pending_notifications.clear()
         return notifications
 
+    def add_notification(self, source: str, result: str) -> None:
+        """Queue a status-bar notification from a non-cron source (e.g. goal mode)."""
+        self._pending_notifications.append(
+            {
+                "job_id": None,
+                "job_name": source,
+                "result": result[:500],
+                "timestamp": datetime.now().isoformat(),
+            }
+        )
+
     # -- Internal ------------------------------------------------------------
 
     def _initialize_schedules(self):

--- a/src/suzent/core/stream_registry.py
+++ b/src/suzent/core/stream_registry.py
@@ -176,18 +176,22 @@ class _BusStreamQueue:
         # returns False as soon as the producer finishes, even if a late
         # /chat/live client hasn't drained the queue yet.
         self.producer_active: bool = True
+        # Set when the None sentinel is put; lets waiters avoid spinning.
+        self.done_event: asyncio.Event = asyncio.Event()
 
     # --- write side ---
 
     async def put(self, item) -> None:
         if item is None:
             self.producer_active = False
+            self.done_event.set()
         await self._q.put(item)
         _fan_chunk_to_bus(self.chat_id, item)
 
     def put_nowait(self, item) -> None:
         if item is None:
             self.producer_active = False
+            self.done_event.set()
         self._q.put_nowait(item)
         _fan_chunk_to_bus(self.chat_id, item)
 

--- a/src/suzent/routes/goal_task_routes.py
+++ b/src/suzent/routes/goal_task_routes.py
@@ -66,6 +66,51 @@ async def get_project_goal(request: Request) -> JSONResponse:
         return JSONResponse({"error": str(e)}, status_code=500)
 
 
+async def update_project_goal(request: Request) -> JSONResponse:
+    """Pause / resume / clear the active goal for a chat (sidebar controls).
+
+    Body JSON: { project_id, chat_id, action }  where action is one of
+    "pause", "resume", "clear". Resuming re-enters the autonomous
+    continuation loop, mirroring the `/goal resume` command. Returns the
+    updated goal (or null if it was cleared / none exists).
+    """
+    try:
+        body = await request.json()
+        project_id = body.get("project_id")
+        chat_id = body.get("chat_id")
+        action = (body.get("action") or "").strip().lower()
+        if not project_id or not chat_id:
+            return JSONResponse(
+                {"error": "project_id and chat_id are required"}, status_code=400
+            )
+        if action not in {"pause", "resume", "clear"}:
+            return JSONResponse(
+                {"error": "action must be pause, resume, or clear"}, status_code=400
+            )
+
+        db = get_database()
+        goal = db.get_goal(project_id, chat_id=chat_id)
+        if not goal:
+            return JSONResponse(None)
+
+        if action == "pause":
+            if goal.status == "active":
+                goal = db.update_goal(goal.id, status="paused")
+        elif action == "resume":
+            goal = db.update_goal(goal.id, status="active", turns_elapsed=0)
+            from suzent.config import CONFIG
+            from suzent.core.goals import schedule_goal_step
+
+            schedule_goal_step(chat_id, CONFIG.user_id)
+        elif action == "clear":
+            db.clear_goal(project_id, chat_id=chat_id)
+            return JSONResponse(None)
+
+        return JSONResponse(_goal_to_dict(goal) if goal else None)
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
 async def get_project_tasks(request: Request) -> JSONResponse:
     """Return tasks for a chat (chat-scoped).
 

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -106,6 +106,7 @@ from suzent.routes.sync_routes import (
 )
 from suzent.routes.goal_task_routes import (
     get_project_goal,
+    update_project_goal,
     get_project_tasks,
     get_project_kanban,
     create_project_task,
@@ -701,6 +702,7 @@ app = Starlette(
         Route("/projects/{project_id}", delete_project, methods=["DELETE"]),
         Route("/projects/{project_id}/move-chats", move_all_chats, methods=["POST"]),
         Route("/project/goal", get_project_goal, methods=["GET"]),
+        Route("/project/goal/action", update_project_goal, methods=["POST"]),
         Route("/project/tasks", get_project_tasks, methods=["GET"]),
         Route("/project/kanban", get_project_kanban, methods=["GET"]),
         Route("/project/tasks", create_project_task, methods=["POST"]),

--- a/tests/core/test_goals.py
+++ b/tests/core/test_goals.py
@@ -1,0 +1,211 @@
+"""Unit tests for goal-mode pure logic (no DB / no network)."""
+
+import asyncio
+
+from suzent.core.goals import (
+    GoalState,
+    STATUS_ACTIVE,
+    STATUS_CLEARED,
+    STATUS_DONE,
+    STATUS_PAUSED,
+    _build_continuation_prompt,
+    _build_judge_user_prompt,
+    _parse_verdict,
+    format_status,
+    judge_goal,
+)
+
+
+# ─── _parse_verdict ──────────────────────────────────────────────────────────
+
+
+def test_parse_verdict_done_true():
+    assert _parse_verdict('{"done": true, "reason": "all tests pass"}') == (
+        True,
+        "all tests pass",
+    )
+
+
+def test_parse_verdict_done_false():
+    assert _parse_verdict('{"done": false, "reason": "still failing"}') == (
+        False,
+        "still failing",
+    )
+
+
+def test_parse_verdict_extracts_json_from_prose():
+    raw = 'Sure! Here is my verdict:\n{"done": true, "reason": "shipped"} \nThanks'
+    assert _parse_verdict(raw) == (True, "shipped")
+
+
+def test_parse_verdict_string_boolean():
+    assert _parse_verdict('{"done": "yes", "reason": "ok"}') == (True, "ok")
+    assert _parse_verdict('{"done": "no", "reason": "nope"}') == (False, "nope")
+
+
+def test_parse_verdict_missing_done_key():
+    assert _parse_verdict('{"reason": "no verdict"}') is None
+
+
+def test_parse_verdict_empty():
+    assert _parse_verdict("") is None
+    assert _parse_verdict("   ") is None
+
+
+def test_parse_verdict_garbage():
+    assert _parse_verdict("not json at all") is None
+
+
+# ─── GoalState serialization ────────────────────────────────────────────────
+
+
+def test_goalstate_roundtrip():
+    state = GoalState(
+        objective="port feature X",
+        status=STATUS_ACTIVE,
+        turn=3,
+        max_turns=20,
+        subgoals=["tests pass", "CI green"],
+        parse_failures=1,
+    )
+    restored = GoalState.from_dict(state.to_dict())
+    assert restored == state
+
+
+def test_goalstate_from_dict_requires_objective():
+    assert GoalState.from_dict({"status": "active"}) is None
+    assert GoalState.from_dict({}) is None
+    assert GoalState.from_dict(None) is None
+
+
+def test_goalstate_from_dict_defaults():
+    state = GoalState.from_dict({"objective": "do a thing"})
+    assert state.status == STATUS_ACTIVE
+    assert state.turn == 0
+    assert state.subgoals == []
+    assert state.parse_failures == 0
+
+
+# ─── format_status ───────────────────────────────────────────────────────────
+
+
+def test_format_status_none():
+    assert "No active goal" in format_status(None)
+
+
+def test_format_status_cleared():
+    state = GoalState(objective="", status=STATUS_CLEARED)
+    assert "No active goal" in format_status(state)
+
+
+def test_format_status_active_with_subgoals():
+    state = GoalState(
+        objective="fix lints",
+        status=STATUS_ACTIVE,
+        turn=2,
+        max_turns=10,
+        subgoals=["ruff clean", "mypy clean"],
+    )
+    out = format_status(state)
+    assert "2/10" in out
+    assert "fix lints" in out
+    assert "ruff clean" in out
+    assert "mypy clean" in out
+
+
+def test_format_status_done_icon():
+    state = GoalState(objective="x", status=STATUS_DONE, turn=5, max_turns=20)
+    assert "✓" in format_status(state)
+
+
+def test_format_status_paused_icon():
+    state = GoalState(objective="x", status=STATUS_PAUSED, turn=20, max_turns=20)
+    assert "⏸" in format_status(state)
+
+
+# ─── prompt builders ─────────────────────────────────────────────────────────
+
+
+def test_judge_prompt_includes_subgoals():
+    prompt = _build_judge_user_prompt(
+        "main goal", ["sub a", "sub b"], "the response"
+    )
+    assert "main goal" in prompt
+    assert "1. sub a" in prompt
+    assert "2. sub b" in prompt
+    assert "the response" in prompt
+
+
+def test_judge_prompt_truncates_long_response():
+    prompt = _build_judge_user_prompt("g", [], "x" * 9000)
+    # Response is capped at 4000 chars in the prompt body.
+    assert "x" * 4001 not in prompt
+
+
+def test_continuation_prompt_includes_step_and_objective():
+    state = GoalState(objective="ship it", turn=4, max_turns=12, subgoals=["a"])
+    prompt = _build_continuation_prompt(state)
+    assert "step 4/12" in prompt
+    assert "ship it" in prompt
+    assert "1. a" in prompt
+
+
+# ─── judge_goal fail-open semantics ──────────────────────────────────────────
+
+
+def _patch_judge(monkeypatch, model, complete_impl):
+    class _Router:
+        def get_model_id(self, role):
+            return model
+
+    class _Client:
+        def __init__(self, model=None):
+            pass
+
+        async def complete(self, **kwargs):
+            return await complete_impl(**kwargs)
+
+    monkeypatch.setattr("suzent.core.role_router.get_role_router", lambda: _Router())
+    monkeypatch.setattr("suzent.llm.LLMClient", _Client)
+
+
+def test_judge_goal_no_model_fails_open(monkeypatch):
+    async def _never(**kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("complete should not be called without a model")
+
+    _patch_judge(monkeypatch, None, _never)
+    verdict, _reason, parse_failed = asyncio.run(judge_goal("g", [], "r"))
+    assert verdict == "continue"
+    assert parse_failed is True
+
+
+def test_judge_goal_transport_error_fails_open(monkeypatch):
+    async def _boom(**kwargs):
+        raise RuntimeError("network down")
+
+    _patch_judge(monkeypatch, "cheap/model", _boom)
+    verdict, _reason, parse_failed = asyncio.run(judge_goal("g", [], "r"))
+    assert verdict == "continue"
+    # Transport errors must NOT count as parse failures (no auto-pause).
+    assert parse_failed is False
+
+
+def test_judge_goal_unparseable_marks_parse_failed(monkeypatch):
+    async def _garbage(**kwargs):
+        return "I cannot decide"
+
+    _patch_judge(monkeypatch, "cheap/model", _garbage)
+    verdict, _reason, parse_failed = asyncio.run(judge_goal("g", [], "r"))
+    assert verdict == "continue"
+    assert parse_failed is True
+
+
+def test_judge_goal_done(monkeypatch):
+    async def _done(**kwargs):
+        return '{"done": true, "reason": "complete"}'
+
+    _patch_judge(monkeypatch, "cheap/model", _done)
+    verdict, reason, parse_failed = asyncio.run(judge_goal("g", [], "r"))
+    assert verdict == "done"
+    assert reason == "complete"
+    assert parse_failed is False

--- a/tests/core/test_goals.py
+++ b/tests/core/test_goals.py
@@ -1,19 +1,33 @@
 """Unit tests for goal-mode pure logic (no DB / no network)."""
 
 import asyncio
+from types import SimpleNamespace
 
 from suzent.core.goals import (
-    GoalState,
     STATUS_ACTIVE,
-    STATUS_CLEARED,
-    STATUS_DONE,
+    STATUS_CANCELLED,
+    STATUS_COMPLETED,
     STATUS_PAUSED,
-    _build_continuation_prompt,
+    _budget_exhausted,
     _build_judge_user_prompt,
     _parse_verdict,
     format_status,
     judge_goal,
 )
+
+
+def _goal(**kw):
+    """Build a GoalModel-like stub for the pure display/budget helpers."""
+    defaults = dict(
+        id=1,
+        objective="do a thing",
+        status=STATUS_ACTIVE,
+        turns_elapsed=0,
+        max_turns=20,
+        subgoals=[],
+    )
+    defaults.update(kw)
+    return SimpleNamespace(**defaults)
 
 
 # ─── _parse_verdict ──────────────────────────────────────────────────────────
@@ -56,34 +70,20 @@ def test_parse_verdict_garbage():
     assert _parse_verdict("not json at all") is None
 
 
-# ─── GoalState serialization ────────────────────────────────────────────────
+# ─── _budget_exhausted ───────────────────────────────────────────────────────
 
 
-def test_goalstate_roundtrip():
-    state = GoalState(
-        objective="port feature X",
-        status=STATUS_ACTIVE,
-        turn=3,
-        max_turns=20,
-        subgoals=["tests pass", "CI green"],
-        parse_failures=1,
-    )
-    restored = GoalState.from_dict(state.to_dict())
-    assert restored == state
+def test_budget_exhausted_true_when_at_limit():
+    assert _budget_exhausted(_goal(turns_elapsed=20, max_turns=20)) is True
+    assert _budget_exhausted(_goal(turns_elapsed=21, max_turns=20)) is True
 
 
-def test_goalstate_from_dict_requires_objective():
-    assert GoalState.from_dict({"status": "active"}) is None
-    assert GoalState.from_dict({}) is None
-    assert GoalState.from_dict(None) is None
+def test_budget_not_exhausted_below_limit():
+    assert _budget_exhausted(_goal(turns_elapsed=5, max_turns=20)) is False
 
 
-def test_goalstate_from_dict_defaults():
-    state = GoalState.from_dict({"objective": "do a thing"})
-    assert state.status == STATUS_ACTIVE
-    assert state.turn == 0
-    assert state.subgoals == []
-    assert state.parse_failures == 0
+def test_budget_never_exhausted_without_max_turns():
+    assert _budget_exhausted(_goal(turns_elapsed=999, max_turns=None)) is False
 
 
 # ─── format_status ───────────────────────────────────────────────────────────
@@ -93,43 +93,36 @@ def test_format_status_none():
     assert "No active goal" in format_status(None)
 
 
-def test_format_status_cleared():
-    state = GoalState(objective="", status=STATUS_CLEARED)
-    assert "No active goal" in format_status(state)
+def test_format_status_completed_and_cancelled_read_as_no_goal():
+    assert "No active goal" in format_status(_goal(status=STATUS_COMPLETED))
+    assert "No active goal" in format_status(_goal(status=STATUS_CANCELLED))
 
 
 def test_format_status_active_with_subgoals():
-    state = GoalState(
-        objective="fix lints",
-        status=STATUS_ACTIVE,
-        turn=2,
-        max_turns=10,
-        subgoals=["ruff clean", "mypy clean"],
+    out = format_status(
+        _goal(
+            objective="fix lints",
+            status=STATUS_ACTIVE,
+            turns_elapsed=2,
+            max_turns=10,
+            subgoals=["ruff clean", "mypy clean"],
+        )
     )
-    out = format_status(state)
     assert "2/10" in out
     assert "fix lints" in out
     assert "ruff clean" in out
     assert "mypy clean" in out
 
 
-def test_format_status_done_icon():
-    state = GoalState(objective="x", status=STATUS_DONE, turn=5, max_turns=20)
-    assert "✓" in format_status(state)
-
-
 def test_format_status_paused_icon():
-    state = GoalState(objective="x", status=STATUS_PAUSED, turn=20, max_turns=20)
-    assert "⏸" in format_status(state)
+    assert "⏸" in format_status(_goal(status=STATUS_PAUSED, turns_elapsed=20, max_turns=20))
 
 
-# ─── prompt builders ─────────────────────────────────────────────────────────
+# ─── judge prompt builder ────────────────────────────────────────────────────
 
 
 def test_judge_prompt_includes_subgoals():
-    prompt = _build_judge_user_prompt(
-        "main goal", ["sub a", "sub b"], "the response"
-    )
+    prompt = _build_judge_user_prompt("main goal", ["sub a", "sub b"], "the response")
     assert "main goal" in prompt
     assert "1. sub a" in prompt
     assert "2. sub b" in prompt
@@ -140,14 +133,6 @@ def test_judge_prompt_truncates_long_response():
     prompt = _build_judge_user_prompt("g", [], "x" * 9000)
     # Response is capped at 4000 chars in the prompt body.
     assert "x" * 4001 not in prompt
-
-
-def test_continuation_prompt_includes_step_and_objective():
-    state = GoalState(objective="ship it", turn=4, max_turns=12, subgoals=["a"])
-    prompt = _build_continuation_prompt(state)
-    assert "step 4/12" in prompt
-    assert "ship it" in prompt
-    assert "1. a" in prompt
 
 
 # ─── judge_goal fail-open semantics ──────────────────────────────────────────


### PR DESCRIPTION
Implements a standing-goal loop (/goal and /subgoal commands) where the
agent works toward an objective across turns without re-prompting:

- After each non-heartbeat turn, a cheap stateless judge LLM decides
  done vs continue; on continue the agent auto-runs again with a
  continuation prompt, up to goals_max_turns (default 20).
- Judge fails open on errors/unparseable output; 3 consecutive parse
  failures auto-pause and prompt for a stronger cheap-role model.
- pause/resume/clear/status give explicit stop control; any real user
  message preempts the loop.
- Goal state persists in chat.config, surviving restarts and resumes.
- Status surfaced via the scheduler notification deque.

Goal state lives in core/goals.py; commands in core/commands/goal.py;
the post-turn hook is wired into ChatProcessor.process_turn.