### PR TITLE
feat(tools): session_search tool with FTS5-backed chat search

### DIFF
--- a/frontend/src/components/chat/ToolsPanel.tsx
+++ b/frontend/src/components/chat/ToolsPanel.tsx
@@ -44,9 +44,8 @@ export function ToolsPanel(): React.ReactElement | null {
     <div className="flex items-center justify-center h-full text-neutral-400 text-xs">Loading…</div>
   );
 
-  const EXCLUDED = ['MemorySearchTool', 'MemoryBlockUpdateTool'];
   const rawTools = Array.isArray(backendConfig.tools) ? backendConfig.tools : [];
-  const available: string[] = rawTools.filter((t: string) => !EXCLUDED.includes(t));
+  const available: string[] = rawTools;
   const selected: string[] = config.tools || [];
 
   const sourceGroups: { label: string; tools: string[] }[] = backendConfig.toolGroups ?? [];

--- a/frontend/src/components/settings/AutomationTab.tsx
+++ b/frontend/src/components/settings/AutomationTab.tsx
@@ -258,7 +258,6 @@ export function AutomationTab({ models, tools = [] }: AutomationTabProps): React
                   saveHeartbeatGlobalConfig({ allowed_tools: newTools });
                 }}
                 options={tools
-                  .filter(t => !['MemorySearchTool', 'MemoryBlockUpdateTool'].includes(t))
                   .map(t => ({
                     value: t,
                     label: t.replace(/Tool$/, '').replace(/([a-z])([A-Z])/g, '$1 $2').toUpperCase(),

--- a/frontend/src/components/sidebar/ConfigView.tsx
+++ b/frontend/src/components/sidebar/ConfigView.tsx
@@ -211,8 +211,7 @@ export function ConfigView({ isActive = true }: ConfigViewProps): React.ReactEle
       <div className="space-y-2">
         <label className="block font-bold tracking-wide text-brutal-black dark:text-white uppercase">{t('config.toolsLabel')}</label>
         {(() => {
-          const EXCLUDED = ['MemorySearchTool', 'MemoryBlockUpdateTool'];
-          const available: string[] = (backendConfig.tools as string[]).filter(t => !EXCLUDED.includes(t));
+          const available: string[] = backendConfig.tools as string[];
           const selected: string[] = config.tools || [];
 
           const sourceGroups: { label: string; tools: string[] }[] = backendConfig.toolGroups ?? [];

--- a/src/suzent/agent_manager.py
+++ b/src/suzent/agent_manager.py
@@ -237,7 +237,8 @@ def create_agent(
         config: Configuration dictionary containing:
             - model: Model identifier (e.g., "gemini/gemini-2.5-pro")
             - tools: List of tool names to enable
-            - memory_enabled: Whether to equip memory tools (default: False)
+            - memory_enabled: Whether to inject memory context (default: False).
+              Does NOT control the memory_search tool, which is equipped via `tools`.
             - mcp_urls: Optional MCP server URLs
             - instructions: Optional custom instructions
 
@@ -266,14 +267,17 @@ def create_agent(
 
     # --- Build tool list ---
     tool_names = (config.get("tools") or CONFIG.default_tools).copy()
-    memory_enabled = config.get("memory_enabled", CONFIG.memory_enabled)
 
     from suzent.tools.registry import get_tool_function, get_tool_session_guidance
 
     tool_functions = []
     enabled_tool_names = set(tool_names)
+    # SkillTool / SocialMessageTool are equipped by their own auto-equip logic below,
+    # so skip them in the normal loop. MemorySearchTool is NOT auto-equipped: it is a
+    # regular sidebar-toggleable equipment tool, equipped when present in `tools`. The
+    # global memory toggle (`memory_enabled`) only governs memory *context injection*,
+    # not whether the search tool is available.
     _auto_equipped = {
-        "MemorySearchTool",
         "SkillTool",
         "SocialMessageTool",
     }
@@ -286,13 +290,6 @@ def create_agent(
             tool_functions.append(fn)
         else:
             logger.warning(f"Tool function not found for: {tool_name}")
-
-    # Equip memory search tool if enabled
-    if memory_enabled and CONFIG.memory_enabled:
-        mem_search = get_tool_function("MemorySearchTool")
-        if mem_search:
-            tool_functions.append(mem_search)
-            enabled_tool_names.add("MemorySearchTool")
 
     # Auto-equip SkillTool if any skills are enabled
     skill_manager = get_skill_manager()

--- a/src/suzent/config/__init__.py
+++ b/src/suzent/config/__init__.py
@@ -310,6 +310,8 @@ class ConfigModel(BaseModel):
         "BashTool",
         "ImageGenerationTool",
         "AgentTool",
+        "MemorySearchTool",
+        "SessionSearchTool",
     ]
     tool_options: Optional[List[str]] = None
 

--- a/src/suzent/database/base.py
+++ b/src/suzent/database/base.py
@@ -40,6 +40,7 @@ class ChatDatabaseBase:
         self._migrate_static_config_from_db()
         self._ensure_default_project()
         self._migrate_legacy_session_dirs()
+        self._init_chat_search()
 
     def _session(self) -> Session:
         """Create a new database session."""

--- a/src/suzent/database/chats.py
+++ b/src/suzent/database/chats.py
@@ -24,12 +24,17 @@ SUMMARY_VISIBLE_COUNT_KEY = "_summary_visible_assistant_count"
 HIDDEN_CHAT_PLATFORMS = ("dream",)
 
 
-def _apply_chat_filters(statement, search, platform, project_id):
+def _apply_chat_filters(statement, search, platform, project_id, fts_ids=None):
     """Apply common search/platform/project filters to a ChatModel statement.
 
     The hidden dream consolidation chat is always excluded from listing — it is an
     internal background agent, not a user conversation (it surfacing in the sidebar
     is the bug this fixes). Sub-agent chats remain visible by design.
+
+    When *fts_ids* is a list, message-content matching is served by the FTS index
+    (``ChatModel.id IN fts_ids``) instead of the ``LIKE`` scan over the JSON column;
+    title matching still uses ``LIKE``. ``fts_ids=None`` means FTS was unavailable or
+    could not serve the query, so we fall back to the original ``LIKE`` message scan.
     """
     # SQLite json_extract returns the platform string or NULL; exclude the hidden set.
     placeholders = ", ".join(f"'{p}'" for p in HIDDEN_CHAT_PLATFORMS)
@@ -40,11 +45,18 @@ def _apply_chat_filters(statement, search, platform, project_id):
         )
     )
     if search:
+        if fts_ids is None:
+            message_match = messages_search_filter(search)
+        elif fts_ids:
+            message_match = ChatModel.id.in_(fts_ids)
+        else:
+            # FTS ran and matched nothing — no message hits possible.
+            message_match = None
+        title_match = ChatModel.title.contains(search)
         statement = statement.where(
-            or_(
-                ChatModel.title.contains(search),
-                messages_search_filter(search),
-            )
+            or_(title_match, message_match)
+            if message_match is not None
+            else title_match
         )
     if project_id is not None:
         statement = statement.where(ChatModel.project_id == project_id)
@@ -161,6 +173,7 @@ class ChatOperationsMixin:
 
         with self._session() as session:
             session.add(chat)
+            self._reindex_in_session(session, chat_id, messages or [])
             session.commit()
 
         return chat_id
@@ -220,6 +233,8 @@ class ChatOperationsMixin:
                 chat.updated_at = datetime.now()
 
             session.add(chat)
+            if messages is not None:
+                self._reindex_in_session(session, chat_id, messages)
             session.commit()
             return True
 
@@ -237,6 +252,7 @@ class ChatOperationsMixin:
             chat.updated_at = datetime.now()
             flag_modified(chat, "config")
             session.add(chat)
+            self._reindex_in_session(session, chat_id, messages)
             session.commit()
             return True
 
@@ -317,6 +333,7 @@ class ChatOperationsMixin:
                 chat.messages = messages
                 chat.config = _with_message_summary(chat.config, messages)
                 flag_modified(chat, "config")
+                self._reindex_in_session(session, chat_id, messages)
             chat.finalized_revision = expected_revision
             chat.state_stage = "finalized"
             chat.state_updated_at = now
@@ -348,8 +365,55 @@ class ChatOperationsMixin:
                         session.delete(c)
 
             session.delete(chat)
+            self._remove_from_fts_in_session(session, chat_id)
             session.commit()
             return True
+
+    def _reindex_in_session(self, session, chat_id: str, messages) -> None:
+        """Reindex a chat's FTS rows inside an open SQLModel session/transaction.
+
+        Runs on the session's SQLAlchemy Connection so it shares the chat write's
+        transaction. No-op (logged) if FTS is unavailable — search must never break
+        a chat write.
+        """
+        try:
+            if not self.fts_available():
+                return
+            self._reindex_chat_fts(session.connection(), chat_id, messages or [])
+        except Exception as exc:
+            from suzent.logger import get_logger
+
+            get_logger(__name__).warning(
+                "Inline FTS reindex failed for chat {}: {}", chat_id, exc
+            )
+
+    def _search_fts_ids(self, search):
+        """Return FTS-matched chat ids for a chat-list search, or None to use LIKE.
+
+        None means "FTS can't serve this" (no search term, FTS unavailable, or query
+        below the trigram minimum) — callers then fall back to the LIKE message scan,
+        preserving prior behaviour (e.g. 2-char CJK substrings).
+        """
+        if not search:
+            return None
+        return self.fts_match_chat_ids(search)
+
+    def _remove_from_fts_in_session(self, session, chat_id: str) -> None:
+        """Delete a chat's FTS rows inside an open session/transaction."""
+        try:
+            if not self.fts_available():
+                return
+            from suzent.database.search import FTS_TABLE
+
+            session.connection().exec_driver_sql(
+                f"DELETE FROM {FTS_TABLE} WHERE chat_id = ?", (chat_id,)
+            )
+        except Exception as exc:
+            from suzent.logger import get_logger
+
+            get_logger(__name__).warning(
+                "Inline FTS delete failed for chat {}: {}", chat_id, exc
+            )
 
     def set_last_result_at(self, chat_id: str) -> None:
         """Mark that a background executor just completed a turn for this chat."""
@@ -404,7 +468,9 @@ class ChatOperationsMixin:
                 .limit(limit)
             )
 
-            statement = _apply_chat_filters(statement, search, platform, project_id)
+            statement = _apply_chat_filters(
+                statement, search, platform, project_id, self._search_fts_ids(search)
+            )
 
             # Build a slug/name lookup so each summary row can carry project info
             # without a per-row query.
@@ -471,17 +537,22 @@ class ChatOperationsMixin:
         """Get total number of chats."""
         with self._session() as session:
             statement = select(func.count()).select_from(ChatModel)
-            statement = _apply_chat_filters(statement, search, platform, project_id)
+            statement = _apply_chat_filters(
+                statement, search, platform, project_id, self._search_fts_ids(search)
+            )
             return session.exec(statement).one()
 
     def get_chat_kind_counts(
         self, search: str = None, platform: str = None, project_id: str = None
     ) -> Dict[str, int]:
         """Get chat totals for the sidebar kind tabs."""
+        fts_ids = self._search_fts_ids(search)
 
         def count(extra_filter=None) -> int:
             statement = select(func.count()).select_from(ChatModel)
-            statement = _apply_chat_filters(statement, search, platform, project_id)
+            statement = _apply_chat_filters(
+                statement, search, platform, project_id, fts_ids
+            )
             if extra_filter is not None:
                 statement = statement.where(extra_filter)
             return session.exec(statement).one()

--- a/src/suzent/database/facade.py
+++ b/src/suzent/database/facade.py
@@ -7,6 +7,7 @@ from .goals import GoalOperationsMixin
 from .migrations import DatabaseMigrationMixin
 from .postprocess import PostprocessOperationsMixin
 from .projects import ProjectOperationsMixin
+from .search import ChatSearchMixin
 from .settings import SettingsOperationsMixin
 from .tasks import TaskOperationsMixin
 
@@ -17,6 +18,7 @@ class ChatDatabase(
     GoalOperationsMixin,
     TaskOperationsMixin,
     ChatOperationsMixin,
+    ChatSearchMixin,
     PostprocessOperationsMixin,
     SettingsOperationsMixin,
     CronOperationsMixin,

--- a/src/suzent/database/migrations.py
+++ b/src/suzent/database/migrations.py
@@ -748,11 +748,13 @@ class DatabaseMigrationMixin:
         return None
 
     def _init_chat_search(self) -> None:
-        """Create the FTS5 chat-message index and backfill it once.
+        """Create the FTS5 chat-message index and backfill any unindexed chats.
 
-        Idempotent: the table is created with IF NOT EXISTS, and the backfill runs
-        only while the index is empty. Failures are logged, never fatal — chat
-        search degrading must not block startup.
+        Idempotent and resumable: the table is created with IF NOT EXISTS, and only
+        chats with no rows in the index are (re)indexed — so an interrupted first
+        backfill is completed on the next startup rather than left permanently
+        partial. Failures are logged, never fatal — chat search degrading must not
+        block startup.
         """
         from suzent.logger import logger
         from suzent.database.search import FTS_TABLE
@@ -766,11 +768,12 @@ class DatabaseMigrationMixin:
 
         try:
             with self.engine.connect() as conn:
-                (count,) = conn.exec_driver_sql(
-                    f"SELECT COUNT(*) FROM {FTS_TABLE}"
-                ).fetchone()
-            if count:
-                return  # Already populated.
+                indexed_ids = {
+                    cid
+                    for (cid,) in conn.exec_driver_sql(
+                        f"SELECT DISTINCT chat_id FROM {FTS_TABLE}"
+                    )
+                }
         except Exception as exc:
             logger.warning("Failed to inspect chat FTS index: {}", exc)
             return
@@ -780,6 +783,8 @@ class DatabaseMigrationMixin:
             with self._session() as session:
                 chat_ids = [c.id for c in session.exec(select(ChatModel)).all()]
             for chat_id in chat_ids:
+                if chat_id in indexed_ids:
+                    continue  # Already indexed; resume only the rest.
                 chat = self.get_chat(chat_id)
                 if chat and chat.messages:
                     self.reindex_chat(chat_id, chat.messages)

--- a/src/suzent/database/migrations.py
+++ b/src/suzent/database/migrations.py
@@ -746,3 +746,47 @@ class DatabaseMigrationMixin:
             ).all():
                 return chat.id
         return None
+
+    def _init_chat_search(self) -> None:
+        """Create the FTS5 chat-message index and backfill it once.
+
+        Idempotent: the table is created with IF NOT EXISTS, and the backfill runs
+        only while the index is empty. Failures are logged, never fatal — chat
+        search degrading must not block startup.
+        """
+        from suzent.logger import logger
+        from suzent.database.search import FTS_TABLE
+
+        try:
+            if not self._ensure_fts_table():
+                return  # FTS5 unavailable; chat search falls back to LIKE.
+        except Exception as exc:
+            logger.warning("Failed to create chat FTS index: {}", exc)
+            return
+
+        try:
+            with self.engine.connect() as conn:
+                (count,) = conn.exec_driver_sql(
+                    f"SELECT COUNT(*) FROM {FTS_TABLE}"
+                ).fetchone()
+            if count:
+                return  # Already populated.
+        except Exception as exc:
+            logger.warning("Failed to inspect chat FTS index: {}", exc)
+            return
+
+        backfilled = 0
+        try:
+            with self._session() as session:
+                chat_ids = [c.id for c in session.exec(select(ChatModel)).all()]
+            for chat_id in chat_ids:
+                chat = self.get_chat(chat_id)
+                if chat and chat.messages:
+                    self.reindex_chat(chat_id, chat.messages)
+                    backfilled += 1
+        except Exception as exc:
+            logger.warning("Chat FTS backfill failed: {}", exc)
+            return
+
+        if backfilled:
+            logger.info("Backfilled chat FTS index for {} chat(s)", backfilled)

--- a/src/suzent/database/search.py
+++ b/src/suzent/database/search.py
@@ -1,0 +1,336 @@
+"""Full-text chat search infrastructure (SQLite FTS5).
+
+Chats persist their messages as a JSON array on ``ChatModel.messages`` rather than
+one row per message, so FTS5's external-content sync triggers cannot be used. Instead
+we maintain a plain FTS5 table (``chat_messages_fts``) and reindex a chat's rows from
+the application layer whenever its messages change (see ChatOperationsMixin write paths).
+
+Indexed/returned text comes from the **AG-UI structured ``parts``** of each message —
+never the legacy HTML ``content`` string — so reasoning ``<details>`` and a2ui ``<div>``
+markup never enter the index or the agent-facing output. See
+``project_session_search_plan.md`` for the full design.
+
+Tokenizer: ``trigram``. It indexes 3-char windows, which gives substring matching for
+both ASCII and CJK text (``unicode61`` treats an undelimited CJK run as one token and
+cannot match a substring of it). The cost is that queries shorter than 3 chars can't be
+served by the index; for those we signal the caller to fall back to a ``LIKE`` scan so
+the existing chat-list search behaviour (2-char CJK substrings included) never regresses.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from suzent.logger import get_logger
+
+logger = get_logger(__name__)
+
+FTS_TABLE = "chat_messages_fts"
+
+# Trigram needs at least this many chars to produce a token.
+MIN_TRIGRAM_CHARS = 3
+
+# Roles a session_search caller may ask to see. Reasoning is never surfaced.
+DEFAULT_ROLE_FILTER = ("user", "assistant")
+
+
+def _supports_fts5(conn: Any) -> bool:
+    """Return True if the live SQLite build can create an FTS5 table."""
+    try:
+        conn.exec_driver_sql(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS _fts5_probe USING fts5(x)"
+        )
+        conn.exec_driver_sql("DROP TABLE IF EXISTS _fts5_probe")
+        return True
+    except Exception as exc:  # pragma: no cover - depends on sqlite build
+        logger.warning(
+            "SQLite FTS5 not available; chat search falls back to LIKE: {}", exc
+        )
+        return False
+
+
+def _message_searchable_text(message: Dict[str, Any], include_tool: bool) -> str:
+    """Extract the indexable / agent-visible text from one display message.
+
+    Reads AG-UI ``parts`` for assistant messages (text + optionally tool output),
+    and the plain ``content`` for user/tool rows. Reasoning and a2ui parts are
+    never included.
+    """
+    role = message.get("role")
+    parts = message.get("parts")
+
+    if isinstance(parts, list) and parts:
+        chunks: List[str] = []
+        for part in parts:
+            if not isinstance(part, dict):
+                continue
+            ptype = part.get("type")
+            if ptype == "text":
+                chunks.append(str(part.get("text", "")))
+            elif ptype == "tool" and include_tool:
+                name = part.get("toolName", "")
+                output = part.get("output", "")
+                chunks.append(f"[tool:{name}] {output}".strip())
+            # reasoning / a2ui: intentionally skipped
+        return "\n".join(c for c in chunks if c).strip()
+
+    # User rows and tool rows carry plain text directly.
+    if role == "tool":
+        return str(message.get("content", "")) if include_tool else ""
+    content = message.get("content")
+    return content.strip() if isinstance(content, str) else ""
+
+
+def sanitize_messages(
+    messages: List[Dict[str, Any]],
+    role_filter: tuple[str, ...] = DEFAULT_ROLE_FILTER,
+) -> List[Dict[str, Any]]:
+    """Project stored display messages into clean, role-filtered records.
+
+    Returns a list of ``{index, role, text, timestamp}`` dicts containing only the
+    roles in *role_filter*. Reasoning is always dropped; tool output is included only
+    when ``"tool"`` is in *role_filter*.
+    """
+    include_tool = "tool" in role_filter
+    out: List[Dict[str, Any]] = []
+    for idx, msg in enumerate(messages or []):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role", "")
+        # "system_triggered" rows (cron/heartbeat) ride along with assistant view.
+        visible_role = "assistant" if role == "system_triggered" else role
+        if visible_role not in role_filter:
+            continue
+        cleaned = _message_searchable_text(msg, include_tool=include_tool)
+        if not cleaned:
+            continue
+        out.append(
+            {
+                "index": idx,
+                "role": role,
+                "text": cleaned,
+                "timestamp": msg.get("timestamp"),
+            }
+        )
+    return out
+
+
+class ChatSearchMixin:
+    """FTS5-backed full-text search over chat messages.
+
+    Mixed into ``ChatDatabase``. Owns the FTS table lifecycle, per-chat reindexing,
+    and the query methods used by both ``session_search`` and the chat-list search.
+    """
+
+    # -- table lifecycle ---------------------------------------------------
+
+    def _ensure_fts_table(self) -> bool:
+        """Create the FTS5 table if missing. Returns False when FTS5 is unavailable."""
+        with self.engine.connect() as conn:
+            if not _supports_fts5(conn):
+                return False
+            conn.exec_driver_sql(
+                f"""
+                CREATE VIRTUAL TABLE IF NOT EXISTS {FTS_TABLE} USING fts5(
+                    chat_id UNINDEXED,
+                    message_index UNINDEXED,
+                    role UNINDEXED,
+                    text,
+                    tokenize = 'trigram'
+                )
+                """
+            )
+            conn.commit()
+        self._fts_available_cache = True
+        return True
+
+    def fts_available(self) -> bool:
+        """Whether the FTS table exists and is usable (memoized after first check)."""
+        cached = getattr(self, "_fts_available_cache", None)
+        if cached is not None:
+            return cached
+        try:
+            with self.engine.connect() as conn:
+                conn.exec_driver_sql(f"SELECT 1 FROM {FTS_TABLE} LIMIT 1")
+            available = True
+        except Exception:
+            available = False
+        self._fts_available_cache = available
+        return available
+
+    # -- indexing ----------------------------------------------------------
+
+    @staticmethod
+    def _reindex_chat_fts(
+        conn: Any, chat_id: str, messages: List[Dict[str, Any]]
+    ) -> None:
+        """Replace all FTS rows for *chat_id* with freshly extracted message text.
+
+        Indexes user + assistant text and tool output (so ``role_filter='tool'``
+        searches work). Must run inside the same transaction as the chat write.
+        """
+        conn.exec_driver_sql(f"DELETE FROM {FTS_TABLE} WHERE chat_id = ?", (chat_id,))
+        rows = sanitize_messages(messages, role_filter=("user", "assistant", "tool"))
+        if not rows:
+            return
+        conn.exec_driver_sql(
+            f"INSERT INTO {FTS_TABLE} (chat_id, message_index, role, text) VALUES "
+            + ",".join(["(?, ?, ?, ?)"] * len(rows)),
+            tuple(v for r in rows for v in (chat_id, r["index"], r["role"], r["text"])),
+        )
+
+    def reindex_chat(self, chat_id: str, messages: List[Dict[str, Any]]) -> None:
+        """Public, self-contained reindex (own transaction). Used by backfill."""
+        if not self.fts_available():
+            return
+        try:
+            with self.engine.connect() as conn:
+                self._reindex_chat_fts(conn, chat_id, messages)
+                conn.commit()
+        except Exception as exc:
+            logger.warning("FTS reindex failed for chat {}: {}", chat_id, exc)
+
+    def remove_chat_from_fts(self, chat_id: str) -> None:
+        """Drop a deleted chat's rows from the index."""
+        if not self.fts_available():
+            return
+        try:
+            with self.engine.connect() as conn:
+                conn.exec_driver_sql(
+                    f"DELETE FROM {FTS_TABLE} WHERE chat_id = ?", (chat_id,)
+                )
+                conn.commit()
+        except Exception as exc:
+            logger.warning("FTS delete failed for chat {}: {}", chat_id, exc)
+
+    # -- querying ----------------------------------------------------------
+
+    def fts_match_chat_ids(self, query: str) -> Optional[List[str]]:
+        """Return chat_ids whose messages match *query*, best-rank first.
+
+        Returns None when FTS can't serve the query (unavailable, or shorter than the
+        trigram minimum) so the caller falls back to a LIKE scan.
+        """
+        if not self.fts_available():
+            return None
+        if len(query.strip()) < MIN_TRIGRAM_CHARS:
+            return None
+        try:
+            with self.engine.connect() as conn:
+                result = conn.exec_driver_sql(
+                    f"SELECT chat_id FROM {FTS_TABLE} WHERE {FTS_TABLE} MATCH ? "
+                    f"ORDER BY rank",
+                    (query,),
+                )
+                seen: List[str] = []
+                seen_set = set()
+                for (cid,) in result:
+                    if cid not in seen_set:
+                        seen_set.add(cid)
+                        seen.append(cid)
+                return seen
+        except Exception as exc:
+            # An invalid FTS query string (bad syntax) should degrade, not crash.
+            logger.info("FTS query failed for {!r}: {}", query, exc)
+            return None
+
+    def search_chat_messages(
+        self,
+        query: str,
+        limit: int = 3,
+        context: int = 5,
+        bookend: int = 3,
+        role_filter: tuple[str, ...] = DEFAULT_ROLE_FILTER,
+    ) -> List[Dict[str, Any]]:
+        """Discovery mode: top-*limit* chats matching *query*.
+
+        Each result: ``{chat_id, title, updated_at, snippet, context, bookends}``
+        where ``context`` is the ±*context* sanitized messages around the first hit
+        and ``bookends`` is the first/last *bookend* sanitized messages of the chat.
+        """
+        chat_ids = self.fts_match_chat_ids(query)
+        if not chat_ids:
+            return []
+
+        results: List[Dict[str, Any]] = []
+        for chat_id in chat_ids[: max(1, limit)]:
+            chat = self.get_chat(chat_id)
+            if not chat:
+                continue
+            if self._is_hidden_platform(chat):
+                continue
+            cleaned = sanitize_messages(chat.messages or [], role_filter=role_filter)
+            if not cleaned:
+                continue
+
+            hit_pos = self._first_hit_position(cleaned, query)
+            lo = max(0, hit_pos - context)
+            hi = min(len(cleaned), hit_pos + context + 1)
+            window = cleaned[lo:hi]
+
+            bookends = {
+                "first": cleaned[:bookend],
+                "last": cleaned[-bookend:] if len(cleaned) > bookend else [],
+            }
+            results.append(
+                {
+                    "chat_id": chat_id,
+                    "title": chat.title,
+                    "updated_at": chat.updated_at.isoformat()
+                    if chat.updated_at
+                    else None,
+                    "snippet": cleaned[hit_pos]["text"][:300],
+                    "context": window,
+                    "bookends": bookends,
+                }
+            )
+        return results
+
+    def read_chat_session(
+        self,
+        chat_id: str,
+        role_filter: tuple[str, ...] = DEFAULT_ROLE_FILTER,
+        head: int = 20,
+        tail: int = 10,
+    ) -> Optional[Dict[str, Any]]:
+        """Read mode: a whole session, sanitized. Large sessions show head+tail."""
+        chat = self.get_chat(chat_id)
+        if not chat:
+            return None
+        cleaned = sanitize_messages(chat.messages or [], role_filter=role_filter)
+        total = len(cleaned)
+        truncated = False
+        if total > head + tail:
+            cleaned = cleaned[:head] + cleaned[-tail:]
+            truncated = True
+        return {
+            "chat_id": chat_id,
+            "title": chat.title,
+            "updated_at": chat.updated_at.isoformat() if chat.updated_at else None,
+            "total_messages": total,
+            "truncated": truncated,
+            "messages": cleaned,
+        }
+
+    # -- helpers -----------------------------------------------------------
+
+    @staticmethod
+    def _first_hit_position(cleaned: List[Dict[str, Any]], query: str) -> int:
+        """Best-effort index of the message most likely to contain the match.
+
+        FTS rank points at a chat, not a message; we re-locate the term within the
+        sanitized list for the context window. Falls back to 0.
+        """
+        terms = [t.strip('"').lower() for t in query.split() if t.strip('"')]
+        for i, msg in enumerate(cleaned):
+            low = msg["text"].lower()
+            if any(t in low for t in terms):
+                return i
+        return 0
+
+    @staticmethod
+    def _is_hidden_platform(chat: Any) -> bool:
+        from suzent.database.chats import HIDDEN_CHAT_PLATFORMS
+
+        config = getattr(chat, "config", None) or {}
+        return config.get("platform") in HIDDEN_CHAT_PLATFORMS

--- a/src/suzent/database/search.py
+++ b/src/suzent/database/search.py
@@ -74,7 +74,12 @@ def _message_searchable_text(message: Dict[str, Any], include_tool: bool) -> str
             # reasoning / a2ui: intentionally skipped
         return "\n".join(c for c in chunks if c).strip()
 
-    # User rows and tool rows carry plain text directly.
+    # User and tool rows carry plain text in `content`. Assistant rows do NOT — their
+    # readable text lives in `parts`; the legacy `content` string is HTML-rendered
+    # markdown (reasoning `<details>`, a2ui `<div>`). An assistant row without `parts`
+    # has no safe text to surface, so return empty rather than leaking that markup.
+    if role == "assistant":
+        return ""
     if role == "tool":
         return str(message.get("content", "")) if include_tool else ""
     content = message.get("content")
@@ -234,6 +239,27 @@ class ChatSearchMixin:
             logger.info("FTS query failed for {!r}: {}", query, exc)
             return None
 
+    def _like_match_chat_ids(self, query: str) -> List[str]:
+        """Substring (LIKE) fallback for Discovery, newest chats first.
+
+        Mirrors the chat-list search's message matching (``messages_search_filter``)
+        so Discovery still works when FTS can't serve the query. Returns [] on error.
+        """
+        from sqlmodel import select
+        from suzent.database.models import ChatModel, messages_search_filter
+
+        try:
+            with self._session() as session:
+                statement = (
+                    select(ChatModel.id)
+                    .where(messages_search_filter(query))
+                    .order_by(ChatModel.updated_at.desc())
+                )
+                return [row for row in session.exec(statement).all()]
+        except Exception as exc:
+            logger.info("LIKE discovery fallback failed for {!r}: {}", query, exc)
+            return []
+
     def search_chat_messages(
         self,
         query: str,
@@ -241,19 +267,32 @@ class ChatSearchMixin:
         context: int = 5,
         bookend: int = 3,
         role_filter: tuple[str, ...] = DEFAULT_ROLE_FILTER,
+        exclude_chat_id: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Discovery mode: top-*limit* chats matching *query*.
 
         Each result: ``{chat_id, title, updated_at, snippet, context, bookends}``
         where ``context`` is the ±*context* sanitized messages around the first hit
         and ``bookends`` is the first/last *bookend* sanitized messages of the chat.
+
+        Candidates come from FTS when it can serve the query, otherwise from a LIKE
+        scan (short/CJK queries, invalid FTS syntax, or builds without FTS5) so
+        Discovery degrades the same way the chat-list search does. ``exclude_chat_id``
+        is dropped from candidates *before* the limit is applied, so excluding the
+        current session never costs a result slot.
         """
         chat_ids = self.fts_match_chat_ids(query)
+        if chat_ids is None:
+            chat_ids = self._like_match_chat_ids(query)
         if not chat_ids:
             return []
 
         results: List[Dict[str, Any]] = []
-        for chat_id in chat_ids[: max(1, limit)]:
+        for chat_id in chat_ids:
+            if len(results) >= max(1, limit):
+                break
+            if chat_id == exclude_chat_id:
+                continue
             chat = self.get_chat(chat_id)
             if not chat:
                 continue

--- a/src/suzent/tools/base.py
+++ b/src/suzent/tools/base.py
@@ -39,6 +39,7 @@ class ToolGroup(str, Enum):
     WEB = "Web"
     AGENT = "Agent"
     CREATIVE = "Creative"
+    MEMORY = "Memory & recall"
 
 
 class ToolErrorCode(Enum):

--- a/src/suzent/tools/memory_tools.py
+++ b/src/suzent/tools/memory_tools.py
@@ -26,7 +26,6 @@ class MemorySearchTool(Tool):
     name = "MemorySearchTool"
     tool_name = "memory_search"
     group = ToolGroup.MEMORY
-    deferrable = False
 
     def __init__(self):
         super().__init__()

--- a/src/suzent/tools/memory_tools.py
+++ b/src/suzent/tools/memory_tools.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from pydantic import Field
 from pydantic_ai import RunContext
 from suzent.core.agent_deps import AgentDeps
-from suzent.tools.base import Tool, ToolErrorCode, ToolResult
+from suzent.tools.base import Tool, ToolErrorCode, ToolGroup, ToolResult
 from suzent.logger import get_logger
 
 logger = get_logger(__name__)
@@ -25,6 +25,7 @@ class MemorySearchTool(Tool):
 
     name = "MemorySearchTool"
     tool_name = "memory_search"
+    group = ToolGroup.MEMORY
     deferrable = False
 
     def __init__(self):

--- a/src/suzent/tools/registry.py
+++ b/src/suzent/tools/registry.py
@@ -98,6 +98,7 @@ def _all_tool_classes() -> list:
     from suzent.tools.image_generation_tool import ImageGenerationTool
     from suzent.tools.image_vision_tool import ImageVisionTool
     from suzent.tools.memory_tools import MemorySearchTool
+    from suzent.tools.session_search_tool import SessionSearchTool
     from suzent.tools.render_ui_tool import RenderUITool
     from suzent.tools.ask_question_tool import AskQuestionTool
     from suzent.tools.agent_tool import AgentTool
@@ -125,6 +126,7 @@ def _all_tool_classes() -> list:
         SocialMessageTool,
         SkillTool,
         MemorySearchTool,
+        SessionSearchTool,
         AgentTool,
     ]
 

--- a/src/suzent/tools/session_search_tool.py
+++ b/src/suzent/tools/session_search_tool.py
@@ -20,7 +20,7 @@ from pydantic_ai import RunContext
 from suzent.core.agent_deps import AgentDeps
 from suzent.database import get_database
 from suzent.logger import get_logger
-from suzent.tools.base import Tool, ToolErrorCode, ToolResult
+from suzent.tools.base import Tool, ToolErrorCode, ToolGroup, ToolResult
 
 logger = get_logger(__name__)
 
@@ -55,6 +55,7 @@ class SessionSearchTool(Tool):
 
     name = "SessionSearchTool"
     tool_name = "session_search"
+    group = ToolGroup.MEMORY
 
     async def forward(
         self,

--- a/src/suzent/tools/session_search_tool.py
+++ b/src/suzent/tools/session_search_tool.py
@@ -1,0 +1,200 @@
+"""Session search tool — recall and navigate past chat sessions.
+
+A single tool with three modes (Hermes-style dispatch by which params are set):
+
+* **Read** (``session_id`` set) — dump one session's messages, sanitized.
+* **Discovery** (``query`` set) — full-text search across past sessions, returning
+  match snippets with a context window and bookends.
+* **Browse** (neither set) — list recent sessions chronologically.
+
+All output is drawn from each message's clean AG-UI ``parts`` (see
+``suzent.database.search``); reasoning traces are never surfaced, and tool output is
+included only when ``role_filter`` requests it.
+"""
+
+from typing import Annotated, Optional
+
+from pydantic import Field
+from pydantic_ai import RunContext
+
+from suzent.core.agent_deps import AgentDeps
+from suzent.database import get_database
+from suzent.logger import get_logger
+from suzent.tools.base import Tool, ToolErrorCode, ToolResult
+
+logger = get_logger(__name__)
+
+VALID_ROLES = {"user", "assistant", "tool"}
+
+
+def _parse_role_filter(role_filter: str) -> tuple[str, ...]:
+    """Parse a comma-separated role filter into a validated tuple.
+
+    Falls back to ``("user", "assistant")`` when nothing valid is given.
+    """
+    roles = tuple(
+        r.strip().lower()
+        for r in (role_filter or "").split(",")
+        if r.strip().lower() in VALID_ROLES
+    )
+    return roles or ("user", "assistant")
+
+
+def _format_messages(messages: list[dict]) -> str:
+    lines = []
+    for m in messages:
+        text = (m.get("text") or "").strip()
+        if not text:
+            continue
+        lines.append(f"[{m.get('role', '?')}] {text}")
+    return "\n".join(lines)
+
+
+class SessionSearchTool(Tool):
+    """Search and read past conversation sessions."""
+
+    name = "SessionSearchTool"
+    tool_name = "session_search"
+
+    async def forward(
+        self,
+        ctx: RunContext[AgentDeps],
+        query: Annotated[
+            Optional[str],
+            Field(
+                default=None,
+                description="Full-text search across past sessions (Discovery mode). "
+                "Supports the SQLite FTS5 query syntax. Omit to browse or read.",
+            ),
+        ] = None,
+        session_id: Annotated[
+            Optional[str],
+            Field(
+                default=None,
+                description="Read one whole session by id (Read mode). Takes precedence "
+                "over query.",
+            ),
+        ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                default=3,
+                ge=1,
+                le=10,
+                description="Max sessions returned in Discovery/Browse modes.",
+            ),
+        ] = 3,
+        role_filter: Annotated[
+            str,
+            Field(
+                default="user,assistant",
+                description="Comma-separated roles to include: 'user,assistant' "
+                "(default), add 'tool' to include tool output, or 'tool' alone. "
+                "Assistant reasoning is never shown.",
+            ),
+        ] = "user,assistant",
+    ) -> ToolResult:
+        """Recall past conversations: read a session, search them, or browse recent ones.
+
+        Modes are chosen by which arguments are provided:
+        - ``session_id`` → Read a whole session.
+        - ``query`` → Discovery search across sessions.
+        - neither → Browse recent sessions.
+        """
+        db = get_database()
+        roles = _parse_role_filter(role_filter)
+        current_chat_id = ctx.deps.chat_id
+
+        try:
+            if session_id:
+                return self._read(db, session_id, roles)
+            if query and query.strip():
+                return self._discover(db, query, limit, roles, current_chat_id)
+            return self._browse(db, limit, current_chat_id)
+        except Exception as e:
+            logger.error(f"session_search failed: {e}")
+            return ToolResult.error_result(
+                ToolErrorCode.EXECUTION_FAILED,
+                f"Session search failed: {e}",
+            )
+
+    # -- modes -------------------------------------------------------------
+
+    def _read(self, db, session_id: str, roles: tuple[str, ...]) -> ToolResult:
+        session = db.read_chat_session(session_id, role_filter=roles)
+        if not session:
+            return ToolResult.error_result(
+                ToolErrorCode.FILE_NOT_FOUND,
+                f"No session found with id '{session_id}'.",
+            )
+        header = f"Session '{session['title']}' ({session['total_messages']} messages"
+        if session["truncated"]:
+            header += ", showing first 20 + last 10"
+        header += "):"
+        body = _format_messages(session["messages"])
+        return ToolResult.success_result(
+            f"{header}\n\n{body}" if body else f"{header}\n\n(no visible messages)",
+            metadata={
+                "mode": "read",
+                "session_id": session_id,
+                "total_messages": session["total_messages"],
+                "truncated": session["truncated"],
+            },
+        )
+
+    def _discover(
+        self,
+        db,
+        query: str,
+        limit: int,
+        roles: tuple[str, ...],
+        current_chat_id: Optional[str],
+    ) -> ToolResult:
+        results = db.search_chat_messages(query, limit=limit, role_filter=roles)
+        # Exclude the current session — recall is about *other* conversations.
+        results = [r for r in results if r["chat_id"] != current_chat_id]
+        if not results:
+            return ToolResult.success_result(
+                f"No past sessions matched '{query}'.",
+                metadata={"mode": "discovery", "query": query, "match_count": 0},
+            )
+
+        blocks = [f"Found {len(results)} session(s) matching '{query}':\n"]
+        for r in results:
+            ctx_text = _format_messages(r["context"])
+            blocks.append(
+                f"### {r['title']}  (session_id: {r['chat_id']})\n"
+                f"Last active: {r['updated_at']}\n"
+                f"Match: {r['snippet']}\n\n"
+                f"Context:\n{ctx_text}"
+            )
+        return ToolResult.success_result(
+            "\n\n".join(blocks),
+            metadata={
+                "mode": "discovery",
+                "query": query,
+                "match_count": len(results),
+            },
+        )
+
+    def _browse(self, db, limit: int, current_chat_id: Optional[str]) -> ToolResult:
+        # Over-fetch by one so excluding the current chat still yields `limit` rows.
+        summaries = db.list_chats(limit=limit + 1)
+        summaries = [s for s in summaries if s.id != current_chat_id][:limit]
+        if not summaries:
+            return ToolResult.success_result(
+                "No past sessions found.",
+                metadata={"mode": "browse", "count": 0},
+            )
+        lines = ["Recent sessions:\n"]
+        for s in summaries:
+            preview = (s.lastMessage or "").strip()
+            lines.append(
+                f"- {s.title}  (session_id: {s.id})\n"
+                f"  Updated: {s.updatedAt}  ·  {s.messageCount} messages\n"
+                f"  {preview}"
+            )
+        return ToolResult.success_result(
+            "\n".join(lines),
+            metadata={"mode": "browse", "count": len(summaries)},
+        )

--- a/src/suzent/tools/session_search_tool.py
+++ b/src/suzent/tools/session_search_tool.py
@@ -179,6 +179,8 @@ class SessionSearchTool(Tool):
         )
 
     def _browse(self, db, limit: int, current_chat_id: Optional[str]) -> ToolResult:
+        from suzent.database.search import sanitize_messages
+
         # Over-fetch by one so excluding the current chat still yields `limit` rows.
         summaries = db.list_chats(limit=limit + 1)
         summaries = [s for s in summaries if s.id != current_chat_id][:limit]
@@ -189,10 +191,15 @@ class SessionSearchTool(Tool):
             )
         lines = ["Recent sessions:\n"]
         for s in summaries:
+            # The sidebar summary count (s.messageCount) counts only assistant turns
+            # and can be stale; recompute the visible (user+assistant) message count
+            # live so Browse never reports a misleading "0 messages".
+            chat = db.get_chat(s.id)
+            msg_count = len(sanitize_messages(chat.messages or [])) if chat else 0
             preview = (s.lastMessage or "").strip()
             lines.append(
                 f"- {s.title}  (session_id: {s.id})\n"
-                f"  Updated: {s.updatedAt}  ·  {s.messageCount} messages\n"
+                f"  Updated: {s.updatedAt}  ·  {msg_count} messages\n"
                 f"  {preview}"
             )
         return ToolResult.success_result(

--- a/src/suzent/tools/session_search_tool.py
+++ b/src/suzent/tools/session_search_tool.py
@@ -151,9 +151,11 @@ class SessionSearchTool(Tool):
         roles: tuple[str, ...],
         current_chat_id: Optional[str],
     ) -> ToolResult:
-        results = db.search_chat_messages(query, limit=limit, role_filter=roles)
-        # Exclude the current session — recall is about *other* conversations.
-        results = [r for r in results if r["chat_id"] != current_chat_id]
+        # Exclude the current session (recall is about *other* conversations) inside the
+        # query, so excluding it never costs a result slot under the limit.
+        results = db.search_chat_messages(
+            query, limit=limit, role_filter=roles, exclude_chat_id=current_chat_id
+        )
         if not results:
             return ToolResult.success_result(
                 f"No past sessions matched '{query}'.",

--- a/tests/core/test_memory_tool_equipment.py
+++ b/tests/core/test_memory_tool_equipment.py
@@ -1,0 +1,43 @@
+"""The memory_search tool is a sidebar-toggleable equipment tool, decoupled from the
+global memory toggle. memory_enabled now governs only memory context injection.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import suzent.agent_manager as am
+
+
+def _equipped_tool_names(config):
+    """Return the tool_name of every function equipped on the agent for *config*."""
+    captured = {}
+
+    def fake_agent(model, **kwargs):
+        captured["tools"] = kwargs.get("tools") or []
+        return MagicMock()
+
+    with (
+        patch.object(am, "create_pydantic_ai_model", return_value=MagicMock()),
+        patch.object(am, "Agent", fake_agent),
+    ):
+        am.create_agent(config)
+
+    return {getattr(fn, "__name__", None) for fn in captured["tools"]}
+
+
+def test_memory_search_equipped_when_in_tools_even_if_memory_disabled():
+    names = _equipped_tool_names(
+        {"tools": ["ReadFileTool", "MemorySearchTool"], "memory_enabled": False}
+    )
+    assert "memory_search" in names
+
+
+def test_memory_search_absent_when_not_in_tools_even_if_memory_enabled():
+    names = _equipped_tool_names({"tools": ["ReadFileTool"], "memory_enabled": True})
+    assert "memory_search" not in names
+
+
+def test_session_search_equipped_when_in_tools():
+    names = _equipped_tool_names(
+        {"tools": ["ReadFileTool", "SessionSearchTool"], "memory_enabled": False}
+    )
+    assert "session_search" in names

--- a/tests/core/test_memory_tool_equipment.py
+++ b/tests/core/test_memory_tool_equipment.py
@@ -41,3 +41,12 @@ def test_session_search_equipped_when_in_tools():
         {"tools": ["ReadFileTool", "SessionSearchTool"], "memory_enabled": False}
     )
     assert "session_search" in names
+
+
+def test_memory_and_recall_tools_are_activatable_via_tool_search():
+    """Both recall tools are deferrable, so tool_search can activate them mid-session
+    when they aren't already equipped."""
+    from suzent.tools.tool_search_tool import TOOL_CATALOG
+
+    assert "MemorySearchTool" in TOOL_CATALOG
+    assert "SessionSearchTool" in TOOL_CATALOG

--- a/tests/integration/test_chat_search.py
+++ b/tests/integration/test_chat_search.py
@@ -216,3 +216,22 @@ def test_tool_browse_mode(tool_db):
     assert res.success
     assert res.metadata["mode"] == "browse"
     assert "One" in res.message or "Two" in res.message
+
+
+def test_browse_counts_visible_messages_not_stale_sidebar_count(tool_db):
+    """Browse must recompute the visible message count, not trust the (assistant-only,
+    possibly stale) sidebar summary. A user msg + a text reply = 2 visible messages."""
+    cid = tool_db.create_chat(
+        "Convo",
+        {},
+        [
+            {"role": "user", "content": "question here"},
+            _assistant("the answer"),
+        ],
+    )
+    # Force the sidebar summary count stale (as happens for chats summarized before
+    # their assistant reply landed).
+    tool_db.merge_chat_config(cid, {"_summary_visible_assistant_count": 0})
+    res = asyncio.run(SessionSearchTool().forward(_ctx(tool_db)))
+    assert "0 messages" not in res.message
+    assert "2 messages" in res.message

--- a/tests/integration/test_chat_search.py
+++ b/tests/integration/test_chat_search.py
@@ -1,0 +1,218 @@
+"""Tests for FTS5-backed chat search infra and the session_search tool."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from suzent.database.search import sanitize_messages
+from suzent.tools.session_search_tool import SessionSearchTool, _parse_role_filter
+
+
+@pytest.fixture
+def db(temp_db):
+    return temp_db
+
+
+def _assistant(text, reasoning=None, tool=None):
+    parts = []
+    if reasoning:
+        parts.append({"type": "reasoning", "text": reasoning})
+    parts.append({"type": "text", "text": text})
+    if tool:
+        parts.append(
+            {"type": "tool", "toolName": tool[0], "args": "{}", "output": tool[1]}
+        )
+    # `content` carries the legacy HTML form; search must ignore it.
+    return {
+        "role": "assistant",
+        "content": f"<details>{reasoning}</details>{text}",
+        "parts": parts,
+    }
+
+
+# --------------------------------------------------------------------------
+# sanitize_messages: reads parts, drops reasoning, gates tool output
+# --------------------------------------------------------------------------
+
+
+def test_sanitize_drops_reasoning_and_tool_by_default():
+    msgs = [
+        {"role": "user", "content": "deploy the rocket"},
+        _assistant(
+            "press the button", reasoning="secret cot", tool=("read_file", "file body")
+        ),
+    ]
+    out = sanitize_messages(msgs)
+    joined = " ".join(m["text"] for m in out)
+    assert "press the button" in joined
+    assert "deploy the rocket" in joined
+    assert "secret cot" not in joined  # reasoning never surfaced
+    assert "file body" not in joined  # tool excluded by default
+    assert "<details>" not in joined  # HTML content ignored
+
+
+def test_sanitize_includes_tool_when_requested():
+    msgs = [_assistant("answer", tool=("read_file", "TOOLBODY"))]
+    out = sanitize_messages(msgs, role_filter=("user", "assistant", "tool"))
+    joined = " ".join(m["text"] for m in out)
+    assert "answer" in joined
+    assert "TOOLBODY" in joined
+
+
+# --------------------------------------------------------------------------
+# reindex on write paths
+# --------------------------------------------------------------------------
+
+
+def test_create_chat_indexes_messages(db):
+    db.create_chat("T", {}, [{"role": "user", "content": "alpha bravo charlie"}])
+    assert db.fts_match_chat_ids("bravo")
+
+
+def test_append_message_updates_index(db):
+    cid = db.create_chat("T", {}, [{"role": "user", "content": "alpha"}])
+    assert not db.fts_match_chat_ids("zulu")
+    db.append_chat_message(cid, {"role": "user", "content": "zulu added later"})
+    assert cid in (db.fts_match_chat_ids("zulu") or [])
+
+
+def test_update_chat_replaces_index(db):
+    cid = db.create_chat("T", {}, [{"role": "user", "content": "original word"}])
+    db.update_chat(cid, messages=[{"role": "user", "content": "replaced text"}])
+    assert not db.fts_match_chat_ids("original")
+    assert cid in (db.fts_match_chat_ids("replaced") or [])
+
+
+def test_delete_chat_removes_from_index(db):
+    cid = db.create_chat("T", {}, [{"role": "user", "content": "deletme token"}])
+    assert db.fts_match_chat_ids("deletme")
+    db.delete_chat(cid)
+    assert not db.fts_match_chat_ids("deletme")
+
+
+# --------------------------------------------------------------------------
+# Discovery / Read DB methods
+# --------------------------------------------------------------------------
+
+
+def test_discovery_returns_snippet_and_context(db):
+    db.create_chat(
+        "Rocket",
+        {},
+        [
+            {"role": "user", "content": "how do I deploy the rocket"},
+            _assistant("press the big red button"),
+        ],
+    )
+    results = db.search_chat_messages("rocket", limit=3)
+    assert len(results) == 1
+    r = results[0]
+    assert r["title"] == "Rocket"
+    assert "rocket" in r["snippet"].lower()
+    assert any("button" in m["text"] for m in r["context"])
+
+
+def test_read_truncates_large_sessions(db):
+    msgs = [{"role": "user", "content": f"msg number {i}"} for i in range(50)]
+    cid = db.create_chat("Big", {}, msgs)
+    out = db.read_chat_session(cid, head=20, tail=10)
+    assert out["total_messages"] == 50
+    assert out["truncated"] is True
+    assert len(out["messages"]) == 30
+
+
+def test_hidden_platform_excluded_from_discovery(db):
+    db.create_chat(
+        "Dreamy", {"platform": "dream"}, [{"role": "user", "content": "xyzzy"}]
+    )
+    assert db.search_chat_messages("xyzzy") == []
+
+
+# --------------------------------------------------------------------------
+# Chat-list search parity (LIKE fallback for short / CJK queries)
+# --------------------------------------------------------------------------
+
+
+def test_chat_list_search_uses_fts(db):
+    db.create_chat(
+        "Deploy notes", {}, [{"role": "user", "content": "deploy the service"}]
+    )
+    db.create_chat("Recipes", {}, [{"role": "user", "content": "pasta and sauce"}])
+    titles = [c.title for c in db.list_chats(search="deploy")]
+    assert "Deploy notes" in titles
+    assert "Recipes" not in titles
+
+
+def test_chat_list_short_cjk_falls_back_to_like(db):
+    db.create_chat("CN", {}, [{"role": "user", "content": "部署火箭的方法"}])
+    # 2-char CJK is below the trigram minimum → LIKE fallback must still match.
+    assert db.fts_match_chat_ids("火箭") is None
+    titles = [c.title for c in db.list_chats(search="火箭")]
+    assert "CN" in titles
+
+
+# --------------------------------------------------------------------------
+# session_search tool: mode dispatch
+# --------------------------------------------------------------------------
+
+
+def _ctx(db, chat_id=""):
+    # The tool reads only ctx.deps.chat_id; get_database() returns the shared singleton,
+    # so point it at the temp db for the duration of the test.
+    return SimpleNamespace(deps=SimpleNamespace(chat_id=chat_id))
+
+
+@pytest.fixture
+def tool_db(db, monkeypatch):
+    monkeypatch.setattr("suzent.tools.session_search_tool.get_database", lambda: db)
+    return db
+
+
+def test_role_filter_parsing():
+    assert _parse_role_filter("user,assistant") == ("user", "assistant")
+    assert _parse_role_filter("tool") == ("tool",)
+    assert _parse_role_filter("garbage") == ("user", "assistant")
+    assert _parse_role_filter("user,assistant,tool") == ("user", "assistant", "tool")
+
+
+def test_tool_read_mode(tool_db):
+    cid = tool_db.create_chat(
+        "Sess",
+        {},
+        [
+            {"role": "user", "content": "hello there"},
+            _assistant("general kenobi", reasoning="hidden"),
+        ],
+    )
+    tool = SessionSearchTool()
+    res = asyncio.run(tool.forward(_ctx(tool_db), session_id=cid))
+    assert res.success
+    assert "general kenobi" in res.message
+    assert "hidden" not in res.message
+    assert res.metadata["mode"] == "read"
+
+
+def test_tool_discovery_excludes_current_chat(tool_db):
+    a = tool_db.create_chat(
+        "A", {}, [{"role": "user", "content": "shared keyword apple"}]
+    )
+    b = tool_db.create_chat(
+        "B", {}, [{"role": "user", "content": "shared keyword apple"}]
+    )
+    tool = SessionSearchTool()
+    # Searching from chat A should not return A itself.
+    res = asyncio.run(tool.forward(_ctx(tool_db, chat_id=a), query="apple"))
+    assert res.success
+    assert "session_id: %s" % b in res.message
+    assert "session_id: %s" % a not in res.message
+
+
+def test_tool_browse_mode(tool_db):
+    tool_db.create_chat("One", {}, [{"role": "user", "content": "first"}])
+    tool_db.create_chat("Two", {}, [{"role": "user", "content": "second"}])
+    tool = SessionSearchTool()
+    res = asyncio.run(tool.forward(_ctx(tool_db)))
+    assert res.success
+    assert res.metadata["mode"] == "browse"
+    assert "One" in res.message or "Two" in res.message

--- a/tests/integration/test_chat_search.py
+++ b/tests/integration/test_chat_search.py
@@ -153,6 +153,59 @@ def test_chat_list_short_cjk_falls_back_to_like(db):
 
 
 # --------------------------------------------------------------------------
+# Codex review fixes
+# --------------------------------------------------------------------------
+
+
+def test_legacy_assistant_without_parts_never_leaks_content():
+    """An assistant row with no `parts` (legacy HTML in `content`) must yield no text,
+    not the raw reasoning/HTML markup."""
+    msgs = [
+        {"role": "user", "content": "a question"},
+        {
+            "role": "assistant",
+            "content": '<details data-reasoning="true">secret cot</details>visible?',
+        },
+    ]
+    out = sanitize_messages(msgs)
+    joined = " ".join(m["text"] for m in out)
+    assert "secret cot" not in joined
+    assert "<details" not in joined
+    # Only the user message survives.
+    assert [m["role"] for m in out] == ["user"]
+
+
+def test_discovery_falls_back_to_like_for_short_query(db):
+    # 2-char CJK is below the trigram minimum; Discovery must still find it via LIKE.
+    db.create_chat("CN", {}, [{"role": "user", "content": "部署火箭的方法"}])
+    assert db.fts_match_chat_ids("火箭") is None
+    results = db.search_chat_messages("火箭")
+    assert [r["title"] for r in results] == ["CN"]
+
+
+def test_discovery_excludes_chat_before_limit(db):
+    # Two chats match; with limit=1 and the higher-ranked one excluded, the other
+    # must still be returned (exclusion must not consume the single slot).
+    a = db.create_chat("A", {}, [{"role": "user", "content": "keyword apple"}])
+    db.create_chat("B", {}, [{"role": "user", "content": "keyword apple"}])
+    results = db.search_chat_messages("apple", limit=1, exclude_chat_id=a)
+    assert len(results) == 1
+    assert results[0]["chat_id"] != a
+
+
+def test_backfill_resumes_for_unindexed_chats(db):
+    # Simulate an interrupted backfill: a chat exists but has no FTS rows.
+    cid = db.create_chat("Resume", {}, [{"role": "user", "content": "resumeword"}])
+    db.remove_chat_from_fts(cid)
+    assert not db.fts_match_chat_ids("resumeword")
+    # Re-running init must index the missing chat rather than skipping because the
+    # index is already non-empty (other chats present).
+    db.create_chat("Other", {}, [{"role": "user", "content": "otherword"}])
+    db._init_chat_search()
+    assert cid in (db.fts_match_chat_ids("resumeword") or [])
+
+
+# --------------------------------------------------------------------------
 # session_search tool: mode dispatch
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds a **`session_search`** tool so the agent can recall and navigate past chat
sessions, plus the shared **FTS5 full-text search infrastructure** it runs on — which
the existing chat-list search now uses too.

Ports the behavior of Hermes-agent's `session_search` (one tool, mode dispatch by which
params are set), adapted to this codebase's storage model.

## Tool modes

| Mode | Trigger | Returns |
|---|---|---|
| **Read** | `session_id` | One whole session, sanitized (first 20 + last 10 if large) |
| **Discovery** | `query` | Top-N matching sessions with snippet, ±context window, bookends |
| **Browse** | neither | Recent sessions, chronological |

`role_filter` (default `user,assistant`) gates tool output; the current session is
excluded from Discovery/Browse (recall is about *other* conversations).

## Infrastructure (`ChatSearchMixin`)

- New `chat_messages_fts` FTS5 virtual table, **trigram tokenizer** so both ASCII and
  CJK substring search work (`unicode61` can't match a substring of an undelimited CJK
  run). Queries below the 3-char trigram minimum fall back to the prior `LIKE` scan, so
  short/CJK **chat-list search never regresses**.
- Messages are stored as a JSON blob, not row-per-message, so FTS5 sync triggers can't
  be used — instead the index is **reindexed at the application layer on every chat
  write path** (`create`/`update`/`append`/`finalize`), with cleanup on delete.
- Idempotent table creation + one-time backfill in migrations. If the SQLite build lacks
  FTS5, everything **degrades to `LIKE`** and chat writes are never blocked.

## Sanitization

All output comes from each message's clean **AG-UI `parts`**, never the legacy HTML
`content` string. Assistant **reasoning is never surfaced**; tool output only appears
when `role_filter` includes `tool`.

## Tests

`tests/integration/test_chat_search.py` — sanitization (reasoning dropped, tool gated,
HTML ignored), reindex on each write path + delete, Discovery/Read DB methods, hidden-
platform exclusion, chat-list FTS parity + CJK `LIKE` fallback, and the three tool modes.
All green; existing DB / chat-processor / chat-route suites still pass.

## UI grouping & equipment

- New **"Memory & recall"** tool group (`ToolGroup.MEMORY`) containing `session_search`
  and `memory_search`. The frontend renders it automatically from the backend
  tool-groups payload — no UI change required.
- **`memory_search` is now a sidebar-toggleable equipment tool**, decoupled from the
  global memory toggle. It is equipped via the `tools` list like any other tool;
  `memory_enabled` now governs only memory *context injection*, not tool availability.
- Both tools added to `default_tools`, so recall works out of the box and existing
  memory users keep `memory_search` after the decoupling.

## Tests (cont.)

`tests/core/test_memory_tool_equipment.py` — memory_search equipped when in `tools`
regardless of `memory_enabled`, and absent when not in `tools` even with memory enabled.

## Notes

- `config/capabilities/dashscope.json` was modified before this work and is intentionally
  left out of this branch.

