### PR TITLE
[codex] add inline citation badges

### DIFF
--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -40,6 +40,7 @@ import { useStatusStore } from '../hooks/useStatusStore';
 import { useContextUsageStore } from '../hooks/useContextUsageStore';
 import { useActivatedToolsStore } from '../hooks/useActivatedToolsStore';
 import type { SubAgentStatus } from './chat/SubAgentCallBlock';
+import type { CitationSourcesMap } from './chat/Citations';
 import type {
   SubAgentSpawnedPayload,
   SubAgentCompletedPayload,
@@ -192,6 +193,10 @@ function aguiPartsToStoreMessage(parts: AGUIPart[], usage?: any, role: Message['
       const encoded = encodeURIComponent(JSON.stringify(part.surface));
       content += `\n\n<div data-a2ui="${encoded}"></div>\n\n`;
       persistedParts.push({ ...part, surface: { ...part.surface } });
+    } else if (part.type === 'citation-sources' && part.citationSources?.length) {
+      // Citation sources travel with the message so inline badges + the sources
+      // panel survive stream completion and reload. They carry no visible text.
+      persistedParts.push({ ...part, citationSources: [...part.citationSources] });
     }
   }
   return { role, content, parts: persistedParts, timestamp: new Date().toISOString(), stepInfo: usage ? formatUsage(usage) : undefined };
@@ -387,7 +392,8 @@ const MessageList: React.FC<{
   onStopSubAgent?: (taskId: string) => void;
   onForceWebContext?: (contextId: string) => void;
   onRetry?: () => void;
-}> = ({ messages, streamingForCurrentChat, messageIndexOffset = 0, chatId, onImageClick, onFileClick, onToolApproval, toolApprovalPolicy, onRemoveApprovalPolicy, onInlineAction, subAgentTasks, onOpenSubAgentSidebar, onStopSubAgent, onForceWebContext, onRetry }) => {
+  chatCitationSources?: CitationSourcesMap;
+}> = ({ messages, streamingForCurrentChat, messageIndexOffset = 0, chatId, onImageClick, onFileClick, onToolApproval, toolApprovalPolicy, onRemoveApprovalPolicy, onInlineAction, subAgentTasks, onOpenSubAgentSidebar, onStopSubAgent, onForceWebContext, onRetry, chatCitationSources }) => {
   const { skipIndices, groupRenders, stepSummaryByMessageIndex } = useMemo(
     () => buildMessageRenderPlan(messages),
     [messages],
@@ -445,6 +451,7 @@ const MessageList: React.FC<{
                   onOpenSubAgentSidebar={onOpenSubAgentSidebar}
                   onStopSubAgent={onStopSubAgent}
                   onForceWebContext={onForceWebContext}
+                  chatCitationSources={chatCitationSources}
                 />
               </div>
             </div>
@@ -505,6 +512,7 @@ const MessageList: React.FC<{
                   onStopSubAgent={onStopSubAgent}
                   onForceWebContext={onForceWebContext}
                   onRetry={idx === lastAssistantIdx && !streamingForCurrentChat ? onRetry : undefined}
+                  chatCitationSources={chatCitationSources}
                 />
               )}
             </div>
@@ -1065,6 +1073,24 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     () => safeMessages.slice(visibleMessageStartIndex),
     [safeMessages, visibleMessageStartIndex],
   );
+
+  // Chat-wide citation sources: aggregate every message's citation-sources parts
+  // (plus the live streaming parts) into one map. Source ids are globally unique
+  // across turns (t{turn}_src_n), so a single flat map lets a badge in any
+  // message resolve a source registered in any (earlier) turn.
+  const chatCitationSources = useMemo<CitationSourcesMap>(() => {
+    const map: CitationSourcesMap = new Map();
+    const addParts = (parts?: AGUIPart[]) => {
+      for (const p of parts || []) {
+        if (p.type === 'citation-sources' && p.citationSources) {
+          for (const s of p.citationSources) if (!map.has(s.id)) map.set(s.id, s);
+        }
+      }
+    };
+    for (const m of safeMessages) addParts(m.parts);
+    if (showTransientAssistant) addParts(streamingParts);
+    return map;
+  }, [safeMessages, streamingParts, showTransientAssistant]);
   const hasHiddenOlderMessages = visibleMessageStartIndex > 0;
   const _prefs = backendConfig?.userPreferences;
   const _base = config || { model: '', agent: '', tools: [] as string[] };
@@ -1824,6 +1850,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
                   <MessageListMemo
                     messages={visibleMessages}
                     streamingForCurrentChat={false}
+                    chatCitationSources={chatCitationSources}
                     messageIndexOffset={visibleMessageStartIndex}
                     chatId={currentChatId ?? undefined}
                     onImageClick={setViewingImage}
@@ -1873,6 +1900,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
                             onOpenSubAgentSidebar={handleOpenSubAgentSidebar}
                             onStopSubAgent={handleStopSubAgent}
                             onForceWebContext={handleForceWebContext}
+                            chatCitationSources={chatCitationSources}
                           />
                         )}
                       </div>

--- a/frontend/src/components/chat/AssistantMessage.tsx
+++ b/frontend/src/components/chat/AssistantMessage.tsx
@@ -17,6 +17,8 @@ import {
   ToolSequenceGroup,
   parseSubAgentTaskId,
 } from './AssistantContent';
+import { CitationProvider, SourcesPanel, formatTextWithCitationReferences, type CitationSourcesMap } from './Citations';
+import type { CitationSource } from '../../lib/streamEvents';
 import {
   ActivityRail,
   ActivityRailItem,
@@ -65,6 +67,8 @@ interface AssistantMessageProps {
   onForceWebContext?: (contextId: string) => void;
   /** Retry handler — re-runs the last user message from this point */
   onRetry?: () => void;
+  /** Chat-wide citation sources (all turns), so inline badges resolve cross-turn ids. */
+  chatCitationSources?: CitationSourcesMap;
 }
 
 // Names that should be filtered out from tool call display
@@ -151,6 +155,8 @@ const AGUIPartsContent: React.FC<{
   let currentType: 'tool' | 'reasoning' | 'text' | 'a2ui' | null = null;
 
   for (const part of normalizedParts) {
+    // citation-sources parts carry metadata, not display content — skip them.
+    if (part.type === 'citation-sources') continue;
     const type = part.type as 'tool' | 'reasoning' | 'text' | 'a2ui';
     if (current.length === 0) {
       currentType = type;
@@ -472,6 +478,7 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
   onStopSubAgent,
   onForceWebContext,
   onRetry,
+  chatCitationSources,
 }) => {
   const isStreamingThis = isStreaming && isLastMessage;
   const effectiveParts = aguiParts ?? message.parts;
@@ -485,6 +492,32 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
     () => (effectiveParts === undefined ? filterBlocks(splitAssistantContent(message.content || '')) : []),
     [effectiveParts, message.content],
   );
+
+  // Citation sources for this message: collected from the 'citation-sources'
+  // part (live stream or persisted parts). Feeds both inline badges (via
+  // context) and the bottom SourcesPanel.
+  const citationSourcesList = useMemo<CitationSource[]>(() => {
+    const parts = effectiveParts ?? message.parts ?? [];
+    const out: CitationSource[] = [];
+    const seen = new Set<string>();
+    for (const p of parts) {
+      if (p.type === 'citation-sources' && p.citationSources) {
+        for (const s of p.citationSources) {
+          if (!seen.has(s.id)) { seen.add(s.id); out.push(s); }
+        }
+      }
+    }
+    return out;
+  }, [effectiveParts, message.parts]);
+
+  // Map used to resolve inline badges. Prefer the chat-wide map (so a badge can
+  // reference a source registered in an earlier turn — ids are globally unique),
+  // falling back to this message's own sources. The per-message
+  // citationSourcesList still drives the bottom SourcesPanel.
+  const citationSourcesMap = useMemo<CitationSourcesMap>(() => {
+    if (chatCitationSources && chatCitationSources.size > 0) return chatCitationSources;
+    return new Map(citationSourcesList.map(s => [s.id, s]));
+  }, [chatCitationSources, citationSourcesList]);
 
   // Suppress the streaming cursor during the assembly→reveal animation.
   // Delay showing the cursor so it doesn't flash while the box is still opening.
@@ -502,21 +535,24 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
   }, [isStreamingThis, cursorReady]);
 
   // ── Compute full message text for copying ──
+  // Convert inline citation protocol markers into portable Markdown references.
   const fullMessageText = useMemo(() => {
     if (effectiveParts) {
-      return effectiveParts
-        .filter(p => p.type === 'text')
-        .map(p => p.text || '')
-        .join('')
-        .trim();
+      return formatTextWithCitationReferences(
+        effectiveParts
+          .filter(p => p.type === 'text')
+          .map(p => p.text || '')
+          .join(''),
+        citationSourcesMap,
+      ).trim();
     } else {
-      return legacyBlocks
+      const text = legacyBlocks
         .filter(b => b.type !== 'log' && b.type !== 'reasoning' && b.type !== 'toolCall' && b.type !== 'a2ui')
         .map(b => (b.type === 'code' ? '```' + (b.lang || '') + '\n' + b.content + '\n```' : b.content))
-        .join('\n\n')
-        .trim();
+        .join('\n\n');
+      return formatTextWithCitationReferences(text, citationSourcesMap).trim();
     }
-  }, [effectiveParts, legacyBlocks]);
+  }, [effectiveParts, legacyBlocks, citationSourcesMap]);
 
   // 1. 抓取当前正在跑的 Tool 和 错误状态
   let currentToolName: string | undefined = undefined;
