### PR TITLE
fix(server): bound subagent task and background-turn-lock registries

### DIFF
--- a/src/suzent/core/stream_registry.py
+++ b/src/suzent/core/stream_registry.py
@@ -41,9 +41,26 @@ stream_controls: Dict[str, StreamControl] = {}
 _background_turn_locks: Dict[str, asyncio.Lock] = {}
 
 
+# Cap on retained per-chat background-turn locks. Without a bound, one Lock per
+# chat_id that ever ran a background turn (heartbeat/cron/wakeup) accumulates for
+# the process lifetime. We prune idle (unlocked) locks once the dict grows past
+# this — locks held or awaited by a live turn are left alone.
+_MAX_BACKGROUND_TURN_LOCKS = 512
+
+
+def _prune_idle_background_turn_locks() -> None:
+    """Drop unlocked background-turn locks when the registry grows too large."""
+    if len(_background_turn_locks) <= _MAX_BACKGROUND_TURN_LOCKS:
+        return
+    idle = [cid for cid, lock in _background_turn_locks.items() if not lock.locked()]
+    for cid in idle:
+        _background_turn_locks.pop(cid, None)
+
+
 def get_background_turn_lock(chat_id: str) -> asyncio.Lock:
     """Return (creating if needed) the serialization lock for background turns on chat_id."""
     if chat_id not in _background_turn_locks:
+        _prune_idle_background_turn_locks()
         _background_turn_locks[chat_id] = asyncio.Lock()
     return _background_turn_locks[chat_id]
 

--- a/src/suzent/core/stream_registry.py
+++ b/src/suzent/core/stream_registry.py
@@ -43,16 +43,34 @@ _background_turn_locks: Dict[str, asyncio.Lock] = {}
 
 # Cap on retained per-chat background-turn locks. Without a bound, one Lock per
 # chat_id that ever ran a background turn (heartbeat/cron/wakeup) accumulates for
-# the process lifetime. We prune idle (unlocked) locks once the dict grows past
-# this — locks held or awaited by a live turn are left alone.
+# the process lifetime. We prune idle locks once the dict grows past this — locks
+# held or awaited by a live turn are left alone.
 _MAX_BACKGROUND_TURN_LOCKS = 512
 
 
+def _lock_in_use(lock: asyncio.Lock) -> bool:
+    """True if a lock is held or has queued waiters.
+
+    Checking ``locked()`` alone is not enough: ``asyncio.Lock.release()``
+    momentarily makes ``locked()`` False during the handoff to a waiter, before
+    that waiter resumes and re-marks the lock held. Pruning in that window would
+    drop a lock with a queued background turn, letting a second lock be minted
+    for the same chat and breaking the serialization guarantee. So also treat a
+    lock with waiters as in-use.
+    """
+    if lock.locked():
+        return True
+    waiters = getattr(lock, "_waiters", None)
+    return bool(waiters)
+
+
 def _prune_idle_background_turn_locks() -> None:
-    """Drop unlocked background-turn locks when the registry grows too large."""
+    """Drop idle background-turn locks when the registry grows too large."""
     if len(_background_turn_locks) <= _MAX_BACKGROUND_TURN_LOCKS:
         return
-    idle = [cid for cid, lock in _background_turn_locks.items() if not lock.locked()]
+    idle = [
+        cid for cid, lock in _background_turn_locks.items() if not _lock_in_use(lock)
+    ]
     for cid in idle:
         _background_turn_locks.pop(cid, None)
 

--- a/src/suzent/core/subagent_runner.py
+++ b/src/suzent/core/subagent_runner.py
@@ -139,6 +139,27 @@ class SubAgentTask:
 _tasks: Dict[str, SubAgentTask] = {}
 _tasks_lock = asyncio.Lock()
 
