### PR TITLE
Add China setup mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ curl -fsSL https://raw.githubusercontent.com/cyzus/suzent/main/scripts/setup.sh 
 powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/cyzus/suzent/main/scripts/setup.ps1 | iex"
 ```
 
+**Mainland China mirror mode**
+```bash
+curl -fsSL https://raw.githubusercontent.com/cyzus/suzent/main/scripts/setup.sh | SUZENT_CHINA_MIRROR=1 bash
+```
+
+```powershell
+$env:SUZENT_CHINA_MIRROR="1"; powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/cyzus/suzent/main/scripts/setup.ps1 | iex"
+```
+
+This uses faster mirrors for PyPI, npm, Playwright, Node via nvm, and Rustup. If GitHub itself is slow, set `SUZENT_REPO_URL` or `SUZENT_RELEASE_BASE_URL` to a mirror you trust before running the command.
+
 Then bind your keys in `~/suzent/.env` and run:
 ```bash
 suzent start

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -123,6 +123,17 @@ curl -fsSL https://raw.githubusercontent.com/cyzus/suzent/main/scripts/setup.sh 
 powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/cyzus/suzent/main/scripts/setup.ps1 | iex"
 ```
 
+**中国大陆镜像模式**
+```bash
+curl -fsSL https://raw.githubusercontent.com/cyzus/suzent/main/scripts/setup.sh | SUZENT_CHINA_MIRROR=1 bash
+```
+
+```powershell
+$env:SUZENT_CHINA_MIRROR="1"; powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/cyzus/suzent/main/scripts/setup.ps1 | iex"
+```
+
+该模式会为 PyPI、npm、Playwright、nvm 下载 Node，以及 Rustup 启用国内镜像。如果 GitHub 本身访问较慢，可在运行前把 `SUZENT_REPO_URL` 或 `SUZENT_RELEASE_BASE_URL` 设置为你信任的镜像地址。
+
 然后在 `~/suzent/.env` 中绑定你的密钥并运行：
 ```bash
 suzent start

--- a/apps/suzent-installer/src/main.rs
+++ b/apps/suzent-installer/src/main.rs
@@ -13,6 +13,9 @@ const PROTOCOL_VERSION: u16 = 1;
 const TARGET_PYTHON_VERSION: &str = "3.12";
 const DEFAULT_BRANCH: &str = "main";
 const REPO_URL: &str = "https://github.com/cyzus/suzent.git";
+const UV_INSTALL_SH_URL: &str = "https://astral.sh/uv/install.sh";
+const UV_INSTALL_PS1_URL: &str = "https://astral.sh/uv/install.ps1";
+const RELEASE_BASE_URL: &str = "https://github.com/cyzus/suzent/releases/latest/download";
 
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
@@ -35,6 +38,11 @@ struct InstallConfig {
     dir: PathBuf,
     branch: String,
     skip_playwright: bool,
+    china_mirror: bool,
+    repo_url: String,
+    repo_url_override: bool,
+    uv_install_url: String,
+    release_base_url: String,
     json: bool,
     non_interactive: bool,
 }
