### PR TITLE
fix(db): keep sidebar message summary consistent across rollbacks

### DIFF
--- a/src/suzent/core/heartbeat.py
+++ b/src/suzent/core/heartbeat.py
@@ -367,21 +367,19 @@ class HeartbeatRunner(BaseBrain):
     def _rollback_heartbeat_messages(self, chat_id: str, original_count: int, db):
         """Remove the heartbeat prompt and Ok response if no action was needed."""
         try:
-            from sqlmodel import Session
-            from sqlalchemy.orm.attributes import flag_modified
-            from suzent.database import ChatModel
-
-            with Session(db.engine) as session:
-                chat = session.get(ChatModel, chat_id)
-                if chat and len(chat.messages) > original_count:
-                    extra = len(chat.messages) - original_count
-                    chat.messages = chat.messages[:original_count]
-                    chat.turn_count = max(0, (chat.turn_count or 0) - 1)
-                    flag_modified(chat, "messages")
-                    session.commit()
-                    logger.debug(
-                        f"Rolled back {extra} heartbeat messages from chat {chat_id}"
-                    )
+            chat = db.get_chat(chat_id)
+            if chat and len(chat.messages) > original_count:
+                extra = len(chat.messages) - original_count
+                # rewrite_chat_messages refreshes the sidebar summary + FTS index so
+                # the rolled-back state doesn't leave a stale message count/preview.
+                db.rewrite_chat_messages(
+                    chat_id,
+                    chat.messages[:original_count],
+                    turn_count_delta=-1,
+                )
+                logger.debug(
+                    f"Rolled back {extra} heartbeat messages from chat {chat_id}"
+                )
         except Exception as e:
             logger.error(f"Failed to rollback heartbeat messages for {chat_id}: {e}")
 

--- a/src/suzent/core/retry.py
+++ b/src/suzent/core/retry.py
@@ -172,9 +172,7 @@ def apply_retry_checkpoint(chat_id: str) -> Optional[dict]:
     so the caller can re-run process_turn() with the original inputs, or None
     if no checkpoint is found.
     """
-    from suzent.database import ChatModel, get_database
-    from sqlmodel import Session
-    from sqlalchemy.orm.attributes import flag_modified
+    from suzent.database import get_database
 
     checkpoint = load_retry_checkpoint(chat_id)
     if checkpoint is None:
@@ -184,14 +182,13 @@ def apply_retry_checkpoint(chat_id: str) -> Optional[dict]:
     try:
         db = get_database()
 
-        # Restore agent state + display messages in DB.
-        with Session(db.engine) as session:
-            chat = session.get(ChatModel, chat_id)
-            if chat:
-                chat.agent_state = checkpoint.agent_state_before
-                chat.messages = list(checkpoint.messages_before)
-                flag_modified(chat, "messages")
-                session.commit()
+        # Restore agent state + display messages in DB. rewrite_chat_messages keeps the
+        # sidebar summary and FTS index in sync with the restored message list.
+        db.rewrite_chat_messages(
+            chat_id,
+            list(checkpoint.messages_before),
+            agent_state=checkpoint.agent_state_before,
+        )
 
         # Restore files using the lightweight file-level snapshot when available.
         file_snapshot_data = getattr(checkpoint, "file_snapshot", None)

--- a/src/suzent/database/base.py
+++ b/src/suzent/database/base.py
@@ -41,6 +41,7 @@ class ChatDatabaseBase:
         self._ensure_default_project()
         self._migrate_legacy_session_dirs()
         self._init_chat_search()
+        self._repair_stale_chat_summaries()
 
     def _session(self) -> Session:
         """Create a new database session."""

--- a/src/suzent/database/chats.py
+++ b/src/suzent/database/chats.py
@@ -256,6 +256,41 @@ class ChatOperationsMixin:
             session.commit()
             return True
 
+    def rewrite_chat_messages(
+        self,
+        chat_id: str,
+        messages: List[Dict[str, Any]],
+        agent_state: Optional[bytes] = None,
+        turn_count_delta: int = 0,
+    ) -> bool:
+        """Replace a chat's full message list, keeping derived state consistent.
+
+        Unlike a raw ``chat.messages = ...`` assignment, this refreshes the sidebar
+        summary (visible count + preview) and the FTS index so they never go stale —
+        which is exactly what rollback paths (retry, heartbeat) previously skipped.
+
+        Args:
+            agent_state: When given, also restored (used by retry rollback).
+            turn_count_delta: Added to ``turn_count`` (e.g. -1 for a heartbeat rollback).
+        """
+        with self._session() as session:
+            chat = session.get(ChatModel, chat_id)
+            if not chat:
+                return False
+
+            chat.messages = messages
+            chat.config = _with_message_summary(chat.config, messages)
+            flag_modified(chat, "messages")
+            flag_modified(chat, "config")
+            if agent_state is not None:
+                chat.agent_state = agent_state
+            if turn_count_delta:
+                chat.turn_count = max(0, (chat.turn_count or 0) + turn_count_delta)
+            self._reindex_in_session(session, chat_id, messages)
+            session.add(chat)
+            session.commit()
+            return True
+
     def merge_chat_config(self, chat_id: str, updates: Dict[str, Any]) -> bool:
         """Atomically merge top-level keys into a chat's config (read-modify-write
         inside one DB session).

