### PR TITLE
Add per-file GitHub sync review

### DIFF
--- a/frontend/src/components/settings/GitHubSyncSection.tsx
+++ b/frontend/src/components/settings/GitHubSyncSection.tsx
@@ -6,6 +6,8 @@ import {
   fetchSyncAheadBehind,
   fetchSyncQuickstartInfo,
   fetchSyncStatus,
+  githubSyncDiscardOutgoing,
+  githubSyncPlan,
   githubSyncPull,
   githubSyncPush,
   logoutGitHub,
@@ -15,6 +17,11 @@ import {
   saveSyncAutoConfig,
   saveSyncProfile,
   startGitHubAuth,
+  syncReviewPlanFromError,
+  SyncFileChange,
+  SyncDirection,
+  SyncOperation,
+  SyncPlan,
   SyncProfile,
   SyncStatus,
 } from '../../lib/dataApi';
@@ -56,7 +63,7 @@ function ActionBtn({
   muted,
 }: {
   children: React.ReactNode;
-  onClick: () => void;
+  onClick: () => void | Promise<void>;
   disabled?: boolean;
   title?: string;
   primary?: boolean;
@@ -65,7 +72,7 @@ function ActionBtn({
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={() => { void onClick(); }}
       disabled={disabled}
       title={title}
       className={`flex items-center gap-1.5 px-3 py-2 border-l-2 border-brutal-black font-bold uppercase text-xs disabled:opacity-40 hover:brightness-95 dark:hover:brightness-125 transition-all ${
@@ -129,6 +136,335 @@ function SyncedFilesPanel({ hashes }: { hashes?: Record<string, string> }): Reac
   );
 }
 
+function syncChangeStatus(changeType: SyncFileChange['change_type']): string {
+  if (changeType === 'added') return 'A';
+  if (changeType === 'deleted') return 'D';
+  return 'M';
+}
+
+function syncChangeTone(change: SyncFileChange): string {
+  if (change.risk === 'high') return 'text-red-600 dark:text-red-300';
+  if (change.change_type === 'added') return 'text-green-600 dark:text-green-300';
+  if (change.change_type === 'deleted') return 'text-red-600 dark:text-red-300';
+  return 'text-amber-600 dark:text-amber-300';
+}
+
+function syncDisplayName(change: SyncFileChange): string {
+  if (change.category === 'secrets') return 'shared encrypted key vault';
+  return change.path.split('/').pop() || change.path;
+}
+
+function syncDisplayDir(change: SyncFileChange): string {
+  if (change.category === 'secrets') return '_sync/secrets';
+  const parts = change.path.split('/');
+  parts.pop();
+  return parts.join('/') || change.category;
+}
+
+function syncGroupLabel(category: SyncFileChange['category']): string {
+  if (category === 'secrets') return 'keys';
+  return category;
+}
+
+function shouldShowSyncChange(change: SyncFileChange): boolean {
+  if (change.category === 'sync') return change.risk !== 'low';
+  if (change.path === 'memory/.index_state.json') return false;
+  return true;
+}
+
+function syncDirectionOf(change: SyncFileChange): SyncDirection {
+  return change.direction ?? 'outgoing';
+}
+
+function syncPlanKey(plan: SyncPlan): string {
+  const files = plan.files
+    .filter(shouldShowSyncChange)
+    .map((file) => `${file.change_type}:${file.risk}:${file.category}:${file.path}`)
+    .sort()
+    .join('|');
+  return `${plan.operation}:${files}`;
+}
+
+type DiffRowKind = 'add' | 'delete' | 'hunk' | 'context';
+
+function diffRows(diffPreview: string): { kind: DiffRowKind; text: string }[] {
+  return diffPreview
+    .split('\n')
+    .filter((line) => (
+      !line.startsWith('diff --git ')
+      && !line.startsWith('index ')
+      && !line.startsWith('deleted file mode ')
+      && !line.startsWith('new file mode ')
+      && !line.startsWith('--- ')
+      && !line.startsWith('+++ ')
+    ))
+    .map((line) => {
+      if (line.startsWith('@@')) return { kind: 'hunk', text: line };
+      if (line.startsWith('+')) return { kind: 'add', text: line.slice(1) };
+      if (line.startsWith('-')) return { kind: 'delete', text: line.slice(1) };
+      return { kind: 'context', text: line.startsWith(' ') ? line.slice(1) : line };
+    });
+}
+
+function DiffPreview({ value }: { value: string }): React.ReactElement {
+  const rows = diffRows(value);
+  return (
+    <div className="mx-3 mb-2 max-h-56 overflow-auto border border-neutral-300 bg-[#ffffff] font-mono text-[10px] leading-relaxed dark:border-zinc-700 dark:bg-[#1e1e1e]">
+      <div className="border-b border-neutral-200 bg-[#f3f3f3] px-2 py-1 text-[10px] font-bold uppercase text-neutral-500 dark:border-zinc-700 dark:bg-[#252526] dark:text-neutral-400">
+        Diff preview
+      </div>
+      {rows.length === 0 ? (
+        <div className="px-2 py-1 text-neutral-400 dark:text-neutral-500">No textual diff available</div>
+      ) : (
+        rows.map((row, index) => {
+          const tone = row.kind === 'add'
+            ? 'bg-green-50 text-green-900 dark:bg-green-950/30 dark:text-green-200'
+            : row.kind === 'delete'
+              ? 'bg-red-50 text-red-900 dark:bg-red-950/30 dark:text-red-200'
+              : row.kind === 'hunk'
+                ? 'bg-blue-50 text-blue-700 dark:bg-blue-950/30 dark:text-blue-300'
+                : 'text-neutral-700 dark:text-neutral-300';
+          const marker = row.kind === 'add' ? '+' : row.kind === 'delete' ? '-' : row.kind === 'hunk' ? '@' : ' ';
+          return (
+            <div key={`${index}:${row.text}`} className={`grid grid-cols-[24px_1fr] ${tone}`}>
+              <span className="select-none border-r border-black/10 px-1 text-right text-neutral-400 dark:border-white/10 dark:text-neutral-500">
+                {marker}
+              </span>
+              <span className="whitespace-pre-wrap px-2">{row.text || ' '}</span>
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}
+
+function SyncReviewPanel({
+  plan,
+  busy,
+  onCancel,
+  onConfirm,
+  onDiscardOutgoing,
+  onPullCloud,
+  onDiscardFile,
+  onUseCloudFile,
+}: {
+  plan: SyncPlan;
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  onDiscardOutgoing: () => void;
+  onPullCloud: () => void;
+  onDiscardFile: (file: SyncFileChange) => void;
+  onUseCloudFile: (file: SyncFileChange) => void;
+}): React.ReactElement {
+  const reviewFiles = plan.files.filter(shouldShowSyncChange);
+  const visibleFiles = reviewFiles.slice(0, 80);
+  const hiddenCount = Math.max(0, reviewFiles.length - visibleFiles.length);
+  const hiddenMetadataCount = plan.files.length - reviewFiles.length;
+  const summary = reviewFiles.reduce(
+    (acc, file) => {
+      acc[file.change_type] += 1;
+      if (file.risk === 'high') acc.high_risk += 1;
+      return acc;
+    },
+    { added: 0, modified: 0, deleted: 0, high_risk: 0 },
+  );
+  const operationLabel = plan.operation === 'auto' ? 'sync' : plan.operation;
+  const directionGroups = visibleFiles.reduce<Record<SyncDirection, Record<string, SyncFileChange[]>>>((acc, file) => {
+    const direction = syncDirectionOf(file);
+    const category = syncGroupLabel(file.category);
+    (acc[direction][category] ??= []).push(file);
+    return acc;
+  }, { outgoing: {}, incoming: {} });
+  const sortedCategoryNames = (groups: Record<string, SyncFileChange[]>): string[] => Object.keys(groups).sort((a, b) => {
+    const order = ['memory', 'keys', 'config', 'skills', 'sync', 'other'];
+    return (order.indexOf(a) === -1 ? 99 : order.indexOf(a)) - (order.indexOf(b) === -1 ? 99 : order.indexOf(b));
+  });
+  const directionOrder: SyncDirection[] = ['outgoing', 'incoming'];
+  const outgoingCount = directionOrder.includes('outgoing')
+    ? Object.values(directionGroups.outgoing).reduce((total, files) => total + files.length, 0)
+    : 0;
+  const incomingCount = directionOrder.includes('incoming')
+    ? Object.values(directionGroups.incoming).reduce((total, files) => total + files.length, 0)
+    : 0;
+
+  return (
+    <div className="mt-3 border-2 border-brutal-black bg-[#f3f3f3] dark:bg-[#181818]">
+      <div className="flex items-center justify-between border-b-2 border-brutal-black bg-[#eeeeee] dark:bg-[#252526] px-3 py-2">
+        <div className="min-w-0">
+          <p className="text-[11px] font-black uppercase text-neutral-700 dark:text-neutral-200">
+            Source Control: GitHub Sync
+          </p>
+          <p className="mt-0.5 text-[10px] font-mono text-neutral-500 dark:text-neutral-400 truncate">
+            Review pending {operationLabel} before applying protected changes
+          </p>
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <span className="font-mono text-[10px] font-bold text-green-700 dark:text-green-300" title="Added">
+            +{summary.added ?? 0}
+          </span>
+          <span className="font-mono text-[10px] font-bold text-amber-700 dark:text-amber-300" title="Modified">
+            ~{summary.modified ?? 0}
+          </span>
+          <span className="font-mono text-[10px] font-bold text-red-700 dark:text-red-300" title="Deleted">
+            -{summary.deleted ?? 0}
+          </span>
+        </div>
+      </div>
+
+      {plan.warnings.length > 0 && (
+        <div className="border-b border-brutal-black/20 bg-red-50 dark:bg-red-950/30 px-3 py-2">
+          {plan.warnings.map((warning) => (
+            <p key={warning} className="text-[11px] font-bold text-red-700 dark:text-red-300">
+              {warning}
+            </p>
+          ))}
+        </div>
+      )}
+
+      <div className="max-h-72 overflow-y-auto bg-[#f8f8f8] dark:bg-[#1e1e1e]">
+        {directionOrder.map((direction) => {
+          const categoryGroups = directionGroups[direction];
+          const categoryNames = sortedCategoryNames(categoryGroups);
+          const count = categoryNames.reduce((total, category) => total + (categoryGroups[category]?.length ?? 0), 0);
+          if (count === 0) return null;
+          return (
+            <div key={direction} className="border-b-2 border-brutal-black/20 last:border-b-0">
+              <div className="flex items-center justify-between bg-[#dddddd] dark:bg-[#303030] px-3 py-1.5">
+                <span className="text-[10px] font-black uppercase text-neutral-700 dark:text-neutral-200">
+                  {direction === 'outgoing' ? 'Outgoing Changes' : 'Incoming Changes'}
+                </span>
+                <span className="font-mono text-[10px] text-neutral-500 dark:text-neutral-400">{count}</span>
+              </div>
+              {categoryNames.map((group) => {
+                const files = categoryGroups[group] ?? [];
+                return (
+                  <div key={`${direction}:${group}`} className="border-t border-brutal-black/10">
+                    <div className="flex items-center justify-between bg-[#eeeeee] dark:bg-[#252526] px-3 py-1.5">
+                      <div className="flex items-center gap-1.5 min-w-0">
+                        <span className="text-[10px] text-neutral-500 dark:text-neutral-400">v</span>
+                        <span className="text-[10px] font-black uppercase text-neutral-600 dark:text-neutral-300 truncate">
+                          {group}
+                        </span>
+                      </div>
+                      <span className="font-mono text-[10px] text-neutral-500 dark:text-neutral-400">
+                        {files.length}
+                      </span>
+                    </div>
+                    <div>
+                      {files.map((file) => (
+                        <div key={`${syncDirectionOf(file)}:${file.change_type}:${file.path}`} className="border-t border-brutal-black/5 first:border-t-0">
+                          <div
+                            className="grid grid-cols-[18px_1fr_auto_28px] items-center gap-2 px-3 py-1.5 hover:bg-[#e8e8e8] dark:hover:bg-[#2a2d2e]"
+                            title={file.path}
+                          >
+                            <span className={`font-mono text-[11px] font-black ${syncChangeTone(file)}`}>
+                              {syncChangeStatus(file.change_type)}
+                            </span>
+                            <span className="min-w-0">
+                              <span className="block truncate font-mono text-[12px] text-neutral-800 dark:text-neutral-100">
+                                {syncDisplayName(file)}
+                              </span>
+                              <span className="block truncate font-mono text-[10px] text-neutral-500 dark:text-neutral-500">
+                                {syncDisplayDir(file)}
+                              </span>
+                            </span>
+                            <button
+                              type="button"
+                              disabled={busy}
+                              onClick={() => {
+                                if (syncDirectionOf(file) === 'outgoing') onDiscardFile(file);
+                                else onUseCloudFile(file);
+                              }}
+                              className="border border-brutal-black/40 bg-white px-2 py-1 text-[9px] font-black uppercase text-neutral-700 hover:bg-neutral-100 disabled:opacity-40 dark:bg-zinc-900 dark:text-neutral-200 dark:hover:bg-zinc-800"
+                              title={syncDirectionOf(file) === 'outgoing'
+                                ? 'Discard this outgoing file and restore it from the sync payload'
+                                : 'Apply this cloud file locally'}
+                            >
+                              {syncDirectionOf(file) === 'outgoing' ? 'Discard' : 'Use Cloud'}
+                            </button>
+                            <span className={`text-right font-mono text-[10px] font-bold uppercase ${syncChangeTone(file)}`}>
+                              {file.risk === 'high' ? '!' : file.risk === 'medium' ? '*' : ''}
+                            </span>
+                          </div>
+                          {file.diff_preview && (
+                            <DiffPreview value={file.diff_preview} />
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+        {hiddenCount > 0 && (
+          <div className="px-3 py-2 font-mono text-[11px] text-neutral-500 dark:text-neutral-400">
+            {hiddenCount} more file{hiddenCount !== 1 ? 's' : ''} hidden
+          </div>
+        )}
+        {hiddenMetadataCount > 0 && (
+          <div className="px-3 py-2 font-mono text-[10px] text-neutral-400 dark:text-neutral-500">
+            {hiddenMetadataCount} routine sync metadata change{hiddenMetadataCount !== 1 ? 's' : ''} hidden
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between border-t-2 border-brutal-black bg-[#eeeeee] dark:bg-[#252526] px-3 py-2">
+        <span className={`font-mono text-[10px] font-bold uppercase ${
+          (summary.high_risk ?? 0) > 0
+            ? 'text-red-700 dark:text-red-300'
+            : 'text-neutral-500 dark:text-neutral-400'
+        }`}>
+          {summary.high_risk ?? 0} high risk
+        </span>
+        <div className="flex gap-2">
+          {outgoingCount > 0 && (
+            <button
+              type="button"
+              onClick={onDiscardOutgoing}
+              disabled={busy}
+              title="Restore local synced files from the current cloud payload and clear outgoing changes"
+              className="px-3 py-2 border-2 border-brutal-black bg-white dark:bg-zinc-900 text-xs font-bold uppercase disabled:opacity-50"
+            >
+              Discard Outgoing
+            </button>
+          )}
+          {incomingCount > 0 && (
+            <button
+              type="button"
+              onClick={onPullCloud}
+              disabled={busy}
+              title="Pull cloud changes and let cloud synced content replace local synced content"
+              className="px-3 py-2 border-2 border-brutal-black bg-blue-600 text-white text-xs font-black uppercase disabled:opacity-50"
+            >
+              Pull Cloud
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            className="px-3 py-2 border-2 border-brutal-black bg-white dark:bg-zinc-900 text-xs font-bold uppercase disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={busy}
+            className="px-3 py-2 border-2 border-brutal-black bg-red-600 text-white text-xs font-black uppercase disabled:opacity-50"
+          >
+            Confirm {operationLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function GitHubSyncSection({
   busy,
   onBusyChange,
@@ -165,6 +501,9 @@ export function GitHubSyncSection({
   const [installUrl, setInstallUrl] = useState<string | null>(null);
   const [ahead, setAhead] = useState<number | null>(null);
   const [behind, setBehind] = useState<number | null>(null);
+  const [reviewPlan, setReviewPlan] = useState<SyncPlan | null>(null);
+  const [reviewOperation, setReviewOperation] = useState<SyncOperation | null>(null);
+  const [dismissedPlanKey, setDismissedPlanKey] = useState<string | null>(null);
 
   const [devicePhase, setDevicePhase] = useState<DeviceFlowPhase>('idle');
   const [deviceCode, setDeviceCode] = useState('');
@@ -172,6 +511,7 @@ export function GitHubSyncSection({
   const [deviceSessionId, setDeviceSessionId] = useState('');
   const [deviceInterval, setDeviceInterval] = useState(5);
   const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const syncPlanWatcherRunning = useRef(false);
 
   useEffect(() => {
     refresh().catch(() => setSyncStatus(null));
@@ -188,6 +528,52 @@ export function GitHubSyncSection({
       if (pollTimer.current) clearTimeout(pollTimer.current);
     };
   }, []);
+
+  useEffect(() => {
+    const profileId = syncStatus?.configured ? syncStatus.profile?.id : null;
+    if (!profileId) {
+      setReviewPlan(null);
+      setReviewOperation(null);
+      setDismissedPlanKey(null);
+      return;
+    }
+
+    let cancelled = false;
+    const refreshWatchedPlan = async (): Promise<void> => {
+      if (busy || syncPlanWatcherRunning.current) return;
+      syncPlanWatcherRunning.current = true;
+      try {
+        const plan = await githubSyncPlan('auto', profileId);
+        if (cancelled) return;
+        if (plan.files.filter(shouldShowSyncChange).length === 0) {
+          setReviewPlan((current) => (current?.operation === 'auto' ? null : current));
+          setReviewOperation((current) => (current === 'auto' ? null : current));
+          setDismissedPlanKey(null);
+          return;
+        }
+
+        const nextKey = syncPlanKey(plan);
+        if (nextKey !== dismissedPlanKey) {
+          setReviewPlan(plan);
+          setReviewOperation('auto');
+        }
+      } catch {
+        // A watcher should stay quiet; manual buttons still surface explicit errors.
+      } finally {
+        syncPlanWatcherRunning.current = false;
+      }
+    };
+
+    void refreshWatchedPlan();
+    const interval = window.setInterval(() => { void refreshWatchedPlan(); }, 8000);
+    const handleFocus = (): void => { void refreshWatchedPlan(); };
+    window.addEventListener('focus', handleFocus);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, [syncStatus?.configured, syncStatus?.profile?.id, busy, dismissedPlanKey]);
 
   async function refresh(): Promise<void> {
     const next = await fetchSyncStatus();
@@ -364,20 +750,44 @@ export function GitHubSyncSection({
     }
   }
 
+  function openReview(plan: SyncPlan, operation: SyncOperation): void {
+    setDismissedPlanKey(null);
+    setReviewPlan(plan);
+    setReviewOperation(operation);
+    onNotify('Review sync changes before continuing.', true);
+  }
+
   function makeSyncHandler(
-    apiFn: (profileId: string) => Promise<unknown>,
+    operation: SyncOperation,
+    apiFn: (profileId: string, confirmDestructive?: boolean) => Promise<unknown>,
     successKey: string,
     notifyComplete = false,
   ) {
-    return async function (): Promise<void> {
+    return async function (confirmDestructive = false): Promise<void> {
       if (!requireShibbolethUnlocked()) return;
       onBusyChange(true);
       try {
         const profile = syncStatus?.profile;
         if (!profile) throw new Error('GitHub sync is not configured.');
-        const result = (await apiFn(profile.id)) as
-          | { secrets?: string; changed_secret_keys?: string[] }
+
+        if (!confirmDestructive) {
+          const plan = await githubSyncPlan(operation, profile.id);
+          if (plan.requires_confirmation) {
+            openReview(plan, operation);
+            return;
+          }
+        }
+
+        const result = (await apiFn(profile.id, confirmDestructive)) as
+          | { secrets?: string; changed_secret_keys?: string[]; blocked_review_required?: boolean; plan?: SyncPlan }
           | undefined;
+        if (result?.blocked_review_required && result.plan) {
+          openReview(result.plan, operation);
+          return;
+        }
+        setReviewPlan(null);
+        setReviewOperation(null);
+        setDismissedPlanKey(null);
         await refresh();
         // Honest push: if a vault exists but this device didn't contribute keys,
         // say so instead of implying the vault was updated.
@@ -396,6 +806,11 @@ export function GitHubSyncSection({
         }
         if (notifyComplete) onSyncComplete?.();
       } catch (error) {
+        const plan = syncReviewPlanFromError(error);
+        if (plan) {
+          openReview(plan, operation);
+          return;
+        }
         onNotify(t('settings.data.githubFailed', { error: errMsg(error) }), true);
       } finally {
         onBusyChange(false);
@@ -403,9 +818,127 @@ export function GitHubSyncSection({
     };
   }
 
-  const handleSync = makeSyncHandler(runSync, 'settings.data.githubPushed', true);
-  const handlePull = makeSyncHandler(githubSyncPull, 'settings.data.githubPulled', true);
-  const handlePush = makeSyncHandler(githubSyncPush, 'settings.data.githubPushed');
+  const handleSync = makeSyncHandler('auto', runSync, 'settings.data.githubPushed', true);
+  const handlePull = makeSyncHandler(
+    'pull',
+    (profileId, confirmDestructive) => githubSyncPull(profileId, undefined, confirmDestructive),
+    'settings.data.githubPulled',
+    true,
+  );
+  const handlePush = makeSyncHandler(
+    'push',
+    (profileId, confirmDestructive) => githubSyncPush(profileId, undefined, confirmDestructive),
+    'settings.data.githubPushed',
+  );
+
+  function handleReviewConfirm(): void {
+    if (reviewOperation === 'auto') void handleSync(true);
+    if (reviewOperation === 'pull') void handlePull(true);
+    if (reviewOperation === 'push') void handlePush(true);
+  }
+
+  async function handleDiscardOutgoing(): Promise<void> {
+    onBusyChange(true);
+    try {
+      const profile = syncStatus?.profile;
+      if (!profile) throw new Error('GitHub sync is not configured.');
+      const result = await githubSyncDiscardOutgoing(profile.id) as { discarded?: string[] };
+      setReviewPlan(null);
+      setReviewOperation(null);
+      setDismissedPlanKey(null);
+      await refresh();
+      const count = result.discarded?.length ?? 0;
+      onNotify(count > 0 ? `Discarded ${count} outgoing sync change${count !== 1 ? 's' : ''}.` : 'No outgoing sync changes to discard.', false);
+    } catch (error) {
+      onNotify(t('settings.data.githubFailed', { error: errMsg(error) }), true);
+    } finally {
+      onBusyChange(false);
+    }
+  }
+
+  async function handleDiscardFile(file: SyncFileChange): Promise<void> {
+    onBusyChange(true);
+    try {
+      const profile = syncStatus?.profile;
+      if (!profile) throw new Error('GitHub sync is not configured.');
+      await githubSyncDiscardOutgoing(profile.id, [file.path]);
+      const plan = await githubSyncPlan(reviewOperation ?? 'auto', profile.id);
+      if (plan.files.filter(shouldShowSyncChange).length > 0) {
+        setReviewPlan(plan);
+      } else {
+        setReviewPlan(null);
+        setReviewOperation(null);
+        setDismissedPlanKey(null);
+      }
+      await refresh();
+      onNotify(`Discarded ${file.path}.`, false);
+    } catch (error) {
+      onNotify(t('settings.data.githubFailed', { error: errMsg(error) }), true);
+    } finally {
+      onBusyChange(false);
+    }
+  }
+
+  async function handlePullCloud(): Promise<void> {
+    if (!requireShibbolethUnlocked()) return;
+    onBusyChange(true);
+    try {
+      const profile = syncStatus?.profile;
+      if (!profile) throw new Error('GitHub sync is not configured.');
+      const result = await githubSyncPull(profile.id, undefined, true, true) as { changed_secret_keys?: string[] };
+      setReviewPlan(null);
+      setReviewOperation(null);
+      setDismissedPlanKey(null);
+      await refresh();
+      if (result.changed_secret_keys && result.changed_secret_keys.length > 0) {
+        const keys = result.changed_secret_keys;
+        const list = keys.slice(0, 4).join(', ') + (keys.length > 4 ? `, +${keys.length - 4} more` : '');
+        onNotify(`${t('settings.data.githubPulled')} - ${keys.length} key${keys.length !== 1 ? 's' : ''} updated from vault: ${list}`, false);
+      } else {
+        onNotify('Cloud changes pulled and applied as the source of truth.', false);
+      }
+      onSyncComplete?.();
+    } catch (error) {
+      const plan = syncReviewPlanFromError(error);
+      if (plan) {
+        openReview(plan, 'pull');
+        return;
+      }
+      onNotify(t('settings.data.githubFailed', { error: errMsg(error) }), true);
+    } finally {
+      onBusyChange(false);
+    }
+  }
+
+  async function handleUseCloudFile(file: SyncFileChange): Promise<void> {
+    if (!requireShibbolethUnlocked()) return;
+    onBusyChange(true);
+    try {
+      const profile = syncStatus?.profile;
+      if (!profile) throw new Error('GitHub sync is not configured.');
+      await githubSyncPull(profile.id, undefined, true, true, [file.path]);
+      const plan = await githubSyncPlan(reviewOperation ?? 'auto', profile.id);
+      if (plan.files.filter(shouldShowSyncChange).length > 0) {
+        setReviewPlan(plan);
+      } else {
+        setReviewPlan(null);
+        setReviewOperation(null);
+        setDismissedPlanKey(null);
+      }
+      await refresh();
+      onNotify(`Applied cloud version of ${file.path}.`, false);
+      onSyncComplete?.();
+    } catch (error) {
+      const plan = syncReviewPlanFromError(error);
+      if (plan) {
+        openReview(plan, 'pull');
+        return;
+      }
+      onNotify(t('settings.data.githubFailed', { error: errMsg(error) }), true);
+    } finally {
+      onBusyChange(false);
+    }
+  }
 
   const configured = Boolean(syncStatus?.configured && syncStatus.profile);
 
@@ -630,6 +1163,23 @@ export function GitHubSyncSection({
 
       {/* Shared key vault — surfaced in the main card (not hidden in Advanced) so
           the lock state and key inventory are always visible. */}
+      {configured && reviewPlan && (
+        <SyncReviewPanel
+          plan={reviewPlan}
+          busy={busy}
+          onCancel={() => {
+            setDismissedPlanKey(syncPlanKey(reviewPlan));
+            setReviewPlan(null);
+            setReviewOperation(null);
+          }}
+          onConfirm={handleReviewConfirm}
+          onDiscardOutgoing={() => { void handleDiscardOutgoing(); }}
+          onPullCloud={() => { void handlePullCloud(); }}
+          onDiscardFile={(file) => { void handleDiscardFile(file); }}
+          onUseCloudFile={(file) => { void handleUseCloudFile(file); }}
+        />
+      )}
+
       {configured && (
         <div className="mt-4">
           <ShibbolethPanel profile={syncStatus?.profile} syncStatus={syncStatus} busy={busy} onBusyChange={onBusyChange} onNotify={onNotify} onChanged={refresh} />

--- a/frontend/src/components/settings/ShibbolethPanel.tsx
+++ b/frontend/src/components/settings/ShibbolethPanel.tsx
@@ -138,6 +138,9 @@ export function ShibbolethPanel({
   const available = profile?.secret_sync_available ?? false;
   const rotation = syncStatus?.rotation_detected ?? null;
   const vault = syncStatus?.vault ?? null;
+  const syncedKeyNames = vault?.synced_keys ?? [];
+  const localOnlyKeyNames = vault?.local_only_keys ?? [];
+  const vaultOnlyKeyNames = vault?.vault_only_keys ?? [];
 
   const autoStarted = useRef(false);
 
@@ -400,6 +403,38 @@ export function ShibbolethPanel({
           fact that would have made the GEMINI-missing-from-vault bug obvious. */}
       {enabled && vault?.exists && (
         <div className="border-2 border-brutal-black bg-white dark:bg-zinc-900">
+          <div className="border-b-2 border-brutal-black/20 bg-neutral-50 dark:bg-zinc-800/60 px-3 py-2">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-[10px] font-black uppercase text-neutral-600 dark:text-neutral-300">
+                Synced key names
+              </p>
+              <span className="font-mono text-[10px] font-bold text-neutral-400">
+                {syncedKeyNames.length}
+              </span>
+            </div>
+            <div className="mt-1.5 flex max-h-16 flex-wrap gap-1 overflow-y-auto">
+              {syncedKeyNames.length > 0 ? (
+                syncedKeyNames.map((key) => (
+                  <span
+                    key={key}
+                    title={key}
+                    className="max-w-full truncate border border-brutal-black/30 bg-white px-1.5 py-0.5 font-mono text-[10px] font-bold text-neutral-700 dark:bg-zinc-900 dark:text-neutral-200"
+                  >
+                    {key}
+                  </span>
+                ))
+              ) : (
+                <span className="font-mono text-[10px] text-neutral-400">No keys selected for sync</span>
+              )}
+            </div>
+            {(localOnlyKeyNames.length > 0 || vaultOnlyKeyNames.length > 0) && (
+              <p className="mt-1.5 text-[9px] text-neutral-500 dark:text-neutral-400">
+                {localOnlyKeyNames.length > 0 && `${localOnlyKeyNames.length} local-only`}
+                {localOnlyKeyNames.length > 0 && vaultOnlyKeyNames.length > 0 ? ' / ' : ''}
+                {vaultOnlyKeyNames.length > 0 && `${vaultOnlyKeyNames.length} vault-only`}
+              </p>
+            )}
+          </div>
           <div className="grid grid-cols-[1fr_auto_auto_auto] gap-x-3 px-3 py-1.5 text-[9px] font-bold uppercase text-neutral-400 border-b-2 border-brutal-black/20">
             <span>Provider</span>
             <span className="text-center w-12">Vault</span>

--- a/frontend/src/lib/dataApi.ts
+++ b/frontend/src/lib/dataApi.ts
@@ -51,6 +51,41 @@ export interface SecretVaultInfo {
   mnemonic_fingerprint: string | null;
 }
 
+export type SyncOperation = 'push' | 'pull' | 'auto';
+export type SyncChangeType = 'added' | 'modified' | 'deleted';
+export type SyncRisk = 'low' | 'medium' | 'high';
+export type SyncDirection = 'outgoing' | 'incoming';
+
+export interface SyncFileChange {
+  path: string;
+  category: 'config' | 'skills' | 'memory' | 'secrets' | 'sync' | 'other';
+  change_type: SyncChangeType;
+  risk: SyncRisk;
+  direction?: SyncDirection;
+  diff_preview?: string | null;
+}
+
+export interface SyncPlan {
+  operation: SyncOperation;
+  files: SyncFileChange[];
+  summary: Record<string, number>;
+  destructive: boolean;
+  requires_confirmation: boolean;
+  warnings: string[];
+}
+
+export class ApiError extends Error {
+  status: number;
+  payload: unknown;
+
+  constructor(message: string, status: number, payload: unknown) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.payload = payload;
+  }
+}
+
 async function postJson<T>(path: string, body: Record<string, unknown>): Promise<T> {
   const res = await fetch(`${getApiBase()}${path}`, {
     method: 'POST',
@@ -59,15 +94,27 @@ async function postJson<T>(path: string, body: Record<string, unknown>): Promise
   });
   if (!res.ok) {
     let detail = res.statusText;
+    let payload: unknown = null;
     try {
-      const payload = await res.json();
-      detail = payload.detail || payload.error || detail;
+      payload = await res.json();
+      if (payload && typeof payload === 'object') {
+        const data = payload as { detail?: unknown; error?: unknown };
+        detail = String(data.detail || data.error || detail);
+      }
     } catch {
       // Keep the HTTP status text when the backend did not return JSON.
     }
-    throw new Error(`Request failed: ${detail}`);
+    throw new ApiError(`Request failed: ${detail}`, res.status, payload);
   }
   return res.json();
+}
+
+export function syncReviewPlanFromError(error: unknown): SyncPlan | null {
+  if (!(error instanceof ApiError)) return null;
+  if (!error.payload || typeof error.payload !== 'object') return null;
+  const plan = (error.payload as { plan?: unknown }).plan;
+  if (!plan || typeof plan !== 'object') return null;
+  return plan as SyncPlan;
 }
 
 export interface SyncQuickstartInfo {
@@ -173,26 +220,48 @@ export async function fetchSyncAheadBehind(profileId?: string): Promise<{ ahead:
   return res.json();
 }
 
+export function githubSyncPlan(operation: SyncOperation, profileId?: string): Promise<SyncPlan> {
+  const body: Record<string, unknown> = { operation };
+  if (profileId) body.profile_id = profileId;
+  return postJson<SyncPlan>('/sync/plan', body);
+}
+
 export function githubSyncPull(
   profileId?: string,
   shibboleth?: string,
+  confirmDestructive = false,
+  preferCloud = false,
+  paths?: string[],
 ): Promise<Record<string, unknown>> {
   const body: Record<string, unknown> = profileId ? { profile_id: profileId } : {};
   if (shibboleth) body.shibboleth = shibboleth;
+  if (confirmDestructive) body.confirm_destructive = true;
+  if (preferCloud) body.prefer_cloud = true;
+  if (paths) body.paths = paths;
   return postJson<Record<string, unknown>>('/sync/pull', body);
+}
+
+export function githubSyncDiscardOutgoing(profileId?: string, paths?: string[]): Promise<Record<string, unknown>> {
+  const body: Record<string, unknown> = profileId ? { profile_id: profileId } : {};
+  if (paths) body.paths = paths;
+  return postJson<Record<string, unknown>>('/sync/discard-outgoing', body);
 }
 
 export function githubSyncPush(
   profileId?: string,
   shibboleth?: string,
+  confirmDestructive = false,
 ): Promise<Record<string, unknown>> {
   const body: Record<string, unknown> = profileId ? { profile_id: profileId } : {};
   if (shibboleth) body.shibboleth = shibboleth;
+  if (confirmDestructive) body.confirm_destructive = true;
   return postJson<Record<string, unknown>>('/sync/push', body);
 }
 
-export function runSync(profileId?: string): Promise<Record<string, unknown>> {
-  return postJson<Record<string, unknown>>('/sync/auto/run', profileId ? { profile_id: profileId } : {});
+export function runSync(profileId?: string, confirmDestructive = false): Promise<Record<string, unknown>> {
+  const body: Record<string, unknown> = profileId ? { profile_id: profileId } : {};
+  if (confirmDestructive) body.confirm_destructive = true;
+  return postJson<Record<string, unknown>>('/sync/auto/run', body);
 }
 
 export function saveSyncAutoConfig(profileId: string, autoSyncEnabled: boolean, intervalHours: number, autoResolveEnabled: boolean): Promise<SyncProfile> {

--- a/src/suzent/routes/sync_routes.py
+++ b/src/suzent/routes/sync_routes.py
@@ -24,7 +24,7 @@ from suzent.sync.github_device_flow import (
 )
 from suzent.sync.models import SyncConflict, SyncProfile
 from suzent.sync.payload import PAYLOAD_DIR_NAME
-from suzent.sync.service import GitHubSyncService
+from suzent.sync.service import DestructiveSyncPlanError, GitHubSyncService
 
 _SESSION_TTL = 900
 
@@ -113,15 +113,39 @@ async def get_sync_ahead_behind(request: Request) -> JSONResponse:
         return _error_response(str(exc), 400)
 
 
+async def get_sync_plan(request: Request) -> JSONResponse:
+    try:
+        payload = await _json_payload(request)
+        operation = payload.get("operation")
+        profile_id = payload.get("profile_id")
+        plan = _service(request).preview_sync_plan(str(operation), profile_id)
+        return JSONResponse(plan.model_dump(mode="json"))
+    except Exception as exc:
+        return _error_response(str(exc), 400)
+
+
 async def pull_sync(request: Request) -> JSONResponse:
     try:
         payload = await _json_payload(request)
         service = _service(request)
+        paths = payload.get("paths")
         return JSONResponse(
             await service.pull(
                 payload.get("profile_id"),
                 shibboleth=_shibboleth_from_payload(payload),
+                confirm_destructive=bool(payload.get("confirm_destructive")),
+                prefer_cloud=bool(payload.get("prefer_cloud")),
+                paths=list(paths) if isinstance(paths, list) else None,
             )
+        )
+    except DestructiveSyncPlanError as exc:
+        return JSONResponse(
+            {
+                "detail": str(exc),
+                "review_required": True,
+                "plan": exc.plan.model_dump(mode="json"),
+            },
+            status_code=409,
         )
     except Exception as exc:
         return _error_response(str(exc), 400)
@@ -135,6 +159,31 @@ async def push_sync(request: Request) -> JSONResponse:
             await service.push(
                 payload.get("profile_id"),
                 shibboleth=_shibboleth_from_payload(payload),
+                confirm_destructive=bool(payload.get("confirm_destructive")),
+            )
+        )
+    except DestructiveSyncPlanError as exc:
+        return JSONResponse(
+            {
+                "detail": str(exc),
+                "review_required": True,
+                "plan": exc.plan.model_dump(mode="json"),
+            },
+            status_code=409,
+        )
+    except Exception as exc:
+        return _error_response(str(exc), 400)
+
+
+async def discard_outgoing_sync(request: Request) -> JSONResponse:
+    try:
+        payload = await _json_payload(request)
+        service = _service(request)
+        paths = payload.get("paths")
+        return JSONResponse(
+            await service.discard_outgoing(
+                payload.get("profile_id"),
+                paths=list(paths) if isinstance(paths, list) else None,
             )
         )
     except Exception as exc:
@@ -197,6 +246,7 @@ async def run_auto_sync(request: Request) -> JSONResponse:
             await service.auto_sync(
                 payload.get("profile_id"),
                 shibboleth=_shibboleth_from_payload(payload),
+                confirm_destructive=bool(payload.get("confirm_destructive")),
             )
         )
     except Exception as exc:

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -94,10 +94,12 @@ from suzent.routes.config_routes import (
 )
 from suzent.routes.sync_routes import (
     create_sync_profile,
+    discard_outgoing_sync,
     disable_secret_sync,
     enable_secret_sync,
     get_github_auth_status,
     get_sync_ahead_behind,
+    get_sync_plan,
     get_sync_profiles,
     get_sync_quickstart_info,
     get_sync_status,
@@ -915,6 +917,8 @@ app = Starlette(
         Route("/sync/profiles", create_sync_profile, methods=["POST"]),
         Route("/sync/validate", validate_sync_profile, methods=["POST"]),
         Route("/sync/ahead-behind", get_sync_ahead_behind, methods=["GET"]),
+        Route("/sync/plan", get_sync_plan, methods=["POST"]),
+        Route("/sync/discard-outgoing", discard_outgoing_sync, methods=["POST"]),
         Route("/sync/pull", pull_sync, methods=["POST"]),
         Route("/sync/push", push_sync, methods=["POST"]),
         Route("/sync/auto", save_auto_config, methods=["POST"]),

--- a/src/suzent/sync/models.py
+++ b/src/suzent/sync/models.py
@@ -40,6 +40,24 @@ class SyncManifest(BaseModel):
     content_hashes: dict[str, str]
 
 
+class SyncFileChange(BaseModel):
+    path: str
+    category: Literal["config", "skills", "memory", "secrets", "sync", "other"]
+    change_type: Literal["added", "modified", "deleted"]
+    risk: Literal["low", "medium", "high"] = "low"
+    direction: Literal["outgoing", "incoming"] = "outgoing"
+    diff_preview: str | None = None
+
+
+class SyncPlan(BaseModel):
+    operation: Literal["push", "pull", "auto"]
+    files: list[SyncFileChange] = Field(default_factory=list)
+    summary: dict[str, int] = Field(default_factory=dict)
+    destructive: bool = False
+    requires_confirmation: bool = False
+    warnings: list[str] = Field(default_factory=list)
+
+
 class DevicePresence(BaseModel):
     device_id: str
     device_name: str

--- a/src/suzent/sync/payload.py
+++ b/src/suzent/sync/payload.py
@@ -13,6 +13,7 @@ from suzent.sync.models import DevicePresence, SyncManifest, SyncProfile
 PAYLOAD_DIR_NAME = "suzent-sync"
 MANIFEST_PATH = "_sync/manifest.json"
 PRESENCE_DIR = "_sync/presence"
+SECRETS_DIR = "_sync/secrets"
 
 EXCLUDED_NAMES = {
     ".env",
@@ -60,38 +61,59 @@ class SyncPayloadBuilder:
 
     def build(self, repo_path: Path, profile: SyncProfile) -> SyncManifest:
         payload_dir = repo_path / PAYLOAD_DIR_NAME
-        if payload_dir.exists():
-            shutil.rmtree(payload_dir)
-        payload_dir.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            preserved_memory = Path(temp_dir) / "memory"
+            existing_memory = payload_dir / "memory"
+            if existing_memory.exists():
+                self._copy_tree(existing_memory, preserved_memory)
+            preserved_secrets = Path(temp_dir) / SECRETS_DIR
+            existing_secrets = payload_dir / SECRETS_DIR
+            if existing_secrets.exists():
+                self._copy_tree(existing_secrets, preserved_secrets)
 
-        self._copy_tree(self.user_config_dir, payload_dir / "config")
-        self._copy_tree(self.user_skills_dir, payload_dir / "skills")
-        self._copy_tree(self._memory_dir(), payload_dir / "memory")
+            if payload_dir.exists():
+                shutil.rmtree(payload_dir)
+            payload_dir.mkdir(parents=True, exist_ok=True)
 
-        presence = DevicePresence(
-            device_id=profile.device_id,
-            device_name=_device_name(),
-            status="online",
-            last_sync_revision=profile.last_revision,
-        )
-        presence_path = payload_dir / PRESENCE_DIR / f"{profile.device_id}.json"
-        presence_path.parent.mkdir(parents=True, exist_ok=True)
-        presence_path.write_text(presence.model_dump_json(indent=2), encoding="utf-8")
+            self._copy_tree(self.user_config_dir, payload_dir / "config")
+            self._copy_tree(self.user_skills_dir, payload_dir / "skills")
+            # Conversation memory is append-heavy and may be partially missing on a
+            # device after recovery. Preserve the repo's existing memory files, then
+            # overlay this device's local updates, so a partial local tree does not
+            # become an authoritative mass deletion on push.
+            self._copy_tree(preserved_memory, payload_dir / "memory")
+            self._copy_tree(self._memory_dir(), payload_dir / "memory")
+            # Secret bundles are produced by the service only when the vault is
+            # unlocked. Planning/rebuilding the portable payload must not turn a
+            # locked or preview-only pass into a vault deletion.
+            self._copy_tree(preserved_secrets, payload_dir / SECRETS_DIR)
 
-        hashes = self.content_hashes(payload_dir)
-        manifest = SyncManifest(
-            revision_id=uuid4().hex,
-            source_device=profile.device_id,
-            included_paths=sorted(hashes),
-            content_hashes=hashes,
-        )
-        manifest_path = payload_dir / MANIFEST_PATH
-        manifest_path.parent.mkdir(parents=True, exist_ok=True)
-        manifest_path.write_text(
-            json.dumps(manifest.model_dump(mode="json"), indent=2, sort_keys=True),
-            encoding="utf-8",
-        )
-        return manifest
+            presence = DevicePresence(
+                device_id=profile.device_id,
+                device_name=_device_name(),
+                status="online",
+                last_sync_revision=profile.last_revision,
+            )
+            presence_path = payload_dir / PRESENCE_DIR / f"{profile.device_id}.json"
+            presence_path.parent.mkdir(parents=True, exist_ok=True)
+            presence_path.write_text(
+                presence.model_dump_json(indent=2), encoding="utf-8"
+            )
+
+            hashes = self.content_hashes(payload_dir)
+            manifest = SyncManifest(
+                revision_id=uuid4().hex,
+                source_device=profile.device_id,
+                included_paths=sorted(hashes),
+                content_hashes=hashes,
+            )
+            manifest_path = payload_dir / MANIFEST_PATH
+            manifest_path.parent.mkdir(parents=True, exist_ok=True)
+            manifest_path.write_text(
+                json.dumps(manifest.model_dump(mode="json"), indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+            return manifest
 
     def content_hashes(self, payload_dir: Path) -> dict[str, str]:
         hashes: dict[str, str] = {}
@@ -116,20 +138,57 @@ class SyncPayloadBuilder:
                 forbidden.append(rel.as_posix())
         return sorted(set(forbidden))
 
-    def apply_to_local(self, payload_dir: Path) -> list[str]:
+    def apply_to_local(
+        self, payload_dir: Path, *, replace_memory: bool = False
+    ) -> list[str]:
         restored: list[str] = []
-        mappings = [
+        replace_mappings = [
             ("config", self.user_config_dir),
             ("skills", self.user_skills_dir),
-            ("memory", self._memory_dir()),
         ]
-        for name, target in mappings:
+        for name, target in replace_mappings:
             source = payload_dir / name
             if not source.exists():
                 continue
             self._remove_tree_preserving_excluded(target)
             self._copy_tree(source, target)
             restored.append(name)
+
+        memory_source = payload_dir / "memory"
+        if memory_source.exists():
+            if replace_memory:
+                self._remove_tree_preserving_excluded(self._memory_dir())
+            self._copy_tree(memory_source, self._memory_dir())
+            restored.append("memory")
+        return restored
+
+    def apply_paths_to_local(self, payload_dir: Path, paths: list[str]) -> list[str]:
+        restored: list[str] = []
+        for raw_path in paths:
+            rel = Path(raw_path.replace("\\", "/"))
+            if rel.is_absolute() or ".." in rel.parts or len(rel.parts) < 2:
+                continue
+            top = rel.parts[0]
+            if top == "config":
+                target = self.user_config_dir.joinpath(*rel.parts[1:])
+            elif top == "skills":
+                target = self.user_skills_dir.joinpath(*rel.parts[1:])
+            elif top == "memory":
+                target = self._memory_dir().joinpath(*rel.parts[1:])
+            else:
+                continue
+
+            source = payload_dir / rel
+            if source.exists():
+                self._copy_tree(source, target)
+            elif target.exists() and not any(
+                _is_excluded_name(part) for part in rel.parts
+            ):
+                if target.is_dir():
+                    shutil.rmtree(target)
+                else:
+                    target.unlink()
+            restored.append(rel.as_posix())
         return restored
 
     def _remove_tree_preserving_excluded(self, target: Path) -> None:

--- a/src/suzent/sync/provider.py
+++ b/src/suzent/sync/provider.py
@@ -68,6 +68,48 @@ class GitHubSyncProvider:
             "behind": behind,
         }
 
+    def payload_diff_name_status(self, left_ref: str, right_ref: str) -> str:
+        self.validate(require_clean=False)
+        return self._git(
+            "diff", "--name-status", left_ref, right_ref, "--", PAYLOAD_DIR_NAME
+        )
+
+    def payload_diff_patch(self, left_ref: str, right_ref: str) -> str:
+        self.validate(require_clean=False)
+        return self._git(
+            "diff",
+            "--no-ext-diff",
+            "--unified=3",
+            left_ref,
+            right_ref,
+            "--",
+            PAYLOAD_DIR_NAME,
+        )
+
+    def payload_worktree_diff_patch(self) -> str:
+        self.validate(require_clean=False)
+        return self._git("diff", "--no-ext-diff", "--unified=3", "--", PAYLOAD_DIR_NAME)
+
+    def discard_payload_changes(self) -> None:
+        self._discard_payload_changes()
+
+    def discard_payload_paths(self, paths: list[str]) -> None:
+        payload_paths: list[str] = []
+        for path in paths:
+            normalized = path.replace("\\", "/").removeprefix(f"{PAYLOAD_DIR_NAME}/")
+            if normalized.strip():
+                payload_paths.append(f"{PAYLOAD_DIR_NAME}/{normalized}")
+        if not payload_paths:
+            return
+        try:
+            self._git("checkout", "--", *payload_paths)
+        except RuntimeError:
+            pass
+        try:
+            self._git("clean", "-f", "--", *payload_paths)
+        except RuntimeError:
+            pass
+
     def pull_ff_only(self) -> str:
         self._discard_payload_changes()
         self.validate(require_clean=False)
@@ -119,6 +161,10 @@ class GitHubSyncProvider:
     def has_meaningful_payload_changes(self) -> bool:
         status = self._git("status", "--porcelain", "--", PAYLOAD_DIR_NAME).strip()
         return bool(status and not _only_metadata_changed(status))
+
+    def payload_status(self) -> str:
+        self.validate(require_clean=False)
+        return self._git("status", "--porcelain", "--", PAYLOAD_DIR_NAME)
 
     def is_clean(self) -> bool:
         return not self._git("status", "--porcelain").strip()
@@ -211,6 +257,8 @@ class GitHubSyncProvider:
             ["git", *args],
             cwd=self.repo_path,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             capture_output=True,
             check=False,
         )

--- a/src/suzent/sync/service.py
+++ b/src/suzent/sync/service.py
@@ -9,7 +9,13 @@ from pathlib import Path
 from suzent.config import get_data_dir
 from suzent.logger import get_logger
 from suzent.sync.conflicts import SyncConflictResolver
-from suzent.sync.models import SecretBundlesFile, SyncManifest, SyncProfile
+from suzent.sync.models import (
+    SecretBundlesFile,
+    SyncFileChange,
+    SyncManifest,
+    SyncPlan,
+    SyncProfile,
+)
 from suzent.sync.payload import MANIFEST_PATH, PAYLOAD_DIR_NAME, SyncPayloadBuilder
 from suzent.sync.provider import GitHubSyncProvider
 from suzent.sync.quickstart import (
@@ -20,6 +26,12 @@ from suzent.sync.quickstart import (
 from suzent.sync.secrets import SECRET_BUNDLES_PATH, EncryptedSecretSync
 
 logger = get_logger(__name__)
+
+
+class DestructiveSyncPlanError(ValueError):
+    def __init__(self, plan: SyncPlan) -> None:
+        super().__init__("Sync requires confirmation before destructive changes")
+        self.plan = plan
 
 
 class GitHubSyncService:
@@ -287,20 +299,72 @@ class GitHubSyncService:
         result["payload_hashes"] = self.payload_builder.content_hashes(payload_dir)
         return result
 
+    def preview_sync_plan(
+        self,
+        operation: str,
+        profile_id: str | None = None,
+    ) -> SyncPlan:
+        if operation not in {"push", "pull", "auto"}:
+            raise ValueError(f"Unknown sync operation: {operation}")
+        profile = self.get_profile(profile_id)
+        repo_path = Path(profile.repo_path)
+        provider = GitHubSyncProvider(
+            repo_path, remote=profile.remote, branch=profile.branch
+        )
+
+        if operation in {"push", "auto"}:
+            self.payload_builder.build(repo_path, profile)
+            status = provider.payload_status()
+            plan = _plan_from_status(operation, status)
+            _attach_diff_previews(plan, provider.payload_worktree_diff_patch())
+            _attach_added_file_previews(plan, repo_path)
+            if operation == "auto":
+                incoming = _incoming_tracking_plan(provider, profile, "auto")
+                plan = _merge_plans("auto", [plan, incoming])
+            return plan
+
+        preview = provider.preview_pull()
+        remote_ref = f"{profile.remote}/{profile.branch}"
+        diff = provider.payload_diff_name_status("HEAD", remote_ref)
+        plan = _plan_from_name_status("pull", diff)
+        _attach_diff_previews(plan, provider.payload_diff_patch("HEAD", remote_ref))
+        behind = int(preview.get("behind") or 0)
+        if behind and not plan.files:
+            plan.warnings.append(f"{behind} remote commit(s) have no payload changes.")
+        return plan
+
     async def pull(
-        self, profile_id: str | None = None, *, shibboleth: str | None = None
+        self,
+        profile_id: str | None = None,
+        *,
+        shibboleth: str | None = None,
+        confirm_destructive: bool = False,
+        prefer_cloud: bool = False,
+        paths: list[str] | None = None,
     ) -> dict:
         profile = self.get_profile(profile_id)
         async with self._lock(profile):
             provider = GitHubSyncProvider(
                 Path(profile.repo_path), remote=profile.remote, branch=profile.branch
             )
+            plan = await asyncio.to_thread(self.preview_sync_plan, "pull", profile.id)
+            if plan.requires_confirmation and not confirm_destructive:
+                raise DestructiveSyncPlanError(plan)
             git_output = await asyncio.to_thread(provider.pull_ff_only)
             payload_dir = Path(profile.repo_path) / PAYLOAD_DIR_NAME
             phrase = self._require_shibboleth_for_pull(profile, payload_dir, shibboleth)
-            restored = await asyncio.to_thread(
-                self.payload_builder.apply_to_local, payload_dir
-            )
+            if paths:
+                restored = await asyncio.to_thread(
+                    self.payload_builder.apply_paths_to_local,
+                    payload_dir,
+                    paths,
+                )
+            else:
+                restored = await asyncio.to_thread(
+                    self.payload_builder.apply_to_local,
+                    payload_dir,
+                    replace_memory=prefer_cloud,
+                )
             imported_keys: list[str] = []
             changed_keys: list[str] = []
             if phrase:
@@ -329,10 +393,54 @@ class GitHubSyncService:
                 "restored": restored,
                 "imported_secret_keys": imported_keys,
                 "changed_secret_keys": changed_keys,
+                "prefer_cloud": prefer_cloud,
+                "paths": paths or [],
+            }
+
+    async def discard_outgoing(
+        self, profile_id: str | None = None, *, paths: list[str] | None = None
+    ) -> dict:
+        profile = self.get_profile(profile_id)
+        async with self._lock(profile):
+            repo_path = Path(profile.repo_path)
+            provider = GitHubSyncProvider(
+                repo_path, remote=profile.remote, branch=profile.branch
+            )
+            plan = await asyncio.to_thread(self.preview_sync_plan, "push", profile.id)
+            outgoing = [
+                change for change in plan.files if change.direction == "outgoing"
+            ]
+            allowed_paths = {change.path for change in outgoing}
+            selected_paths = [
+                path
+                for path in (paths or sorted(allowed_paths))
+                if path in allowed_paths
+            ]
+            if paths and len(selected_paths) != len(paths):
+                unknown = sorted(set(paths) - allowed_paths)
+                raise ValueError(f"Unknown outgoing sync path(s): {', '.join(unknown)}")
+            if selected_paths:
+                await asyncio.to_thread(provider.discard_payload_paths, selected_paths)
+            payload_dir = repo_path / PAYLOAD_DIR_NAME
+            restored = await asyncio.to_thread(
+                self.payload_builder.apply_paths_to_local,
+                payload_dir,
+                selected_paths,
+            )
+            await asyncio.to_thread(_reload_runtime)
+            return {
+                "success": True,
+                "discarded": selected_paths,
+                "restored": restored,
+                "plan": plan.model_dump(mode="json"),
             }
 
     async def push(
-        self, profile_id: str | None = None, *, shibboleth: str | None = None
+        self,
+        profile_id: str | None = None,
+        *,
+        shibboleth: str | None = None,
+        confirm_destructive: bool = False,
     ) -> dict:
         profile = self.get_profile(profile_id)
         async with self._lock(profile):
@@ -373,6 +481,11 @@ class GitHubSyncService:
             provider = GitHubSyncProvider(
                 repo_path, remote=profile.remote, branch=profile.branch
             )
+            plan = _plan_from_status("push", provider.payload_status())
+            _attach_diff_previews(plan, provider.payload_worktree_diff_patch())
+            _attach_added_file_previews(plan, repo_path)
+            if plan.requires_confirmation and not confirm_destructive:
+                raise DestructiveSyncPlanError(plan)
             git_output = await asyncio.to_thread(
                 provider.commit_and_push_payload, manifest.revision_id
             )
@@ -387,7 +500,11 @@ class GitHubSyncService:
             }
 
     async def auto_sync(
-        self, profile_id: str | None = None, *, shibboleth: str | None = None
+        self,
+        profile_id: str | None = None,
+        *,
+        shibboleth: str | None = None,
+        confirm_destructive: bool = False,
     ) -> dict:
         profile = self.get_profile(profile_id)
         async with self._lock(profile):
@@ -418,6 +535,18 @@ class GitHubSyncService:
             forbidden = self.payload_builder.validate_no_forbidden_paths(payload_dir)
             if forbidden:
                 raise ValueError(f"Sync payload contains forbidden paths: {forbidden}")
+
+            plan = _plan_from_status("auto", provider.payload_status())
+            _attach_diff_previews(plan, provider.payload_worktree_diff_patch())
+            _attach_added_file_previews(plan, repo_path)
+            incoming = _incoming_tracking_plan(provider, profile, "auto")
+            plan = _merge_plans("auto", [plan, incoming])
+            if plan.requires_confirmation and not confirm_destructive:
+                return {
+                    "success": False,
+                    "blocked_review_required": True,
+                    "plan": plan.model_dump(mode="json"),
+                }
 
             restored: list[str] = []
             imported: list[str] = []
@@ -671,6 +800,241 @@ def _replace_tree(source: Path, target: Path) -> None:
     if target.exists():
         shutil.rmtree(target)
     shutil.copytree(source, target)
+
+
+def _plan_from_status(operation: str, porcelain_output: str) -> SyncPlan:
+    changes: list[SyncFileChange] = []
+    for line in porcelain_output.splitlines():
+        if not line.strip():
+            continue
+        status = line[:2]
+        path = _status_path(line).removeprefix(f"{PAYLOAD_DIR_NAME}/")
+        changes.append(_make_change(path, _change_type_from_status(status), "outgoing"))
+    return _finalize_plan(operation, changes)
+
+
+def _plan_from_name_status(operation: str, diff_output: str) -> SyncPlan:
+    changes: list[SyncFileChange] = []
+    for line in diff_output.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        status = parts[0]
+        path = parts[-1].replace("\\", "/").removeprefix(f"{PAYLOAD_DIR_NAME}/")
+        changes.append(
+            _make_change(path, _change_type_from_name_status(status), "incoming")
+        )
+    return _finalize_plan(operation, changes)
+
+
+def _merge_plans(operation: str, plans: list[SyncPlan]) -> SyncPlan:
+    changes: list[SyncFileChange] = []
+    warnings: list[str] = []
+    for plan in plans:
+        changes.extend(plan.files)
+        warnings.extend(plan.warnings)
+    merged = _finalize_plan(operation, changes)
+    merged.warnings = list(dict.fromkeys([*merged.warnings, *warnings]))
+    return merged
+
+
+def _incoming_tracking_plan(
+    provider: GitHubSyncProvider,
+    profile: SyncProfile,
+    operation: str,
+) -> SyncPlan:
+    remote_ref = f"{profile.remote}/{profile.branch}"
+    try:
+        plan = _plan_from_name_status(
+            operation,
+            provider.payload_diff_name_status("HEAD", remote_ref),
+        )
+        _attach_diff_previews(plan, provider.payload_diff_patch("HEAD", remote_ref))
+        return plan
+    except Exception as exc:
+        logger.debug("Unable to preview incoming sync changes: %s", exc)
+        return _finalize_plan(operation, [])
+
+
+def _attach_diff_previews(plan: SyncPlan, diff_output: str) -> None:
+    if not diff_output.strip():
+        return
+    patches = _split_diff_by_path(diff_output)
+    for change in plan.files:
+        if change.category == "secrets":
+            continue
+        patch = patches.get(change.path)
+        if patch:
+            change.diff_preview = _trim_diff_preview(patch)
+
+
+def _attach_added_file_previews(plan: SyncPlan, repo_path: Path) -> None:
+    for change in plan.files:
+        if (
+            change.diff_preview
+            or change.change_type != "added"
+            or change.category in {"secrets", "sync"}
+        ):
+            continue
+        path = repo_path / PAYLOAD_DIR_NAME / change.path
+        if not path.is_file():
+            continue
+        try:
+            raw = path.read_bytes()
+        except OSError:
+            continue
+        if b"\x00" in raw:
+            continue
+        text = raw[:12000].decode("utf-8", errors="replace")
+        if len(raw) > len(raw[:12000]):
+            text += "\n... file truncated ..."
+        change.diff_preview = f"+++ {change.path}\n{text}"
+
+
+def _split_diff_by_path(diff_output: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    current_path: str | None = None
+    current_lines: list[str] = []
+    for line in diff_output.splitlines():
+        if line.startswith("diff --git "):
+            if current_path and current_lines:
+                result[current_path] = "\n".join(current_lines)
+            current_path = _path_from_diff_header(line)
+            current_lines = [line]
+            continue
+        if current_path:
+            current_lines.append(line)
+    if current_path and current_lines:
+        result[current_path] = "\n".join(current_lines)
+    return result
+
+
+def _path_from_diff_header(line: str) -> str | None:
+    parts = line.split()
+    if len(parts) < 4:
+        return None
+    path = parts[3]
+    if path.startswith("b/"):
+        path = path[2:]
+    return path.replace("\\", "/").removeprefix(f"{PAYLOAD_DIR_NAME}/")
+
+
+def _trim_diff_preview(patch: str) -> str:
+    lines = patch.splitlines()
+    preview_lines = lines[:120]
+    preview = "\n".join(preview_lines)
+    if len(lines) > len(preview_lines):
+        preview += "\n... diff truncated ..."
+    if len(preview) > 12000:
+        preview = preview[:12000] + "\n... diff truncated ..."
+    return preview
+
+
+def _status_path(line: str) -> str:
+    value = line[3:] if len(line) > 3 else line
+    if " -> " in value:
+        value = value.split(" -> ", 1)[1]
+    return value.strip().replace("\\", "/")
+
+
+def _change_type_from_status(status: str) -> str:
+    if "D" in status:
+        return "deleted"
+    if "A" in status or "?" in status:
+        return "added"
+    return "modified"
+
+
+def _change_type_from_name_status(status: str) -> str:
+    if status.startswith("D"):
+        return "deleted"
+    if status.startswith("A"):
+        return "added"
+    return "modified"
+
+
+def _make_change(path: str, change_type: str, direction: str) -> SyncFileChange:
+    category = _sync_category(path)
+    risk = _risk_for_change(path, category, change_type)
+    return SyncFileChange(
+        path=path,
+        category=category,
+        change_type=change_type,
+        risk=risk,
+        direction=direction,
+    )
+
+
+def _sync_category(path: str) -> str:
+    if path.startswith("config/"):
+        return "config"
+    if path.startswith("skills/"):
+        return "skills"
+    if path.startswith("memory/"):
+        return "memory"
+    if path == SECRET_BUNDLES_PATH:
+        return "secrets"
+    if path.startswith("_sync/"):
+        return "sync"
+    return "other"
+
+
+def _risk_for_change(path: str, category: str, change_type: str) -> str:
+    if category == "memory" and change_type == "deleted":
+        return "high"
+    if category == "memory" and path in {
+        "memory/MEMORY.md",
+        "memory/persona.md",
+        "memory/user.md",
+    }:
+        return "high"
+    if category == "secrets" and change_type == "deleted":
+        return "high"
+    if category == "secrets":
+        return "medium"
+    if change_type == "deleted":
+        return "medium"
+    return "low"
+
+
+def _finalize_plan(operation: str, changes: list[SyncFileChange]) -> SyncPlan:
+    summary = {"added": 0, "modified": 0, "deleted": 0, "high_risk": 0}
+    for change in changes:
+        summary[change.change_type] += 1
+        if change.risk == "high":
+            summary["high_risk"] += 1
+
+    memory_deletes = [
+        change
+        for change in changes
+        if change.category == "memory" and change.change_type == "deleted"
+    ]
+    warnings: list[str] = []
+    if memory_deletes:
+        warnings.append(f"{len(memory_deletes)} memory file(s) would be deleted.")
+    if len(memory_deletes) >= 5:
+        warnings.append("Large memory deletion detected; review before syncing.")
+    secret_deletes = [
+        change
+        for change in changes
+        if change.category == "secrets" and change.change_type == "deleted"
+    ]
+    if secret_deletes:
+        warnings.append("The shared encrypted key vault would be deleted.")
+
+    destructive = bool(
+        memory_deletes or secret_deletes or any(c.risk == "high" for c in changes)
+    )
+    return SyncPlan(
+        operation=operation,
+        files=changes,
+        summary=summary,
+        destructive=destructive,
+        requires_confirmation=destructive,
+        warnings=warnings,
+    )
 
 
 _KEYRING_SERVICE = "suzent-sync-mnemonic"

--- a/tests/routes/test_sync_routes.py
+++ b/tests/routes/test_sync_routes.py
@@ -3,9 +3,27 @@ from pathlib import Path
 from starlette.testclient import TestClient
 
 from suzent.server import app
-from suzent.sync.models import SyncProfile
+from suzent.sync.models import SyncPlan, SyncProfile
 from suzent.sync.payload import PAYLOAD_DIR_NAME
-from suzent.sync.service import GitHubSyncService
+from suzent.sync.service import DestructiveSyncPlanError, GitHubSyncService
+
+
+def _review_plan(operation: str = "push") -> SyncPlan:
+    return SyncPlan(
+        operation=operation,
+        files=[
+            {
+                "path": "memory/archive/2026-07-08.md",
+                "category": "memory",
+                "change_type": "deleted",
+                "risk": "high",
+            }
+        ],
+        summary={"added": 0, "modified": 0, "deleted": 1, "high_risk": 1},
+        destructive=True,
+        requires_confirmation=True,
+        warnings=["1 memory file(s) would be deleted."],
+    )
 
 
 def test_sync_profile_create_read_status(tmp_path: Path):
@@ -82,3 +100,167 @@ def test_unlock_shibboleth_endpoint(tmp_path: Path):
     assert response.json()["shibboleth_unlocked"] is True
     status = client.get("/sync/status").json()
     assert status["shibboleth_unlocked"] is True
+
+
+def test_sync_plan_endpoint_returns_review_plan():
+    class FakeService:
+        def preview_sync_plan(self, operation: str, profile_id: str | None = None):
+            assert operation == "push"
+            assert profile_id == "profile-1"
+            return _review_plan(operation)
+
+    app.state.github_sync_service = FakeService()
+    client = TestClient(app)
+
+    response = client.post(
+        "/sync/plan",
+        json={"operation": "push", "profile_id": "profile-1"},
+    )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["requires_confirmation"] is True
+    assert result["files"][0]["path"] == "memory/archive/2026-07-08.md"
+    assert result["files"][0]["risk"] == "high"
+
+
+def test_push_sync_returns_409_when_review_is_required():
+    class FakeService:
+        async def push(
+            self,
+            profile_id: str | None = None,
+            *,
+            shibboleth: str | None = None,
+            confirm_destructive: bool = False,
+        ):
+            assert profile_id == "profile-1"
+            assert shibboleth is None
+            assert confirm_destructive is False
+            raise DestructiveSyncPlanError(_review_plan("push"))
+
+    app.state.github_sync_service = FakeService()
+    client = TestClient(app)
+
+    response = client.post("/sync/push", json={"profile_id": "profile-1"})
+
+    assert response.status_code == 409
+    result = response.json()
+    assert result["review_required"] is True
+    assert result["plan"]["operation"] == "push"
+    assert result["plan"]["warnings"] == ["1 memory file(s) would be deleted."]
+
+
+def test_confirmed_sync_routes_pass_destructive_confirmation():
+    calls: list[tuple[str, bool, bool]] = []
+
+    class FakeService:
+        async def pull(
+            self,
+            profile_id: str | None = None,
+            *,
+            shibboleth: str | None = None,
+            confirm_destructive: bool = False,
+            prefer_cloud: bool = False,
+            paths: list[str] | None = None,
+        ):
+            assert profile_id == "profile-1"
+            assert paths is None
+            calls.append(("pull", confirm_destructive, prefer_cloud))
+            return {"success": True}
+
+        async def push(
+            self,
+            profile_id: str | None = None,
+            *,
+            shibboleth: str | None = None,
+            confirm_destructive: bool = False,
+        ):
+            assert profile_id == "profile-1"
+            calls.append(("push", confirm_destructive, False))
+            return {"success": True}
+
+        async def auto_sync(
+            self,
+            profile_id: str | None = None,
+            *,
+            shibboleth: str | None = None,
+            confirm_destructive: bool = False,
+        ):
+            assert profile_id == "profile-1"
+            calls.append(("auto", confirm_destructive, False))
+            return {"success": True}
+
+    app.state.github_sync_service = FakeService()
+    client = TestClient(app)
+
+    for route in ("/sync/pull", "/sync/push", "/sync/auto/run"):
+        response = client.post(
+            route,
+            json={"profile_id": "profile-1", "confirm_destructive": True},
+        )
+        assert response.status_code == 200
+
+    assert calls == [
+        ("pull", True, False),
+        ("push", True, False),
+        ("auto", True, False),
+    ]
+
+
+def test_pull_sync_passes_prefer_cloud():
+    class FakeService:
+        async def pull(
+            self,
+            profile_id: str | None = None,
+            *,
+            shibboleth: str | None = None,
+            confirm_destructive: bool = False,
+            prefer_cloud: bool = False,
+            paths: list[str] | None = None,
+        ):
+            assert profile_id == "profile-1"
+            assert confirm_destructive is True
+            assert prefer_cloud is True
+            assert paths == ["memory/MEMORY.md"]
+            return {"success": True, "prefer_cloud": prefer_cloud, "paths": paths}
+
+    app.state.github_sync_service = FakeService()
+    client = TestClient(app)
+
+    response = client.post(
+        "/sync/pull",
+        json={
+            "profile_id": "profile-1",
+            "confirm_destructive": True,
+            "prefer_cloud": True,
+            "paths": ["memory/MEMORY.md"],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["prefer_cloud"] is True
+    assert response.json()["paths"] == ["memory/MEMORY.md"]
+
+
+def test_discard_outgoing_route_calls_service():
+    class FakeService:
+        async def discard_outgoing(
+            self,
+            profile_id: str | None = None,
+            *,
+            paths: list[str] | None = None,
+        ):
+            assert profile_id == "profile-1"
+            assert paths == ["memory/MEMORY.md"]
+            return {"success": True, "discarded": paths}
+
+    app.state.github_sync_service = FakeService()
+    client = TestClient(app)
+
+    response = client.post(
+        "/sync/discard-outgoing",
+        json={"profile_id": "profile-1", "paths": ["memory/MEMORY.md"]},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["discarded"] == ["memory/MEMORY.md"]

--- a/tests/sync/test_payload.py
+++ b/tests/sync/test_payload.py
@@ -97,6 +97,74 @@ def test_manifest_hashes_change_when_portable_file_changes(tmp_path: Path):
     )
 
 
+def test_build_preserves_existing_payload_memory_when_local_memory_is_partial(
+    tmp_path: Path,
+):
+    config_dir = tmp_path / "config"
+    skills_dir = tmp_path / "skills"
+    memory_dir = tmp_path / "sandbox" / "shared" / "memory"
+    repo = tmp_path / "repo"
+    payload_memory = repo / PAYLOAD_DIR_NAME / "memory"
+    config_dir.mkdir()
+    skills_dir.mkdir()
+    memory_dir.mkdir(parents=True)
+    payload_memory.mkdir(parents=True)
+    (payload_memory / "MEMORY.md").write_text("remote summary\n", encoding="utf-8")
+    (payload_memory / "archive" / "2026-07-08.md").parent.mkdir()
+    (payload_memory / "archive" / "2026-07-08.md").write_text(
+        "older fact\n",
+        encoding="utf-8",
+    )
+    (memory_dir / "archive").mkdir()
+    (memory_dir / "archive" / "2026-07-09.md").write_text(
+        "new fact\n",
+        encoding="utf-8",
+    )
+
+    builder = SyncPayloadBuilder(
+        user_config_dir=config_dir,
+        user_skills_dir=skills_dir,
+        sandbox_data_path=tmp_path / "sandbox",
+    )
+
+    manifest = builder.build(repo, SyncProfile(repo_path=str(repo)))
+
+    included = set(manifest.included_paths)
+    assert "memory/MEMORY.md" in included
+    assert "memory/archive/2026-07-08.md" in included
+    assert "memory/archive/2026-07-09.md" in included
+    assert (payload_memory / "MEMORY.md").read_text(
+        encoding="utf-8"
+    ) == "remote summary\n"
+
+
+def test_build_preserves_existing_encrypted_secret_vault(tmp_path: Path):
+    config_dir = tmp_path / "config"
+    skills_dir = tmp_path / "skills"
+    memory_dir = tmp_path / "sandbox" / "shared" / "memory"
+    repo = tmp_path / "repo"
+    bundles_path = repo / PAYLOAD_DIR_NAME / "_sync" / "secrets" / "bundles.json"
+    config_dir.mkdir()
+    skills_dir.mkdir()
+    memory_dir.mkdir(parents=True)
+    bundles_path.parent.mkdir(parents=True)
+    bundles_path.write_text('{"format_version":2,"bundles":[]}\n', encoding="utf-8")
+
+    builder = SyncPayloadBuilder(
+        user_config_dir=config_dir,
+        user_skills_dir=skills_dir,
+        sandbox_data_path=tmp_path / "sandbox",
+    )
+
+    manifest = builder.build(repo, SyncProfile(repo_path=str(repo)))
+
+    assert (
+        bundles_path.read_text(encoding="utf-8")
+        == '{"format_version":2,"bundles":[]}\n'
+    )
+    assert "_sync/secrets/bundles.json" in manifest.included_paths
+
+
 def test_apply_to_local_preserves_device_local_sync_profile(tmp_path: Path):
     payload_dir = tmp_path / "payload"
     source_config = payload_dir / "config"
@@ -129,3 +197,135 @@ def test_apply_to_local_preserves_device_local_sync_profile(tmp_path: Path):
     assert "local-device" in (target_config / "sync_profiles.json").read_text(
         encoding="utf-8"
     )
+
+
+def test_apply_to_local_merges_memory_without_deleting_local_only_files(
+    tmp_path: Path,
+):
+    payload_dir = tmp_path / "payload"
+    source_memory = payload_dir / "memory"
+    target_sandbox = tmp_path / "local" / "sandbox"
+    target_memory = target_sandbox / "shared" / "memory"
+    source_memory.mkdir(parents=True)
+    target_memory.mkdir(parents=True)
+    (source_memory / "archive").mkdir()
+    (source_memory / "archive" / "2026-07-09.md").write_text(
+        "remote today\n",
+        encoding="utf-8",
+    )
+    (target_memory / "MEMORY.md").write_text("local summary\n", encoding="utf-8")
+    (target_memory / "archive").mkdir(exist_ok=True)
+    (target_memory / "archive" / "2026-07-08.md").write_text(
+        "local older fact\n",
+        encoding="utf-8",
+    )
+
+    builder = SyncPayloadBuilder(
+        user_config_dir=tmp_path / "local" / "config",
+        user_skills_dir=tmp_path / "local" / "skills",
+        sandbox_data_path=target_sandbox,
+    )
+
+    restored = builder.apply_to_local(payload_dir)
+
+    assert restored == ["memory"]
+    assert (target_memory / "MEMORY.md").read_text(
+        encoding="utf-8"
+    ) == "local summary\n"
+    assert (target_memory / "archive" / "2026-07-08.md").read_text(
+        encoding="utf-8"
+    ) == "local older fact\n"
+    assert (target_memory / "archive" / "2026-07-09.md").read_text(
+        encoding="utf-8"
+    ) == "remote today\n"
+
+
+def test_apply_to_local_can_replace_memory_when_cloud_is_authority(tmp_path: Path):
+    payload_dir = tmp_path / "payload"
+    source_memory = payload_dir / "memory"
+    target_sandbox = tmp_path / "local" / "sandbox"
+    target_memory = target_sandbox / "shared" / "memory"
+    source_memory.mkdir(parents=True)
+    target_memory.mkdir(parents=True)
+    (source_memory / "MEMORY.md").write_text("cloud summary\n", encoding="utf-8")
+    (target_memory / "MEMORY.md").write_text("local summary\n", encoding="utf-8")
+    (target_memory / "local-only.md").write_text("local only\n", encoding="utf-8")
+    (target_memory / "sessions" / "abc").mkdir(parents=True)
+    (target_memory / "sessions" / "abc" / "context.md").write_text(
+        "device local\n",
+        encoding="utf-8",
+    )
+
+    builder = SyncPayloadBuilder(
+        user_config_dir=tmp_path / "local" / "config",
+        user_skills_dir=tmp_path / "local" / "skills",
+        sandbox_data_path=target_sandbox,
+    )
+
+    restored = builder.apply_to_local(payload_dir, replace_memory=True)
+
+    assert restored == ["memory"]
+    assert (target_memory / "MEMORY.md").read_text(
+        encoding="utf-8"
+    ) == "cloud summary\n"
+    assert not (target_memory / "local-only.md").exists()
+    assert (target_memory / "sessions" / "abc" / "context.md").read_text(
+        encoding="utf-8"
+    ) == "device local\n"
+
+
+def test_apply_paths_to_local_restores_selected_file(tmp_path: Path):
+    payload_dir = tmp_path / "payload"
+    source_config = payload_dir / "config"
+    target_config = tmp_path / "local" / "config"
+    source_config.mkdir(parents=True)
+    target_config.mkdir(parents=True)
+    (source_config / "providers.json").write_text('{"cloud": true}\n', encoding="utf-8")
+    (source_config / "other.json").write_text('{"cloud": "other"}\n', encoding="utf-8")
+    (target_config / "providers.json").write_text('{"local": true}\n', encoding="utf-8")
+    (target_config / "other.json").write_text('{"local": "other"}\n', encoding="utf-8")
+
+    builder = SyncPayloadBuilder(
+        user_config_dir=target_config,
+        user_skills_dir=tmp_path / "local" / "skills",
+        sandbox_data_path=tmp_path / "local" / "sandbox",
+    )
+
+    restored = builder.apply_paths_to_local(payload_dir, ["config/providers.json"])
+
+    assert restored == ["config/providers.json"]
+    assert (target_config / "providers.json").read_text(
+        encoding="utf-8"
+    ) == '{"cloud": true}\n'
+    assert (target_config / "other.json").read_text(
+        encoding="utf-8"
+    ) == '{"local": "other"}\n'
+
+
+def test_apply_paths_to_local_deletes_selected_missing_file(tmp_path: Path):
+    payload_dir = tmp_path / "payload"
+    target_sandbox = tmp_path / "local" / "sandbox"
+    target_memory = target_sandbox / "shared" / "memory"
+    payload_dir.mkdir()
+    target_memory.mkdir(parents=True)
+    (target_memory / "scratch.md").write_text("local only\n", encoding="utf-8")
+    (target_memory / "sessions" / "abc").mkdir(parents=True)
+    (target_memory / "sessions" / "abc" / "context.md").write_text(
+        "device local\n",
+        encoding="utf-8",
+    )
+
+    builder = SyncPayloadBuilder(
+        user_config_dir=tmp_path / "local" / "config",
+        user_skills_dir=tmp_path / "local" / "skills",
+        sandbox_data_path=target_sandbox,
+    )
+
+    restored = builder.apply_paths_to_local(
+        payload_dir,
+        ["memory/scratch.md", "memory/sessions/abc/context.md"],
+    )
+
+    assert restored == ["memory/scratch.md", "memory/sessions/abc/context.md"]
+    assert not (target_memory / "scratch.md").exists()
+    assert (target_memory / "sessions" / "abc" / "context.md").exists()

--- a/tests/sync/test_service_auto_sync.py
+++ b/tests/sync/test_service_auto_sync.py
@@ -25,14 +25,24 @@ class FakePayloadBuilder:
         self.calls.append("validate")
         return []
 
-    def apply_to_local(self, payload_dir: Path) -> list[str]:
-        self.calls.append("apply")
+    def apply_to_local(
+        self, payload_dir: Path, *, replace_memory: bool = False
+    ) -> list[str]:
+        self.calls.append("apply-replace" if replace_memory else "apply")
         return ["config"]
+
+    def apply_paths_to_local(self, payload_dir: Path, paths: list[str]) -> list[str]:
+        self.calls.append(f"apply-paths:{','.join(paths)}")
+        return paths
 
 
 class FakeProvider:
     git_output = "pushed"
     meaningful_changes = True
+    payload_status_output = ""
+    payload_diff_output = ""
+    payload_remote_status_output = ""
+    payload_remote_diff_output = ""
     calls: list[str] = []
 
     def __init__(self, repo_path: Path, *, remote: str, branch: str) -> None:
@@ -46,9 +56,31 @@ class FakeProvider:
         self.calls.append("changed")
         return self.meaningful_changes
 
+    def payload_status(self) -> str:
+        self.calls.append("status")
+        return self.payload_status_output
+
+    def payload_worktree_diff_patch(self) -> str:
+        self.calls.append("diff")
+        return self.payload_diff_output
+
+    def payload_diff_name_status(self, left_ref: str, right_ref: str) -> str:
+        self.calls.append("remote-status")
+        return self.payload_remote_status_output
+
+    def payload_diff_patch(self, left_ref: str, right_ref: str) -> str:
+        self.calls.append("remote-diff")
+        return self.payload_remote_diff_output
+
     def pull_ff_only(self) -> str:
         self.calls.append("pull")
         return "pulled"
+
+    def discard_payload_changes(self) -> None:
+        self.calls.append("discard")
+
+    def discard_payload_paths(self, paths: list[str]) -> None:
+        self.calls.append(f"discard-paths:{','.join(paths)}")
 
 
 def test_auto_sync_pushes_local_payload_before_remote_apply(
@@ -58,6 +90,10 @@ def test_auto_sync_pushes_local_payload_before_remote_apply(
     FakeProvider.calls = calls
     FakeProvider.git_output = "pushed"
     FakeProvider.meaningful_changes = True
+    FakeProvider.payload_status_output = ""
+    FakeProvider.payload_diff_output = ""
+    FakeProvider.payload_remote_status_output = ""
+    FakeProvider.payload_remote_diff_output = ""
     monkeypatch.setattr(service_module, "GitHubSyncProvider", FakeProvider)
     monkeypatch.setattr(
         service_module, "_reload_runtime", lambda: calls.append("reload")
@@ -71,7 +107,17 @@ def test_auto_sync_pushes_local_payload_before_remote_apply(
 
     asyncio.run(service.auto_sync(profile.id))
 
-    assert calls == ["build", "validate", "changed", "pull", "push"]
+    assert calls == [
+        "build",
+        "validate",
+        "status",
+        "diff",
+        "remote-status",
+        "remote-diff",
+        "changed",
+        "pull",
+        "push",
+    ]
 
 
 def test_auto_sync_applies_remote_when_local_payload_has_no_changes(
@@ -81,6 +127,10 @@ def test_auto_sync_applies_remote_when_local_payload_has_no_changes(
     FakeProvider.calls = calls
     FakeProvider.git_output = "No sync payload changes to push."
     FakeProvider.meaningful_changes = False
+    FakeProvider.payload_status_output = ""
+    FakeProvider.payload_diff_output = ""
+    FakeProvider.payload_remote_status_output = ""
+    FakeProvider.payload_remote_diff_output = ""
     monkeypatch.setattr(service_module, "GitHubSyncProvider", FakeProvider)
     monkeypatch.setattr(
         service_module, "_reload_runtime", lambda: calls.append("reload")
@@ -94,4 +144,179 @@ def test_auto_sync_applies_remote_when_local_payload_has_no_changes(
 
     asyncio.run(service.auto_sync(profile.id))
 
-    assert calls == ["build", "validate", "changed", "pull", "apply", "reload"]
+    assert calls == [
+        "build",
+        "validate",
+        "status",
+        "diff",
+        "remote-status",
+        "remote-diff",
+        "changed",
+        "pull",
+        "apply",
+        "reload",
+    ]
+
+
+def test_auto_sync_blocks_destructive_memory_deletes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    calls: list[str] = []
+    FakeProvider.calls = calls
+    FakeProvider.meaningful_changes = True
+    FakeProvider.payload_status_output = " D suzent-sync/memory/archive/2026-07-08.md\n"
+    FakeProvider.payload_remote_status_output = ""
+    FakeProvider.payload_remote_diff_output = ""
+    FakeProvider.payload_diff_output = """diff --git a/suzent-sync/memory/archive/2026-07-08.md b/suzent-sync/memory/archive/2026-07-08.md
+deleted file mode 100644
+--- a/suzent-sync/memory/archive/2026-07-08.md
++++ /dev/null
+@@ -1 +0,0 @@
+-old memory
+"""
+    monkeypatch.setattr(service_module, "GitHubSyncProvider", FakeProvider)
+
+    service = GitHubSyncService(
+        profiles_path=tmp_path / "profiles.json",
+        payload_builder=FakePayloadBuilder(calls),
+    )
+    profile = service.save_profile(SyncProfile(repo_path=str(tmp_path / "repo")))
+
+    result = asyncio.run(service.auto_sync(profile.id))
+
+    assert result["success"] is False
+    assert result["blocked_review_required"] is True
+    assert result["plan"]["requires_confirmation"] is True
+    assert "old memory" in result["plan"]["files"][0]["diff_preview"]
+    assert result["plan"]["files"][0]["direction"] == "outgoing"
+    assert calls == [
+        "build",
+        "validate",
+        "status",
+        "diff",
+        "remote-status",
+        "remote-diff",
+    ]
+
+
+def test_auto_sync_blocks_shared_key_vault_delete(tmp_path: Path, monkeypatch) -> None:
+    calls: list[str] = []
+    FakeProvider.calls = calls
+    FakeProvider.meaningful_changes = True
+    FakeProvider.payload_status_output = " D suzent-sync/_sync/secrets/bundles.json\n"
+    FakeProvider.payload_remote_status_output = ""
+    FakeProvider.payload_remote_diff_output = ""
+    FakeProvider.payload_diff_output = """diff --git a/suzent-sync/_sync/secrets/bundles.json b/suzent-sync/_sync/secrets/bundles.json
+deleted file mode 100644
+--- a/suzent-sync/_sync/secrets/bundles.json
++++ /dev/null
+@@ -1 +0,0 @@
+-ciphertext
+"""
+    monkeypatch.setattr(service_module, "GitHubSyncProvider", FakeProvider)
+
+    service = GitHubSyncService(
+        profiles_path=tmp_path / "profiles.json",
+        payload_builder=FakePayloadBuilder(calls),
+    )
+    profile = service.save_profile(SyncProfile(repo_path=str(tmp_path / "repo")))
+
+    result = asyncio.run(service.auto_sync(profile.id))
+
+    assert result["success"] is False
+    assert result["blocked_review_required"] is True
+    assert result["plan"]["requires_confirmation"] is True
+    assert result["plan"]["summary"]["high_risk"] == 1
+    assert result["plan"]["files"][0]["category"] == "secrets"
+    assert result["plan"]["files"][0]["risk"] == "high"
+    assert result["plan"]["files"][0]["direction"] == "outgoing"
+    assert result["plan"]["files"][0]["diff_preview"] is None
+    assert (
+        "shared encrypted key vault would be deleted" in result["plan"]["warnings"][0]
+    )
+    assert calls == [
+        "build",
+        "validate",
+        "status",
+        "diff",
+        "remote-status",
+        "remote-diff",
+    ]
+
+
+def test_discard_outgoing_restores_local_from_cloud_payload(
+    tmp_path: Path, monkeypatch
+) -> None:
+    calls: list[str] = []
+    FakeProvider.calls = calls
+    FakeProvider.payload_status_output = " M suzent-sync/memory/MEMORY.md\n"
+    FakeProvider.payload_diff_output = """diff --git a/suzent-sync/memory/MEMORY.md b/suzent-sync/memory/MEMORY.md
+--- a/suzent-sync/memory/MEMORY.md
++++ b/suzent-sync/memory/MEMORY.md
+@@ -1 +1 @@
+-cloud
++local
+"""
+    FakeProvider.payload_remote_status_output = ""
+    FakeProvider.payload_remote_diff_output = ""
+    monkeypatch.setattr(service_module, "GitHubSyncProvider", FakeProvider)
+    monkeypatch.setattr(
+        service_module, "_reload_runtime", lambda: calls.append("reload")
+    )
+
+    service = GitHubSyncService(
+        profiles_path=tmp_path / "profiles.json",
+        payload_builder=FakePayloadBuilder(calls),
+    )
+    profile = service.save_profile(SyncProfile(repo_path=str(tmp_path / "repo")))
+
+    result = asyncio.run(service.discard_outgoing(profile.id))
+
+    assert result["success"] is True
+    assert result["discarded"] == ["memory/MEMORY.md"]
+    assert calls == [
+        "build",
+        "status",
+        "diff",
+        "discard-paths:memory/MEMORY.md",
+        "apply-paths:memory/MEMORY.md",
+        "reload",
+    ]
+
+
+def test_discard_outgoing_can_restore_one_selected_path(
+    tmp_path: Path, monkeypatch
+) -> None:
+    calls: list[str] = []
+    FakeProvider.calls = calls
+    FakeProvider.payload_status_output = (
+        " M suzent-sync/memory/MEMORY.md\n M suzent-sync/config/providers.json\n"
+    )
+    FakeProvider.payload_diff_output = ""
+    FakeProvider.payload_remote_status_output = ""
+    FakeProvider.payload_remote_diff_output = ""
+    monkeypatch.setattr(service_module, "GitHubSyncProvider", FakeProvider)
+    monkeypatch.setattr(
+        service_module, "_reload_runtime", lambda: calls.append("reload")
+    )
+
+    service = GitHubSyncService(
+        profiles_path=tmp_path / "profiles.json",
+        payload_builder=FakePayloadBuilder(calls),
+    )
+    profile = service.save_profile(SyncProfile(repo_path=str(tmp_path / "repo")))
+
+    result = asyncio.run(
+        service.discard_outgoing(profile.id, paths=["config/providers.json"])
+    )
+
+    assert result["success"] is True
+    assert result["discarded"] == ["config/providers.json"]
+    assert calls == [
+        "build",
+        "status",
+        "diff",
+        "discard-paths:config/providers.json",
+        "apply-paths:config/providers.json",
+        "reload",
+    ]


### PR DESCRIPTION
## Summary

Adds a VS Code-style GitHub sync review flow with per-file decisions for outgoing and incoming sync changes.

## Changes

- Preserves memory during sync payload rebuilds so partial local memory cannot become an accidental mass deletion.
- Preserves the encrypted secret vault during preview/rebuild so the watcher does not create a false `_sync/secrets/bundles.json` deletion.
- Adds sync plan preview models, backend planning, diff previews, destructive-change confirmation, and incoming/outgoing direction metadata.
- Adds row-level review actions in the frontend:
  - discard one outgoing file
  - apply one cloud/incoming file
  - discard all outgoing changes
  - pull cloud as source of truth
- Surfaces synced key names in the shared key vault panel without showing secret values.
- Fixes Git subprocess decoding to use UTF-8 replacement handling.

## Validation

- `ruff check src\suzent\sync\payload.py tests\sync\test_payload.py`
- `pytest tests\sync\test_payload.py tests\sync\test_service_auto_sync.py tests\routes\test_sync_routes.py` - 23 passed
- Earlier full PR validation also included frontend `npm run build`

Note: `gh` is not installed locally, so this PR was opened through the GitHub connector.