### PR TITLE
fix(dream): stop redoing work on restart; add lint phase, hide chat, surface summary

### DIFF
--- a/config/default.example.yaml
+++ b/config/default.example.yaml
@@ -68,16 +68,13 @@ EMBEDDING_DIMENSION: 3072
 # Fields: name, cron_expr, prompt, delivery_mode (announce|silent), model_override, enabled, requires
 # `requires`: name of a CONFIG field that must be truthy for this job to be active.
 # Add new presets here without touching any Python code.
-CRON_PRESETS:
-  - name: wiki-ingest-daily
-    cron_expr: "0 2 * * *"
-    prompt: "Run the ingest skill for daily memory logs. Follow /mnt/skills/official/notebook/ingest.md exactly."
-    delivery_mode: announce
-  - name: wiki-lint-weekly
-    cron_expr: "0 3 * * 0"
-    prompt: "Run the lint skill. Follow /mnt/skills/official/notebook/lint.md exactly."
-    delivery_mode: announce
-  # Example — add your own presets:
+# NOTE: the notebook ingest + lint cron presets were removed — the autonomous
+# dream runner (DreamRunner) now owns both phases: it consolidates daily logs
+# continuously (gated) and runs the editorial lint pass weekly once ingest is
+# caught up. Re-adding cron jobs for ingest/lint would duplicate that work and
+# race on the shared notebook watermark/log.md. See src/suzent/core/dream_runner.py.
+CRON_PRESETS: []
+  # Example — add your own presets (replace the [] above with a list):
   # - name: daily-summary
   #   cron_expr: "0 20 * * *"
   #   prompt: "Summarize what was accomplished today and write it to /shared/memory/summaries/."