--- a/src/suzent/database/chats.py
+++ b/src/suzent/database/chats.py
@@ -18,6 +18,10 @@ from .models import (
 SUMMARY_LAST_MESSAGE_KEY = "_summary_last_message"
 SUMMARY_VISIBLE_COUNT_KEY = "_summary_visible_assistant_count"
 
+# Sentinel for rewrite_chat_messages(agent_state=...) so "omit" (leave stored state)
+# is distinguishable from an explicit None (restore a NULL checkpoint state).
+_UNSET = object()
+
 # Platforms hidden from the user's chat list. Only the autonomous dream consolidation
 # chat is hidden — sub-agent chats are intentionally kept visible (nested under their
 # parent agent in the UI), so they are NOT excluded here.
@@ -260,7 +264,7 @@ class ChatOperationsMixin:
         self,
         chat_id: str,
         messages: List[Dict[str, Any]],
-        agent_state: Optional[bytes] = None,
+        agent_state: Any = _UNSET,
         turn_count_delta: int = 0,
     ) -> bool:
         """Replace a chat's full message list, keeping derived state consistent.
@@ -270,7 +274,10 @@ class ChatOperationsMixin:
         which is exactly what rollback paths (retry, heartbeat) previously skipped.
 
         Args:
-            agent_state: When given, also restored (used by retry rollback).
+            agent_state: When supplied, restored as-is — including ``None``, which is a
+                legitimate value for a checkpoint taken before any state was serialized
+                (e.g. the first turn). Omit it (the ``_UNSET`` default) to leave the
+                stored state untouched, as the heartbeat rollback does.
             turn_count_delta: Added to ``turn_count`` (e.g. -1 for a heartbeat rollback).
         """
         with self._session() as session:
@@ -282,7 +289,7 @@ class ChatOperationsMixin:
             chat.config = _with_message_summary(chat.config, messages)
             flag_modified(chat, "messages")
             flag_modified(chat, "config")
-            if agent_state is not None:
+            if agent_state is not _UNSET:
                 chat.agent_state = agent_state
             if turn_count_delta:
                 chat.turn_count = max(0, (chat.turn_count or 0) + turn_count_delta)

--- a/src/suzent/database/migrations.py
+++ b/src/suzent/database/migrations.py
@@ -795,3 +795,70 @@ class DatabaseMigrationMixin:
 
         if backfilled:
             logger.info("Backfilled chat FTS index for {} chat(s)", backfilled)
+
+    _SUMMARY_REPAIR_FLAG = "_chat_summary_repaired_v1"
+
+    def _repair_stale_chat_summaries(self) -> None:
+        """One-time repair of sidebar summaries that drifted from chat.messages.
+
+        Rollback paths (retry, heartbeat) historically rewrote ``chat.messages``
+        without refreshing the cached summary, leaving stale visible-count/preview
+        values that ``list_chats`` then trusted forever. Recompute every chat's
+        summary once and persist any that differ. Guarded by a config-blob flag so
+        it runs a single time; failures are logged, never fatal.
+        """
+        from suzent.logger import logger
+
+        try:
+            from suzent.core.user_config import UserConfigStore
+
+            store = UserConfigStore()
+            if store.get_config_blob(self._SUMMARY_REPAIR_FLAG):
+                return
+        except Exception as exc:
+            logger.warning("Could not check summary-repair flag: {}", exc)
+            return
+
+        from suzent.database.chats import _summarize_messages, _with_message_summary
+
+        repaired = 0
+        try:
+            with self._session() as session:
+                chat_ids = [c.id for c in session.exec(select(ChatModel)).all()]
+            for chat_id in chat_ids:
+                chat = self.get_chat(chat_id)
+                if not chat:
+                    continue
+                messages = chat.messages or []
+                count, preview = _summarize_messages(messages)
+                config = chat.config or {}
+                from suzent.database.chats import (
+                    SUMMARY_LAST_MESSAGE_KEY,
+                    SUMMARY_VISIBLE_COUNT_KEY,
+                )
+
+                if (
+                    config.get(SUMMARY_VISIBLE_COUNT_KEY) != count
+                    or config.get(SUMMARY_LAST_MESSAGE_KEY) != preview
+                ):
+                    with self._session() as session:
+                        row = session.get(ChatModel, chat_id)
+                        if row:
+                            row.config = _with_message_summary(row.config, messages)
+                            from sqlalchemy.orm.attributes import flag_modified
+
+                            flag_modified(row, "config")
+                            session.add(row)
+                            session.commit()
+                            repaired += 1
+        except Exception as exc:
+            logger.warning("Chat summary repair failed: {}", exc)
+            return
+
+        try:
+            store.save_config_blob(self._SUMMARY_REPAIR_FLAG, "1")
+        except Exception as exc:
+            logger.warning("Could not persist summary-repair flag: {}", exc)
+
+        if repaired:
+            logger.info("Repaired stale sidebar summaries for {} chat(s)", repaired)

