### PR TITLE
[codex] implement peer file retrieval

### DIFF
--- a/src/suzent/auth_boundary.py
+++ b/src/suzent/auth_boundary.py
@@ -72,6 +72,14 @@ AGENT_ALLOWED_PATHS = {
     "/channels/suzent/whoami",  # peer token-validity self-check
 }
 
+AGENT_ALLOWED_PREFIXES = ("/nodes/peer-files/",)
+
+
+def agent_path_allowed(path: str) -> bool:
+    return path in AGENT_ALLOWED_PATHS or any(
+        path.startswith(prefix) for prefix in AGENT_ALLOWED_PREFIXES
+    )
+
 
 def token_scope(token: str, device_store) -> str | None:
     """Return the scope of a token (node | agent | full), or None if invalid.
@@ -97,7 +105,7 @@ def scope_allows(scope: str | None, path: str) -> bool:
     if scope == "full":
         return True
     if scope == "agent":
-        return path in AGENT_ALLOWED_PATHS
+        return agent_path_allowed(path)
     # "node" tokens are for the WS handshake only; no HTTP surface.
     return False
 

--- a/src/suzent/nodes/peer_files.py
+++ b/src/suzent/nodes/peer_files.py
@@ -1,0 +1,101 @@
+"""Peer-retrievable file artifact registry."""
+
+from __future__ import annotations
+
+import mimetypes
+import secrets
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from suzent.logger import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_PEER_FILE_TTL_SECONDS = 3600
+
+
+class PeerFileArtifact(BaseModel):
+    file_id: str
+    path: Path
+    name: str
+    media_type: str
+    size: int
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    expires_at: datetime
+    producer: str = "unknown"
+
+    def to_reference(self) -> dict:
+        return {
+            "id": self.file_id,
+            "url": f"/nodes/peer-files/{self.file_id}",
+            "name": self.name,
+            "media_type": self.media_type,
+            "size": self.size,
+            "expires_at": self.expires_at.isoformat().replace("+00:00", "Z"),
+        }
+
+
+class PeerFileRegistry:
+    """Short-lived in-memory registry of files intentionally exposed to peers."""
+
+    def __init__(self) -> None:
+        self._artifacts: dict[str, PeerFileArtifact] = {}
+
+    def register(
+        self,
+        path: str | Path,
+        *,
+        producer: str = "unknown",
+        name: str | None = None,
+        media_type: str | None = None,
+        ttl_seconds: int = DEFAULT_PEER_FILE_TTL_SECONDS,
+    ) -> PeerFileArtifact:
+        resolved = Path(path).expanduser().resolve(strict=True)
+        if not resolved.is_file():
+            raise ValueError("Peer artifact path is not a file")
+
+        self.prune_expired()
+        file_id = self._new_file_id()
+        guessed_type = mimetypes.guess_type(resolved.name)[0]
+        artifact = PeerFileArtifact(
+            file_id=file_id,
+            path=resolved,
+            name=name or resolved.name,
+            media_type=media_type or guessed_type or "application/octet-stream",
+            size=resolved.stat().st_size,
+            expires_at=datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds),
+            producer=producer,
+        )
+        self._artifacts[file_id] = artifact
+        logger.debug("Registered peer file artifact {}", file_id)
+        return artifact
+
+    def get(self, file_id: str) -> PeerFileArtifact | None:
+        artifact = self._artifacts.get(file_id)
+        if artifact is None:
+            return None
+        if artifact.expires_at <= datetime.now(timezone.utc):
+            self._artifacts.pop(file_id, None)
+            return None
+        if not artifact.path.exists() or not artifact.path.is_file():
+            self._artifacts.pop(file_id, None)
+            return None
+        return artifact
+
+    def prune_expired(self) -> None:
+        now = datetime.now(timezone.utc)
+        expired = [
+            file_id
+            for file_id, artifact in self._artifacts.items()
+            if artifact.expires_at <= now
+        ]
+        for file_id in expired:
+            self._artifacts.pop(file_id, None)
+
+    def _new_file_id(self) -> str:
+        while True:
+            file_id = f"pf_{secrets.token_urlsafe(24)}"
+            if file_id not in self._artifacts:
+                return file_id

--- a/src/suzent/routes/node_routes.py
+++ b/src/suzent/routes/node_routes.py
@@ -12,13 +12,14 @@ import uuid
 
 from pydantic import ValidationError
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import FileResponse, JSONResponse, StreamingResponse
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from suzent.config import CONFIG
 from suzent.logger import get_logger
 from suzent.nodes.base import NodeCapability
 from suzent.nodes.manager import PENDING_TTL_SECONDS
+from suzent.nodes.peer_files import PeerFileRegistry
 from suzent.nodes.models import (
     ConnectMessage,
     ConnectedResponse,
@@ -129,6 +130,81 @@ def _get_peer_store(request):
         store = PeerGrantStore()
         app.state.peer_store = store
     return store
+
+
+def _get_peer_file_registry(request):
+    """Get (or lazily create) the local peer file registry."""
+    app = getattr(request, "app", None)
+    if app is None:
+        return None
+    registry = getattr(app.state, "peer_file_registry", None)
+    if registry is None:
+        registry = PeerFileRegistry()
+        app.state.peer_file_registry = registry
+    return registry
+
+
+def _peer_file_media_type(command: str, result: dict) -> str | None:
+    if command != "camera.snap":
+        return None
+    fmt = str(result.get("format") or "").lower()
+    if fmt in ("jpg", "jpeg"):
+        return "image/jpeg"
+    if fmt == "png":
+        return "image/png"
+    return None
+
+
+def _normalize_peer_file_result(request: Request, command: str, payload: dict) -> dict:
+    if not payload.get("success") or not isinstance(payload.get("result"), dict):
+        return payload
+    result = dict(payload["result"])
+    raw_file = result.get("file")
+    if not isinstance(raw_file, str):
+        return payload
+
+    media_type = _peer_file_media_type(command, result)
+    if media_type is None:
+        return payload
+
+    registry = _get_peer_file_registry(request)
+    if registry is None:
+        return payload
+    try:
+        artifact = registry.register(
+            raw_file,
+            producer=command,
+            media_type=media_type,
+        )
+    except (OSError, ValueError) as exc:
+        logger.warning("Unable to register peer file artifact: {}", exc)
+        redacted = dict(payload)
+        result.pop("file", None)
+        result["file_error"] = "File was produced but could not be exposed to peers"
+        redacted["result"] = result
+        return redacted
+
+    result["file"] = artifact.to_reference()
+    normalized = dict(payload)
+    normalized["result"] = result
+    return normalized
+
+
+def _rewrite_peer_file_references(value, peer_id: str):
+    if isinstance(value, dict):
+        if (
+            isinstance(value.get("id"), str)
+            and isinstance(value.get("url"), str)
+            and value["url"].startswith("/nodes/peer-files/")
+        ):
+            rewritten = dict(value)
+            rewritten["peer_id"] = peer_id
+            rewritten["url"] = f"/nodes/peers/{peer_id}/files/{value['id']}"
+            return rewritten
+        return {k: _rewrite_peer_file_references(v, peer_id) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_rewrite_peer_file_references(item, peer_id) for item in value]
+    return value
 
 
 async def node_websocket_endpoint(websocket: WebSocket):
@@ -1010,11 +1086,87 @@ async def peer_invoke(request: Request) -> JSONResponse:
         result = await node_manager.invoke(
             target.node_id, command, params, timeout=timeout
         )
-        return JSONResponse(result)
+        return JSONResponse(_normalize_peer_file_result(request, command, result))
     except TimeoutError as e:
         return JSONResponse({"error": str(e)}, status_code=504)
     except Exception as e:
         return JSONResponse({"error": str(e)}, status_code=500)
+
+
+async def serve_peer_file(request: Request):
+    """GET /nodes/peer-files/{file_id} — serve a registered local artifact."""
+    registry = _get_peer_file_registry(request)
+    file_id = request.path_params.get("file_id", "")
+    artifact = registry.get(file_id) if registry else None
+    if artifact is None:
+        return JSONResponse({"error": "Peer file not found"}, status_code=404)
+    return FileResponse(
+        artifact.path,
+        media_type=artifact.media_type,
+        filename=artifact.name,
+        headers={"Content-Length": str(artifact.size)},
+    )
+
+
+async def proxy_peer_file(request: Request):
+    """GET /nodes/peers/{peer_id}/files/{file_id} — stream a file from a peer."""
+    import httpx
+
+    store = _get_peer_store(request)
+    peer_id = request.path_params.get("peer_id", "")
+    file_id = request.path_params.get("file_id", "")
+    peer = store.get(peer_id) if store else None
+    if not peer:
+        return JSONResponse({"error": "Unknown peer"}, status_code=404)
+    if peer.get("mode") == "paused":
+        return JSONResponse({"error": "Peer is paused"}, status_code=409)
+
+    url = f"{peer['base_url']}/nodes/peer-files/{file_id}"
+    headers = {"Authorization": f"Bearer {peer['token']}"}
+
+    try:
+        upstream_client = httpx.AsyncClient(timeout=None)
+        request_upstream = upstream_client.build_request("GET", url, headers=headers)
+        upstream = await upstream_client.send(request_upstream, stream=True)
+        if upstream.status_code == 404:
+            await upstream.aclose()
+            await upstream_client.aclose()
+            return JSONResponse({"error": "Peer file not found"}, status_code=404)
+        if upstream.status_code == 401:
+            await upstream.aclose()
+            await upstream_client.aclose()
+            return JSONResponse({"error": "Unauthorized by peer"}, status_code=401)
+        if upstream.status_code == 403:
+            await upstream.aclose()
+            await upstream_client.aclose()
+            return JSONResponse({"error": "Forbidden by peer"}, status_code=403)
+        if upstream.status_code >= 400:
+            status_code = upstream.status_code
+            await upstream.aclose()
+            await upstream_client.aclose()
+            return JSONResponse(
+                {"error": f"Peer returned {status_code}"}, status_code=502
+            )
+
+        async def _stream():
+            try:
+                async for chunk in upstream.aiter_bytes():
+                    yield chunk
+            finally:
+                await upstream.aclose()
+                await upstream_client.aclose()
+
+        response_headers = {}
+        for header in ("content-length", "content-disposition"):
+            if header in upstream.headers:
+                response_headers[header] = upstream.headers[header]
+        return StreamingResponse(
+            _stream(),
+            media_type=upstream.headers.get("content-type", "application/octet-stream"),
+            headers=response_headers,
+        )
+    except httpx.HTTPError as e:
+        return JSONResponse({"error": f"Couldn't reach peer: {e}"}, status_code=502)
 
 
 async def invoke_peer(request: Request) -> JSONResponse:
@@ -1051,6 +1203,7 @@ async def invoke_peer(request: Request) -> JSONResponse:
                 headers={"Authorization": f"Bearer {peer['token']}"},
             )
             data = r.json()
+            data = _rewrite_peer_file_references(data, peer_id)
             return JSONResponse(data, status_code=r.status_code)
     except httpx.HTTPError as e:
         return JSONResponse({"error": f"Couldn't reach peer: {e}"}, status_code=502)

--- a/src/suzent/routes/node_routes.py
+++ b/src/suzent/routes/node_routes.py
@@ -1124,6 +1124,7 @@ async def proxy_peer_file(request: Request):
     url = f"{peer['base_url']}/nodes/peer-files/{file_id}"
     headers = {"Authorization": f"Bearer {peer['token']}"}
 
+    upstream_client = None
     try:
         upstream_client = httpx.AsyncClient(timeout=None)
         request_upstream = upstream_client.build_request("GET", url, headers=headers)
@@ -1166,6 +1167,8 @@ async def proxy_peer_file(request: Request):
             headers=response_headers,
         )
     except httpx.HTTPError as e:
+        if upstream_client is not None:
+            await upstream_client.aclose()
         return JSONResponse({"error": f"Couldn't reach peer: {e}"}, status_code=502)
 
 

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -202,7 +202,9 @@ from suzent.routes.node_routes import (
     trigger_peer,
     peer_offer,
     peer_invoke,
+    serve_peer_file,
     invoke_peer,
+    proxy_peer_file,
     peer_capabilities,
 )
 from suzent.routes.cron_routes import (
@@ -997,6 +999,7 @@ app = Starlette(
         Route("/nodes/control-status", control_status, methods=["GET"]),
         Route("/nodes/peer-offer", peer_offer, methods=["POST"]),
         Route("/nodes/peer-invoke", peer_invoke, methods=["POST"]),
+        Route("/nodes/peer-files/{file_id}", serve_peer_file, methods=["GET"]),
         Route("/channels/suzent/inbound", suzent_channel_inbound, methods=["POST"]),
         Route("/channels/suzent/whoami", suzent_channel_whoami, methods=["GET"]),
         Route(
@@ -1006,6 +1009,11 @@ app = Starlette(
         ),
         Route("/nodes/peers", list_peers, methods=["GET"]),
         Route("/nodes/peers/{peer_id}/invoke", invoke_peer, methods=["POST"]),
+        Route(
+            "/nodes/peers/{peer_id}/files/{file_id}",
+            proxy_peer_file,
+            methods=["GET"],
+        ),
         Route(
             "/nodes/peers/{peer_id}/capabilities",
             peer_capabilities,

--- a/tests/nodes/test_auth_boundary.py
+++ b/tests/nodes/test_auth_boundary.py
@@ -9,6 +9,7 @@ import pytest
 
 from suzent.auth_boundary import (
     AuthBoundaryMiddleware,
+    agent_path_allowed,
     extract_token,
     is_loopback,
     scope_allows,
@@ -57,6 +58,12 @@ def test_scope_allows():
     assert not scope_allows("agent", "/sandbox/files")
     assert not scope_allows("node", "/chat")
     assert not scope_allows(None, "/chat")
+
+
+def test_agent_path_allowed_peer_files_prefix_only():
+    assert agent_path_allowed("/nodes/peer-files/pf_abc123")
+    assert not agent_path_allowed("/nodes/peer-files")
+    assert not agent_path_allowed("/sandbox/serve/chat/file.png")
 
 
 # ─── Middleware behavior ─────────────────────────────────────────────

--- a/tests/nodes/test_peer_file_retrieval.py
+++ b/tests/nodes/test_peer_file_retrieval.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from suzent.nodes.base import NodeBase, NodeCapability
+from suzent.nodes.manager import NodeManager
+from suzent.nodes.peer_store import PeerGrantStore
+from suzent.routes.node_routes import (
+    invoke_peer,
+    peer_invoke,
+    proxy_peer_file,
+    serve_peer_file,
+)
+
+
+class FakeCameraNode(NodeBase):
+    def __init__(self, file_path: str):
+        super().__init__(
+            "camera-node",
+            "Camera",
+            "test",
+            [NodeCapability(name="camera.snap")],
+        )
+        self.file_path = file_path
+
+    async def invoke(self, command, params=None, timeout=None):
+        return {
+            "success": True,
+            "result": {"file": self.file_path, "format": "png"},
+        }
+
+    async def heartbeat(self):
+        return True
+
+
+def test_peer_invoke_registers_and_serves_camera_file(tmp_path):
+    image_path = tmp_path / "snap.png"
+    image_path.write_bytes(b"png-bytes")
+
+    manager = NodeManager()
+    manager.register_node(FakeCameraNode(str(image_path)))
+    app = Starlette(
+        routes=[
+            Route("/nodes/peer-invoke", peer_invoke, methods=["POST"]),
+            Route("/nodes/peer-files/{file_id}", serve_peer_file, methods=["GET"]),
+        ]
+    )
+    app.state.node_manager = manager
+    client = TestClient(app)
+
+    response = client.post("/nodes/peer-invoke", json={"command": "camera.snap"})
+
+    assert response.status_code == 200
+    body = response.json()
+    file_ref = body["result"]["file"]
+    assert file_ref["id"].startswith("pf_")
+    assert file_ref["url"] == f"/nodes/peer-files/{file_ref['id']}"
+    assert file_ref["media_type"] == "image/png"
+    assert file_ref["size"] == len(b"png-bytes")
+    assert str(image_path) not in str(body)
+
+    download = client.get(file_ref["url"])
+    assert download.status_code == 200
+    assert download.content == b"png-bytes"
+    assert download.headers["content-type"].startswith("image/png")
+
+
+def test_invoke_peer_rewrites_peer_file_reference(tmp_path, monkeypatch):
+    store = PeerGrantStore(path=tmp_path / "peers.json")
+    peer_id = store.add("Peer", "http://peer.example", "peer-token")
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self) -> dict[str, Any]:
+            return {
+                "success": True,
+                "result": {
+                    "file": {
+                        "id": "pf_123",
+                        "url": "/nodes/peer-files/pf_123",
+                        "name": "snap.png",
+                        "media_type": "image/png",
+                    }
+                },
+            }
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            assert url == "http://peer.example/nodes/peer-invoke"
+            assert headers == {"Authorization": "Bearer peer-token"}
+            return FakeResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+    app = Starlette(
+        routes=[Route("/nodes/peers/{peer_id}/invoke", invoke_peer, methods=["POST"])]
+    )
+    app.state.peer_store = store
+    client = TestClient(app)
+
+    response = client.post(
+        f"/nodes/peers/{peer_id}/invoke",
+        json={"command": "camera.snap"},
+    )
+
+    assert response.status_code == 200
+    file_ref = response.json()["result"]["file"]
+    assert file_ref["peer_id"] == peer_id
+    assert file_ref["url"] == f"/nodes/peers/{peer_id}/files/pf_123"
+
+
+def test_proxy_peer_file_streams_from_peer(tmp_path, monkeypatch):
+    store = PeerGrantStore(path=tmp_path / "peers.json")
+    peer_id = store.add("Peer", "http://peer.example", "peer-token")
+
+    class ByteStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b"hello "
+            yield b"peer"
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.closed = False
+
+        def build_request(self, method, url, headers=None):
+            assert method == "GET"
+            assert url == "http://peer.example/nodes/peer-files/pf_123"
+            assert headers == {"Authorization": "Bearer peer-token"}
+            return httpx.Request(method, url, headers=headers)
+
+        async def send(self, request, stream=False):
+            assert stream is True
+            return httpx.Response(
+                200,
+                headers={
+                    "content-type": "text/plain",
+                    "content-length": "10",
+                    "content-disposition": 'attachment; filename="peer.txt"',
+                },
+                stream=ByteStream(),
+                request=request,
+            )
+
+        async def aclose(self):
+            self.closed = True
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+    app = Starlette(
+        routes=[
+            Route(
+                "/nodes/peers/{peer_id}/files/{file_id}",
+                proxy_peer_file,
+                methods=["GET"],
+            )
+        ]
+    )
+    app.state.peer_store = store
+    client = TestClient(app)
+
+    response = client.get(f"/nodes/peers/{peer_id}/files/pf_123")
+
+    assert response.status_code == 200
+    assert response.content == b"hello peer"
+    assert response.headers["content-type"].startswith("text/plain")
+    assert response.headers["content-disposition"] == 'attachment; filename="peer.txt"'

--- a/tests/nodes/test_peer_file_retrieval.py
+++ b/tests/nodes/test_peer_file_retrieval.py
@@ -177,3 +177,42 @@ def test_proxy_peer_file_streams_from_peer(tmp_path, monkeypatch):
     assert response.content == b"hello peer"
     assert response.headers["content-type"].startswith("text/plain")
     assert response.headers["content-disposition"] == 'attachment; filename="peer.txt"'
+
+
+def test_proxy_peer_file_closes_client_when_send_fails(tmp_path, monkeypatch):
+    store = PeerGrantStore(path=tmp_path / "peers.json")
+    peer_id = store.add("Peer", "http://peer.example", "peer-token")
+    clients = []
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.closed = False
+            clients.append(self)
+
+        def build_request(self, method, url, headers=None):
+            return httpx.Request(method, url, headers=headers)
+
+        async def send(self, request, stream=False):
+            raise httpx.ConnectError("offline", request=request)
+
+        async def aclose(self):
+            self.closed = True
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+    app = Starlette(
+        routes=[
+            Route(
+                "/nodes/peers/{peer_id}/files/{file_id}",
+                proxy_peer_file,
+                methods=["GET"],
+            )
+        ]
+    )
+    app.state.peer_store = store
+    client = TestClient(app)
+
+    response = client.get(f"/nodes/peers/{peer_id}/files/pf_123")
+
+    assert response.status_code == 502
+    assert clients
+    assert clients[0].closed is True


### PR DESCRIPTION
## Summary

Implements peer-retrievable file artifacts for capability results, starting with `camera.snap`.

- Adds an in-memory peer file artifact registry with expiring, unguessable `pf_` ids.
- Normalizes remote `camera.snap` results in `/nodes/peer-invoke` so peers receive a file reference instead of a local filesystem path.
- Adds `/nodes/peer-files/{file_id}` for serving registered artifacts and `/nodes/peers/{peer_id}/files/{file_id}` for controller-side proxy downloads.
- Adds prefix-aware agent-scope auth for peer file downloads without exposing `/sandbox/serve`.
- Rewrites peer artifact URLs returned from `/nodes/peers/{peer_id}/invoke` to controller-local proxy URLs.

## Validation

- `uv run --no-sync pytest tests/nodes/test_auth_boundary.py tests/nodes/test_peer_file_retrieval.py`
- `uv run --no-sync pytest tests/nodes tests/cli/test_cli_nodes.py`
- `uv run --no-sync ruff check src/suzent/auth_boundary.py src/suzent/nodes/peer_files.py src/suzent/routes/node_routes.py tests/nodes/test_auth_boundary.py tests/nodes/test_peer_file_retrieval.py`
- pre-commit commit hooks: `ruff check`, `ruff format`