@@ -588,6 +624,7 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
   // ── AG-UI parts-based rendering path (for streaming messages) ──
   if (effectiveParts !== undefined) {
     return (
+      <CitationProvider sources={citationSourcesMap}>
       <div className="group w-full max-w-4xl break-all overflow-x-hidden text-sm leading-relaxed relative pr-4 md:pr-12 animate-brutal-pop">
         {/* Badge/Assembly Container */}
         {badgeContainer}
@@ -619,6 +656,7 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
               {onRetry && !isStreamingThis && !isThinking && (
                 <RetryButton onClick={onRetry} />
               )}
+              {!isThinking && <SourcesPanel sources={citationSourcesList} />}
               {message.timestamp && !isStreamingThis && (
                 <div className="text-[10px] text-neutral-400 select-none">
                   {formatMessageTime(message.timestamp)}
@@ -628,6 +666,7 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
           </div>
         </div>
       </div>
+      </CitationProvider>
     );
   }
 
@@ -712,6 +751,7 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
   );
 
   return (
+    <CitationProvider sources={citationSourcesMap}>
     <div className="group w-full max-w-4xl break-all overflow-x-hidden text-sm leading-relaxed relative pr-4 md:pr-12 animate-brutal-pop">
       {/* Badge/Assembly Container is rendered at the top of the entire message timeline */}
       {badgeContainer}
@@ -883,6 +923,7 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
             {onRetry && !isStreamingThis && !isThinking && (
               <RetryButton onClick={onRetry} />
             )}
+            {!isThinking && <SourcesPanel sources={citationSourcesList} />}
             {message.timestamp && !isStreamingThis && (
               <div className="text-[10px] text-neutral-400 select-none">
                 {formatMessageTime(message.timestamp)}
@@ -892,5 +933,6 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
         </div>
       </div>
     </div>
+    </CitationProvider>
   );
 };

--- a/frontend/src/components/chat/Citations.test.tsx
+++ b/frontend/src/components/chat/Citations.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { MarkdownRenderer } from './MarkdownRenderer';
+import { CitationProvider, formatTextWithCitationReferences, type CitationSourcesMap } from './Citations';
+
+const sources: CitationSourcesMap = new Map([
+  [
+    't0_src_1',
+    {
+      id: 't0_src_1',
+      type: 'search',
+      title: 'Example Source',
+      url: 'https://example.com',
+    },
+  ],
+  [
+    't0_src_2',
+    {
+      id: 't0_src_2',
+      type: 'webpage',
+      title: 'Second Source',
+      url: 'https://example.org',
+    },
+  ],
+]);
+
+function render(content: string): string {
+  return renderToStaticMarkup(
+    <CitationProvider sources={sources}>
+      <MarkdownRenderer content={content} />
+    </CitationProvider>,
+  );
+}
+
+function renderWithSources(content: string, sourceMap: CitationSourcesMap): string {
+  return renderToStaticMarkup(
+    <CitationProvider sources={sourceMap}>
+      <MarkdownRenderer content={content} />
+    </CitationProvider>,
+  );
+}
+
+describe('citation rendering', () => {
+  it('renders PUA citation markers as badges', () => {
+    const html = render('Fact\ue200cite\ue202t0_src_1\ue201.');
+
+    expect(html).toContain('example.com');
+    expect(html).not.toContain('citet0_src_1');
+  });
+
+  it('renders PUA citation markers even when wrapped in inline code', () => {
+    const html = render('Fact `\ue200cite\ue202t0_src_1\ue201`.');
+
+    expect(html).toContain('example.com');
+    expect(html).not.toContain('<code');
+    expect(html).not.toContain('citet0_src_1');
+  });
+
+  it('renders OBJ-normalized PUA citation markers as badges', () => {
+    const html = render('Fact\ufffccite\ufffct0_src_1\ufffc.');
+
+    expect(html).toContain('example.com');
+    expect(html).not.toContain('citet0_src_1');
+    expect(html).not.toContain('\ufffc');
+  });
+
+  it('renders multiple source ids in OBJ-normalized markers', () => {
+    const html = render('Fact\ufffccite\ufffct0_src_1\ufffct0_src_2\ufffc.');
+
+    expect(html).toContain('example.com');
+    expect(html).toContain('+1');
+    expect(html).not.toContain('citet0_src_1');
+    expect(html).not.toContain('t0_src_2');
+  });
+
+  it('renders a fallback chip when source metadata is missing', () => {
+    const html = renderWithSources('Fact\ufffccite\ufffct0_src_99\ufffc.', new Map());
+
+    expect(html).toContain('t0_src_99');
+    expect(html).toContain('Citation source metadata missing');
+    expect(html).not.toContain('citet0_src_99');
+    expect(html).not.toContain('\ufffc');
+  });
+
+  it('renders loose cite-source text as a badge', () => {
+    const html = render('Fact cite-t0_src_1.');
+
+    expect(html).toContain('example.com');
+    expect(html).not.toContain('cite-t0_src_1');
+  });
+
+  it('formats citation markers as markdown references for copy', () => {
+    const text = formatTextWithCitationReferences(
+      'Fact\ue200cite\ue202t0_src_1\ue201. More\ufffccite\ufffct0_src_1\ufffct0_src_2\ufffc.',
+      sources,
+    );
+
+    expect(text).toContain('Fact [example.com][1].');
+    expect(text).toContain('More [example.com][1] [example.org][2].');
+    expect(text).toContain('[1]: https://example.com "Example Source"');
+    expect(text).toContain('[2]: https://example.org "Second Source"');
+    expect(text).not.toContain('\ue200');
+    expect(text).not.toContain('\ufffc');
+  });
+
+  it('formats loose citation text as markdown references for copy', () => {
+    const text = formatTextWithCitationReferences('Fact cite-t0_src_1.', sources);
+
+    expect(text).toContain('Fact [example.com][1].');
+    expect(text).toContain('[1]: https://example.com "Example Source"');
+    expect(text).not.toContain('cite-t0_src_1');
+  });
+});

--- a/frontend/src/components/chat/Citations.tsx
+++ b/frontend/src/components/chat/Citations.tsx
@@ -1,0 +1,537 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import type { CitationSource } from '../../lib/streamEvents';
+
+/**
+ * Inline-citation rendering.
+ *
+ * The assistant text contains literal `[[cite:t0_src_1]]`
+ * (or `[[cite:t0_src_1,t0_src_2]]`)
+ * markers. `MarkdownRenderer` splits text nodes on these markers and renders a
+ * `CitationBadge` in place. Both the badge and the bottom `SourcesPanel` resolve
+ * source ids to titles/urls via this context, which is populated from the
+ * `citation_sources` stream event (stored as a 'citation-sources' AGUIPart).
+ */
+
+export type CitationSourcesMap = Map<string, CitationSource>;
+
+const CitationContext = createContext<CitationSourcesMap | null>(null);
+
+export const CitationProvider: React.FC<{
+  sources: CitationSourcesMap;
+  children: React.ReactNode;
+}> = ({ sources, children }) => (
+  <CitationContext.Provider value={sources}>{children}</CitationContext.Provider>
+);
+
+export function useCitationSources(): CitationSourcesMap | null {
+  return useContext(CitationContext);
+}
+
+// Rich-content markers are typed: a TYPE keyword + payload, in one of three forms:
+//   ASCII:  [[TYPE:payload]]        e.g. [[cite:t0_src_1]] or [[cite:t0_src_1,t0_src_2]]
+//   PUA:    \ue200TYPE\ue202payload\ue201   e.g. \ue200cite\ue202t0_src_1\ue201
+//   OBJ:    \ufffcTYPE\ufffcpayload\ufffc   e.g. \ufffccite\ufffct0_src_1\ufffc
+// The PUA form matches ChatGPT's invisible-character scheme; ASCII is a
+// debuggable fallback. Some Markdown/browser paths surface the private-use
+// delimiters as U+FFFC object replacement boxes, so we parse that too. Today
+// only TYPE="cite" is rendered (as a CitationBadge);
+// other types are recognised by the grammar but ignored, so adding a new rich
+// type later (e.g. filecite, image) is a renderer change, not a parser rewrite.
+const ASCII_MARKER = /\[\[([a-zA-Z]+):\s*([^\]\n]+?)\s*\]\]/;
+const PUA_MARKER = /\ue200([a-zA-Z]+)\ue202([^\ue201]+)\ue201/;
+const OBJ_MARKER = /\ufffc([a-zA-Z]+)\ufffc([a-zA-Z0-9_,\s]+(?:\ufffc[a-zA-Z0-9_,\s]+)*)\ufffc/;
+const LOOSE_CITE_MARKER = /\bcite[-:]((?:t\d+_src_\d+)(?:\s*,\s*t\d+_src_\d+)*)\b/;
+export const CITATION_MARKER_RE = new RegExp(
+  `${ASCII_MARKER.source}|${PUA_MARKER.source}|${OBJ_MARKER.source}|${LOOSE_CITE_MARKER.source}`,
+  'g',
+);
+
+/** True when the string may contain a typed marker (either form). */
+export function hasCitationMarker(text: string): boolean {
+  return (
+    text.includes('[[') ||
+    text.includes('\ue200') ||
+    text.includes('\ufffc') ||
+    /\bcite[-:]t\d+_src_\d+\b/.test(text)
+  );
+}
+
+/** Source-id separators: comma, PUA separator, or OBJ-normalized separator. */
+const ID_SEPARATORS = /[,\ue202\ufffc]/;
+
+/** A parsed marker: its TYPE keyword and the list of payload tokens (e.g. ids). */
+interface ParsedMarker { type: string; tokens: string[]; }
+
+function parseMarker(m: RegExpExecArray): ParsedMarker {
+  // ASCII groups are 1/2; PUA groups are 3/4; OBJ groups are 5/6;
+  // loose fallback is group 7 and always means "cite".
+  const type = (m[1] ?? m[3] ?? m[5] ?? (m[7] ? 'cite' : '')).toLowerCase();
+  const payload = m[2] ?? m[4] ?? m[6] ?? m[7] ?? '';
+  const tokens = payload.split(ID_SEPARATORS).map(s => s.trim()).filter(Boolean);
+  return { type, tokens };
+}
+
+function escapeMarkdownLinkText(text: string): string {
+  return text.replace(/\\/g, '\\\\').replace(/\]/g, '\\]');
+}
+
+function escapeMarkdownReferenceTitle(text: string): string {
+  return text.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, ' ');
+}
+
+/**
+ * Convert inline citation protocol markers into portable Markdown references for
+ * clipboard/export. Screen rendering uses badges; copied text should be useful
+ * outside Suzent.
+ */
+export function formatTextWithCitationReferences(
+  text: string,
+  sourcesMap: CitationSourcesMap,
+): string {
+  if (!hasCitationMarker(text)) return text;
+
+  const refs: CitationSource[] = [];
+  const refById = new Map<string, number>();
+  const re = new RegExp(CITATION_MARKER_RE.source, 'g');
+
+  const body = text.replace(re, (...args: unknown[]) => {
+    const match = args.slice(0, -2) as unknown as RegExpExecArray;
+    const offset = Number(args[args.length - 2] ?? 0);
+    const { type, tokens } = parseMarker(match);
+    if (type !== 'cite' || tokens.length === 0) return '';
+
+    const labels = tokens.map(id => {
+      const source = sourcesMap.get(id);
+      if (!source || !source.url) return `[source: ${id}]`;
+      let ref = refById.get(id);
+      if (!ref) {
+        refs.push(source);
+        ref = refs.length;
+        refById.set(id, ref);
+      }
+      return `[${escapeMarkdownLinkText(sourceName(source))}][${ref}]`;
+    });
+    const prefix = offset > 0 && !/\s/.test(text[offset - 1]) ? ' ' : '';
+    return labels.length > 0 ? `${prefix}${labels.join(' ')}` : '';
+  });
+
+  if (refs.length === 0) return body;
+
+  const referenceLines = refs.map((source, idx) => {
+    const title = sourceLabel(source);
+    const titlePart = title ? ` "${escapeMarkdownReferenceTitle(title)}"` : '';
+    return `[${idx + 1}]: ${source.url}${titlePart}`;
+  });
+  return `${body.trimEnd()}\n\n${referenceLines.join('\n')}`;
+}
+
+/**
+ * Split a plain string on typed markers, returning strings interleaved with
+ * rendered marker elements. The badge number is the source's 1-based position in
+ * the sources map (matching the SourcesPanel ordering). Used by both the full
+ * and lite markdown renderers.
+ */
+export function renderTextWithCitations(
+  text: string,
+  sourcesMap: CitationSourcesMap | null,
+  keyPrefix: string,
+): React.ReactNode[] {
+  if (!sourcesMap || !hasCitationMarker(text)) return [text];
+
+  const nodes: React.ReactNode[] = [];
+  const re = new RegExp(CITATION_MARKER_RE.source, 'g');
+  let last = 0;
+  let m: RegExpExecArray | null;
+  let n = 0;
+
+  while ((m = re.exec(text)) !== null) {
+    const before = text.slice(last, m.index);
+    const { type, tokens } = parseMarker(m);
+    last = re.lastIndex;
+
+    if (type === 'cite' && tokens.length > 0) {
+      nodes.push(before);
+      nodes.push(
+        <CitationBadge key={`${keyPrefix}-cite-${n++}`} sourceIds={tokens} />,
+      );
+    } else {
+      // Unknown/unsupported marker type: keep the leading text, drop the marker.
+      nodes.push(before);
+    }
+  }
+  if (last < text.length) nodes.push(text.slice(last));
+  return nodes;
+}
+
+/** Per-type emoji fallback, used when a source has no favicon. */
+const TYPE_ICON: Record<string, string> = {
+  search: '🔍',
+  webpage: '🌐',
+  file: '📄',
+  notebook: '📓',
+  memory: '🧠',
+  mcp: '🔌',
+  code: '💻',
+  browser: '🖥️',
+  subagent: '🤖',
+};
+
+function typeIcon(type?: string): string {
+  return (type && TYPE_ICON[type]) || '🔗';
+}
+
+/** Best-effort hostname for display (e.g. "www.bbc.co.uk" -> "bbc.co.uk"). */
+function domainOf(url?: string | null): string {
+  if (!url) return '';
+  try {
+    const host = new URL(url).hostname.replace(/^www\./, '');
+    return host;
+  } catch {
+    return '';
+  }
+}
+
+/** Short, human label for a source: its title, else its domain, else its id. */
+function sourceLabel(s: CitationSource): string {
+  if (s.title && s.title.trim()) return s.title.trim();
+  const d = domainOf(s.url);
+  if (d) return d;
+  return s.id;
+}
+
+/** Compact source name for inline badges: prefer the site/source over article title. */
+function sourceName(s: CitationSource): string {
+  const d = domainOf(s.url);
+  if (d) return d;
+  if (s.title && s.title.trim()) return s.title.trim();
+  return s.id;
+}
+
+async function openSource(url: string) {
+  if (!url) return;
+  try {
+    if (window.__TAURI__) {
+      const { open } = await import('@tauri-apps/plugin-shell');
+      await open(url);
+      return;
+    }
+    window.open(url, '_blank', 'noopener,noreferrer');
+  } catch (err) {
+    console.warn('Failed to open citation source', err);
+  }
+}
+
+/**
+ * Favicon with graceful fallback: if the image fails to load (or there's no
+ * favicon url), render the source type's emoji instead so we never show a
+ * broken-image glyph.
+ */
+const Favicon: React.FC<{ src?: string | null; type?: string; className?: string }> = ({
+  src,
+  type,
+  className = 'w-3.5 h-3.5',
+}) => {
+  const [failed, setFailed] = useState(false);
+  if (!src || failed) {
+    return <span className={`inline-flex items-center justify-center leading-none ${className}`}>{typeIcon(type)}</span>;
+  }
+  return (
+    <img
+      src={src}
+      alt=""
+      className={`${className} shrink-0 rounded-[2px] object-contain`}
+      onError={() => setFailed(true)}
+      loading="lazy"
+    />
+  );
+};
+
+/** Hover-intent: small open/close delay so the card doesn't flicker on transit. */
+function useHoverCard() {
+  const [open, setOpen] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clear = () => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+  };
+  const onEnter = () => {
+    clear();
+    timer.current = setTimeout(() => setOpen(true), 80);
+  };
+  const onLeave = () => {
+    clear();
+    timer.current = setTimeout(() => setOpen(false), 140);
+  };
+  return { open, onEnter, onLeave };
+}
+
+/** One row in the hover card: favicon, title, domain, optional snippet. */
+const SourceCardRow: React.FC<{ source: CitationSource }> = ({ source: s }) => {
+  const domain = domainOf(s.url);
+  return (
+    <a
+      href={s.url || '#'}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={e => {
+        if (!s.url) return;
+        e.preventDefault();
+        e.stopPropagation();
+        void openSource(s.url);
+      }}
+      className="flex items-start gap-2 p-2 rounded-[2px] hover:bg-neutral-100 dark:hover:bg-zinc-700/70 no-underline group/srow max-w-full overflow-hidden"
+    >
+      <Favicon src={s.favicon} type={s.type} className="w-4 h-4 mt-0.5" />
+      <span className="min-w-0 flex flex-col leading-tight">
+        <span className="text-[12px] font-bold text-brutal-black dark:text-neutral-100 line-clamp-2 break-words group-hover/srow:underline">
+          {sourceLabel(s)}
+        </span>
+        {domain && (
+          <span className="mt-0.5 text-[10px] font-medium text-neutral-500 dark:text-neutral-400 truncate">{domain}</span>
+        )}
+        {s.snippet && (
+          <span className="mt-1 text-[10px] text-neutral-500 dark:text-neutral-400 line-clamp-2 break-words">
+            {s.snippet}
+          </span>
+        )}
+      </span>
+    </a>
+  );
+};
+
+/**
+ * Inline citation chip — favicon + source name (Perplexity style), not a number.
+ * Hovering reveals a card with the full title, domain, and snippet for each
+ * cited source. For multiple sources, shows stacked favicons + the primary name.
+ * If metadata is missing (for example an older persisted chat without
+ * citation_sources), it still renders a muted fallback chip so the citation does
+ * not disappear.
+ */
+export const CitationBadge: React.FC<{ sourceIds: string[] }> = ({ sourceIds }) => {
+  const sourcesMap = useCitationSources();
+  const { open, onEnter, onLeave } = useHoverCard();
+  const anchorRef = useRef<HTMLSpanElement>(null);
+  const [cardStyle, setCardStyle] = useState<React.CSSProperties | null>(null);
+
+  const sources = sourceIds
+    .map(id => sourcesMap?.get(id))
+    .filter((s): s is CitationSource => Boolean(s));
+  const unresolvedIds = sourceIds.filter(id => !sourcesMap?.has(id));
+
+  useEffect(() => {
+    if (!open || !anchorRef.current) return;
+
+    const updatePosition = () => {
+      const rect = anchorRef.current?.getBoundingClientRect();
+      if (!rect) return;
+
+      const margin = 12;
+      const width = Math.min(360, Math.max(220, window.innerWidth - margin * 2));
+      const left = Math.min(
+        Math.max(rect.left + rect.width / 2 - width / 2, margin),
+        window.innerWidth - width - margin,
+      );
+      const top = rect.top >= 132 ? rect.top - margin : rect.bottom + margin;
+      const placeBelow = rect.top < 132;
+
+      setCardStyle({
+        left,
+        top,
+        width,
+        transform: placeBelow ? undefined : 'translateY(-100%)',
+      });
+    };
+
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [open]);
+
+  if (sources.length === 0) {
+    const label = sourceIds[0] || 'source';
+    const extra = Math.max(0, sourceIds.length - 1);
+    return (
+      <span className="relative inline-flex align-baseline mx-0.5">
+        <span
+          className="inline-flex items-center gap-1 max-w-[180px] h-[18px] pl-1 pr-1.5
+            align-[-0.2em] rounded-full border border-dashed border-neutral-300 dark:border-zinc-600
+            bg-neutral-50/70 dark:bg-zinc-800/70 text-neutral-500 dark:text-neutral-400
+            no-underline"
+          title={`Citation source metadata missing: ${sourceIds.join(', ')}`}
+        >
+          <span className="text-[10px] leading-none">↗</span>
+          <span className="text-[10px] font-medium leading-none truncate">
+            {label}
+            {extra > 0 && <span className="text-neutral-400"> +{extra}</span>}
+          </span>
+        </span>
+      </span>
+    );
+  }
+
+  const primary = sources[0];
+  const label = sourceName(primary);
+  const extra = sources.length + unresolvedIds.length - 1;
+  const popover = open && typeof document !== 'undefined' ? createPortal(
+    <span
+      className="fixed z-[9999] block
+        bg-white dark:bg-zinc-800 border-2 border-brutal-black dark:border-zinc-500
+        rounded-[3px] p-1.5 min-w-0"
+      style={cardStyle ?? { left: -9999, top: -9999, width: 360 }}
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+    >
+      {sources.map((s, i) => (
+        <SourceCardRow key={i} source={s} />
+      ))}
+    </span>,
+    document.body,
+  ) : null;
+
+  return (
+    <span
+      ref={anchorRef}
+      className="relative inline-flex align-baseline mx-0.5"
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+    >
+      <button
+        type="button"
+        onClick={() => primary.url && void openSource(primary.url)}
+        className="inline-flex items-center gap-1 max-w-[180px] h-[18px] pl-1 pr-1.5
+          align-[-0.2em] rounded-full border border-neutral-300 dark:border-zinc-600
+          bg-neutral-50 dark:bg-zinc-800 text-neutral-700 dark:text-neutral-200
+          hover:border-brutal-black dark:hover:border-white hover:bg-brutal-yellow/40
+          transition-colors cursor-pointer no-underline"
+        title={[...sources.map(sourceName), ...unresolvedIds].join(', ')}
+      >
+        {/* Stacked favicons for multi-source, single otherwise */}
+        <span className="flex items-center">
+          {sources.slice(0, 2).map((s, i) => (
+            <Favicon
+              key={i}
+              src={s.favicon}
+              type={s.type}
+              className={`w-3 h-3 ${i > 0 ? '-ml-1 ring-1 ring-neutral-50 dark:ring-zinc-800 rounded-full' : ''}`}
+            />
+          ))}
+        </span>
+        <span className="text-[10px] font-medium leading-none truncate">
+          {label}
+          {extra > 0 && <span className="text-neutral-400"> +{extra}</span>}
+        </span>
+      </button>
+
+      {popover}
+    </span>
+  );
+};
+
+/**
+ * Compact, inline sources control meant to sit on the message action row next to
+ * copy/retry. The collapsed pill shows stacked favicons + a count; clicking pops
+ * an absolutely-positioned source list above it (so it doesn't shift the row).
+ * Closes on outside click and Escape.
+ */
+export const SourcesPanel: React.FC<{ sources: CitationSource[] }> = ({ sources }) => {
+  const [expanded, setExpanded] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+
+  React.useEffect(() => {
+    if (!expanded) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setExpanded(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setExpanded(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [expanded]);
+
+  if (sources.length === 0) return null;
+
+  return (
+    <span ref={ref} className="relative inline-flex">
+      <button
+        onClick={() => setExpanded(e => !e)}
+        className="flex items-center gap-1.5 text-[10px] font-mono font-bold uppercase tracking-tight
+          text-neutral-400 hover:text-brutal-black dark:hover:text-white transition-colors"
+      >
+        <span className="flex items-center">
+          {sources.slice(0, 4).map((s, i) => (
+            <Favicon
+              key={i}
+              src={s.favicon}
+              type={s.type}
+              className={`w-3.5 h-3.5 ${i > 0 ? '-ml-1 ring-1 ring-white dark:ring-zinc-900 rounded-full' : ''}`}
+            />
+          ))}
+          {sources.length > 4 && (
+            <span className="text-[9px] text-neutral-400 ml-1">+{sources.length - 4}</span>
+          )}
+        </span>
+        <span>{sources.length} {sources.length === 1 ? 'Source' : 'Sources'}</span>
+        <svg
+          className={`w-3 h-3 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={3}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {expanded && (
+        <div
+          className="absolute bottom-full left-0 mb-1.5 z-50 flex flex-col gap-0.5
+            bg-white dark:bg-zinc-800 border-2 border-brutal-black dark:border-zinc-500
+            rounded-[3px] p-1.5 min-w-[280px] max-w-[440px]
+            max-h-[320px] overflow-y-auto"
+        >
+          {sources.map((s, i) => {
+            const domain = domainOf(s.url);
+            return (
+              <a
+                key={s.id}
+                href={s.url || '#'}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={e => {
+                  if (!s.url) return;
+                  e.preventDefault();
+                  e.stopPropagation();
+                  void openSource(s.url);
+                }}
+                className="flex items-start gap-2 p-2 rounded-[2px] hover:bg-neutral-100 dark:hover:bg-zinc-700/70 group no-underline"
+              >
+                <span className="font-mono font-bold text-neutral-400 text-[11px] w-4 shrink-0 mt-0.5 text-right">{i + 1}</span>
+                <Favicon src={s.favicon} type={s.type} className="w-4 h-4 mt-0.5" />
+                <span className="min-w-0 flex flex-col leading-tight">
+                  <span className="text-[12px] font-semibold text-brutal-black dark:text-neutral-100 line-clamp-1 group-hover:underline">
+                    {sourceLabel(s)}
+                  </span>
+                  {domain && (
+                    <span className="text-[10px] text-neutral-500 dark:text-neutral-400 truncate">{domain}</span>
+                  )}
+                </span>
+              </a>
+            );
+          })}
+        </div>
+      )}
+    </span>
+  );
+};

--- a/frontend/src/components/chat/MarkdownRenderer.tsx
+++ b/frontend/src/components/chat/MarkdownRenderer.tsx
@@ -3,6 +3,12 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { CodeBlockComponent } from './CodeBlockComponent';
 import { ClickableContent } from '../ClickableContent';
+import {
+  hasCitationMarker,
+  renderTextWithCitations,
+  useCitationSources,
+  type CitationSourcesMap,
+} from './Citations';
 import { DocumentTextIcon } from '@heroicons/react/24/outline';
 import { useI18n } from '../../i18n';
 import { getApiBase } from '../../lib/api';
@@ -126,15 +132,25 @@ function extractCodeText(children: React.ReactNode): string {
   return children == null ? '' : String(children);
 }
 
-function renderLiteInline(text: string): React.ReactNode[] {
+function renderLiteInline(text: string, sourcesMap?: CitationSourcesMap | null): React.ReactNode[] {
   const nodes: React.ReactNode[] = [];
   const pattern = /(`[^`\n]+`|\*\*[^*\n]+\*\*)/g;
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 
+  // Plain-text segments are routed through the citation splitter so [[cite:..]]
+  // markers become badges; code/bold tokens pass through untouched.
+  const pushText = (value: string, key: string) => {
+    if (sourcesMap && hasCitationMarker(value)) {
+      nodes.push(...renderTextWithCitations(value, sourcesMap, key));
+    } else {
+      nodes.push(value);
+    }
+  };
+
   while ((match = pattern.exec(text)) !== null) {
     if (match.index > lastIndex) {
-      nodes.push(text.slice(lastIndex, match.index));
+      pushText(text.slice(lastIndex, match.index), `lite-${lastIndex}`);
     }
 
     const token = match[0];
@@ -152,7 +168,7 @@ function renderLiteInline(text: string): React.ReactNode[] {
   }
 
   if (lastIndex < text.length) {
-    nodes.push(text.slice(lastIndex));
+    pushText(text.slice(lastIndex), `lite-${lastIndex}`);
   }
 
   return nodes;
@@ -185,7 +201,7 @@ function isLiteTableSeparator(line: string): boolean {
   return cells.length > 0 && cells.every(cell => /^:?-{3,}:?$/.test(cell));
 }
 
-const LiteTable: React.FC<{ lines: string[] }> = ({ lines }) => {
+const LiteTable: React.FC<{ lines: string[]; sourcesMap?: CitationSourcesMap | null }> = ({ lines, sourcesMap }) => {
   const headers = splitLiteTableRow(lines[0] || '');
   const rows = lines.slice(2).map(splitLiteTableRow);
 
@@ -196,7 +212,7 @@ const LiteTable: React.FC<{ lines: string[] }> = ({ lines }) => {
           <tr>
             {headers.map((header, idx) => (
               <th key={idx} className="border-2 border-brutal-black dark:border-zinc-500 px-2 py-1 bg-brutal-yellow text-brutal-black font-black uppercase text-left align-top">
-                {renderLiteInline(header)}
+                {renderLiteInline(header, sourcesMap)}
               </th>
             ))}
           </tr>
@@ -206,7 +222,7 @@ const LiteTable: React.FC<{ lines: string[] }> = ({ lines }) => {
             <tr key={rowIdx}>
               {headers.map((_header, colIdx) => (
                 <td key={colIdx} className="border-2 border-brutal-black dark:border-zinc-500 px-2 py-1 align-top text-brutal-black dark:text-neutral-100">
-                  {renderLiteInline(row[colIdx] ?? '')}
+                  {renderLiteInline(row[colIdx] ?? '', sourcesMap)}
                 </td>
               ))}
             </tr>
@@ -218,6 +234,7 @@ const LiteTable: React.FC<{ lines: string[] }> = ({ lines }) => {
 };
 
 const LiteMarkdownRenderer: React.FC<{ content: string }> = ({ content }) => {
+  const sourcesMap = useCitationSources();
   const parts: React.ReactNode[] = [];
   const fencePattern = /```([a-zA-Z0-9_-]*)[ \t]*\n?([\s\S]*?)(?:```|$)/g;
   let lastIndex = 0;
@@ -247,11 +264,11 @@ const LiteMarkdownRenderer: React.FC<{ content: string }> = ({ content }) => {
           : level === 2
             ? 'text-lg font-brutal font-bold mb-2 break-words uppercase'
             : 'text-base font-bold mb-1 break-words uppercase';
-        parts.push(<div key={key} className={className}>{renderLiteInline(body)}</div>);
+        parts.push(<div key={key} className={className}>{renderLiteInline(body, sourcesMap)}</div>);
         return;
       }
 
-      parts.push(<p key={key} className="leading-relaxed break-words whitespace-pre-wrap m-0">{renderLiteInline(text)}</p>);
+      parts.push(<p key={key} className="leading-relaxed break-words whitespace-pre-wrap m-0">{renderLiteInline(text, sourcesMap)}</p>);
     };
 
     for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
@@ -274,7 +291,7 @@ const LiteMarkdownRenderer: React.FC<{ content: string }> = ({ content }) => {
           lineIndex++;
         }
         lineIndex--;
-        parts.push(<LiteTable key={`${keyPrefix}-table-${parts.length}`} lines={tableLines} />);
+        parts.push(<LiteTable key={`${keyPrefix}-table-${parts.length}`} lines={tableLines} sourcesMap={sourcesMap} />);
         continue;
       }
 
@@ -286,7 +303,7 @@ const LiteMarkdownRenderer: React.FC<{ content: string }> = ({ content }) => {
         parts.push(
           <div key={`${keyPrefix}-li-${parts.length}-${lineIndex}`} className="flex gap-2 leading-relaxed">
             <span className="shrink-0 text-neutral-500">{ordered ? `${ordered[1]}.` : '•'}</span>
-            <span className="min-w-0 break-words">{renderLiteInline(body)}</span>
+            <span className="min-w-0 break-words">{renderLiteInline(body, sourcesMap)}</span>
           </div>,
         );
         continue;
@@ -315,6 +332,7 @@ const LiteMarkdownRenderer: React.FC<{ content: string }> = ({ content }) => {
 
 export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({ content, onFileClick, streamingLite = false }) => {
   const RM: any = ReactMarkdown;
+  const sourcesMap = useCitationSources();
   const openingLinksRef = React.useRef(new Map<string, number>());
 
   const isExternalLink = React.useCallback((href: string): boolean => {
@@ -350,6 +368,35 @@ export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({ content, on
       }, 750);
     }
   }, []);
+
+  // Walk rendered children, splitting string nodes that contain a citation
+  // marker into text + <CitationBadge> nodes. This is recursive because
+  // react-markdown may wrap text in <strong>, <em>, links, etc.
+  const applyCitations = React.useCallback((children: React.ReactNode, keyPrefix: string): React.ReactNode => {
+    if (!sourcesMap) return children;
+
+    const walk = (child: React.ReactNode, key: string): React.ReactNode => {
+      if (typeof child === 'string' && hasCitationMarker(child)) {
+        return renderTextWithCitations(child, sourcesMap, key);
+      }
+      if (React.isValidElement(child) && child.props?.children) {
+        if (child.type === 'code' || child.props?.node?.tagName === 'code') {
+          return child;
+        }
+        const nextChildren = React.Children.map(child.props.children, (nested, i) =>
+          walk(nested, `${key}-${i}`),
+        );
+        return React.cloneElement(child as React.ReactElement<any>, undefined, nextChildren);
+      }
+      return child;
+    };
+
+    const arr = React.Children.toArray(children);
+    if (!arr.some(c => typeof c === 'string' ? hasCitationMarker(c) : React.isValidElement(c))) {
+      return children;
+    }
+    return arr.map((child, i) => walk(child, `${keyPrefix}-${i}`));
+  }, [sourcesMap]);
 
   // Normalize content
   const normalized = String(content)
@@ -445,6 +492,10 @@ export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({ content, on
             const isMultilineInlineCode = !lang && codeContent.includes('\n');
             const isInline = inline !== false && !lang && !isMultilineInlineCode;
 
+            if (isInline && sourcesMap && hasCitationMarker(codeContent)) {
+              return <>{renderTextWithCitations(codeContent, sourcesMap, 'code')}</>;
+            }
+
             // Check if inline code contains a file path pattern
             if (isInline && onFileClick) {
               // Pattern 1: Markdown file:// link in backticks: `[text](file:///path)`
@@ -529,13 +580,14 @@ export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({ content, on
               <table className="text-xs border-3 border-brutal-black">{p.children}</table>
             </div>
           ),
-          th: (p: any) => <th className="border-2 border-brutal-black px-2 py-1 bg-brutal-yellow font-bold">{p.children}</th>,
-          td: (p: any) => <td className="border-2 border-brutal-black px-2 py-1 align-top">{p.children}</td>,
+          th: (p: any) => <th className="border-2 border-brutal-black px-2 py-1 bg-brutal-yellow font-bold">{applyCitations(p.children, 'th')}</th>,
+          td: (p: any) => <td className="border-2 border-brutal-black px-2 py-1 align-top">{applyCitations(p.children, 'td')}</td>,
           ul: (p: any) => <ul className="list-disc pl-5">{p.children}</ul>,
           ol: (p: any) => <ol className="list-decimal pl-5">{p.children}</ol>,
-          h1: (p: any) => <h1 className="text-xl font-brutal font-bold mb-2 break-words uppercase">{p.children}</h1>,
-          h2: (p: any) => <h2 className="text-lg font-brutal font-bold mb-2 break-words uppercase">{p.children}</h2>,
-          h3: (p: any) => <h3 className="text-base font-bold mb-1 break-words uppercase">{p.children}</h3>,
+          li: (p: any) => <li>{applyCitations(p.children, 'li')}</li>,
+          h1: (p: any) => <h1 className="text-xl font-brutal font-bold mb-2 break-words uppercase">{applyCitations(p.children, 'h1')}</h1>,
+          h2: (p: any) => <h2 className="text-lg font-brutal font-bold mb-2 break-words uppercase">{applyCitations(p.children, 'h2')}</h2>,
+          h3: (p: any) => <h3 className="text-base font-bold mb-1 break-words uppercase">{applyCitations(p.children, 'h3')}</h3>,
           p: (pArg: any) => {
             const text = String(pArg.children?.[0] || '');
             if (text.startsWith('Step: ') && text.includes('tokens')) {
@@ -553,8 +605,13 @@ export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({ content, on
                 (React.isValidElement(child) && (child.type === 'strong' || child.type === 'em'))
             );
 
-            // Apply ClickableContent for plain text paragraphs to detect file paths
-            if (isSimpleText && onFileClick) {
+            // Apply ClickableContent for plain text paragraphs to detect file
+            // paths — but only when there are no citation markers, since that
+            // path flattens children to a string and would drop citation badges.
+            const hasCite = React.Children.toArray(pArg.children).some(
+              c => typeof c === 'string' && hasCitationMarker(c),
+            );
+            if (isSimpleText && onFileClick && !hasCite) {
               const extractText = (children: any): string => {
                 return React.Children.toArray(children)
                   .map((child) => {
@@ -575,7 +632,7 @@ export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({ content, on
               );
             }
 
-            return <p className="leading-relaxed break-words whitespace-pre-wrap m-0">{pArg.children}</p>;
+            return <p className="leading-relaxed break-words whitespace-pre-wrap m-0">{applyCitations(pArg.children, 'p')}</p>;
           },
           blockquote: (p: any) => (
             <blockquote className="border-l-4 border-brutal-black pl-3 italic text-neutral-600 dark:text-neutral-400 break-words bg-neutral-50 dark:bg-zinc-800 py-1 pr-2">

--- a/frontend/src/hooks/useAGUI.ts
+++ b/frontend/src/hooks/useAGUI.ts
@@ -7,6 +7,7 @@
 import { useState, useCallback, useRef } from 'react';
 import type { A2UISurface } from '../types/a2ui';
 import type { AGUIPart, ApprovalRememberScope } from '../types/agui';
+import type { CitationSource } from '../lib/streamEvents';
 
 // ── Types ────────────────────────────────────────────────────────────
 export type AGUIStatus = 'idle' | 'submitted' | 'streaming' | 'error';
@@ -376,6 +377,23 @@ export function processEvent(
           if (next[i].type === 'tool' && next[i].toolCallId === tcId) {
             next[i] = { ...next[i], displayData: display };
             break;
+          }
+        }
+      } else if (name === 'citation_sources') {
+        // Citable sources registered during this run. Stored as a single part so
+        // they travel with the message (persist + reload) and so badges can
+        // resolve src ids to titles/urls. Merge in case the event fires twice.
+        const payload = value as { sources?: CitationSource[] };
+        const incoming = Array.isArray(payload?.sources) ? payload.sources : [];
+        if (incoming.length > 0) {
+          const idx = next.findIndex(p => p.type === 'citation-sources');
+          if (idx >= 0) {
+            const existing = next[idx].citationSources || [];
+            const byId = new Map(existing.map(s => [s.id, s]));
+            for (const s of incoming) byId.set(s.id, s);
+            next[idx] = { ...next[idx], citationSources: Array.from(byId.values()) };
+          } else {
+            next.push({ type: 'citation-sources', citationSources: incoming });
           }
         }
       } else if (name === 'a2ui.render') {

--- a/frontend/src/lib/streamEvents.ts
+++ b/frontend/src/lib/streamEvents.ts
@@ -45,11 +45,39 @@ export enum CustomEventName {
   TOOL_DISPLAY = 'tool_display',
   PLAN_REFRESH = 'plan_refresh',
   USAGE_UPDATE = 'usage_update',
+  // Inline citations
+  CITATION_SOURCES = 'citation_sources',
   // Sub-agent lifecycle events (S2O Phase 3)
   SUBAGENT_SPAWNED = 'subagent_spawned',
   SUBAGENT_PROGRESS = 'subagent_progress',
   SUBAGENT_COMPLETED = 'subagent_completed',
   SUBAGENT_FAILED = 'subagent_failed',
+}
+
+// ─── Inline citation payloads ──────────────────────────────────────────────
+
+export type CitationSourceType =
+  | 'search'
+  | 'webpage'
+  | 'file'
+  | 'notebook'
+  | 'memory'
+  | 'mcp'
+  | 'code'
+  | 'browser'
+  | 'subagent';
+
+export interface CitationSource {
+  id: string; // "src_1", "src_2", ...
+  type: CitationSourceType;
+  title: string;
+  url?: string | null;
+  snippet?: string | null;
+  favicon?: string | null;
+}
+
+export interface CitationSourcesPayload {
+  sources: CitationSource[];
 }
 
 // ─── Sub-agent event payloads ──────────────────────────────────────────────

--- a/frontend/src/types/agui.ts
+++ b/frontend/src/types/agui.ts
@@ -1,7 +1,8 @@
 import type { A2UISurface } from './a2ui';
+import type { CitationSource } from '../lib/streamEvents';
 
 export interface AGUIPart {
-  type: 'text' | 'reasoning' | 'tool' | 'a2ui';
+  type: 'text' | 'reasoning' | 'tool' | 'a2ui' | 'citation-sources';
   text?: string;
   messageId?: string;
   toolCallId?: string;
@@ -14,6 +15,8 @@ export interface AGUIPart {
   permission?: PermissionPrompt;
   displayData?: unknown;
   surface?: A2UISurface & { target?: string };
+  /** For 'citation-sources' parts: the sources registered during this run. */
+  citationSources?: CitationSource[];
 }
 
 export type ApprovalRememberScope = 'session' | 'global' | null;

--- a/src/suzent/core/agent_deps.py
+++ b/src/suzent/core/agent_deps.py
@@ -87,6 +87,11 @@ class AgentDeps:
     )
     inline_a2ui_surfaces: dict[str, dict[str, Any]] = field(default_factory=dict)
 
+    # --- Inline citations ---
+    # CitationManager instance for this run; tools register citable sources on it
+    # and streaming.py injects its prompt context + emits citation events.
+    citation_manager: Any = None
+
     # --- Prompt Context Cache ---
     section_cache: dict[str, str] = field(default_factory=dict)
 

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -1590,6 +1590,7 @@ class ChatProcessor:
                 # 100% Backend Authored: rebuild the complete display log from the full agent history
                 # so chat.messages is always a faithful log of all exchanges, including tools and reasoning.
                 rebuilt = _rebuild_display_messages(messages)
+                rebuilt = _preserve_citation_sources(rebuilt, chat_messages)
                 rebuilt = _append_inline_a2ui_surfaces(rebuilt, inline_a2ui_surfaces)
 
                 # Guard: if the agent produced no output and this is a social chat, the
@@ -2005,6 +2006,155 @@ def _rebuild_display_messages(messages: list) -> list:
             result.append(entry)
 
     return result
+
+
+def _preserve_citation_sources(rebuilt: list, existing: list | None) -> list:
+    """Carry citation metadata from draft display rows into rebuilt rows."""
+    sources_by_id = _collect_citation_sources(existing or [])
+    sources_by_id.update(_collect_citation_sources(rebuilt))
+
+    if not sources_by_id:
+        return rebuilt
+
+    for message in rebuilt:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        content = str(message.get("content") or "")
+        matched = [
+            source
+            for source_id, source in sources_by_id.items()
+            if source_id in content
+        ]
+        if not matched:
+            continue
+
+        parts = message.setdefault("parts", [])
+        if not isinstance(parts, list):
+            continue
+
+        existing_idx = next(
+            (
+                idx
+                for idx, part in enumerate(parts)
+                if isinstance(part, dict) and part.get("type") == "citation-sources"
+            ),
+            None,
+        )
+        if existing_idx is None:
+            parts.append({"type": "citation-sources", "citationSources": matched})
+            continue
+
+        part = parts[existing_idx]
+        existing_sources = part.get("citationSources")
+        if not isinstance(existing_sources, list):
+            existing_sources = []
+        merged = {
+            str(source.get("id")): dict(source)
+            for source in existing_sources
+            if isinstance(source, dict) and source.get("id")
+        }
+        for source in matched:
+            merged[str(source["id"])] = dict(source)
+        part["citationSources"] = list(merged.values())
+
+    return rebuilt
+
+
+def _collect_citation_sources(messages: list) -> dict[str, dict]:
+    sources_by_id: dict[str, dict] = {}
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        for part in message.get("parts") or []:
+            if not isinstance(part, dict) or part.get("type") != "citation-sources":
+                continue
+            for source in part.get("citationSources") or []:
+                if isinstance(source, dict) and source.get("id"):
+                    sources_by_id[str(source["id"])] = dict(source)
+        if message.get("role") == "tool":
+            sources_by_id.update(_extract_sources_from_tool_content(message))
+    return sources_by_id
+
+
+def _extract_sources_from_tool_content(message: dict) -> dict[str, dict]:
+    """Recover citation metadata from persisted tool results.
+
+    Streaming drafts should normally carry a citation-sources part, but final
+    post-processing can rebuild display rows from model/tool history after that
+    draft. Tool returns still contain the source ids plus titles/URLs, so use
+    them as the durable fallback.
+    """
+    content = message.get("content")
+    if not isinstance(content, str) or not content.strip():
+        return {}
+    try:
+        envelope = json.loads(content)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(envelope, dict):
+        return {}
+
+    raw_message = envelope.get("message")
+    if not isinstance(raw_message, str):
+        return {}
+
+    parsed_message: Any
+    try:
+        parsed_message = json.loads(raw_message)
+    except json.JSONDecodeError:
+        parsed_message = raw_message
+
+    if isinstance(parsed_message, dict):
+        return _extract_sources_from_search_payload(parsed_message)
+    return _extract_sources_from_labeled_webpage(raw_message, envelope)
+
+
+def _extract_sources_from_search_payload(payload: dict) -> dict[str, dict]:
+    from urllib.parse import urlparse
+
+    sources: dict[str, dict] = {}
+    for result in payload.get("results") or []:
+        if not isinstance(result, dict):
+            continue
+        source_id = result.get("source_id")
+        if not source_id:
+            continue
+        url = result.get("url") or result.get("href")
+        netloc = urlparse(str(url)).netloc if url else ""
+        source: dict[str, Any] = {
+            "id": str(source_id),
+            "type": "search",
+            "title": result.get("title") or url or str(source_id),
+            "url": url,
+            "snippet": result.get("description") or result.get("body"),
+        }
+        if netloc:
+            source["favicon"] = (
+                f"https://www.google.com/s2/favicons?domain={netloc}&sz=32"
+            )
+        sources[str(source_id)] = {k: v for k, v in source.items() if v is not None}
+    return sources
+
+
+def _extract_sources_from_labeled_webpage(
+    raw_message: str, envelope: dict
+) -> dict[str, dict]:
+    match = re.match(r"^\[(t\d+_src_\d+)\]\s+(.+?)(?:\r?\n|$)", raw_message)
+    if not match:
+        return {}
+    source_id, title = match.groups()
+    metadata = envelope.get("metadata")
+    url = metadata.get("url") if isinstance(metadata, dict) else None
+    snippet = raw_message[:200] if raw_message else None
+    return {
+        source_id: {
+            "id": source_id,
+            "type": "webpage",
+            "title": title.strip() or url or source_id,
+            "url": url,
+            "snippet": snippet,
+        }
+    }
 
 
 def _append_inline_a2ui_surfaces(

--- a/src/suzent/core/citation_manager.py
+++ b/src/suzent/core/citation_manager.py
@@ -1,0 +1,138 @@
+"""Citation source manager for tracking all citable information sources.
+
+Any tool that produces citable information can register a source with the
+manager. The manager is the single authority for source IDs (``src_N``) and
+generates both the LLM prompt context and the frontend event payload.
+
+LIFECYCLE: one CitationManager is created per agent run (see streaming.py) and
+injected into tools via ``AgentDeps.citation_manager``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+
+class CitationSourceType(str, Enum):
+    """Types of citable information sources."""
+
+    WEB_SEARCH = "search"
+    WEBPAGE = "webpage"
+    FILE = "file"
+    NOTEBOOK = "notebook"
+    MEMORY = "memory"
+    MCP = "mcp"
+    CODE = "code"
+    BROWSER = "browser"
+    SUBAGENT = "subagent"
+
+
+@dataclass
+class CitationSource:
+    """A single citable information source."""
+
+    id: str  # "src_1", "src_2", ...
+    type: CitationSourceType
+    title: str  # display name
+    url: Optional[str] = None  # web URL / file:// path
+    snippet: Optional[str] = None  # short summary (<= 200 chars)
+    favicon: Optional[str] = None  # icon URL
+    metadata: dict = field(default_factory=dict)
+
+
+class CitationManager:
+    """Manages all citable sources for a single agent run.
+
+    The manager assigns IDs (``src_1``, ``src_2``, ...). Tools must NOT invent
+    their own IDs — call :meth:`register` and use the returned ID so the prompt
+    context, LLM output markers, and frontend sources stay in one ID space.
+    """
+
+    def __init__(self, turn: int = 0) -> None:
+        self._sources: dict[str, CitationSource] = {}
+        self._counter = 0
+        # Conversation turn index. Ids are prefixed with it (``t{turn}_src_{n}``)
+        # so they are globally unique across the whole chat — a citation that
+        # references an earlier turn's source resolves correctly instead of
+        # colliding with this turn's ``src_1``.
+        self._turn = turn
+        # Dedup by (type, url|title) so registering the same page twice across
+        # tool calls reuses one ID instead of producing duplicate badges.
+        self._dedup: dict[tuple[str, str], str] = {}
+
+    def register(
+        self,
+        type: CitationSourceType,
+        title: str,
+        url: Optional[str] = None,
+        snippet: Optional[str] = None,
+        favicon: Optional[str] = None,
+        metadata: Optional[dict] = None,
+    ) -> str:
+        """Register a new source and return its ``t{turn}_src_{n}`` ID.
+
+        Re-registering the same source (same type + url, or type + title when no
+        url) returns the existing ID instead of allocating a new one.
+        """
+        dedup_key = (type.value, url or title or "")
+        existing = self._dedup.get(dedup_key)
+        if existing is not None:
+            return existing
+
+        self._counter += 1
+        source_id = f"t{self._turn}_src_{self._counter}"
+        self._sources[source_id] = CitationSource(
+            id=source_id,
+            type=type,
+            title=title,
+            url=url,
+            snippet=snippet[:200] if snippet else None,
+            favicon=favicon,
+            metadata=metadata or {},
+        )
+        self._dedup[dedup_key] = source_id
+        return source_id
+
+    def get_all(self) -> list[CitationSource]:
+        """Return all registered sources in registration order."""
+        return list(self._sources.values())
+
+    def get(self, source_id: str) -> Optional[CitationSource]:
+        """Get a source by ID."""
+        return self._sources.get(source_id)
+
+    def to_prompt_context(self) -> str:
+        """Render the available-sources block for injection into the prompt."""
+        if not self._sources:
+            return ""
+        lines = []
+        for sid, src in self._sources.items():
+            desc = src.title
+            if src.url:
+                desc += f" ({src.url})"
+            if src.snippet:
+                desc += f": {src.snippet[:150]}"
+            lines.append(f"  [{sid}] {desc}")
+        return "\n".join(lines)
+
+    def to_event_payload(self) -> list[dict]:
+        """Build the payload for the ``citation_sources`` custom event."""
+        return [
+            {
+                "id": src.id,
+                "type": src.type.value,
+                "title": src.title,
+                "url": src.url,
+                "snippet": src.snippet,
+                "favicon": src.favicon,
+            }
+            for src in self._sources.values()
+        ]
+
+    def clear(self) -> None:
+        """Reset for a new run."""
+        self._sources.clear()
+        self._dedup.clear()
+        self._counter = 0

--- a/src/suzent/prompts.py
+++ b/src/suzent/prompts.py
@@ -392,6 +392,48 @@ def format_session_guidance_debug(entries: list[dict]) -> str:
     return "\n".join(lines)
 
 
+# Inline-citation rules. STATIC behavioural instruction — kept separate from the
+# (dynamic) source list, which is NOT injected here: each tool prefixes its
+# results with the assigned `t{turn}_src_N` id, so the model sees the id right next to
+# the evidence it cites. The citation marker is rendered as a badge by the
+# frontend MarkdownRenderer.
+#
+# Uses ChatGPT-style invisible PUA characters
+# (U+E200 cite U+E202 {id} U+E201) as the model-facing marker. The frontend
+# also parses the ASCII [[cite:t0_src_N]] fallback for older/debug output.
+CITATION_RULES_SECTION = """# Citation Rules (REQUIRED)
+Tool results may be labelled with source ids like `[t0_src_1]`. Whenever your answer states a specific fact, figure, date, name, or quote that came from a labelled tool result, you MUST attach an inline citation marker for that exact source id. This is not optional: an answer drawn from labelled sources that contains no markers is incorrect.
+
+## Marker syntax
+Output a citation marker by copying this exact sequence, replacing only the id with the exact id shown in the tool result:
+
+    citet0_src_1
+
+The delimiter glyphs around `cite` and the id are special marker characters. Copy them exactly from the example; do not replace them with plain text, square brackets, parentheses, or words like "cite".
+
+Place the marker immediately after the phrase it supports, before punctuation. For several sources, repeat the separator character: citet0_src_1t0_src_2.
+
+## Examples
+- The UK's all-time record is 40.3Ccitet0_src_1, set in July 2022citet0_src_1.
+- Both the UK and France saw extreme heatcitet0_src_2t0_src_4.
+
+## Rules
+- Cite EACH sourced sentence (or clause). Do not gather all citations only at the end.
+- Copy the exact marker characters shown above; do not put them in backticks or code formatting, spell them out, or use any other style such as (src_1), [1], superscripts, or footnotes.
+- Use only the source ids shown in the tool results. Never invent an id, shorten it, remove the turn prefix, or put a source's name or URL inside the marker.
+- Do NOT cite general knowledge, your own reasoning, or analysis.
+- The markers are rendered as small badges and stripped from display, so never mention or describe them in prose."""
+
+
+def build_citation_section(deps: Any) -> str:
+    """Return the static citation rules.
+
+    The rules are constant (so this string is cacheable); the source *list* is
+    not injected here — tools embed source ids in their own output.
+    """
+    return CITATION_RULES_SECTION
+
+
 def register_dynamic_instructions(
     agent: Any,
     *,
@@ -451,6 +493,12 @@ def register_dynamic_instructions(
             "session_guidance",
             lambda: build_session_guidance_section(session_guidance_items),
         )
+
+    @agent.instructions
+    def inject_citation_rules(ctx: Any) -> str:
+        # Static rules only; source ids travel in tool output and source metadata
+        # travels in citation_sources stream events.
+        return build_citation_section(ctx.deps)
 
     @agent.instructions
     def inject_permission_mode(ctx: Any) -> str:

--- a/src/suzent/routes/chat_routes.py
+++ b/src/suzent/routes/chat_routes.py
@@ -609,6 +609,12 @@ async def get_chat(request: Request) -> JSONResponse:
         response_chat = chat.model_dump(
             mode="json", by_alias=True, exclude={"agent_state"}
         )
+        if isinstance(response_chat.get("messages"), list):
+            from suzent.core.chat_processor import _preserve_citation_sources
+
+            response_chat["messages"] = _preserve_citation_sources(
+                response_chat["messages"], []
+            )
         context_usage = dict(chat.context_usage or {})
 
         if chat.agent_state and context_usage.get("context_tokens") is None:

--- a/src/suzent/streaming.py
+++ b/src/suzent/streaming.py
@@ -35,6 +35,7 @@ from ag_ui.encoder import EventEncoder
 
 from suzent.core.agent_serializer import serialize_state
 from suzent.core.agent_deps import AgentDeps
+from suzent.core.citation_manager import CitationManager
 from suzent.core.stream_registry import (
     StreamControl,
     stream_controls,
@@ -247,6 +248,9 @@ class _DraftDisplayAccumulator:
         if event_type == "CUSTOM":
             self._apply_custom(event)
 
+    def apply_citation_sources(self, sources: list[dict[str, Any]]) -> None:
+        self._merge_citation_sources(sources)
+
     async def maybe_persist(self, *, force: bool = False) -> None:
         if not self.chat_id or not self.parts or not self.dirty:
             return
@@ -322,6 +326,40 @@ class _DraftDisplayAccumulator:
             if value.get("target") == "inline":
                 self.parts.append({"type": "a2ui", "surface": value})
                 self.dirty = True
+        elif name == "citation_sources" and isinstance(value, dict):
+            self._merge_citation_sources(value.get("sources"))
+
+    def _merge_citation_sources(self, incoming: Any) -> None:
+        if not isinstance(incoming, list) or not incoming:
+            return
+        for part in self.parts:
+            if part.get("type") != "citation-sources":
+                continue
+            existing = part.get("citationSources")
+            if not isinstance(existing, list):
+                existing = []
+            by_id = {
+                str(source.get("id")): dict(source)
+                for source in existing
+                if isinstance(source, dict) and source.get("id")
+            }
+            for source in incoming:
+                if isinstance(source, dict) and source.get("id"):
+                    by_id[str(source["id"])] = dict(source)
+            part["citationSources"] = list(by_id.values())
+            self.dirty = True
+            return
+        self.parts.append(
+            {
+                "type": "citation-sources",
+                "citationSources": [
+                    dict(source)
+                    for source in incoming
+                    if isinstance(source, dict) and source.get("id")
+                ],
+            }
+        )
+        self.dirty = True
 
 
 def _persist_draft_display_message(
@@ -559,6 +597,27 @@ async def stream_agent_responses(
 
     sse_queue: asyncio.Queue = asyncio.Queue()
     deps.cancel_event = control.cancel_event
+
+    # --- Inline citations ---
+    # One manager per run. Tools register citable sources on the manager via
+    # deps and embed [[cite:t{turn}_src_n]] markers in their output; the model
+    # echoes those markers in its answer. The markers are emitted to the client
+    # as-is (the frontend renders them as badges). We re-emit citation_sources
+    # whenever new sources are registered so the frontend can resolve every cited
+    # id — tracked by the count last sent.
+    #
+    # The turn index makes ids globally unique across the conversation, so a
+    # citation that references an earlier turn's source resolves correctly. It is
+    # the count of prior model responses in the history.
+    _turn_index = sum(
+        1
+        for _m in (message_history or [])
+        if getattr(_m, "kind", None) == "response"
+        or (isinstance(_m, dict) and _m.get("role") == "assistant")
+    )
+    citation_mgr = CitationManager(turn=_turn_index)
+    deps.citation_manager = citation_mgr
+    citation_sources_last_sent = 0
 
     # Auto-title: kick off in parallel for the first turn using only the user message
     # Extract text content for title generation
@@ -955,6 +1014,8 @@ async def stream_agent_responses(
 
     # --- Native stream generator that feeds AGUIEventStream ---
     async def native_stream_generator() -> AsyncGenerator[Any, None]:
+        nonlocal citation_sources_last_sent
+
         async def _drain_a2ui_events() -> None:
             a2ui_queue = getattr(deps, "a2ui_queue", None)
             while a2ui_queue and not a2ui_queue.empty():
@@ -1087,6 +1148,27 @@ async def stream_agent_responses(
                         )
                         # Continue to next event instead of crashing
 
+                    # Re-emit citation sources whenever new ones were registered
+                    # (each tool call can add more). The frontend merges by id, so
+                    # sending the full list each time keeps every cited id
+                    # resolvable.
+                    _all_sources = citation_mgr.get_all()
+                    if len(_all_sources) > citation_sources_last_sent:
+                        logger.debug(
+                            f"[citation] emitting citation_sources event with "
+                            f"{len(_all_sources)} sources"
+                        )
+                        await out_queue.put(
+                            (
+                                "chunk",
+                                _encode_custom(
+                                    "citation_sources",
+                                    {"sources": citation_mgr.to_event_payload()},
+                                ),
+                            )
+                        )
+                        citation_sources_last_sent = len(_all_sources)
+
                 elif msg_type == "approval":
                     # HITL: emit as AG-UI CustomEvent with all approval info
                     approval_info = {
@@ -1198,6 +1280,13 @@ async def stream_agent_responses(
             async for agui_event in agui_events:
                 if control.cancel_event.is_set():
                     break
+
+                # Inline citation markers ([[cite:src_1]]) are intentionally left
+                # in the assistant text: the frontend MarkdownRenderer transforms
+                # them into citation badges and looks up titles via the
+                # citation_sources custom event. Keeping them in the text (and
+                # therefore in the persisted draft) means reloaded chats render
+                # identical badges.
                 if draft_accumulator is not None:
                     draft_accumulator.apply(agui_event)
                     await draft_accumulator.maybe_persist()
@@ -1209,6 +1298,9 @@ async def stream_agent_responses(
         finally:
             if draft_accumulator is not None:
                 try:
+                    final_sources = citation_mgr.to_event_payload()
+                    if final_sources:
+                        draft_accumulator.apply_citation_sources(final_sources)
                     await draft_accumulator.maybe_persist(force=True)
                 except Exception as exc:
                     logger.debug(f"[Streaming] Failed to persist final draft: {exc}")

--- a/src/suzent/tools/webpage_tool.py
+++ b/src/suzent/tools/webpage_tool.py
@@ -1,7 +1,10 @@
 from typing import Annotated
 
 from pydantic import Field
+from pydantic_ai import RunContext
 
+from suzent.core.agent_deps import AgentDeps
+from suzent.core.citation_manager import CitationSourceType
 from suzent.tools.base import Tool, ToolErrorCode, ToolGroup, ToolResult
 
 
@@ -11,6 +14,17 @@ def __getattr__(name):
 
         return AsyncWebCrawler
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def _title_from_markdown(markdown: str) -> str | None:
+    """Return the first markdown heading text, if any, for use as a source title."""
+    for line in markdown.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            title = stripped.lstrip("#").strip()
+            if title:
+                return title[:120]
+    return None
 
 
 class WebpageTool(Tool):
@@ -51,6 +65,7 @@ class WebpageTool(Tool):
 
     async def forward(
         self,
+        ctx: RunContext[AgentDeps],
         url: Annotated[
             str,
             Field(
@@ -63,4 +78,18 @@ class WebpageTool(Tool):
         Args:
             url: The URL of the page to retrieve content from.
         """
-        return await self._crawl_url(url)
+        result = await self._crawl_url(url)
+        if result.success:
+            mgr = getattr(ctx.deps, "citation_manager", None)
+            if mgr is not None:
+                # Derive a display title from the first markdown heading, else host.
+                title = _title_from_markdown(result.message) or url
+                source_id = mgr.register(
+                    type=CitationSourceType.WEBPAGE,
+                    title=title,
+                    url=url,
+                    snippet=result.message,
+                )
+                # Label the content with its id so the model cites it correctly.
+                result.message = f"[{source_id}] {title}\n\n{result.message}"
+        return result

--- a/src/suzent/tools/websearch_tool.py
+++ b/src/suzent/tools/websearch_tool.py
@@ -15,7 +15,10 @@ from urllib.parse import urlparse
 from typing import Annotated, Optional, List, Dict, Any, Literal
 
 from pydantic import Field
+from pydantic_ai import RunContext
 
+from suzent.core.agent_deps import AgentDeps
+from suzent.core.citation_manager import CitationSourceType
 from suzent.tools.base import Tool, ToolGroup, ToolResult, ToolErrorCode
 from suzent.logger import get_logger
 
@@ -87,6 +90,7 @@ class WebSearchTool(Tool):
 
     async def forward(
         self,
+        ctx: RunContext[AgentDeps],
         query: Annotated[
             str, Field(description="Search query to send to the web search provider.")
         ],
@@ -126,13 +130,64 @@ class WebSearchTool(Tool):
             page: Page number for pagination (default 1).
         """
         if self.use_searxng:
-            return await self._search_with_searxng(
+            result = await self._search_with_searxng(
                 query, categories, max_results, time_range, page
             )
         else:
-            return await self._search_with_ddgs(
+            result = await self._search_with_ddgs(
                 query, categories, max_results, time_range, page
             )
+
+        self._register_citations(ctx, result)
+        return result
+
+    def _register_citations(
+        self, ctx: "RunContext[AgentDeps]", result: ToolResult
+    ) -> None:
+        """Register each search result as a citable source and label it inline.
+
+        CitationManager owns the source ids. After registering, the assigned
+        ``src_N`` id is written back into each result object so the model sees
+        the id right next to the content it will cite (``result.message`` is the
+        text the model reads).
+        """
+        mgr = getattr(ctx.deps, "citation_manager", None)
+        if mgr is None or not result.success:
+            logger.debug(
+                f"[citation] websearch skip register: mgr={mgr is not None} "
+                f"success={result.success}"
+            )
+            return
+        try:
+            payload = json.loads(result.message)
+        except (json.JSONDecodeError, TypeError):
+            logger.debug("[citation] websearch result message not JSON; skip register")
+            return
+        before = len(mgr.get_all())
+        for r in payload.get("results", []):
+            url = r.get("url") or ""
+            if not url:
+                continue
+            netloc = urlparse(url).netloc
+            source_id = mgr.register(
+                type=CitationSourceType.WEB_SEARCH,
+                title=r.get("title") or url,
+                url=url,
+                snippet=r.get("description"),
+                favicon=(
+                    f"https://www.google.com/s2/favicons?domain={netloc}&sz=32"
+                    if netloc
+                    else None
+                ),
+            )
+            # Surface the id to the model alongside this result.
+            r["source_id"] = source_id
+        # Re-serialise so the model reads the ids embedded in the results.
+        result.message = json.dumps(payload, ensure_ascii=False)
+        logger.debug(
+            f"[citation] websearch registered {len(mgr.get_all()) - before} sources "
+            f"(total {len(mgr.get_all())})"
+        )
 
     async def _search_with_ddgs(
         self,

--- a/tests/core/test_chat_processor_display_rebuild.py
+++ b/tests/core/test_chat_processor_display_rebuild.py
@@ -1,3 +1,5 @@
+import json
+
 from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
@@ -12,6 +14,7 @@ from suzent.core.chat_processor import (
     _append_command_messages,
     _append_inline_a2ui_surfaces,
     _build_file_mention_context,
+    _preserve_citation_sources,
     _rebuild_display_messages,
     _strip_attachment_annotations,
 )
@@ -117,6 +120,110 @@ def test_append_inline_a2ui_surfaces_attaches_to_last_assistant_message():
 
     assert updated[1]["role"] == "assistant"
     assert "data-a2ui=" in updated[1]["content"]
+
+
+def test_preserve_citation_sources_attaches_matching_sources_to_rebuilt_message():
+    rebuilt = [
+        {"role": "user", "content": "what happened?"},
+        {
+            "role": "assistant",
+            "content": "Gold rose\ue200cite\ue202t0_src_1\ue201.",
+            "parts": [
+                {"type": "text", "text": "Gold rose\ue200cite\ue202t0_src_1\ue201."}
+            ],
+        },
+    ]
+    existing = [
+        {
+            "role": "assistant",
+            "content": "draft",
+            "parts": [
+                {
+                    "type": "citation-sources",
+                    "citationSources": [
+                        {
+                            "id": "t0_src_1",
+                            "type": "search",
+                            "title": "Reuters",
+                            "url": "https://reuters.com/a",
+                        },
+                        {
+                            "id": "t0_src_2",
+                            "type": "search",
+                            "title": "Unused",
+                            "url": "https://example.com/unused",
+                        },
+                    ],
+                }
+            ],
+        }
+    ]
+
+    updated = _preserve_citation_sources(rebuilt, existing)
+
+    assert updated[1]["parts"][1] == {
+        "type": "citation-sources",
+        "citationSources": [
+            {
+                "id": "t0_src_1",
+                "type": "search",
+                "title": "Reuters",
+                "url": "https://reuters.com/a",
+            }
+        ],
+    }
+
+
+def test_preserve_citation_sources_recovers_sources_from_tool_results():
+    tool_content = {
+        "success": True,
+        "message": json.dumps(
+            {
+                "source": "DDGS (news)",
+                "results": [
+                    {
+                        "title": "Stock Market Today",
+                        "url": "https://example.com/markets",
+                        "description": "Nasdaq and S&P 500 moved lower.",
+                        "source_id": "t0_src_14",
+                    },
+                    {
+                        "title": "Unused",
+                        "url": "https://example.com/unused",
+                        "description": "Unused source.",
+                        "source_id": "t0_src_15",
+                    },
+                ],
+            }
+        ),
+    }
+    rebuilt = [
+        {"role": "tool", "content": json.dumps(tool_content)},
+        {
+            "role": "assistant",
+            "content": "Tech stocks fell \ue200cite\ue202t0_src_14\ue201.",
+            "parts": [
+                {
+                    "type": "text",
+                    "text": "Tech stocks fell \ue200cite\ue202t0_src_14\ue201.",
+                }
+            ],
+        },
+    ]
+
+    updated = _preserve_citation_sources(rebuilt, [])
+
+    assert updated[1]["parts"][1]["type"] == "citation-sources"
+    assert updated[1]["parts"][1]["citationSources"] == [
+        {
+            "id": "t0_src_14",
+            "type": "search",
+            "title": "Stock Market Today",
+            "url": "https://example.com/markets",
+            "snippet": "Nasdaq and S&P 500 moved lower.",
+            "favicon": "https://www.google.com/s2/favicons?domain=example.com&sz=32",
+        }
+    ]
 
 
 def test_append_command_messages_adds_user_and_notice_entries():

--- a/tests/core/test_citation_manager.py
+++ b/tests/core/test_citation_manager.py
@@ -1,0 +1,93 @@
+"""Unit tests for CitationManager — the single authority for source IDs."""
+
+from suzent.core.citation_manager import CitationManager, CitationSourceType
+
+
+def test_register_assigns_sequential_ids():
+    mgr = CitationManager()
+    a = mgr.register(CitationSourceType.WEB_SEARCH, "A", url="https://a.com")
+    b = mgr.register(CitationSourceType.WEB_SEARCH, "B", url="https://b.com")
+    assert a == "t0_src_1"
+    assert b == "t0_src_2"
+    assert [s.id for s in mgr.get_all()] == ["t0_src_1", "t0_src_2"]
+
+
+def test_turn_prefix_makes_ids_unique_across_turns():
+    t0 = CitationManager(turn=0)
+    t3 = CitationManager(turn=3)
+    assert (
+        t0.register(CitationSourceType.WEB_SEARCH, "A", url="https://a.com")
+        == "t0_src_1"
+    )
+    assert (
+        t3.register(CitationSourceType.WEB_SEARCH, "B", url="https://b.com")
+        == "t3_src_1"
+    )
+
+
+def test_register_dedups_same_url():
+    mgr = CitationManager()
+    first = mgr.register(CitationSourceType.WEBPAGE, "Page", url="https://x.com")
+    again = mgr.register(
+        CitationSourceType.WEBPAGE, "Page (again)", url="https://x.com"
+    )
+    assert first == again
+    assert len(mgr.get_all()) == 1
+
+
+def test_dedup_is_per_type():
+    mgr = CitationManager()
+    s = mgr.register(CitationSourceType.WEB_SEARCH, "X", url="https://x.com")
+    w = mgr.register(CitationSourceType.WEBPAGE, "X", url="https://x.com")
+    assert s != w
+    assert len(mgr.get_all()) == 2
+
+
+def test_snippet_truncated_to_200():
+    mgr = CitationManager()
+    sid = mgr.register(CitationSourceType.FILE, "f", snippet="z" * 500)
+    assert len(mgr.get(sid).snippet) == 200
+
+
+def test_prompt_context_lists_ids_and_titles():
+    mgr = CitationManager()
+    mgr.register(
+        CitationSourceType.WEB_SEARCH, "Reuters", url="https://r.com", snippet="hot"
+    )
+    ctx = mgr.to_prompt_context()
+    assert "[t0_src_1]" in ctx
+    assert "Reuters" in ctx
+    assert "https://r.com" in ctx
+
+
+def test_empty_prompt_context_is_blank():
+    assert CitationManager().to_prompt_context() == ""
+
+
+def test_event_payload_shape():
+    mgr = CitationManager()
+    mgr.register(
+        CitationSourceType.WEB_SEARCH,
+        "Reuters",
+        url="https://r.com",
+        favicon="https://r.com/fav.ico",
+    )
+    payload = mgr.to_event_payload()
+    assert payload == [
+        {
+            "id": "t0_src_1",
+            "type": "search",
+            "title": "Reuters",
+            "url": "https://r.com",
+            "snippet": None,
+            "favicon": "https://r.com/fav.ico",
+        }
+    ]
+
+
+def test_clear_resets_counter_and_sources():
+    mgr = CitationManager()
+    mgr.register(CitationSourceType.FILE, "f", url="file:///a")
+    mgr.clear()
+    assert mgr.get_all() == []
+    assert mgr.register(CitationSourceType.FILE, "g", url="file:///b") == "t0_src_1"

--- a/tests/prompts/test_prompt_architecture.py
+++ b/tests/prompts/test_prompt_architecture.py
@@ -35,7 +35,58 @@ def test_register_dynamic_instructions_registers_all_sections():
         memory_context="",
     )
 
-    assert len(agent.functions) == 10
+    assert len(agent.functions) == 11
+
+
+def test_citation_rules_available_before_sources_exist():
+    agent = _FakeAgent()
+    register_dynamic_instructions(agent, base_instructions="", memory_context="")
+    funcs = {fn.__name__: fn for fn in agent.functions}
+
+    # The model needs the marker rules before it calls tools; labelled tool
+    # output will provide the source ids later in the run.
+    ctx = SimpleNamespace(deps=SimpleNamespace(citation_manager=None))
+    result = funcs["inject_citation_rules"](ctx)
+    assert "# Citation Rules" in result
+    assert "citet0_src_1" in result
+
+
+def test_citation_rules_appear_once_sources_exist():
+    from suzent.core.citation_manager import CitationManager, CitationSourceType
+
+    agent = _FakeAgent()
+    register_dynamic_instructions(agent, base_instructions="", memory_context="")
+    funcs = {fn.__name__: fn for fn in agent.functions}
+
+    mgr = CitationManager()
+    mgr.register(CitationSourceType.WEB_SEARCH, "Reuters", url="https://r.com")
+    ctx = SimpleNamespace(deps=SimpleNamespace(citation_manager=mgr))
+
+    result = funcs["inject_citation_rules"](ctx)
+    # Rules show the marker syntax but NOT the source list — ids travel with
+    # tool output, not the prompt.
+    assert "# Citation Rules" in result
+    assert "citet0_src_1" in result
+    assert "Reuters" not in result
+    assert "https://r.com" not in result
+
+
+def test_citation_rules_are_static_and_cacheable():
+    """Same string regardless of which sources are registered (no interpolation)."""
+    from suzent.core.citation_manager import CitationManager, CitationSourceType
+
+    agent = _FakeAgent()
+    register_dynamic_instructions(agent, base_instructions="", memory_context="")
+    inject = {fn.__name__: fn for fn in agent.functions}["inject_citation_rules"]
+
+    mgr_a = CitationManager()
+    mgr_a.register(CitationSourceType.WEB_SEARCH, "A", url="https://a.com")
+    mgr_b = CitationManager()
+    mgr_b.register(CitationSourceType.WEBPAGE, "B", url="https://b.com")
+
+    out_a = inject(SimpleNamespace(deps=SimpleNamespace(citation_manager=mgr_a)))
+    out_b = inject(SimpleNamespace(deps=SimpleNamespace(citation_manager=mgr_b)))
+    assert out_a == out_b
 
 
 def test_permission_feedback_instruction_includes_user_guidance():

--- a/tests/test_streaming_timeout.py
+++ b/tests/test_streaming_timeout.py
@@ -1,4 +1,5 @@
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 from pydantic_ai.messages import FunctionToolCallEvent, FunctionToolResultEvent
@@ -93,3 +94,90 @@ def test_non_bash_tool_stream_timeout_defaults_to_one_minute():
     )
 
     assert streaming._tool_timeout_from_event(event) == 60.0
+
+
+def test_draft_accumulator_persists_citation_sources():
+    acc = streaming._DraftDisplayAccumulator(chat_id="chat-1", run_id="run-1")
+
+    acc.apply(
+        SimpleNamespace(
+            type="CUSTOM",
+            name="citation_sources",
+            value={
+                "sources": [
+                    {
+                        "id": "t0_src_1",
+                        "type": "search",
+                        "title": "Example",
+                        "url": "https://example.com",
+                    }
+                ]
+            },
+        )
+    )
+
+    assert acc.parts == [
+        {
+            "type": "citation-sources",
+            "citationSources": [
+                {
+                    "id": "t0_src_1",
+                    "type": "search",
+                    "title": "Example",
+                    "url": "https://example.com",
+                }
+            ],
+        }
+    ]
+    assert acc.dirty is True
+
+
+def test_draft_accumulator_merges_citation_sources_by_id():
+    acc = streaming._DraftDisplayAccumulator(chat_id="chat-1", run_id="run-1")
+
+    acc.apply(
+        SimpleNamespace(
+            type="CUSTOM",
+            name="citation_sources",
+            value={"sources": [{"id": "t0_src_1", "type": "search", "title": "Old"}]},
+        )
+    )
+    acc.apply(
+        SimpleNamespace(
+            type="CUSTOM",
+            name="citation_sources",
+            value={
+                "sources": [
+                    {"id": "t0_src_1", "type": "search", "title": "New"},
+                    {"id": "t0_src_2", "type": "webpage", "title": "Page"},
+                ]
+            },
+        )
+    )
+
+    assert acc.parts == [
+        {
+            "type": "citation-sources",
+            "citationSources": [
+                {"id": "t0_src_1", "type": "search", "title": "New"},
+                {"id": "t0_src_2", "type": "webpage", "title": "Page"},
+            ],
+        }
+    ]
+
+
+def test_draft_accumulator_snapshots_final_citation_sources():
+    acc = streaming._DraftDisplayAccumulator(chat_id="chat-1", run_id="run-1")
+
+    acc.apply_citation_sources(
+        [{"id": "t0_src_1", "type": "search", "title": "Example"}]
+    )
+
+    assert acc.parts == [
+        {
+            "type": "citation-sources",
+            "citationSources": [
+                {"id": "t0_src_1", "type": "search", "title": "Example"}
+            ],
+        }
+    ]

--- a/tests/tools/test_tool_cleanup_smoke.py
+++ b/tests/tools/test_tool_cleanup_smoke.py
@@ -203,7 +203,8 @@ async def test_webpage_tool_wraps_result(monkeypatch):
         "suzent.tools.webpage_tool.AsyncWebCrawler", lambda: _DummyCrawler()
     )
 
-    result = await WebpageTool().forward("https://example.com")
+    ctx = SimpleNamespace(deps=SimpleNamespace(citation_manager=None))
+    result = await WebpageTool().forward(ctx, url="https://example.com")
 
     assert result.success
     assert result.metadata["url"] == "https://example.com"
@@ -229,8 +230,9 @@ async def test_websearch_tool_can_be_mocked(monkeypatch):
 
     monkeypatch.setattr(tool, "_search_with_ddgs", fake_ddgs)
 
+    ctx = SimpleNamespace(deps=SimpleNamespace(citation_manager=None))
     result = await tool.forward(
-        query="test", categories="general", max_results=3, time_range="day", page=1
+        ctx, query="test", categories="general", max_results=3, time_range="day", page=1
     )
 
     assert result.success

--- a/tests/tools/test_webpage_tool.py
+++ b/tests/tools/test_webpage_tool.py
@@ -1,6 +1,17 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from suzent.tools.webpage_tool import WebpageTool
+
+
+@pytest.fixture
+def mock_ctx():
+    from suzent.core.citation_manager import CitationManager
+
+    ctx = MagicMock()
+    ctx.deps.citation_manager = CitationManager()
+    return ctx
 
 
 class _DummyCrawlerResult:
@@ -25,25 +36,37 @@ class _DummyCrawler:
 
 
 @pytest.mark.asyncio
-async def test_forward_returns_markdown(monkeypatch):
+async def test_forward_returns_markdown(monkeypatch, mock_ctx):
     dummy = _DummyCrawler("# title")
 
     monkeypatch.setattr("suzent.tools.webpage_tool.AsyncWebCrawler", lambda: dummy)
 
-    result = await WebpageTool().forward("https://example.com")
+    result = await WebpageTool().forward(mock_ctx, "https://example.com")
 
     assert result.success
-    assert result.message == "# title"
     assert dummy.arun_calls == ["https://example.com"]
+
+    # The fetched page is registered as a citable source, titled from its heading.
+    sources = mock_ctx.deps.citation_manager.get_all()
+    assert len(sources) == 1
+    assert sources[0].title == "title"
+    assert sources[0].url == "https://example.com"
+
+    # The content is labelled with its src id so the model can cite it inline,
+    # and the original markdown is preserved after the label.
+    assert result.message.startswith(f"[{sources[0].id}] title")
+    assert "# title" in result.message
 
 
 @pytest.mark.asyncio
-async def test_forward_handles_empty_result(monkeypatch):
+async def test_forward_handles_empty_result(monkeypatch, mock_ctx):
     dummy = _DummyCrawler(None)
 
     monkeypatch.setattr("suzent.tools.webpage_tool.AsyncWebCrawler", lambda: dummy)
 
-    result = await WebpageTool().forward("https://example.com")
+    result = await WebpageTool().forward(mock_ctx, "https://example.com")
 
     assert not result.success
+    # A failed fetch registers no source.
+    assert mock_ctx.deps.citation_manager.get_all() == []
     assert result.message == "Unable to retrieve content from the specified URL."

--- a/tests/tools/test_websearch_tool.py
+++ b/tests/tools/test_websearch_tool.py
@@ -5,6 +5,16 @@ from suzent.tools.websearch_tool import WebSearchTool
 
 
 @pytest.fixture
+def mock_ctx():
+    """Minimal RunContext stand-in: deps with a real CitationManager."""
+    from suzent.core.citation_manager import CitationManager
+
+    ctx = MagicMock()
+    ctx.deps.citation_manager = CitationManager()
+    return ctx
+
+
+@pytest.fixture
 def clean_env():
     # Store original env
     original_url = os.environ.get("SEARXNG_BASE_URL")
@@ -36,7 +46,7 @@ def test_init_uses_searxng_when_env_set(clean_env):
         mock_client.assert_called_once()
 
 
-async def test_ddgs_search_usage(clean_env):
+async def test_ddgs_search_usage(clean_env, mock_ctx):
     """Verify DDGS is used with correct parameters."""
     # We patch 'ddgs.DDGS' so when 'from ddgs import DDGS' runs, it gets our mock
     with patch("ddgs.DDGS") as MockDDGS:
@@ -47,9 +57,18 @@ async def test_ddgs_search_usage(clean_env):
         ]
 
         tool = WebSearchTool()
-        result = await tool.forward(query="test", max_results=5)
+        result = await tool.forward(mock_ctx, query="test", max_results=5)
 
         assert "Test" in result.message
+
+        # The result is registered and its src id is embedded in the output the
+        # model reads, so it can cite the source inline.
+        import json
+
+        sources = mock_ctx.deps.citation_manager.get_all()
+        assert len(sources) == 1
+        payload = json.loads(result.message)
+        assert payload["results"][0]["source_id"] == sources[0].id
 
         # Verify context manager usage
         MockDDGS.assert_called_once()
@@ -60,7 +79,7 @@ async def test_ddgs_search_usage(clean_env):
         mock_instance.text.assert_called_with("test", timelimit=None, max_results=5)
 
 
-async def test_ddgs_category_dispatch(clean_env):
+async def test_ddgs_category_dispatch(clean_env, mock_ctx):
     with patch("ddgs.DDGS") as MockDDGS:
         mock_instance = MockDDGS.return_value
         mock_instance.__enter__.return_value = mock_instance
@@ -69,16 +88,16 @@ async def test_ddgs_category_dispatch(clean_env):
 
         # News
         mock_instance.news.return_value = []
-        await tool.forward(query="news test", categories="news")
+        await tool.forward(mock_ctx, query="news test", categories="news")
         mock_instance.news.assert_called_once()
 
         # Images
         mock_instance.images.return_value = []
-        await tool.forward(query="image test", categories="images")
+        await tool.forward(mock_ctx, query="image test", categories="images")
         mock_instance.images.assert_called_once()
 
 
-async def test_searxng_search(clean_env):
+async def test_searxng_search(clean_env, mock_ctx):
     os.environ["SEARXNG_BASE_URL"] = "http://localhost:8080"
     with patch("httpx.AsyncClient") as MockClient:
         mock_client_instance = MagicMock()
@@ -92,14 +111,14 @@ async def test_searxng_search(clean_env):
 
         tool = WebSearchTool()
 
-        await tool.forward(query="test")
+        await tool.forward(mock_ctx, query="test")
 
         mock_client_instance.get.assert_awaited_with(
             "/search", params={"q": "test", "format": "json", "page": 1}
         )
 
 
-async def test_searxng_fallback_to_ddgs(clean_env):
+async def test_searxng_fallback_to_ddgs(clean_env, mock_ctx):
     os.environ["SEARXNG_BASE_URL"] = "http://localhost:8080"
     with patch("httpx.AsyncClient") as MockClient:
         mock_client_instance = MagicMock()
@@ -118,7 +137,7 @@ async def test_searxng_fallback_to_ddgs(clean_env):
             ]
 
             tool = WebSearchTool()
-            result = await tool.forward(query="test", max_results=5)
+            result = await tool.forward(mock_ctx, query="test", max_results=5)
 
             assert "Fallback" in result.message
             # Verify DDGS called with forwarded params


### PR DESCRIPTION
## Summary

Adds end-to-end inline citation support for sourced assistant answers.

- Registers citable web search and webpage sources with stable turn-scoped ids.
- Injects citation instructions and preserves source metadata through streaming, persistence, retry, post-processing rebuilds, and refresh.
- Renders inline citation badges in the chat UI, including PUA and object-replacement-normalized markers, with fallback chips when metadata is missing.
- Adds citation source panels, hover cards, copy stripping, and focused backend/frontend regression coverage.

## Root Cause

Citation markers could survive in assistant text while the `citation_sources` metadata was lost. The live stream emitted source metadata, but persistence and display-log rebuild paths could drop it, so refresh/retry left badges unresolved or invisible.

## Validation

- `uv run --no-sync pytest tests/core/test_chat_processor_display_rebuild.py tests/test_streaming_timeout.py tests/prompts/test_prompt_architecture.py tests/core/test_citation_manager.py`
- `uv run --no-sync ruff check src/suzent/core/chat_processor.py src/suzent/streaming.py src/suzent/prompts.py src/suzent/core/citation_manager.py src/suzent/tools/webpage_tool.py src/suzent/tools/websearch_tool.py tests/core/test_chat_processor_display_rebuild.py tests/test_streaming_timeout.py tests/prompts/test_prompt_architecture.py tests/core/test_citation_manager.py tests/tools/test_webpage_tool.py tests/tools/test_websearch_tool.py`
- `npm run test -- Citations.test.tsx`
- `npm run build`