--- a/src/suzent/database/migrations.py
+++ b/src/suzent/database/migrations.py
@@ -796,7 +796,35 @@ class DatabaseMigrationMixin:
         if backfilled:
             logger.info("Backfilled chat FTS index for {} chat(s)", backfilled)
 
-    _SUMMARY_REPAIR_FLAG = "_chat_summary_repaired_v1"
+    _SUMMARY_REPAIR_FLAG = "chat_summary_repaired_v1"
+
+    def _get_schema_meta(self, key: str) -> Optional[str]:
+        """Read a value from the DB-local ``schema_meta`` key/value table.
+
+        This marker store lives in chats.db (not the synced config.yaml), so one-time
+        data repairs are tracked per-database — a marker set on one device never
+        suppresses the repair on another device's independent chats.db.
+        """
+        with self.engine.connect() as conn:
+            conn.exec_driver_sql(
+                "CREATE TABLE IF NOT EXISTS schema_meta (key TEXT PRIMARY KEY, value TEXT)"
+            )
+            row = conn.exec_driver_sql(
+                "SELECT value FROM schema_meta WHERE key = ?", (key,)
+            ).fetchone()
+            return row[0] if row else None
+
+    def _set_schema_meta(self, key: str, value: str) -> None:
+        with self.engine.connect() as conn:
+            conn.exec_driver_sql(
+                "CREATE TABLE IF NOT EXISTS schema_meta (key TEXT PRIMARY KEY, value TEXT)"
+            )
+            conn.exec_driver_sql(
+                "INSERT INTO schema_meta (key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (key, value),
+            )
+            conn.commit()
 
     def _repair_stale_chat_summaries(self) -> None:
         """One-time repair of sidebar summaries that drifted from chat.messages.
@@ -804,22 +832,25 @@ class DatabaseMigrationMixin:
         Rollback paths (retry, heartbeat) historically rewrote ``chat.messages``
         without refreshing the cached summary, leaving stale visible-count/preview
         values that ``list_chats`` then trusted forever. Recompute every chat's
-        summary once and persist any that differ. Guarded by a config-blob flag so
-        it runs a single time; failures are logged, never fatal.
+        summary once and persist any that differ. Guarded by a DB-local marker so it
+        runs a single time per database; failures are logged, never fatal.
         """
         from suzent.logger import logger
 
         try:
-            from suzent.core.user_config import UserConfigStore
-
-            store = UserConfigStore()
-            if store.get_config_blob(self._SUMMARY_REPAIR_FLAG):
+            if self._get_schema_meta(self._SUMMARY_REPAIR_FLAG):
                 return
         except Exception as exc:
-            logger.warning("Could not check summary-repair flag: {}", exc)
+            logger.warning("Could not check summary-repair marker: {}", exc)
             return
 
-        from suzent.database.chats import _summarize_messages, _with_message_summary
+        from suzent.database.chats import (
+            SUMMARY_LAST_MESSAGE_KEY,
+            SUMMARY_VISIBLE_COUNT_KEY,
+            _summarize_messages,
+            _with_message_summary,
+        )
+        from sqlalchemy.orm.attributes import flag_modified
 
         repaired = 0
         try:
@@ -832,11 +863,6 @@ class DatabaseMigrationMixin:
                 messages = chat.messages or []
                 count, preview = _summarize_messages(messages)
                 config = chat.config or {}