@@ -220,11 +228,40 @@ impl InstallConfig {
             || env::var("SUZENT_SKIP_PLAYWRIGHT")
                 .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
                 .unwrap_or(false);
+        let china_mirror = has_flag(args, "--china-mirror")
+            || env::var("SUZENT_CHINA_MIRROR")
+                .map(|value| truthy_env(&value))
+                .unwrap_or(false);
+        let repo_url_env = env::var("SUZENT_REPO_URL")
+            .ok()
+            .filter(|value| !value.trim().is_empty());
+        let repo_url_override = repo_url_env.is_some();
+        let repo_url = repo_url_env.unwrap_or_else(|| REPO_URL.to_string());
+        let uv_install_url = env::var("SUZENT_UV_INSTALL_URL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| {
+                if cfg!(windows) {
+                    UV_INSTALL_PS1_URL.to_string()
+                } else {
+                    UV_INSTALL_SH_URL.to_string()
+                }
+            });
+        let release_base_url = env::var("SUZENT_RELEASE_BASE_URL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .map(|value| value.trim_end_matches('/').to_string())
+            .unwrap_or_else(|| RELEASE_BASE_URL.to_string());
 
         Self {
             dir,
             branch,
             skip_playwright,
+            china_mirror,
+            repo_url,
+            repo_url_override,
+            uv_install_url,
+            release_base_url,
             json: has_flag(args, "--json"),
             non_interactive: has_flag(args, "--non-interactive")
                 || has_flag(args, "--json")
@@ -412,18 +449,29 @@ fn stage_uv(_config: &InstallConfig) -> StageOutcome {
                 "-ExecutionPolicy",
                 "Bypass",
                 "-Command",
-                "irm https://astral.sh/uv/install.ps1 | iex",
+                &format!(
+                    "irm '{}' | iex",
+                    escape_powershell_single_quoted(&_config.uv_install_url)
+                ),
             ])
             .stdout(child_stdio())
             .stderr(child_stdio());
+        configure_mirror_env(&mut command, _config);
         hide_command_window(&mut command);
         run_command(&mut command)
     } else {
         let mut command = Command::new("sh");
         command
-            .args(["-c", "curl -LsSf https://astral.sh/uv/install.sh | sh"])
+            .args([
+                "-c",
+                &format!(
+                    "curl -LsSf '{}' | sh",
+                    shell_single_quote(&_config.uv_install_url)
+                ),
+            ])
             .stdout(child_stdio())
             .stderr(child_stdio());
+        configure_mirror_env(&mut command, _config);
         run_command(&mut command)
     };
 
@@ -435,7 +483,7 @@ fn stage_uv(_config: &InstallConfig) -> StageOutcome {
     StageOutcome::fail("uv is required. Install it from https://docs.astral.sh/uv/ and retry.")
 }
 
