### PR TITLE
Reuse running Suzent server from CLI

### DIFF
--- a/src/suzent/cli/main.py
+++ b/src/suzent/cli/main.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import urllib.error
 import urllib.request
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -108,6 +109,19 @@ def _has_unreleased_ui_changes(root: Path) -> bool:
 
     return False
 
+
+def _is_suzent_server_running(host: str, port: int, timeout: float = 1.0) -> bool:
+    """Return True when a Suzent backend responds on host:port."""
+    probe_host = "127.0.0.1" if host in {"0.0.0.0", "::"} else host
+    url = f"http://{probe_host}:{port}/health"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            if response.status != 200:
+                return False
+            payload = json.loads(response.read().decode("utf-8"))
+    except (OSError, json.JSONDecodeError, urllib.error.URLError):
+        return False
+    return payload.get("app") == "suzent" and payload.get("status") == "ok"
 
 def _platform_asset_name() -> str:
     machine = platform.machine().lower()
@@ -747,7 +761,17 @@ def register_commands(app: typer.Typer):
         ensure_cargo_in_path()
         ensure_msvc_linker()
 
-        for port, name in [(DEFAULT_PORT, "Backend"), (18080, "Frontend")]:
+        backend_running = _is_suzent_server_running("127.0.0.1", DEFAULT_PORT)
+        ports_to_check = [(18080, "Frontend")]
+        if not backend_running:
+            ports_to_check.insert(0, (DEFAULT_PORT, "Backend"))
+        else:
+            typer.echo(
+                f"  ✅ Backend already running on http://127.0.0.1:{DEFAULT_PORT}; "
+                "reusing it."
+            )
+
+        for port, name in ports_to_check:
             pid = get_pid_on_port(port)
             if pid:
                 typer.echo(f"\n⚠️  {name} Port {port} is already in use by PID {pid}.")
@@ -770,15 +794,19 @@ def register_commands(app: typer.Typer):
         if dev:
             backend_env["SUZENT_CAPABILITIES_TO_REPO"] = "1"
 
-        typer.echo("  • Starting backend...")
-        backend_cmd = [sys.executable, "-m", "suzent.server"]
-        if debug:
-            backend_cmd.append("--debug")
-        backend_proc = subprocess.Popen(
-            backend_cmd,
-            cwd=root,
-            env=backend_env,
-        )
+        backend_proc = None
+        if backend_running:
+            typer.echo("  • Skipping backend startup.")
+        else:
+            typer.echo("  • Starting backend...")
+            backend_cmd = [sys.executable, "-m", "suzent.server"]
+            if debug:
+                backend_cmd.append("--debug")
+            backend_proc = subprocess.Popen(
+                backend_cmd,
+                cwd=root,
+                env=backend_env,
+            )
 
         typer.echo("  • Starting frontend (Tauri dev)...")
         _ensure_npm_deps(root)
@@ -790,8 +818,9 @@ def register_commands(app: typer.Typer):
         except (subprocess.CalledProcessError, KeyboardInterrupt):
             pass
         finally:
-            typer.echo("\n🛑 Stopping backend...")
-            _terminate_process_gracefully(backend_proc)
+            if backend_proc is not None:
+                typer.echo("\n🛑 Stopping backend...")
+                _terminate_process_gracefully(backend_proc)
 
     @app.command()
     def serve(
@@ -806,6 +835,13 @@ def register_commands(app: typer.Typer):
         ),
     ):
         """Start the Suzent backend server (headless/standalone mode)."""
+        if _is_suzent_server_running(host, port):
+            typer.echo(
+                f"✅ Suzent Server is already running on http://{host}:{port}; "
+                "reusing it."
+            )
+            return
+
         typer.echo(f"🚀 Starting Suzent Server on {host}:{port}...")
 
         env = os.environ.copy()

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -245,6 +245,11 @@ sync_automation_runner: SyncAutomationRunner = None
 _social_reload_lock = asyncio.Lock()
 
 
+async def health(_request: Request) -> JSONResponse:
+    """Lightweight readiness probe used by the CLI to detect running servers."""
+    return JSONResponse({"app": "suzent", "status": "ok"})
+
+
 def _build_social_from_config(
     social_config: dict,
 ) -> tuple["ChannelManager", "SocialBrain"]:
@@ -716,6 +721,7 @@ app = Starlette(
     debug=True,
     lifespan=lifespan,
     routes=[
+        Route("/health", health, methods=["GET"]),
         Route("/chat", chat, methods=["POST"]),
         Route("/chat/send", chat_send, methods=["POST"]),
         Route("/chat/live", live_stream, methods=["POST"]),


### PR DESCRIPTION
### Motivation
- Avoid launching duplicate backend processes when users run `suzent start` or `suzent serve` by detecting and reusing an already-running Suzent server.

### Description
- Add a lightweight `/health` endpoint in `src/suzent/server.py` that returns a small readiness payload identifying the app.
- Add `_is_suzent_server_running(host, port)` to `src/suzent/cli/main.py` which probes `http://<host>:<port>/health` and validates the response.
- Update developer `start` flow in `src/suzent/cli/main.py` to probe for an existing backend, skip starting a new backend when one is present, only check/handle the frontend port otherwise, and only shut down the backend if this invocation started it.
- Update `serve` in `src/suzent/cli/main.py` to detect an existing server and return successfully instead of launching a second instance.

### Testing
- Ran `python -m compileall src/suzent/cli/main.py src/suzent/server.py` which succeeded. 
- Ran `uv run ruff check src/suzent/cli/main.py src/suzent/server.py` which succeeded. 
- Ran `uv run pytest -m "not sandbox"` which failed during collection due to the environment missing `pytest_asyncio`. 
- `pre-commit run --all-files` could not be executed in this environment because `pre-commit` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46acc87e3883279612cca5ccc3980b)