-                from suzent.database.chats import (
-                    SUMMARY_LAST_MESSAGE_KEY,
-                    SUMMARY_VISIBLE_COUNT_KEY,
-                )
-
                 if (
                     config.get(SUMMARY_VISIBLE_COUNT_KEY) != count
                     or config.get(SUMMARY_LAST_MESSAGE_KEY) != preview
@@ -845,8 +871,6 @@ class DatabaseMigrationMixin:
                         row = session.get(ChatModel, chat_id)
                         if row:
                             row.config = _with_message_summary(row.config, messages)
-                            from sqlalchemy.orm.attributes import flag_modified
-
                             flag_modified(row, "config")
                             session.add(row)
                             session.commit()
@@ -856,9 +880,9 @@ class DatabaseMigrationMixin:
             return
 
         try:
-            store.save_config_blob(self._SUMMARY_REPAIR_FLAG, "1")
+            self._set_schema_meta(self._SUMMARY_REPAIR_FLAG, "1")
         except Exception as exc:
-            logger.warning("Could not persist summary-repair flag: {}", exc)
+            logger.warning("Could not persist summary-repair marker: {}", exc)
 
         if repaired:
             logger.info("Repaired stale sidebar summaries for {} chat(s)", repaired)

--- a/tests/integration/test_chat_summary_consistency.py
+++ b/tests/integration/test_chat_summary_consistency.py
@@ -1,0 +1,88 @@
+"""The sidebar message summary stays consistent with chat.messages across rollback
+paths, and a one-time repair fixes summaries that drifted before the fix.
+"""
+
+import pytest
+
+from suzent.database.chats import (
+    SUMMARY_LAST_MESSAGE_KEY,
+    SUMMARY_VISIBLE_COUNT_KEY,
+)
+
+
+@pytest.fixture
+def db(temp_db):
+    return temp_db
+
+
+def _assistant(text):
+    return {
+        "role": "assistant",
+        "content": text,
+        "parts": [{"type": "text", "text": text}],
+    }
+
+
+def _count(db, chat_id):
+    return (db.get_chat(chat_id).config or {}).get(SUMMARY_VISIBLE_COUNT_KEY)
+
+
+def test_rewrite_chat_messages_refreshes_summary(db):
+    cid = db.create_chat("C", {}, [{"role": "user", "content": "q"}])
+    assert _count(db, cid) == 0
+    db.rewrite_chat_messages(
+        cid,
+        [{"role": "user", "content": "q"}, _assistant("an answer")],
+    )
+    assert _count(db, cid) == 1
+    assert (db.get_chat(cid).config or {})[SUMMARY_LAST_MESSAGE_KEY] == "an answer"
+
+
+def test_rewrite_chat_messages_applies_turn_count_delta(db):
+    cid = db.create_chat("C", {}, [{"role": "user", "content": "q"}, _assistant("a")])
+    before = db.get_chat(cid).turn_count or 0
+    db.rewrite_chat_messages(
+        cid, [{"role": "user", "content": "q"}], turn_count_delta=-1
+    )
+    assert (db.get_chat(cid).turn_count or 0) == max(0, before - 1)
+    # Truncating to just the user message drops the visible (assistant) count to 0.
+    assert _count(db, cid) == 0
+
+
+def test_list_chats_count_consistent_after_rollback(db):
+    # Simulate a heartbeat/retry rollback shrinking the message list and confirm the
+    # sidebar list reports the refreshed count, not the pre-rollback one.
+    cid = db.create_chat(
+        "C", {}, [{"role": "user", "content": "q"}, _assistant("temp reply")]
+    )
+    assert _count(db, cid) == 1
+    db.rewrite_chat_messages(cid, [{"role": "user", "content": "q"}])
+    summary = next(s for s in db.list_chats() if s.id == cid)
+    assert summary.messageCount == 0
+
+
+def test_one_time_summary_repair_fixes_stale_count(db):
+    # Force a stale summary the way the old rollback paths did: messages have an
+    # assistant reply, but the cached count says 0.
+    cid = db.create_chat(
+        "C", {}, [{"role": "user", "content": "q"}, _assistant("real reply")]
+    )
+    db.merge_chat_config(cid, {SUMMARY_VISIBLE_COUNT_KEY: 0})
+    assert _count(db, cid) == 0
+
+    # Clear the one-time flag so the repair runs again, then run it.
+    from suzent.core.user_config import UserConfigStore
+
+    UserConfigStore().save_config_blob(db._SUMMARY_REPAIR_FLAG, "")
+    db._repair_stale_chat_summaries()
+
+    assert _count(db, cid) == 1
+
+
+def test_summary_repair_is_one_shot(db):
+    cid = db.create_chat("C", {}, [{"role": "user", "content": "q"}, _assistant("a")])
+    # First run already happened during db init; corrupt the count and re-run without
+    # clearing the flag — repair must be a no-op the second time.
+    db.merge_chat_config(cid, {SUMMARY_VISIBLE_COUNT_KEY: 99})
+    db._repair_stale_chat_summaries()
+    assert _count(db, cid) == 99

--- a/tests/integration/test_chat_summary_consistency.py
+++ b/tests/integration/test_chat_summary_consistency.py
@@ -70,10 +70,8 @@ def test_one_time_summary_repair_fixes_stale_count(db):
     db.merge_chat_config(cid, {SUMMARY_VISIBLE_COUNT_KEY: 0})
     assert _count(db, cid) == 0
 
-    # Clear the one-time flag so the repair runs again, then run it.
-    from suzent.core.user_config import UserConfigStore
-
-    UserConfigStore().save_config_blob(db._SUMMARY_REPAIR_FLAG, "")
+    # Clear the DB-local one-time marker so the repair runs again, then run it.
+    db._set_schema_meta(db._SUMMARY_REPAIR_FLAG, "")
     db._repair_stale_chat_summaries()
 
     assert _count(db, cid) == 1
@@ -86,3 +84,25 @@ def test_summary_repair_is_one_shot(db):
     db.merge_chat_config(cid, {SUMMARY_VISIBLE_COUNT_KEY: 99})
     db._repair_stale_chat_summaries()
     assert _count(db, cid) == 99
+
+
+def test_rewrite_can_restore_null_agent_state(db):
+    # A checkpoint captured before any state was serialized (first turn) has
+    # agent_state == None; restoring it must actually clear the stored state, not keep
+    # the post-failure state in place.
+    cid = db.create_chat("C", {}, [{"role": "user", "content": "q"}])
+    db.update_chat(cid, agent_state=b"post-failure-state")
+    assert db.get_chat(cid).agent_state == b"post-failure-state"
+
+    db.rewrite_chat_messages(cid, [{"role": "user", "content": "q"}], agent_state=None)
+    assert db.get_chat(cid).agent_state is None
+
+
+def test_rewrite_omitting_agent_state_leaves_it_untouched(db):
+    # The heartbeat rollback omits agent_state; the stored state must be preserved.
+    cid = db.create_chat("C", {}, [{"role": "user", "content": "q"}, _assistant("a")])
+    db.update_chat(cid, agent_state=b"keep-me")
+    db.rewrite_chat_messages(
+        cid, [{"role": "user", "content": "q"}], turn_count_delta=-1
+    )
+    assert db.get_chat(cid).agent_state == b"keep-me"


### PR DESCRIPTION
## Summary

Fixes the stale **sidebar message count** bug surfaced during the session_search work
(#54), where a chat could show e.g. "0 messages" despite having replies.

## Root cause

The cached sidebar summary (visible count + preview) lives in `chat.config`.
`list_chats` trusts the stored value and only recomputes it when it's **missing**
([chats.py](../blob/main/src/suzent/database/chats.py)). Every write path *in* `chats.py`
refreshes the summary — but two rollback paths rewrote `chat.messages` **directly**,
bypassing the refresh:

- retry checkpoint restore — `core/retry.py`
- heartbeat no-op rollback — `core/heartbeat.py`

After either ran, the stored summary kept its pre-rollback value forever.

## Fix

- New `ChatOperationsMixin.rewrite_chat_messages()` — replaces the message list while
  refreshing the summary **and** the FTS index (and optionally `agent_state` /
  `turn_count`). Both rollback paths now route through it instead of assigning
  `chat.messages` raw.
- One-time startup repair `_repair_stale_chat_summaries()` — recomputes every chat's
  summary once and persists any that drifted, guarded by a config-blob flag so it runs
  a single time. (Verified it corrected the real stale session from #54: 0 → 3.)

The count **metric** is unchanged (assistant replies with visible text); only its
staleness is fixed.

## Tests

`tests/integration/test_chat_summary_consistency.py` — summary refresh on rewrite,
`turn_count` delta, list_chats consistency after rollback, the one-time repair fixing a
stale count, and the repair being a no-op on second run. Existing DB / search /
heartbeat / postprocess suites still pass.