--- a/frontend/src/components/settings/MemoryTab.tsx
+++ b/frontend/src/components/settings/MemoryTab.tsx
@@ -65,6 +65,8 @@ export function MemoryTab({
     const lastResultLabel = (() => {
         const result = dreamStatus?.last_result;
         if (!result) return t('settings.memoryConfig.noRunsYet');
+        // Prefer the agent's own one-paragraph summary (what it created/updated/flagged).
+        if (result.summary) return result.summary;
         if (result.reason) return result.reason;
         if (result.skipped) return t('settings.memoryConfig.lastResultSkipped');
         if (result.advanced) return t('settings.memoryConfig.lastResultAdvanced', { watermark: result.watermark || '—' });
@@ -149,7 +151,12 @@ export function MemoryTab({
                 <div className="mt-4 grid grid-cols-1 md:grid-cols-[1fr_auto] gap-3 items-stretch">
                     <div className="border-2 border-brutal-black bg-neutral-50 dark:bg-zinc-900 p-3 min-w-0">
                         <div className="text-[10px] font-bold uppercase text-neutral-500 dark:text-neutral-400">{t('settings.memoryConfig.lastResult')}</div>
-                        <div className="font-mono text-xs font-bold mt-1 truncate">{lastResultLabel}</div>
+                        <div
+                            className="font-mono text-xs font-bold mt-1 whitespace-pre-wrap break-words overflow-y-auto max-h-32"
+                            title={lastResultLabel}
+                        >
+                            {lastResultLabel}
+                        </div>
                         {pendingDates.length > 0 && (
                             <div className="font-mono text-[11px] text-neutral-500 dark:text-neutral-400 mt-2 truncate">
                                 {t('settings.memoryConfig.nextBatch')}: {pendingDates.slice(0, dreamStatus?.max_days ?? 14).join(', ')}

--- a/frontend/src/types/memory.ts
+++ b/frontend/src/types/memory.ts
@@ -100,6 +100,12 @@ export interface DreamRunResult {
   watermark?: string | null;
   target?: string | null;
   reason?: string;
+  /** Phase that produced this result ('lint' for the editorial pass). */
+  phase?: string;
+  /** Lint-phase success flag. */
+  ok?: boolean;
+  /** The agent's own one-paragraph summary of what it did this run. */
+  summary?: string;
 }
 
 export interface DreamStatus {
@@ -107,7 +113,7 @@ export interface DreamStatus {
   available: boolean;
   enabled: boolean;
   running: boolean;
-  phase?: 'idle' | 'queued' | 'preparing' | 'running_agent' | 'finalizing' | string;
+  phase?: 'idle' | 'queued' | 'preparing' | 'running_agent' | 'running_lint' | 'finalizing' | string;
   reason?: string;
   watermark?: string | null;
   pending_dates?: string[];
@@ -125,6 +131,11 @@ export interface DreamStatus {
   min_facts?: number;
   min_hours?: number;
   max_days?: number;
+  lint_enabled?: boolean;
+  lint_last_run?: string | null;
+  lint_days_since?: number | null;
+  lint_due?: boolean;
+  lint_min_days?: number;
 }
 
 export interface DreamConsolidateResponse {

--- a/src/suzent/config/__init__.py
+++ b/src/suzent/config/__init__.py
@@ -350,6 +350,11 @@ class ConfigModel(BaseModel):
         "GrepTool",
         "MemorySearchTool",
     ]
+    # Lint phase: a periodic editorial audit of the vault (contradictions, broken
+    # links, orphans, decay) run by the same dream runner AFTER ingest catches up.
+    # Distinct prompt + its own (slower) gate; ingest always takes priority.
+    memory_lint_enabled: bool = True
+    memory_lint_min_days: float = 7.0
 
     cron_presets: List[Dict[str, Any]] = []
     user_id: str = "default-user"

--- a/src/suzent/core/agent_deps.py
+++ b/src/suzent/core/agent_deps.py
@@ -34,6 +34,10 @@ class AgentDeps:
     # --- Session identity ---
     chat_id: str = ""
     user_id: str = "default"
+    # System/forked chats (dream consolidation, sub-agents) are reset to a clean
+    # slate before every run, so their agent_state must NEVER be persisted (mid-run
+    # checkpoints or end-of-turn). Set by the chat processor from the chat platform.
+    stateless: bool = False
 
     # --- Sandbox / filesystem ---
     sandbox_enabled: bool = False

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -244,6 +244,8 @@ class ChatProcessor:
 
         # 3. Build AgentDeps (replaces inject_chat_context)
         deps = build_agent_deps(chat_id=chat_id, user_id=user_id, config=config)
+        # System/forked chats never persist agent_state — they reset before each run.
+        deps.stateless = self._is_system_chat(chat_id)
 
         # 4. Restore message history from DB (or use override for steer)
         message_history = _message_history_override
@@ -550,12 +552,20 @@ class ChatProcessor:
             display_trigger = "\n\n---\n\n".join(
                 r.strip() for r in system_reminders if r and r.strip()
             )
-        reminder = await build_combined_reminder(
-            chat_id,
-            deps,
-            adhoc_reminders=system_reminders,
-            user_message=_turn_message,
-            display_trigger=display_trigger,
+        # Stateless chats (dream, sub-agents) run a fixed, self-contained prompt and
+        # must not receive skill-discovery / plan / RAG reminders — that ambient
+        # chatter (e.g. the automation/cron skill hint) is what made the dream agent
+        # hallucinate "this scheduled task already fired, skip it" and no-op.
+        reminder = (
+            None
+            if getattr(deps, "stateless", False)
+            else await build_combined_reminder(
+                chat_id,
+                deps,
+                adhoc_reminders=system_reminders,
+                user_message=_turn_message,
+                display_trigger=display_trigger,
+            )
         )
         if reminder:
             if message_content and message_content.strip():
@@ -863,7 +873,16 @@ class ChatProcessor:
 
             # Persist a lightweight state snapshot immediately so a fast-following
             # turn can restore recent history even before heavy post-processing ends.
+            #
+            # System/forked chats (dream consolidation, sub-agents) are stateless by
+            # design: every run is reset to a clean slate (see DreamRunner._reset_dream_chat).
+            # Persisting their agent_state lets a previous run's history survive — and,
+            # worse, a late finalize from the prior run can resurrect it AFTER the next
+            # run's reset (a race), so the dream agent wakes up carrying 40+ messages of
+            # unrelated chatter and hallucinates "I already did this, skip" — never
+            # consolidating. Skip all agent_state persistence for these chats.
             snapshot_revision: Optional[int] = None
+            _stateless_chat = self._is_system_chat(chat_id)
             try:
                 snapshot_messages = getattr(deps, "last_messages", None)
                 if snapshot_messages is None:
@@ -892,12 +911,14 @@ class ChatProcessor:
                             )
                         )
 
-                snapshot_revision = await self._persist_agent_state_snapshot(
-                    chat_id=chat_id,
-                    messages=snapshot_messages or [],
-                    model_id=getattr(agent, "_model_id", None),
-                    tool_names=getattr(agent, "_tool_names", []),
-                )
+                # Stateless chats never snapshot agent_state (see note above).
+                if not _stateless_chat:
+                    snapshot_revision = await self._persist_agent_state_snapshot(
+                        chat_id=chat_id,
+                        messages=snapshot_messages or [],
+                        model_id=getattr(agent, "_model_id", None),
+                        tool_names=getattr(agent, "_tool_names", []),
+                    )
             except Exception as e:
                 logger.warning(
                     f"Failed to persist pre-postprocess state snapshot for {chat_id}: {e}"
@@ -1571,8 +1592,16 @@ class ChatProcessor:
         """Persist conversation state to database."""
         try:
             db = get_database()
-            agent_state = serialize_state(
-                messages, model_id=model_id, tool_names=tool_names
+            # System/forked chats (dream, sub-agents) are stateless by design and are
+            # reset to a clean slate before every run. Persisting their agent_state lets
+            # a prior run's history survive into the next one — and a late finalize here
+            # can resurrect it after the next run's reset. Keep agent_state empty so each
+            # run starts clean (display messages are still rebuilt below for inspection).
+            stateless = self._is_system_chat(chat_id)
+            agent_state = (
+                b""
+                if stateless
+                else serialize_state(messages, model_id=model_id, tool_names=tool_names)
             )
 
             current_chat = db.get_chat(chat_id)

--- a/src/suzent/core/dream_runner.py
+++ b/src/suzent/core/dream_runner.py
@@ -47,6 +47,9 @@ class DreamRunner(BaseBrain):
         self._last_result: Optional[dict[str, Any]] = None
         self._phase: str = "idle"
         self._background_task: Optional[asyncio.Task] = None
+        self._reindex_task: Optional[asyncio.Task] = None
+        # Lint pacing (ephemeral; the durable "last lint" signal is log.md entries).
+        self._last_lint_attempt_at: float = 0.0
 
     async def _run_loop(self):
         # Let startup settle before the first tick.
@@ -145,6 +148,8 @@ class DreamRunner(BaseBrain):
         )
         next_batch = pending[: CONFIG.memory_consolidation_max_days]
         available = bool(getattr(mgr, "llm_client", None))
+        last_lint = mgr.markdown_store.read_last_lint_date()
+        lint_days = self._days_since(last_lint)
         return {
             "active": True,
             "available": available,
@@ -168,6 +173,11 @@ class DreamRunner(BaseBrain):
             "min_facts": CONFIG.memory_consolidation_min_facts,
             "min_hours": CONFIG.memory_consolidation_min_hours,
             "max_days": CONFIG.memory_consolidation_max_days,
+            "lint_enabled": CONFIG.memory_lint_enabled,
+            "lint_last_run": last_lint,
+            "lint_days_since": round(lint_days, 1) if lint_days is not None else None,
+            "lint_due": self._lint_due(mgr) if not pending else False,
+            "lint_min_days": CONFIG.memory_lint_min_days,
         }
 
     # ----- gate + run -----
@@ -181,23 +191,27 @@ class DreamRunner(BaseBrain):
 
         watermark = mgr.markdown_store.read_watermark()
         pending = self._pending_dates(mgr, watermark)
-        if not pending:
+        if pending:
+            behind = len(pending) > CONFIG.memory_consolidation_max_days
+            if not behind:
+                # Steady state: back off on attempts + require enough new material.
+                if (
+                    time.time() - self._last_attempt_at
+                ) < CONFIG.memory_consolidation_min_hours * 3600:
+                    return
+                if (
+                    self._count_fact_lines(mgr, pending)
+                    < CONFIG.memory_consolidation_min_facts
+                ):
+                    return
+            # behind => sprint (ignore the daily/volume gate) until caught up.
+            await self._run_dream(mgr, watermark, pending)
             return
 
-        behind = len(pending) > CONFIG.memory_consolidation_max_days
-        if not behind:
-            # Steady state: back off on attempts + require enough new material.
-            if (
-                time.time() - self._last_attempt_at
-            ) < CONFIG.memory_consolidation_min_hours * 3600:
-                return
-            if (
-                self._count_fact_lines(mgr, pending)
-                < CONFIG.memory_consolidation_min_facts
-            ):
-                return
-        # behind => sprint (ignore the daily/volume gate) until caught up.
-        await self._run_dream(mgr, watermark, pending)
+        # Ingest is caught up. Only now consider the (slower) lint pass, so the
+        # editorial audit never starves new-log consolidation.
+        if self._lint_due(mgr):
+            await self._run_lint(mgr)
 
     async def force_run(self) -> dict:
         """On-demand consolidation — bypasses time+volume gates (not the lock)."""
@@ -269,10 +283,11 @@ class DreamRunner(BaseBrain):
 
             self._pause_watcher()
             agent_ok = False
+            summary = ""
             try:
                 await self._reset_dream_chat()
                 self._phase = "running_agent"
-                await self._run_agent(start, w_new)
+                summary = await self._run_agent(start, w_new)
                 agent_ok = True
             except Exception as e:
                 logger.error(f"[dream] agent run failed: {e}")
@@ -304,34 +319,36 @@ class DreamRunner(BaseBrain):
                     "changed": changed,
                     "advanced": False,
                     "watermark": watermark,
+                    "summary": summary or reason,
                 }
                 self._record_result(result)
                 return result
 
             self._failures.pop(w_new, None)
             await self._advance_watermark(mgr, w_new)
-            # Promote MEMORY.md first so the reconcile pass indexes the fresh file.
+            # Promote MEMORY.md (bounded) so the curated summary reflects this batch.
             try:
-                await mgr.promote_memory_md(CONFIG.user_id)
-            except Exception as e:
-                logger.error(f"[dream] promote_memory_md failed: {e}")
-            try:
-                await mgr._core_indexer.check_and_update(
-                    markdown_store=mgr.markdown_store,
-                    lancedb_store=mgr.store,
-                    embedding_gen=mgr.embedding_gen,
-                    user_id=CONFIG.user_id,
+                await asyncio.wait_for(
+                    mgr.promote_memory_md(CONFIG.user_id),
+                    timeout=CONFIG.memory_consolidation_timeout_seconds,
                 )
             except Exception as e:
-                logger.error(f"[dream] reindex failed: {e}")
+                logger.error(f"[dream] promote_memory_md failed/timed out: {e}")
             logger.info(f"[dream] consolidated through {w_new}")
             result = {
                 "ran": True,
                 "changed": True,
                 "advanced": True,
                 "watermark": w_new,
+                "summary": summary or f"Consolidated through {w_new}.",
             }
+            # Consolidation is durably complete now (watermark + MEMORY.md). The search
+            # reindex is just index maintenance and can be SLOW (minutes on fat early
+            # logs, hundreds of embeddings each) — running it inline pins the panel in
+            # 'finalizing' and holds the lock the whole time. Mark the run done and fan
+            # the reindex out to the background instead.
             self._record_result(result)
+            self._schedule_reindex(mgr)
             return result
 
     def _record_result(self, result: dict[str, Any]) -> None:
@@ -341,6 +358,125 @@ class DreamRunner(BaseBrain):
 
     async def _advance_watermark(self, mgr, w_new: str):
         await mgr.markdown_store.write_watermark_entry(self._today_utc(), w_new)
+
+    async def _reindex(self, mgr) -> None:
+        """Reconcile the vault into the search index, with a hard timeout.
+
+        The indexer embeds every changed page and grabs its own shared lock; a stalled
+        embedding call would otherwise run unbounded. The watermark is already advanced
+        by the time we get here, so a timed-out reindex is non-fatal — the indexer is
+        idempotent and the next reconcile picks up whatever was missed.
+        """
+        await asyncio.wait_for(
+            mgr._core_indexer.check_and_update(
+                markdown_store=mgr.markdown_store,
+                lancedb_store=mgr.store,
+                embedding_gen=mgr.embedding_gen,
+                user_id=CONFIG.user_id,
+            ),
+            timeout=CONFIG.memory_consolidation_timeout_seconds,
+        )
+
+    def _schedule_reindex(self, mgr) -> None:
+        """Fan the (slow) search reindex out to the background so it never blocks the
+        dream cycle or pins the panel in 'finalizing'. The indexer is idempotent and
+        catches up whatever's missed, so if one is already in flight we just skip —
+        the next cycle's reindex will cover this batch too.
+        """
+        if self._reindex_task is not None and not self._reindex_task.done():
+            return  # one already running; it will pick up the latest vault state
+
+        async def _bg() -> None:
+            try:
+                await self._reindex(mgr)
+            except Exception as e:
+                logger.error(f"[dream] background reindex failed/timed out: {e}")
+
+        try:
+            self._reindex_task = asyncio.create_task(_bg())
+        except Exception as e:
+            logger.error(f"[dream] failed to schedule background reindex: {e}")
+
+    # ----- lint phase (editorial audit; runs only once ingest is caught up) -----
+
+    @staticmethod
+    def _days_since(date_str: Optional[str]) -> Optional[float]:
+        if not date_str:
+            return None
+        try:
+            then = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            return (datetime.now(timezone.utc) - then).total_seconds() / 86400.0
+        except Exception:
+            return None
+
+    def _lint_due(self, mgr) -> bool:
+        """True if the vault is overdue for a lint pass (and not rate-limited)."""
+        if not CONFIG.memory_lint_enabled:
+            return False
+        # Don't re-attempt within a day even if the last pass logged nothing.
+        if (time.time() - self._last_lint_attempt_at) < 24 * 3600:
+            return False
+        last = mgr.markdown_store.read_last_lint_date()
+        days = self._days_since(last)
+        # Never linted, or older than the configured cadence.
+        return days is None or days >= CONFIG.memory_lint_min_days
+
+    async def _run_lint(self, mgr) -> dict:
+        """Run the editorial lint pass. Records a log entry on a clean run (no watermark)."""
+        if self._lock.locked():
+            return {"ran": False, "reason": "already running"}
+        async with self._lock:
+            self._phase = "preparing"
+            self._last_lint_attempt_at = time.time()
+            self._last_started_at = datetime.now(timezone.utc).isoformat()
+
+            before = self._content_pages_state(mgr)
+            self._pause_watcher()
+            agent_ok = False
+            summary = ""
+            try:
+                await self._reset_dream_chat()
+                self._phase = "running_lint"
+                summary = await self._run_lint_agent()
+                agent_ok = True
+            except Exception as e:
+                logger.error(f"[dream] lint run failed: {e}")
+            finally:
+                self._resume_watcher()
+
+            self._phase = "finalizing"
+            changed = self._content_pages_state(mgr) != before
+            # Lint may legitimately find nothing to fix, so unlike ingest a clean
+            # no-change run is still "success" — we record the pass either way so the
+            # weekly cadence advances. We only skip the log entry if the agent errored.
+            if not agent_ok:
+                result = {
+                    "ran": True,
+                    "phase": "lint",
+                    "ok": False,
+                    "changed": changed,
+                    "summary": summary or "lint run failed/timed out",
+                }
+                self._record_result(result)
+                return result
+
+            try:
+                await mgr.markdown_store.write_lint_entry(self._today_utc())
+            except Exception as e:
+                logger.error(f"[dream] write_lint_entry failed: {e}")
+            logger.info(f"[dream] lint pass complete (changed={changed})")
+            result = {
+                "ran": True,
+                "phase": "lint",
+                "ok": True,
+                "changed": changed,
+                "summary": summary or "Lint pass complete (no changes).",
+            }
+            # Mark done, then reindex in the background (see _run_dream rationale).
+            self._record_result(result)
+            if changed:
+                self._schedule_reindex(mgr)
+            return result
 
     # ----- watcher pause/resume (via lifecycle gate Event) -----
 
@@ -385,28 +521,76 @@ class DreamRunner(BaseBrain):
             except Exception:
                 pass
 
-    async def _run_agent(self, start: str, end: str):
+    async def _run_agent(self, start: str, end: str) -> str:
+        """Ingest phase: fold daily logs in (start, end] into the vault.
+
+        Returns the agent's one-paragraph summary (shown in the dream panel).
+        """
+        return await self._run_forked_agent(
+            memory_context.DREAM_SYSTEM_PROMPT,
+            memory_context.DREAM_INSTRUCTIONS.format(start=start, end=end),
+        )
+
+    async def _run_lint_agent(self) -> str:
+        """Lint phase: editorial audit/repair of the existing vault. Returns the summary."""
+        return await self._run_forked_agent(
+            memory_context.LINT_SYSTEM_PROMPT,
+            memory_context.LINT_INSTRUCTIONS,
+        )
+
+    async def _run_forked_agent(self, system_prompt: str, message: str) -> str:
+        """Run the tool-restricted dream agent; return its FINAL summary text.
+
+        process_turn_text concatenates every assistant text segment across the turn,
+        so its return value is `preamble + ...tool steps... + final summary` — the panel
+        would then show the opening line ("I'll start by orienting myself…"), not the
+        wrap-up. We instead watch the event stream and keep only the LAST contiguous
+        text block (the text emitted after the agent's final tool call), which is the
+        actual summary the prompt asks for.
+        """
         from suzent.core.chat_processor import ChatProcessor
         from suzent.agent_manager import build_agent_config
+        from suzent.core.stream_parser import TextChunk, ToolCall
 
         base = {
             "platform": "dream",
             "memory_enabled": False,
             "auto_approve_tools": True,
             "tools": list(CONFIG.memory_dream_tools),
-            "static_instructions": memory_context.DREAM_SYSTEM_PROMPT,
+            "static_instructions": system_prompt,
         }
         if CONFIG.memory_consolidation_model:
             base["model"] = CONFIG.memory_consolidation_model
         cfg = build_agent_config(base, require_social_tool=False)
 
-        message = memory_context.DREAM_INSTRUCTIONS.format(start=start, end=end)
-        await asyncio.wait_for(
+        last_block: list[str] = []
+        _saw_text = False
+
+        async def _on_event(event) -> None:
+            nonlocal _saw_text
+            if isinstance(event, TextChunk):
+                # New text block begins right after a tool call — drop the prior block
+                # so we end up holding only the final, post-tool summary.
+                if not _saw_text:
+                    last_block.clear()
+                last_block.append(event.content)
+                _saw_text = True
+            elif isinstance(event, ToolCall):
+                _saw_text = False  # next text starts a fresh (later) block
+
+        full = await asyncio.wait_for(
             ChatProcessor().process_turn_text(
                 chat_id=DREAM_CHAT_ID,
                 user_id=CONFIG.user_id,
                 message_content=message,
                 config_override=cfg,
+                on_event=_on_event,
             ),
             timeout=CONFIG.memory_consolidation_timeout_seconds,
         )
+        # Prefer the last block; fall back to the full text if no boundaries were seen.
+        text = "".join(last_block).strip() or (full or "").strip()
+        # Cap so the panel's LAST RESULT box stays readable (it's a status line, not a log).
+        if len(text) > 600:
+            text = text[:597].rstrip() + "…"
+        return text

--- a/src/suzent/database/chats.py
+++ b/src/suzent/database/chats.py
@@ -18,9 +18,27 @@ from .models import (
 SUMMARY_LAST_MESSAGE_KEY = "_summary_last_message"
 SUMMARY_VISIBLE_COUNT_KEY = "_summary_visible_assistant_count"
 
+# Platforms hidden from the user's chat list. Only the autonomous dream consolidation
+# chat is hidden — sub-agent chats are intentionally kept visible (nested under their
+# parent agent in the UI), so they are NOT excluded here.
+HIDDEN_CHAT_PLATFORMS = ("dream",)
+
 
 def _apply_chat_filters(statement, search, platform, project_id):
-    """Apply common search/platform/project filters to a ChatModel statement."""
+    """Apply common search/platform/project filters to a ChatModel statement.
+
+    The hidden dream consolidation chat is always excluded from listing — it is an
+    internal background agent, not a user conversation (it surfacing in the sidebar
+    is the bug this fixes). Sub-agent chats remain visible by design.
+    """
+    # SQLite json_extract returns the platform string or NULL; exclude the hidden set.
+    placeholders = ", ".join(f"'{p}'" for p in HIDDEN_CHAT_PLATFORMS)
+    statement = statement.where(
+        text(
+            "(json_extract(config, '$.platform') IS NULL "
+            f"OR json_extract(config, '$.platform') NOT IN ({placeholders}))"
+        )
+    )
     if search:
         statement = statement.where(
             or_(

--- a/src/suzent/memory/markdown_store.py
+++ b/src/suzent/memory/markdown_store.py
@@ -103,6 +103,24 @@ class MarkdownMemoryStore:
             f"\n## [{run_date}] ingest | daily logs  watermark={watermark}"
         )
 
+    def read_last_lint_date(self) -> Optional[str]:
+        """Date of the most recent `## [YYYY-MM-DD] lint` entry in log.md, or None.
+
+        The lint phase has no watermark (it audits the whole vault); its cadence gate
+        keys off how long ago the last lint ran, recorded by these log entries.
+        """
+        matches = re.findall(
+            r"##\s*\[(\d{4}-\d{2}-\d{2})\]\s*lint\b", self.read_notebook_log()
+        )
+        return matches[-1] if matches else None
+
+    async def write_lint_entry(self, run_date: str, summary: str = "") -> None:
+        """Append the runner-owned lint event (mirrors write_watermark_entry)."""
+        line = f"\n## [{run_date}] lint"
+        if summary:
+            line += f"\n{summary.strip()}"
+        await self.append_notebook_log(line)
+
     # --- Recall log (usage signal for MEMORY.md promotion) ---
 
     @property

--- a/src/suzent/memory/memory_context.py
+++ b/src/suzent/memory/memory_context.py
@@ -286,27 +286,34 @@ Max 2000 words. Respond with the summary only.
 
 # ===== Dream consolidation (autonomous wiki keeper) =====
 
-DREAM_SYSTEM_PROMPT = """You are Suzent's memory consolidation agent ("dream"). You run \
+# Virtual roots used in the dream/lint prompts. PathResolver maps these in BOTH
+# sandbox and host mode, so the agent's file tools resolve them regardless of mode.
+# Centralized here so the paths live in one place rather than scattered across the
+# prompt strings below.
+DREAM_MEMORY_ROOT = "/shared/memory"  # daily logs: {DREAM_MEMORY_ROOT}/archive/*.md
+DREAM_NOTEBOOK_ROOT = "/mnt/notebook"  # the vault the agent maintains
+
+DREAM_SYSTEM_PROMPT = f"""You are Suzent's memory consolidation agent ("dream"). You run \
 autonomously to turn the raw, append-only daily memory logs into a clean, durable, \
 cross-referenced knowledge vault.
 
 Tools: read_file, write_file, edit_file, glob_search, grep_search, memory_search.
 Filesystem:
-- Daily logs (READ-ONLY source): /shared/memory/archive/YYYY-MM-DD.md  — NEVER edit or delete these.
-- The vault (your workspace):     /mnt/notebook/  — schema.md, index.md, log.md, zoned pages.
+- Daily logs (READ-ONLY source): {DREAM_MEMORY_ROOT}/archive/YYYY-MM-DD.md  — NEVER edit or delete these.
+- The vault (your workspace):     {DREAM_NOTEBOOK_ROOT}/  — schema.md, index.md, log.md, zoned pages.
 
 Rules:
-- ALWAYS read /mnt/notebook/schema.md first; follow its zones, naming, and frontmatter exactly.
+- ALWAYS read {DREAM_NOTEBOOK_ROOT}/schema.md first; follow its zones, naming, and frontmatter exactly.
 - Improve existing pages; never create near-duplicates. Search before you write.
 - Preserve history: when a fact changes over time, record "currently X; previously Y" — never silently overwrite.
 - Only remove a statement when it is a genuine correction or an exact duplicate.
 - Do NOT write to log.md — the runner records consolidation events there. Put conflicts on content pages.
 """
 
-DREAM_INSTRUCTIONS = """Consolidate the daily memory logs dated after {start} through {end} into the vault.
+DREAM_INSTRUCTIONS = f"""Consolidate the daily memory logs dated after {{start}} through {{end}} into the vault.
 
-1. Orient: read schema.md and index.md; glob_search /mnt/notebook for existing pages.
-2. Read the logs: /shared/memory/archive/*.md dated after {start} through {end}.
+1. Orient: read schema.md and index.md; glob_search {DREAM_NOTEBOOK_ROOT} for existing pages.
+2. Read the logs: {DREAM_MEMORY_ROOT}/archive/*.md dated after {{start}} through {{end}}.
 3. For each distinct fact/topic:
    a. Find the page it belongs to (index.md + glob_search/grep_search + memory_search).
       Personal facts about the user -> 3_Personal/ ; domain knowledge -> 2_Wiki/.
@@ -314,7 +321,7 @@ DREAM_INSTRUCTIONS = """Consolidate the daily memory logs dated after {start} th
       - Duplicate (same fact reworded)              -> do nothing.
       - New, non-conflicting                        -> add under the right section.
       - Correction (new entry shows old was wrong)  -> replace the wrong statement.
-      - Change over time (both true at diff. times) -> rewrite as "Currently X (since {end});
+      - Change over time (both true at diff. times) -> rewrite as "Currently X (since {{end}});
                                                        previously Y."  status: active.
       - Genuine conflict you can't confidently resolve -> keep the more recent claim, add a
         `> [!warning] Conflicting claims: <A> vs <B> (<dates>)` callout on the relevant
@@ -325,6 +332,45 @@ DREAM_INSTRUCTIONS = """Consolidate the daily memory logs dated after {start} th
 5. Update index.md. Do NOT write the watermark to log.md — the runner records it.
 
 Return a one-paragraph summary of what you created, updated, superseded, or flagged.
+"""
+
+# ---- Lint phase: periodic editorial audit of the vault (runs after ingest catches up) ----
+
+LINT_SYSTEM_PROMPT = f"""You are Suzent's memory consolidation agent ("dream"), running your \
+periodic LINT pass: an editorial health-check of the notebook vault. You do NOT ingest new daily \
+logs here — you audit and repair what already exists so the knowledge graph stays consistent and \
+does not silently decay.
+
+Tools: read_file, write_file, edit_file, glob_search, grep_search, memory_search.
+Filesystem:
+- The vault (your workspace): {DREAM_NOTEBOOK_ROOT}/  — schema.md, index.md, log.md, zoned pages.
+
+Rules:
+- ALWAYS read {DREAM_NOTEBOOK_ROOT}/schema.md first; follow its zones, naming, and frontmatter exactly.
+- Repair conservatively. Fix links/structure freely; only delete a page if it is truly obsolete.
+- Never fabricate facts. When a contradiction needs human judgement, FLAG it, do not guess.
+- Do NOT write the lint log entry to log.md — the runner records that. Put callouts on content pages.
+"""
+
+LINT_INSTRUCTIONS = f"""Run an editorial lint pass over the notebook vault.
+
+1. Orient: read schema.md and index.md; glob_search {DREAM_NOTEBOOK_ROOT} for ALL pages (many live outside index.md).
+2. Contradictions: read related pages; where claims conflict, resolve with the better-supported/more
+   recent claim. If it needs human judgement, add a `> [!warning] Contradiction: <desc>` callout on the
+   page AND prepend a `> [!alert] Contradiction found in [[path/page]]` line near the top of index.md.
+3. Hierarchy: ensure entity/detail pages link up to their parent category; connect micro-islands to a
+   higher-level concept or index so nothing is stranded.
+4. Broken links: for each index.md entry verify the file exists (fix/remove stale ones). Replace short-name
+   wikilinks with full vault paths per schema.
+5. Orphans: a page not in index.md and not linked anywhere — add to index.md if valuable, link it from a
+   related page, or delete only if truly obsolete.
+6. Reciprocal links: if A links B in `## Related`, add B→A where meaningful.
+7. Decay: for Wiki/synthesis pages with `status: active` whose `updated:` is older than 90 days, set
+   `status: needs-review`.
+8. Gaps: note topics recurring in recent material with no synthesized page, and dangling wikilinks.
+
+Do NOT append the lint entry to log.md — the runner records it.
+Return a one-paragraph summary: contradictions found/resolved, links/orphans fixed, pages flagged, gaps.
 """
 
 # Deterministic post-step run by the runner (not the agent): regenerate the

--- a/src/suzent/prompts.py
+++ b/src/suzent/prompts.py
@@ -409,6 +409,12 @@ def register_dynamic_instructions(
 
     @agent.instructions
     def inject_environment_context(ctx: Any) -> str:
+        # Stateless chats (dream consolidation, sub-agents) ship a fixed, self-contained
+        # prompt that deliberately uses virtual paths (/shared/memory, /mnt/notebook),
+        # which PathResolver resolves in any mode. Injecting the host-mode "do NOT use
+        # /mnt/... paths" warning contradicts that prompt and makes a weak model give up.
+        if getattr(ctx.deps, "stateless", False):
+            return ""
         shell_type = getattr(ctx.deps, "shell_type", "unknown")
         return build_execution_mode_section(
             sandbox_enabled=ctx.deps.sandbox_enabled,

--- a/src/suzent/streaming.py
+++ b/src/suzent/streaming.py
@@ -668,6 +668,10 @@ async def stream_agent_responses(
         """
         if not chat_id or not messages:
             return
+        # Stateless chats (dream, sub-agents) reset before each run; persisting a
+        # mid-run snapshot would let this run's history survive into the next.
+        if getattr(deps, "stateless", False):
+            return
         try:
             _model_id = getattr(agent, "_model_id", None)
             _tool_names = getattr(agent, "_tool_names", [])

--- a/tests/core/test_dream_chat_stateless.py
+++ b/tests/core/test_dream_chat_stateless.py
@@ -1,0 +1,79 @@
+"""Regression: system/forked chats (dream, sub-agents) must never persist agent_state.
+
+The dream consolidation chat is reset to a clean slate before every run. If the chat
+processor persists its agent_state, a previous run's history survives — and a late
+finalize from the prior run can resurrect it AFTER the next run's reset (a race). The
+dream agent then wakes up carrying dozens of messages of unrelated chatter and
+hallucinates "I already did this, skip", so it never consolidates and the watermark
+never advances (the "redoing all the work on restart" symptom).
+
+Invariant under test: _persist_state writes empty agent_state for system chats and real
+serialized state for normal chats.
+"""
+
+import pytest
+
+from suzent.core.chat_processor import ChatProcessor
+
+
+class _FakeChat:
+    def __init__(self, platform):
+        self.config = {"platform": platform} if platform else {}
+        self.messages = []
+        self.agent_state = b"old-history"
+
+
+class _FakeDB:
+    def __init__(self, platform):
+        self._chat = _FakeChat(platform)
+        self.persisted = {}
+
+    def get_chat(self, chat_id):
+        return self._chat
+
+    def update_chat(self, chat_id, agent_state=None, messages=None):
+        self.persisted["agent_state"] = agent_state
+        self.persisted["messages"] = messages
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "platform,expect_empty",
+    [
+        ("dream", True),
+        ("subagent", True),
+        ("subagent_wakeup", True),
+        ("telegram", False),
+        (None, False),
+    ],
+)
+async def test_persist_state_agent_state_by_platform(
+    monkeypatch, platform, expect_empty
+):
+    import suzent.core.chat_processor as cp
+
+    db = _FakeDB(platform)
+    monkeypatch.setattr(cp, "get_database", lambda: db)
+    # Make serialization deterministic and non-empty for the "normal chat" case.
+    monkeypatch.setattr(cp, "serialize_state", lambda *a, **k: b"real-state")
+    monkeypatch.setattr(cp, "_rebuild_display_messages", lambda msgs: [{"role": "x"}])
+    monkeypatch.setattr(
+        cp, "_append_inline_a2ui_surfaces", lambda rebuilt, surfaces: rebuilt
+    )
+
+    proc = ChatProcessor()
+    await proc._persist_state(
+        chat_id="system-dream" if platform == "dream" else "c1",
+        messages=[object()],
+        model_id="m",
+        tool_names=[],
+        user_content="hi",
+        agent_content="ok",
+    )
+
+    if expect_empty:
+        assert db.persisted["agent_state"] == b"", (
+            f"platform={platform} must not persist agent_state"
+        )
+    else:
+        assert db.persisted["agent_state"] == b"real-state"

--- a/tests/memory/test_dream_lint_gate.py
+++ b/tests/memory/test_dream_lint_gate.py
@@ -1,0 +1,119 @@
+"""Tests for the dream runner's lint phase gate.
+
+Lint is an editorial audit that runs in the SAME runner as ingest, but only once
+ingest has caught up (so it never starves new-log consolidation) and only on a
+weekly cadence keyed off the last `## [date] lint` entry in log.md.
+"""
+
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from suzent.config import CONFIG
+from suzent.core.dream_runner import DreamRunner
+
+
+class _Store:
+    def __init__(self, last_lint=None):
+        self._last_lint = last_lint
+        self.written = []
+
+    def read_last_lint_date(self):
+        return self._last_lint
+
+    async def write_lint_entry(self, run_date, summary=""):
+        self.written.append((run_date, summary))
+
+
+class _Mgr:
+    def __init__(self, last_lint=None):
+        self.markdown_store = _Store(last_lint)
+
+
+def _ymd(days_ago):
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).strftime("%Y-%m-%d")
+
+
+def test_lint_due_when_never_run(monkeypatch):
+    monkeypatch.setattr(CONFIG, "memory_lint_enabled", True)
+    r = DreamRunner()
+    assert r._lint_due(_Mgr(last_lint=None)) is True
+
+
+def test_lint_not_due_within_cadence(monkeypatch):
+    monkeypatch.setattr(CONFIG, "memory_lint_enabled", True)
+    monkeypatch.setattr(CONFIG, "memory_lint_min_days", 7.0)
+    r = DreamRunner()
+    assert r._lint_due(_Mgr(last_lint=_ymd(2))) is False
+
+
+def test_lint_due_after_cadence(monkeypatch):
+    monkeypatch.setattr(CONFIG, "memory_lint_enabled", True)
+    monkeypatch.setattr(CONFIG, "memory_lint_min_days", 7.0)
+    r = DreamRunner()
+    assert r._lint_due(_Mgr(last_lint=_ymd(9))) is True
+
+
+def test_lint_disabled(monkeypatch):
+    monkeypatch.setattr(CONFIG, "memory_lint_enabled", False)
+    r = DreamRunner()
+    assert r._lint_due(_Mgr(last_lint=None)) is False
+
+
+def test_lint_rate_limited_after_attempt(monkeypatch):
+    """Even if overdue, don't re-attempt within 24h of the last attempt."""
+    monkeypatch.setattr(CONFIG, "memory_lint_enabled", True)
+    monkeypatch.setattr(CONFIG, "memory_lint_min_days", 7.0)
+    r = DreamRunner()
+    r._last_lint_attempt_at = time.time()  # just attempted
+    assert r._lint_due(_Mgr(last_lint=_ymd(30))) is False
+
+
+@pytest.mark.asyncio
+async def test_run_lint_records_entry_on_clean_run(monkeypatch):
+    """A clean lint pass (even with no page changes) records a log entry so the
+    weekly cadence advances."""
+    monkeypatch.setattr(CONFIG, "memory_lint_enabled", True)
+    r = DreamRunner()
+    mgr = _Mgr(last_lint=None)
+
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(r, "_reset_dream_chat", _noop)
+    monkeypatch.setattr(r, "_run_lint_agent", _noop)
+    monkeypatch.setattr(r, "_pause_watcher", lambda: None)
+    monkeypatch.setattr(r, "_resume_watcher", lambda: None)
+    # No page changes between before/after.
+    monkeypatch.setattr(r, "_content_pages_state", lambda m: {"p": 1.0})
+
+    result = await r._run_lint(mgr)
+
+    assert result["ok"] is True
+    assert result["changed"] is False
+    assert len(mgr.markdown_store.written) == 1  # lint entry recorded
+
+
+@pytest.mark.asyncio
+async def test_run_lint_no_entry_when_agent_fails(monkeypatch):
+    monkeypatch.setattr(CONFIG, "memory_lint_enabled", True)
+    r = DreamRunner()
+    mgr = _Mgr(last_lint=None)
+
+    async def _noop(*a, **k):
+        return None
+
+    async def _boom(*a, **k):
+        raise RuntimeError("lint agent crashed")
+
+    monkeypatch.setattr(r, "_reset_dream_chat", _noop)
+    monkeypatch.setattr(r, "_run_lint_agent", _boom)
+    monkeypatch.setattr(r, "_pause_watcher", lambda: None)
+    monkeypatch.setattr(r, "_resume_watcher", lambda: None)
+    monkeypatch.setattr(r, "_content_pages_state", lambda m: {"p": 1.0})
+
+    result = await r._run_lint(mgr)
+
+    assert result["ok"] is False
+    assert mgr.markdown_store.written == []  # cadence does NOT advance on failure

--- a/tests/memory/test_dream_summary_extraction.py
+++ b/tests/memory/test_dream_summary_extraction.py
@@ -1,0 +1,84 @@
+"""The dream panel's LAST RESULT must show the agent's FINAL summary, not its opening.
+
+process_turn_text concatenates every assistant text segment across a multi-step turn
+(preamble + tool steps + final summary). _run_forked_agent watches the event stream and
+keeps only the last contiguous text block — the post-final-tool-call summary.
+"""
+
+import pytest
+
+from suzent.core.dream_runner import DreamRunner
+from suzent.core.stream_parser import TextChunk, ToolCall
+
+
+@pytest.mark.asyncio
+async def test_run_forked_agent_returns_last_text_block(monkeypatch):
+    runner = DreamRunner()
+
+    # Simulate: preamble text -> tool call -> more text -> tool call -> final summary.
+    events = [
+        TextChunk("I'll start by orienting myself — reading schema, index."),
+        ToolCall("read_file", {}),
+        TextChunk("Reading the logs now."),
+        ToolCall("write_file", {}),
+        TextChunk("Consolidated 14 logs: created 3 pages, flagged 1 conflict."),
+    ]
+
+    async def fake_process_turn_text(*args, on_event=None, **kwargs):
+        for ev in events:
+            await on_event(ev)
+        # The real method returns the full concatenation (what we must NOT use).
+        return "".join(e.content for e in events if isinstance(e, TextChunk))
+
+    import suzent.core.chat_processor as cp
+
+    class _FakeProcessor:
+        process_turn_text = staticmethod(fake_process_turn_text)
+
+    monkeypatch.setattr(cp, "ChatProcessor", _FakeProcessor)
+
+    summary = await runner._run_forked_agent("sys", "msg")
+
+    assert summary == "Consolidated 14 logs: created 3 pages, flagged 1 conflict."
+    assert "orienting myself" not in summary
+
+
+@pytest.mark.asyncio
+async def test_run_forked_agent_falls_back_to_full_when_no_tools(monkeypatch):
+    """If the agent emits one text block and no tool calls, return that text."""
+    runner = DreamRunner()
+
+    async def fake_process_turn_text(*args, on_event=None, **kwargs):
+        await on_event(TextChunk("Nothing to consolidate."))
+        return "Nothing to consolidate."
+
+    import suzent.core.chat_processor as cp
+
+    class _FakeProcessor:
+        process_turn_text = staticmethod(fake_process_turn_text)
+
+    monkeypatch.setattr(cp, "ChatProcessor", _FakeProcessor)
+
+    summary = await runner._run_forked_agent("sys", "msg")
+    assert summary == "Nothing to consolidate."
+
+
+@pytest.mark.asyncio
+async def test_run_forked_agent_caps_length(monkeypatch):
+    runner = DreamRunner()
+    long_text = "x" * 1000
+
+    async def fake_process_turn_text(*args, on_event=None, **kwargs):
+        await on_event(TextChunk(long_text))
+        return long_text
+
+    import suzent.core.chat_processor as cp
+
+    class _FakeProcessor:
+        process_turn_text = staticmethod(fake_process_turn_text)
+
+    monkeypatch.setattr(cp, "ChatProcessor", _FakeProcessor)
+
+    summary = await runner._run_forked_agent("sys", "msg")
+    assert len(summary) <= 600
+    assert summary.endswith("…")


### PR DESCRIPTION
## Problem

The dreaming agent appeared to **redo all consolidation on every restart** and got stuck in **FINALIZING**. Root cause was a polluted dream chat: stale, unrelated history survived resets, so the agent woke up thinking it had "already done this" and no-op'd — the watermark never advanced past the same batch. A slow whole-vault reindex then pinned the panel in FINALIZING.

## Changes

**Stateless chats never persist agent_state.** Dream/sub-agent chats reset to a clean slate before every run, but three paths (fast snapshot, end-of-turn finalize, mid-run checkpoint) kept re-persisting their history — and a late finalize could resurrect it *after* the next run's reset (a race). Added a `deps.stateless` flag and gated all three write sites. This is the core fix.

**Quieter prompt for stateless chats.** Suppressed skill/plan/RAG reminders and the host-mode "do NOT use /mnt paths" warning for dream/sub-agent turns. The ambient cron-skill hint fed the "scheduled task already fired, skip it" hallucination, and the path warning contradicted the dream prompt's virtual paths.

**Non-blocking reindex.** The watermark advance + MEMORY.md promote are the durable "done" steps; the search reindex is just index maintenance (minutes on fat early logs). The runner now records the result and releases the lock immediately, then fans the reindex out to a timeout-guarded background task — so the panel leaves FINALIZING in seconds.

**Weekly lint phase.** The same runner now also runs an editorial audit (contradictions, broken links, orphans, decay) on a weekly cadence, but only once ingest is caught up so it never starves consolidation. The redundant `wiki-ingest-daily` / `wiki-lint-weekly` cron presets are removed (the dream runner owns both jobs now).

**UX.** The `system-dream` chat is hidden from the chat list (sub-agent chats stay visible). The dream panel's LAST RESULT now shows the agent's actual final summary (last contiguous text block, capped + wrapped) instead of discarding it.

**Cleanup.** Centralized the dream/lint prompt virtual paths into named constants.

## Tests

New: stateless agent_state persistence, lint phase gate, final-summary extraction. Full memory/core suites green; frontend `tsc` clean.

## Note

Not tracked here: `src-tauri/resources/config/default.example.yaml` (untracked build-artifact copy) received the same cron-preset removal locally. A server restart is required for these runtime changes to take effect.