+# Cap on finished (completed/failed) tasks retained for UI history. Active
+# (queued/running) tasks are never evicted. Without this, _tasks grows without
+# bound for the process lifetime — one SubAgentTask (with its result/error) per
+# spawn, forever — a slow leak on long-running servers.
+_MAX_FINISHED_TASKS = 200
+_TERMINAL_STATUSES = ("completed", "failed")
+
+
+def _evict_old_finished_tasks() -> None:
+    """Drop the oldest finished tasks beyond _MAX_FINISHED_TASKS.
+
+    Caller must hold _tasks_lock. Active tasks are kept regardless of count.
+    """
+    finished = [t for t in _tasks.values() if t.status in _TERMINAL_STATUSES]
+    if len(finished) <= _MAX_FINISHED_TASKS:
+        return
+    # Oldest first — evict by finish time (falling back to start time).
+    finished.sort(key=lambda t: t.finished_at or t.started_at or datetime.min)
+    for task in finished[: len(finished) - _MAX_FINISHED_TASKS]:
+        _tasks.pop(task.task_id, None)
+
 
 def get_task(task_id: str) -> Optional[SubAgentTask]:
     return _tasks.get(task_id)
@@ -287,6 +308,7 @@ async def spawn_subagent(
 
     async with _tasks_lock:
         _tasks[task_id] = task
+        _evict_old_finished_tasks()
     _broadcast_task_update(task)
 
     if run_in_background:

--- a/src/suzent/core/subagent_runner.py
+++ b/src/suzent/core/subagent_runner.py
@@ -161,6 +161,18 @@ def _evict_old_finished_tasks() -> None:
         _tasks.pop(task.task_id, None)
 
 
+async def _evict_old_finished_tasks_locked() -> None:
+    """Acquire _tasks_lock and evict old finished tasks.
+
+    Called when a task reaches a terminal state, so a burst of subagents that
+    all finish without any new spawn still gets pruned (registration-time
+    eviction alone would leave those result summaries resident until the next
+    spawn).
+    """
+    async with _tasks_lock:
+        _evict_old_finished_tasks()
+
+
 def get_task(task_id: str) -> Optional[SubAgentTask]:
     return _tasks.get(task_id)
 
@@ -497,6 +509,9 @@ async def _run_subagent(
         # Phase 3: always tear down the worktree, even on failure
         if task.isolation == "worktree" and task.worktree_path:
             await _teardown_worktree(task)
+        # The task is now terminal; prune here too so a burst that all finishes
+        # without a new spawn doesn't leave result summaries resident.
+        await _evict_old_finished_tasks_locked()
 
 
 # ─── Phase 2: Context forking ─────────────────────────────────────────────────
@@ -813,6 +828,8 @@ async def clear_stuck_tasks() -> list[str]:
             task.finished_at = datetime.now()
             _broadcast_task_update(task)
             cleared.append(task.task_id)
+    if cleared:
+        await _evict_old_finished_tasks_locked()
     return cleared
 
 

--- a/tests/core/test_stream_registry.py
+++ b/tests/core/test_stream_registry.py
@@ -107,3 +107,34 @@ def test_background_turn_locks_prune_idle(monkeypatch):
 
 def test_background_turn_lock_is_stable_per_chat():
     assert get_background_turn_lock("stable") is get_background_turn_lock("stable")
+
+
+def test_background_turn_locks_keep_locks_with_waiters(monkeypatch):
+    async def scenario():
+        monkeypatch.setattr(stream_registry, "_MAX_BACKGROUND_TURN_LOCKS", 3)
+
+        contended = get_background_turn_lock("contended")
+        await contended.acquire()  # holder
+
+        # A second turn queues up as a waiter on the same lock.
+        async def waiter():
+            async with contended:
+                pass
+
+        waiter_task = asyncio.create_task(waiter())
+        await asyncio.sleep(0)  # let the waiter enqueue
+
+        # Release the holder: during the handoff, locked() briefly reads False,
+        # but the lock still has a queued waiter and must not be pruned.
+        contended.release()
+        assert stream_registry._lock_in_use(contended)
+
+        for i in range(3):
+            get_background_turn_lock(f"idle_{i}")
+        get_background_turn_lock("trigger")  # trips the prune
+
+        assert "contended" in stream_registry._background_turn_locks
+
+        await waiter_task
+
+    asyncio.run(scenario())

--- a/tests/core/test_stream_registry.py
+++ b/tests/core/test_stream_registry.py
@@ -1,7 +1,9 @@
 import asyncio
 
+import suzent.core.stream_registry as stream_registry
 from suzent.core.stream_registry import (
     background_queues,
+    get_background_turn_lock,
     merge_pending_auto_approvals,
     pending_auto_approvals,
     pop_pending_auto_approvals,
@@ -14,6 +16,7 @@ from suzent.core.stream_registry import (
 def teardown_function():
     pending_auto_approvals.clear()
     background_queues.clear()
+    stream_registry._background_turn_locks.clear()
 
 
 def test_merge_and_pop_pending_auto_approvals():
@@ -78,3 +81,29 @@ def test_unregister_background_stream_keeps_newer_queue():
     unregister_background_stream(chat_id, old_queue)
 
     assert background_queues[chat_id] is new_queue
+
+
+def test_background_turn_locks_prune_idle(monkeypatch):
+    async def scenario():
+        monkeypatch.setattr(stream_registry, "_MAX_BACKGROUND_TURN_LOCKS", 3)
+
+        # Hold one lock so it is not idle and must survive pruning.
+        held = get_background_turn_lock("held")
+        async with held:
+            # Fill past the cap with idle (unlocked) locks.
+            for i in range(3):
+                get_background_turn_lock(f"idle_{i}")
+            # This insertion trips the prune: idle locks are dropped, held stays.
+            get_background_turn_lock("trigger")
+
+            assert "held" in stream_registry._background_turn_locks
+            assert "trigger" in stream_registry._background_turn_locks
+            assert not any(
+                k.startswith("idle_") for k in stream_registry._background_turn_locks
+            )
+
+    asyncio.run(scenario())
+
+
+def test_background_turn_lock_is_stable_per_chat():
+    assert get_background_turn_lock("stable") is get_background_turn_lock("stable")

--- a/tests/core/test_subagent_runner.py
+++ b/tests/core/test_subagent_runner.py
@@ -6,6 +6,7 @@ import suzent.core.subagent_runner as subagent_runner
 from suzent.core.subagent_runner import (
     SubAgentTask,
     _evict_old_finished_tasks,
+    _evict_old_finished_tasks_locked,
     _task_to_sse_dict,
     _wakeup_parent_batch,
 )
@@ -59,6 +60,27 @@ def test_evict_old_finished_tasks_noop_under_cap(monkeypatch):
             subagent_runner._tasks[t.task_id] = t
         _evict_old_finished_tasks()
         assert len(subagent_runner._tasks) == 4
+    finally:
+        subagent_runner._tasks.clear()
+
+
+@pytest.mark.asyncio
+async def test_evict_on_terminal_prunes_burst_that_finishes(monkeypatch):
+    # Simulates the burst case: many subagents were queued (so registration-time
+    # eviction saw them as active), then all transition to finished with no new
+    # spawn. The terminal-transition prune must still cap the registry.
+    monkeypatch.setattr(subagent_runner, "_MAX_FINISHED_TASKS", 3)
+    subagent_runner._tasks.clear()
+    try:
+        for i in range(6):
+            t = _make_task(f"done_{i}", "completed", finished_offset=i)
+            subagent_runner._tasks[t.task_id] = t
+
+        await _evict_old_finished_tasks_locked()
+
+        remaining = set(subagent_runner._tasks)
+        assert len(remaining) == 3
+        assert {"done_3", "done_4", "done_5"} == remaining
     finally:
         subagent_runner._tasks.clear()
 

--- a/tests/core/test_subagent_runner.py
+++ b/tests/core/test_subagent_runner.py
@@ -1,10 +1,66 @@
+from datetime import datetime, timedelta
+
 import pytest
 
+import suzent.core.subagent_runner as subagent_runner
 from suzent.core.subagent_runner import (
     SubAgentTask,
+    _evict_old_finished_tasks,
     _task_to_sse_dict,
     _wakeup_parent_batch,
 )
+
+
+def _make_task(task_id: str, status: str, finished_offset: int | None = None):
+    task = SubAgentTask(
+        task_id=task_id,
+        parent_chat_id="chat-1",
+        description="x",
+        tools_allowed=[],
+        chat_id=f"subagent-{task_id}",
+    )
+    task.status = status
+    if finished_offset is not None:
+        task.finished_at = datetime(2026, 1, 1) + timedelta(seconds=finished_offset)
+    return task
+
+
+def test_evict_old_finished_tasks_keeps_active_and_recent(monkeypatch):
+    monkeypatch.setattr(subagent_runner, "_MAX_FINISHED_TASKS", 3)
+    subagent_runner._tasks.clear()
+    try:
+        # 5 finished (oldest → newest) + 2 active that must never be evicted.
+        for i in range(5):
+            t = _make_task(f"done_{i}", "completed", finished_offset=i)
+            subagent_runner._tasks[t.task_id] = t
+        for i in range(2):
+            t = _make_task(f"live_{i}", "running")
+            subagent_runner._tasks[t.task_id] = t
+
+        _evict_old_finished_tasks()
+
+        remaining = set(subagent_runner._tasks)
+        # Both active tasks survive.
+        assert {"live_0", "live_1"} <= remaining
+        # Only the 3 newest finished tasks survive; the 2 oldest are gone.
+        assert "done_0" not in remaining
+        assert "done_1" not in remaining
+        assert {"done_2", "done_3", "done_4"} <= remaining
+    finally:
+        subagent_runner._tasks.clear()
+
+
+def test_evict_old_finished_tasks_noop_under_cap(monkeypatch):
+    monkeypatch.setattr(subagent_runner, "_MAX_FINISHED_TASKS", 10)
+    subagent_runner._tasks.clear()
+    try:
+        for i in range(4):
+            t = _make_task(f"done_{i}", "completed", finished_offset=i)
+            subagent_runner._tasks[t.task_id] = t
+        _evict_old_finished_tasks()
+        assert len(subagent_runner._tasks) == 4
+    finally:
+        subagent_runner._tasks.clear()
 
 
 def test_task_to_sse_dict_includes_model_override():


### PR DESCRIPTION
### Motivation

Audit of long-horizon (days/weeks) server uptime turned up two module-level registries that grow with **cumulative** activity and have **no eviction path** — classic slow leaks that only surface on long-running instances, not under concurrent load.

### The leaks

1. **`subagent_runner._tasks`** ([subagent_runner.py](../blob/main/src/suzent/core/subagent_runner.py)) — one `SubAgentTask` is added per `spawn_subagent` and **never removed**. Each retains its `result_summary`/`error`, so this is the heavier of the two. `clear_stuck_tasks()` only flips `status` to `failed`; it doesn't free entries.

2. **`stream_registry._background_turn_locks`** ([stream_registry.py](../blob/main/src/suzent/core/stream_registry.py)) — one `asyncio.Lock` is minted per `chat_id` that ever runs a heartbeat / cron / wakeup turn, and **never removed**. Small per entry, but strictly monotonic.

### Fix

- `_tasks`: on each new registration (already under `_tasks_lock`), evict the oldest **finished** tasks beyond a 200-entry cap. **Active (queued/running) tasks are never evicted**, so live views and in-flight work are untouched; recent history is preserved for the UI.
- `_background_turn_locks`: once the dict passes 512 entries, prune **idle (unlocked)** locks. Locks currently held or awaited by a live turn (`lock.locked()`) are left alone, preserving the serialization guarantee.

Both caps are generous relative to any realistic concurrent load, so normal operation is unaffected — they only bound unbounded cumulative growth.

### Tests

- `tests/core/test_subagent_runner.py`: eviction keeps active + newest-N finished, drops oldest; no-op under cap.
- `tests/core/test_stream_registry.py`: pruning drops idle locks while preserving a held lock; per-chat lock identity stays stable.

`python -m pytest tests/core/test_stream_registry.py tests/core/test_subagent_runner.py` → 12 passed. `ruff check` clean.

### Not in scope (follow-up)

The audit also flagged `AsyncBaseClient` ([client/base.py](../blob/main/src/suzent/client/base.py)) creating an `httpx.AsyncClient` with no `aclose()`/context manager. Whether that leaks depends on whether instances are per-request or long-lived singletons — left out of this PR pending that confirmation rather than shipping an unverified change. SSE subscriber sets and callback-tracked background tasks were checked and are **not** leaking (they clean up in `finally` / via `add_done_callback`).