-fn stage_python(_config: &InstallConfig) -> StageOutcome {
+fn stage_python(config: &InstallConfig) -> StageOutcome {
     let Some(uv) = find_uv_after_install() else {
         return StageOutcome::fail("uv is not installed; run the uv stage first.");
     };
@@ -445,6 +493,7 @@ fn stage_python(_config: &InstallConfig) -> StageOutcome {
         .args(["python", "find", TARGET_PYTHON_VERSION])
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
+    configure_mirror_env(&mut find_command, config);
     hide_command_window(&mut find_command);
     log_command_start(&find_command);
     let found = find_command.output();
@@ -465,6 +514,7 @@ fn stage_python(_config: &InstallConfig) -> StageOutcome {
         .args(["python", "install", TARGET_PYTHON_VERSION])
         .stdout(child_stdio())
         .stderr(child_stdio());
+    configure_mirror_env(&mut install_command, config);
     let status = run_command(&mut install_command);
 
     if status {
@@ -482,9 +532,14 @@ fn stage_repository(config: &InstallConfig) -> StageOutcome {
 
     if config.dir.join(".git").exists() {
         print_human("Existing Suzent repository found. Updating...");
+        let update_remote = if config.repo_url_override {
+            config.repo_url.as_str()
+        } else {
+            "origin"
+        };
         if !run_command(
             Command::new(&git)
-                .args(["fetch", "origin"])
+                .args(["fetch", update_remote, &config.branch])
                 .current_dir(&config.dir),
         ) {
             return StageOutcome::fail("Failed to fetch repository updates.");
@@ -498,7 +553,7 @@ fn stage_repository(config: &InstallConfig) -> StageOutcome {
         let _ = run_command(&mut checkout_command);
         if !run_command(
             Command::new(&git)
-                .args(["pull", "origin", &config.branch])
+                .args(["pull", update_remote, &config.branch])
                 .current_dir(&config.dir),
         ) {
             return StageOutcome::fail("Failed to update repository.");
@@ -525,7 +580,7 @@ fn stage_repository(config: &InstallConfig) -> StageOutcome {
         "clone",
         "--branch",
         &config.branch,
-        REPO_URL,
+        &config.repo_url,
         config.dir.to_string_lossy().as_ref(),
     ])) {
         StageOutcome::ok()
@@ -560,20 +615,22 @@ fn stage_dependencies(config: &InstallConfig) -> StageOutcome {
         return StageOutcome::fail("uv is not installed; run the uv stage first.");
     };
 
-    if run_command(
-        Command::new(&uv)
-            .args(["sync", "--extra", "social"])
-            .current_dir(&config.dir),
-    ) {
+    let mut command = Command::new(&uv);
+    command
+        .args(["sync", "--frozen", "--extra", "social"])
+        .current_dir(&config.dir);
+    configure_mirror_env(&mut command, config);
+
+    if run_command(&mut command) {
         StageOutcome::ok()
     } else {
-        StageOutcome::fail("uv sync --extra social failed.")
+        StageOutcome::fail("uv sync --frozen --extra social failed.")
     }
 }
 
 fn stage_ui(config: &InstallConfig) -> StageOutcome {
     let asset = ui_asset_name();
-    let url = format!("https://github.com/cyzus/suzent/releases/latest/download/{asset}");
+    let url = format!("{}/{asset}", config.release_base_url);
     let bin_dir = config.dir.join("bin");
     let dest = bin_dir.join(ui_binary_name());
     let tmp = dest.with_extension("tmp");
@@ -582,7 +639,11 @@ fn stage_ui(config: &InstallConfig) -> StageOutcome {
         return StageOutcome::fail(format!("Failed to create bin directory: {error}"));
     }
 
-    let response = reqwest::blocking::get(&url).and_then(|resp| resp.error_for_status());
+    let client = reqwest::blocking::Client::new();
+    let response = client
+        .get(&url)
+        .send()
+        .and_then(|resp| resp.error_for_status());
     let bytes = match response.and_then(|resp| resp.bytes()) {
         Ok(bytes) => bytes,
         Err(error) => {
@@ -620,15 +681,25 @@ fn stage_playwright(config: &InstallConfig) -> StageOutcome {
         return StageOutcome::skipped("Playwright Chromium skipped by request.");
     }
 
-    let Some(uv) = find_uv_after_install() else {
-        return StageOutcome::fail("uv is not installed; run the uv stage first.");
-    };
-
-    if run_command(
-        Command::new(&uv)
+    let mut command = if let Some(playwright) = playwright_executable(&config.dir) {
+        let mut command = Command::new(playwright);
+        command
+            .args(["install", "chromium"])
+            .current_dir(&config.dir);
+        command
+    } else {
+        let Some(uv) = find_uv_after_install() else {
+            return StageOutcome::fail("uv is not installed; run the uv stage first.");
+        };
+        let mut command = Command::new(&uv);
+        command
             .args(["run", "playwright", "install", "chromium"])
-            .current_dir(&config.dir),
-    ) {
+            .current_dir(&config.dir);
+        command
+    };
+    configure_mirror_env(&mut command, config);
+
+    if run_command(&mut command) {
         StageOutcome::ok()
     } else {
         StageOutcome::skipped(
@@ -871,7 +942,10 @@ exec \"{}\" \"$@\"\n",
         ));
     }
 
-    print_human(format!("[OK] macOS app shortcut created at {}", app_link.display()));
+    print_human(format!(
+        "[OK] macOS app shortcut created at {}",
+        app_link.display()
+    ));
     StageOutcome::ok()
 }
 
@@ -922,6 +996,64 @@ fn escape_powershell_single_quoted(value: &str) -> String {
     value.replace('\'', "''")
 }
 
+fn shell_single_quote(value: &str) -> String {
+    value.replace('\'', "'\\''")
+}
+
+fn truthy_env(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "cn"
+    )
+}
+
+fn configure_mirror_env(command: &mut Command, config: &InstallConfig) {
+    if !config.china_mirror {
+        return;
+    }
+
+    env_if_missing(
+        command,
+        "UV_DEFAULT_INDEX",
+        "https://pypi.tuna.tsinghua.edu.cn/simple",
+    );
+    env_if_missing(
+        command,
+        "NPM_CONFIG_REGISTRY",
+        "https://registry.npmmirror.com",
+    );
+    env_if_missing(
+        command,
+        "PLAYWRIGHT_DOWNLOAD_HOST",
+        "https://npmmirror.com/mirrors/playwright",
+    );
+    env_if_missing(
+        command,
+        "NVM_NODEJS_ORG_MIRROR",
+        "https://npmmirror.com/mirrors/node",
+    );
+    env_if_missing(
+        command,
+        "RUSTUP_DIST_SERVER",
+        "https://mirrors.tuna.tsinghua.edu.cn/rustup",
+    );
+    env_if_missing(
+        command,
+        "RUSTUP_UPDATE_ROOT",
+        "https://mirrors.tuna.tsinghua.edu.cn/rustup/rustup",
+    );
+}
+
+fn env_if_missing(command: &mut Command, key: &str, value: &str) {
+    if env::var(key)
+        .ok()
+        .filter(|existing| !existing.trim().is_empty())
+        .is_none()
+    {
+        command.env(key, value);
+    }
+}
+
 fn is_empty_dir(path: &Path) -> bool {
     path.is_dir()
         && fs::read_dir(path)
@@ -964,6 +1096,9 @@ fn write_banner(config: &InstallConfig) {
     println!();
     println!("Install directory: {}", config.dir.display());
     println!("Branch: {}", config.branch);
+    if config.china_mirror {
+        println!("China mirror mode: enabled");
+    }
     println!();
 }
 
@@ -974,10 +1109,10 @@ fn print_preview(config: &InstallConfig) {
         println!("Step {}/{}: {}", idx + 1, stages().len(), stage.title);
         match stage.name {
             "repository" => {
-                println!("  Clone or update {REPO_URL}");
+                println!("  Clone or update {}", config.repo_url);
                 println!("  Target: {}", config.dir.display());
             }
-            "dependencies" => println!("  uv sync --extra social"),
+            "dependencies" => println!("  uv sync --frozen --extra social"),
             "ui" => println!("  {}", ui_asset_name()),
             "playwright" => {
                 if config.skip_playwright {
@@ -1012,7 +1147,10 @@ fn run_command(command: &mut Command) -> bool {
     log_command_start(command);
 
     if machine_mode() {
-        let result = command.stdout(Stdio::piped()).stderr(Stdio::piped()).output();
+        let result = command
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output();
         let success = matches!(&result, Ok(output) if output.status.success());
         log_command_output(&result);
         return success;
@@ -1096,6 +1234,18 @@ fn find_uv_after_install() -> Option<PathBuf> {
         };
         candidates.into_iter().find(|path| path.exists())
     })
+}
+
+fn playwright_executable(workspace: &Path) -> Option<PathBuf> {
+    let path = if cfg!(windows) {
+        workspace
+            .join(".venv")
+            .join("Scripts")
+            .join("playwright.exe")
+    } else {
+        workspace.join(".venv").join("bin").join("playwright")
+    };
+    path.exists().then_some(path)
 }
 
 fn default_install_dir() -> PathBuf {
@@ -1190,14 +1340,22 @@ fn log_command_output(result: &io::Result<std::process::Output>) {
 
 fn log_stream(name: &str, bytes: &[u8]) {
     let text = String::from_utf8_lossy(bytes);
-    for line in text.lines().map(str::trim_end).filter(|line| !line.is_empty()) {
+    for line in text
+        .lines()
+        .map(str::trim_end)
+        .filter(|line| !line.is_empty())
+    {
         log_detail(format!("{name}: {line}"));
     }
 }
 
 fn command_display(command: &Command) -> String {
     let mut parts = vec![command.get_program().to_string_lossy().to_string()];
-    parts.extend(command.get_args().map(|arg| arg.to_string_lossy().to_string()));
+    parts.extend(
+        command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().to_string()),
+    );
     parts.join(" ")
 }
 

--- a/docs/01-getting-started/quickstart.md
+++ b/docs/01-getting-started/quickstart.md
@@ -35,6 +35,29 @@ curl -fsSL https://raw.githubusercontent.com/cyzus/suzent/main/scripts/setup.sh 
 
 The script installs Suzent and any missing dependencies (Python/uv, Rust, build tools).
 
+### Mainland China Mirror Mode
+
+If package downloads are slow from mainland China, enable mirror mode before running setup:
+
+<Tabs groupId="os">
+<TabItem value="windows" label="Windows" default>
+
+```powershell
+$env:SUZENT_CHINA_MIRROR="1"; powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/cyzus/suzent/main/scripts/setup.ps1 | iex"
+```
+
+</TabItem>
+<TabItem value="mac-linux" label="Mac / Linux">
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/cyzus/suzent/main/scripts/setup.sh | SUZENT_CHINA_MIRROR=1 bash
+```
+
+</TabItem>
+</Tabs>
+
+Mirror mode configures PyPI, npm, Playwright, Node via nvm, and Rustup mirrors. If GitHub itself is slow, set `SUZENT_REPO_URL` or `SUZENT_RELEASE_BASE_URL` to a mirror you trust before running setup.
+
 ---
 
 ## 2. Launch

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -3,10 +3,12 @@
 #   Fresh install:  powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/cyzus/suzent/main/scripts/setup.ps1 | iex"
 #   Update:         suzent update   (or re-run this script inside the repo)
 # Flags (env vars): $env:SUZENT_DIR, $env:SUZENT_BRANCH, $env:SUZENT_SKIP_PLAYWRIGHT
+#                   $env:SUZENT_CHINA_MIRROR, $env:SUZENT_REPO_URL, $env:SUZENT_RELEASE_BASE_URL
 
 param(
     [string]$Dir    = "",
     [string]$Branch = "",
+    [switch]$ChinaMirror,
     [switch]$SkipPlaywright,
     [switch]$Update
 )
@@ -17,7 +19,11 @@ $ErrorActionPreference = "Stop"
 $SuzentDir    = if ($Dir)    { $Dir }    elseif ($env:SUZENT_DIR)    { $env:SUZENT_DIR }    else { Join-Path $env:USERPROFILE "suzent" }
 $SuzentBranch = if ($Branch) { $Branch } elseif ($env:SUZENT_BRANCH) { $env:SUZENT_BRANCH } else { "main" }
 $SkipPW       = $SkipPlaywright -or ($env:SUZENT_SKIP_PLAYWRIGHT -eq "1")
-$RepoUrl      = "https://github.com/cyzus/suzent.git"
+$UseChinaMirror = $ChinaMirror -or ($env:SUZENT_CHINA_MIRROR -match "^(1|true|yes|cn)$")
+$RepoUrl      = if ($env:SUZENT_REPO_URL) { $env:SUZENT_REPO_URL } else { "https://github.com/cyzus/suzent.git" }
+$UpdateRemote = if ($env:SUZENT_REPO_URL) { $env:SUZENT_REPO_URL } else { "origin" }
+$UvInstallUrl = if ($env:SUZENT_UV_INSTALL_URL) { $env:SUZENT_UV_INSTALL_URL } else { "https://astral.sh/uv/install.ps1" }
+$ReleaseBaseUrl = if ($env:SUZENT_RELEASE_BASE_URL) { $env:SUZENT_RELEASE_BASE_URL.TrimEnd("/") } else { "https://github.com/cyzus/suzent/releases/latest/download" }
 $MinNodeMajor = 20
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -40,6 +46,17 @@ function Add-ToUserPath {
     Write-Warn "Added $NewDir to user PATH (restart terminal if command not found)"
 }
 
+function Enable-ChinaMirrors {
+    if (-not $UseChinaMirror) { return }
+
+    if (-not $env:UV_DEFAULT_INDEX) { $env:UV_DEFAULT_INDEX = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+    if (-not $env:NPM_CONFIG_REGISTRY) { $env:NPM_CONFIG_REGISTRY = "https://registry.npmmirror.com" }
+    if (-not $env:PLAYWRIGHT_DOWNLOAD_HOST) { $env:PLAYWRIGHT_DOWNLOAD_HOST = "https://npmmirror.com/mirrors/playwright" }
+    if (-not $env:RUSTUP_DIST_SERVER) { $env:RUSTUP_DIST_SERVER = "https://mirrors.tuna.tsinghua.edu.cn/rustup" }
+    if (-not $env:RUSTUP_UPDATE_ROOT) { $env:RUSTUP_UPDATE_ROOT = "https://mirrors.tuna.tsinghua.edu.cn/rustup/rustup" }
+    Write-Info "China mirror mode enabled for PyPI, npm, Playwright, and Rustup."
+}
+
 # ── Banner ────────────────────────────────────────────────────────────────────
 Write-Host ""
 Write-Host "  ███████╗██╗   ██╗███████╗███████╗███╗   ██╗████████╗" -ForegroundColor White
@@ -50,6 +67,7 @@ Write-Host "  ███████║╚██████╔╝█████
 Write-Host "  ╚══════╝ ╚═════╝ ╚══════╝╚══════╝╚═╝  ╚═══╝   ╚═╝   " -ForegroundColor White
 Write-Host ""
 
+Enable-ChinaMirrors
 
 # ── Detect update vs fresh install ───────────────────────────────────────────
 $IsUpdate = (Test-Path (Join-Path $SuzentDir ".git"))
@@ -132,7 +150,8 @@ Ensure-Node
 function Ensure-Uv {
     if (Get-Command uv -ErrorAction SilentlyContinue) { return }
     Write-Info "Installing uv..."
-    powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://astral.sh/uv/install.ps1 | iex"
+    $escapedUvInstallUrl = $UvInstallUrl.Replace("'", "''")
+    powershell -NoProfile -ExecutionPolicy Bypass -Command "irm '$escapedUvInstallUrl' | iex"
     Refresh-Path
     if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
         Write-Fail "uv installation failed. See https://docs.astral.sh/uv/"
@@ -190,9 +209,9 @@ if ($IsUpdate) {
         git stash push -m "suzent-update-$stamp"
     }
 
-    git fetch origin
+    git fetch $UpdateRemote $SuzentBranch
     try { git checkout $SuzentBranch --quiet 2>&1 | Out-Null } catch {}
-    git pull origin $SuzentBranch
+    git pull $UpdateRemote $SuzentBranch
     $sha = git rev-parse --short HEAD
     Write-Ok "Repository updated to $sha"
 } else {
@@ -218,15 +237,15 @@ if (-not (Test-Path ".env")) {
 }
 
 # ── Python dependencies ───────────────────────────────────────────────────────
-Write-Info "Syncing Python dependencies with social channel support (uv sync --extra social)..."
-uv sync --extra social
-if ($LASTEXITCODE -ne 0) { Write-Fail "uv sync --extra social failed — check errors above." }
+Write-Info "Syncing Python dependencies with social channel support (uv sync --frozen --extra social)..."
+uv sync --frozen --extra social
+if ($LASTEXITCODE -ne 0) { Write-Fail "uv sync --frozen --extra social failed — check errors above." }
 Write-Ok "Python dependencies ready"
 
 # ── Download pre-built UI binary ─────────────────────────────────────────────
 function Get-UiBinary {
     $asset = "suzent-windows-x86_64.exe"
-    $url = "https://github.com/cyzus/suzent/releases/latest/download/$asset"
+    $url = "$ReleaseBaseUrl/$asset"
     $tmp = $null
     try {
         $binDir = Join-Path $SuzentDir "bin"
@@ -276,7 +295,12 @@ if ($env:SUZENT_DEV_SETUP -eq "1") {
 # ── Playwright Chromium ───────────────────────────────────────────────────────
 if (-not $SkipPW) {
     Write-Info "Installing Playwright Chromium (for web browsing tool)..."
-    uv run playwright install chromium
+    $playwrightExe = Join-Path $SuzentDir ".venv\Scripts\playwright.exe"
+    if (Test-Path $playwrightExe) {
+        & $playwrightExe install chromium
+    } else {
+        uv run playwright install chromium
+    }
     if ($LASTEXITCODE -ne 0) {
         Write-Warn "Playwright install failed — web browsing may not work (non-fatal)."
     }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,6 +4,7 @@
 #   Fresh install:  curl -fsSL https://raw.githubusercontent.com/cyzus/suzent/main/scripts/setup.sh | bash
 #   Update:         suzent update   (or re-run this script inside the repo)
 #   Flags (env):    SUZENT_DIR=~/suzent  SUZENT_BRANCH=main  SUZENT_SKIP_PLAYWRIGHT=1
+#                   SUZENT_CHINA_MIRROR=1  SUZENT_REPO_URL=...  SUZENT_RELEASE_BASE_URL=...
 
 set -euo pipefail
 
@@ -15,10 +16,30 @@ warn() { echo -e "${YELLOW}[!]${RESET} $*"; }
 die()  { echo -e "${RED}[✗]${RESET} $*"; exit 1; }
 
 # ── Config ────────────────────────────────────────────────────────────────────
-REPO_URL="https://github.com/cyzus/suzent.git"
+REPO_URL="${SUZENT_REPO_URL:-https://github.com/cyzus/suzent.git}"
+UPDATE_REMOTE="${SUZENT_REPO_URL:-origin}"
+UV_INSTALL_URL="${SUZENT_UV_INSTALL_URL:-https://astral.sh/uv/install.sh}"
+NVM_INSTALL_URL="${SUZENT_NVM_INSTALL_URL:-https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh}"
+RELEASE_BASE_URL="${SUZENT_RELEASE_BASE_URL:-https://github.com/cyzus/suzent/releases/latest/download}"
 SUZENT_DIR="${SUZENT_DIR:-$HOME/suzent}"
 SUZENT_BRANCH="${SUZENT_BRANCH:-main}"
+CHINA_MIRROR="${SUZENT_CHINA_MIRROR:-0}"
 MIN_NODE_MAJOR=20
+
+enable_china_mirrors() {
+    case "$CHINA_MIRROR" in
+        1|true|TRUE|yes|YES|cn|CN) ;;
+        *) return ;;
+    esac
+
+    export UV_DEFAULT_INDEX="${UV_DEFAULT_INDEX:-https://pypi.tuna.tsinghua.edu.cn/simple}"
+    export NPM_CONFIG_REGISTRY="${NPM_CONFIG_REGISTRY:-https://registry.npmmirror.com}"
+    export PLAYWRIGHT_DOWNLOAD_HOST="${PLAYWRIGHT_DOWNLOAD_HOST:-https://npmmirror.com/mirrors/playwright}"
+    export NVM_NODEJS_ORG_MIRROR="${NVM_NODEJS_ORG_MIRROR:-https://npmmirror.com/mirrors/node}"
+    export RUSTUP_DIST_SERVER="${RUSTUP_DIST_SERVER:-https://mirrors.tuna.tsinghua.edu.cn/rustup}"
+    export RUSTUP_UPDATE_ROOT="${RUSTUP_UPDATE_ROOT:-https://mirrors.tuna.tsinghua.edu.cn/rustup/rustup}"
+    info "China mirror mode enabled for PyPI, npm, Playwright, Node, and Rustup."
+}
 
 # ── Banner ────────────────────────────────────────────────────────────────────
 echo ""
@@ -44,6 +65,7 @@ case "$OS" in
     *)      die "Unsupported OS: $OS" ;;
 esac
 ok "$OS_NAME detected"
+enable_china_mirrors
 
 # ── Helper: refresh PATH after install ───────────────────────────────────────
 refresh_path() {
@@ -84,7 +106,7 @@ install_node() {
         die "curl is required to install nvm. Please install curl first."
     fi
     export NVM_DIR="$HOME/.nvm"
-    curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash
+    curl -fsSL "$NVM_INSTALL_URL" | bash
     # shellcheck source=/dev/null
     [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
     nvm install --lts
@@ -115,7 +137,7 @@ fi
 # ── Check/install: uv ────────────────────────────────────────────────────────
 if ! command -v uv &>/dev/null; then
     info "Installing uv..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    curl -LsSf "$UV_INSTALL_URL" | sh
     refresh_path
 fi
 command -v uv &>/dev/null || die "uv installation failed. See https://docs.astral.sh/uv/"
@@ -163,9 +185,9 @@ if [ "$IS_UPDATE" = true ]; then
         git stash push -m "suzent-update-$(date +%Y%m%d-%H%M%S)"
     fi
 
-    git fetch origin
+    git fetch "$UPDATE_REMOTE" "$SUZENT_BRANCH"
     git checkout "$SUZENT_BRANCH" 2>/dev/null || true
-    git pull origin "$SUZENT_BRANCH"
+    git pull "$UPDATE_REMOTE" "$SUZENT_BRANCH"
     ok "Repository updated to $(git rev-parse --short HEAD)"
 else
     if [ -d "$SUZENT_DIR" ]; then
@@ -191,8 +213,8 @@ else
 fi
 
 # ── Install / sync Python dependencies ───────────────────────────────────────
-info "Syncing Python dependencies with social channel support (uv sync --extra social)..."
-uv sync --extra social || die "uv sync --extra social failed — check errors above."
+info "Syncing Python dependencies with social channel support (uv sync --frozen --extra social)..."
+uv sync --frozen --extra social || die "uv sync --frozen --extra social failed — check errors above."
 ok "Python dependencies ready"
 
 # ── Download pre-built UI binary ─────────────────────────────────────────────
@@ -212,7 +234,7 @@ download_binary() {
 
     mkdir -p bin
     local url tmp
-    url="https://github.com/cyzus/suzent/releases/latest/download/$asset"
+    url="${RELEASE_BASE_URL%/}/$asset"
     tmp="bin/suzent-ui.tmp"
 
     info "Downloading pre-built UI binary..."
@@ -251,7 +273,11 @@ fi
 # ── Playwright Chromium ───────────────────────────────────────────────────────
 if [ "${SUZENT_SKIP_PLAYWRIGHT:-0}" != "1" ]; then
     info "Installing Playwright Chromium (for web browsing tool)..."
-    uv run playwright install chromium || warn "Playwright install failed — web browsing may not work (non-fatal)."
+    if [ -x ".venv/bin/playwright" ]; then
+        .venv/bin/playwright install chromium || warn "Playwright install failed — web browsing may not work (non-fatal)."
+    else
+        uv run playwright install chromium || warn "Playwright install failed — web browsing may not work (non-fatal)."
+    fi
 fi
 
 # ── Global CLI shim ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds an opt-in `SUZENT_CHINA_MIRROR=1` setup mode for users installing Suzent from mainland China.

## What changed

- Configure mirror-friendly environment variables for PyPI, npm, Playwright, Node via nvm, and Rustup in `setup.sh` and `setup.ps1`.
- Add trusted override knobs for GitHub-hosted artifacts: `SUZENT_REPO_URL`, `SUZENT_RELEASE_BASE_URL`, plus installer URL overrides for uv and nvm.
- Thread the same mirror behavior through the standalone Rust installer.
- Prefer the venv Playwright executable after `uv sync`, falling back to `uv run playwright` only if needed.
- Document mirror-mode install commands in English and Chinese quickstart docs.

## Why

The default setup path depends on several endpoints that can be slow or unreliable from mainland China: PyPI, npm, Playwright browser downloads, Node/nvm downloads, Rustup, and GitHub release assets. This keeps the default path unchanged while giving users a single opt-in mirror mode.

## Validation

- `cargo check` in `apps/suzent-installer`
- PowerShell parser check for `scripts/setup.ps1`
- `git diff --check`
- Playwright dry-run with `PLAYWRIGHT_DOWNLOAD_HOST=https://npmmirror.com/mirrors/playwright`, confirming Chromium, headless shell, ffmpeg, and winldd URLs resolve to npmmirror

Note: I did not run a full Chromium download; the validation was a dry-run URL check.