### PR TITLE
Fix social permission approvals

### DIFF
--- a/src/suzent/core/approval_manager.py
+++ b/src/suzent/core/approval_manager.py
@@ -56,16 +56,24 @@ class PendingApprovalSession:
         Includes ``remember``, ``tool_name``, and ``args`` so ChatProcessor can
         apply the standard permission pathway (command-level rules, global persist).
         """
-        return [
-            {
+        approvals: list[dict] = []
+        for req in self.requests:
+            remembered = self.remember_decisions.get(req.request_id)
+            payload = {
                 "request_id": req.request_id,
                 "tool_call_id": req.tool_call_id,
                 "approved": self.decisions[req.request_id],
-                "remember": "session"
-                if self.remember_decisions.get(req.request_id)
-                else "",
+                "remember": "session" if remembered else "",
                 "tool_name": req.tool_name,
                 "args": req.args,
             }
-            for req in self.requests
-        ]
+            if remembered and self.decisions[req.request_id] and req.decision:
+                action_ids = {
+                    str(action.get("id"))
+                    for action in req.decision.get("actions", [])
+                    if isinstance(action, dict)
+                }
+                if "allow_session" in action_ids:
+                    payload["action_id"] = "allow_session"
+            approvals.append(payload)
+        return approvals

--- a/src/suzent/core/commands/approve.py
+++ b/src/suzent/core/commands/approve.py
@@ -51,7 +51,7 @@ async def _resolve_approval(ctx: typer.Context, approved: bool, req_id: str):
     if not brain:
         return None
 
-    cmd_name = "/" + ctx.info_name
+    cmd_name = cmd_ctx.invoked_alias or f"/{ctx.info_name}"
     remember = cmd_name in _REMEMBER
 
     target_id = cmd_ctx.sender_id or ""

--- a/src/suzent/core/commands/base.py
+++ b/src/suzent/core/commands/base.py
@@ -32,6 +32,7 @@ class CommandContext:
     chat_id: str
     user_id: str
     surface: str = "all"
+    invoked_alias: str = ""
     # Social-specific — None when called from frontend / API
     platform: str | None = None
     sender_id: str | None = None
@@ -134,6 +135,8 @@ async def dispatch(ctx: CommandContext, message: str) -> str | None:
         # If the command is not valid for this surface, let it fall through
         # to the LLM naturally (e.g. typing "/y" on frontend).
         return None
+
+    ctx.invoked_alias = cmd_name
 
     from typer.main import get_command
 

--- a/src/suzent/core/social_brain.py
+++ b/src/suzent/core/social_brain.py
@@ -3,6 +3,7 @@ Social Brain: The bridge between Social Channels and the Suzent Agent.
 """
 
 import asyncio
+from datetime import datetime, timezone
 import secrets
 import string
 import time
@@ -25,6 +26,62 @@ from suzent.core.stream_registry import (
 logger = get_logger(__name__)
 
 _TOKEN_CHARS = string.ascii_uppercase + string.digits
+
+
+def _pending_approval_payload(req: ApprovalRequest) -> dict:
+    return {
+        "approvalId": req.request_id,
+        "toolCallId": req.tool_call_id or req.request_id,
+        "toolName": req.tool_name,
+        "args": req.args,
+        "decision": req.decision or {},
+        "savedAt": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _ensure_approval_decision(req: ApprovalRequest) -> ApprovalRequest:
+    decision = req.decision if isinstance(req.decision, dict) else None
+    if decision and isinstance(decision.get("actions"), list) and decision["actions"]:
+        return req
+
+    from suzent.permissions.actions import build_approval_decision
+
+    req.decision = build_approval_decision(
+        req.tool_name,
+        req.args,
+        reason="This restored social tool call requires approval",
+        reason_code="social_approval_contract_restored",
+    ).model_dump(mode="json", by_alias=True)
+    return req
+
+
+def _persist_pending_approval_session(
+    chat_id: str,
+    requests: list[ApprovalRequest],
+) -> None:
+    if not requests:
+        return
+    db = get_database()
+    chat = db.get_chat(chat_id)
+    if chat is None:
+        return
+    existing = (chat.config or {}).get("_pending_approvals") or []
+    if not isinstance(existing, list):
+        existing = []
+    incoming = [
+        _pending_approval_payload(_ensure_approval_decision(req)) for req in requests
+    ]
+    incoming_ids = {
+        str(item.get("toolCallId") or item.get("approvalId") or "") for item in incoming
+    }
+    remaining = [
+        item
+        for item in existing
+        if not isinstance(item, dict)
+        or str(item.get("toolCallId") or item.get("approvalId") or "")
+        not in incoming_ids
+    ]
+    db.merge_chat_config(chat_id, {"_pending_approvals": [*remaining, *incoming]})
 
 
 def get_active_social_brain() -> Optional["SocialBrain"]:
@@ -699,6 +756,7 @@ class SocialBrain(BaseBrain):
 
             async def on_event(event):
                 if isinstance(event, ApprovalRequest):
+                    event = _ensure_approval_decision(event)
                     logger.info(
                         f"SocialBrain: Collected approval request for {event.tool_name}"
                     )
@@ -792,6 +850,17 @@ class SocialBrain(BaseBrain):
                     sender_id=message.sender_id,
                 )
                 self._sessions[social_chat_id] = session
+                try:
+                    _persist_pending_approval_session(
+                        social_chat_id,
+                        collected_approvals,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to persist social pending approvals for {}: {}",
+                        social_chat_id,
+                        exc,
+                    )
                 await self._prompt_next_approval(session)
 
             # Send Final Response (non-streaming path, or steer)
@@ -910,8 +979,10 @@ class SocialBrain(BaseBrain):
             platform, target_id, f"{status} {tool_name}{remember_label}"
         )
 
-        # Persist "always" policy for this session
-        if remember and req:
+        # Persist legacy "always" policy for this session. Modern approval
+        # requests carry a decision contract; those are remembered by resuming
+        # with action_id=allow_session so ChatProcessor applies permissionUpdates.
+        if remember and req and not req.decision:
             is_bash = req.tool_name in ("bash_execute", "BashTool")
             if is_bash and approved:
                 # For bash, store a prefix rule on the base command in the chat DB
@@ -980,6 +1051,7 @@ class SocialBrain(BaseBrain):
 
             async def on_event(event):
                 if isinstance(event, _AR):
+                    event = _ensure_approval_decision(event)
                     logger.info(
                         f"SocialBrain: New approval request during resume for {event.tool_name}"
                     )
@@ -1005,6 +1077,17 @@ class SocialBrain(BaseBrain):
                     sender_id=session.sender_id,
                 )
                 self._sessions[social_chat_id] = new_session
+                try:
+                    _persist_pending_approval_session(
+                        social_chat_id,
+                        new_approvals,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to persist resumed social pending approvals for {}: {}",
+                        social_chat_id,
+                        exc,
+                    )
                 await self._prompt_next_approval(new_session)
                 return  # agent hasn't finished yet; response will come after approvals
 

--- a/src/suzent/permissions/engine.py
+++ b/src/suzent/permissions/engine.py
@@ -7,9 +7,7 @@ from typing import Any
 from suzent.permissions.actions import build_approval_decision
 from suzent.permissions.auto import AutoPermissionClassifier
 from suzent.permissions.auto.denial_tracker import (
-    limit_exceeded,
     record_allowed,
-    record_denied,
 )
 from suzent.permissions.context import PermissionContext
 from suzent.permissions.models import (
@@ -140,6 +138,7 @@ class PermissionEngine:
         if (
             context.mode == PermissionMode.AUTO
             and decision.behavior == CommandDecision.ASK
+            and decision.reason_code != "shell_policy_high_risk"
         ):
             return await self._evaluate_auto(request, context, decision)
         return decision
@@ -206,19 +205,17 @@ class PermissionEngine:
                 },
             )
 
-        denial_state = record_denied(context.chat_id)
-        if (
-            limit_exceeded(denial_state)
-            and context.interaction_profile == "interactive"
-        ):
+        if context.interaction_profile == "interactive":
             payload = fallback.model_dump(by_alias=True)
             payload.update(
                 {
-                    "reason": (
-                        "Auto mode repeatedly blocked actions. "
-                        f"Review this request manually: {result.reason}"
-                    ),
-                    "reasonCode": "auto_denial_limit",
+                    "reason": result.reason,
+                    "reasonCode": "auto_classifier_high_risk",
+                    "risk": PermissionRisk.HIGH.value,
+                    "metadata": {
+                        "confidence": result.confidence,
+                        "risk_categories": result.risk_categories,
+                    },
                 }
             )
             return PermissionDecision.model_validate(payload)
@@ -230,8 +227,6 @@ class PermissionEngine:
             metadata={
                 "confidence": result.confidence,
                 "risk_categories": result.risk_categories,
-                "consecutive_denials": denial_state.consecutive,
-                "total_denials": denial_state.total,
             },
         )
 
@@ -358,6 +353,19 @@ class PermissionEngine:
                 metadata=evaluation.metadata,
             )
         if evaluation.decision == CommandDecision.DENY:
+            if (
+                context.mode == PermissionMode.AUTO
+                and context.interaction_profile == "interactive"
+            ):
+                payload = build_approval_decision(
+                    request.tool_name,
+                    request.args,
+                    reason=evaluation.reason,
+                    reason_code="shell_policy_high_risk",
+                    risk=PermissionRisk.CRITICAL,
+                ).model_dump(by_alias=True)
+                payload["metadata"] = evaluation.metadata
+                return PermissionDecision.model_validate(payload)
             return _decision(
                 CommandDecision.DENY,
                 evaluation.reason,

--- a/src/suzent/tools/shell/bash_tool.py
+++ b/src/suzent/tools/shell/bash_tool.py
@@ -322,27 +322,26 @@ class BashTool(Tool):
                 baseline_eval.decision == CommandDecision.DENY
                 and baseline_eval.reason.startswith(baseline_hard_reasons)
             ):
+                tool_call_approved = bool(getattr(ctx, "tool_call_approved", False))
                 self.audit_operation(
                     self.tool_name,
                     "policy",
-                    "deny",
+                    "allow" if tool_call_approved else "ask",
                     language=lang,
                     mode="baseline",
                     reason=baseline_eval.reason,
                     description=description,
                     command_class=baseline_eval.command_class.value,
                 )
-                return self._error_result(
-                    ToolErrorCode.PERMISSION_DENIED,
-                    f"Command blocked by baseline guardrails: {baseline_eval.reason}",
-                    mode="unknown",
-                    language=lang,
-                    timeout=timeout,
-                    background=background,
-                    policy_decision="deny",
-                    policy_reason=baseline_eval.reason,
-                    command_class=baseline_eval.command_class.value,
-                )
+                if not tool_call_approved:
+                    raise ApprovalRequired(
+                        metadata={
+                            "reason": baseline_eval.reason,
+                            "mode": "baseline",
+                            "command_class": baseline_eval.command_class.value,
+                            "description": description,
+                        }
+                    )
 
             baseline_ask_reasons = (
                 "Command requires approval due to shell chaining semantics",
@@ -393,17 +392,21 @@ class BashTool(Tool):
             )
 
             if policy_eval.decision == CommandDecision.DENY:
-                return self._error_result(
-                    ToolErrorCode.PERMISSION_DENIED,
-                    f"Command blocked by bash policy: {policy_eval.reason}",
-                    mode="unknown",
-                    language=lang,
-                    timeout=timeout,
-                    background=background,
-                    policy_decision=policy_eval.decision.value,
-                    policy_reason=policy_eval.reason,
-                    command_class=policy_eval.command_class.value,
-                )
+                approved_high_risk = bool(
+                    getattr(ctx, "tool_call_approved", False)
+                ) and policy_eval.reason.startswith(baseline_hard_reasons)
+                if not approved_high_risk:
+                    return self._error_result(
+                        ToolErrorCode.PERMISSION_DENIED,
+                        f"Command blocked by bash policy: {policy_eval.reason}",
+                        mode="unknown",
+                        language=lang,
+                        timeout=timeout,
+                        background=background,
+                        policy_decision=policy_eval.decision.value,
+                        policy_reason=policy_eval.reason,
+                        command_class=policy_eval.command_class.value,
+                    )
 
             if policy_eval.decision == CommandDecision.ASK:
                 if not bool(getattr(ctx, "tool_call_approved", False)):

--- a/tests/core/test_approval_manager.py
+++ b/tests/core/test_approval_manager.py
@@ -1,0 +1,44 @@
+from suzent.core.approval_manager import PendingApprovalSession
+from suzent.core.stream_parser import ApprovalRequest
+from suzent.permissions.actions import build_approval_decision
+
+
+def test_remembered_modern_approval_uses_allow_session_action() -> None:
+    decision = build_approval_decision(
+        "bash_execute",
+        {"content": "npm test"},
+    ).model_dump(mode="json", by_alias=True)
+    session = PendingApprovalSession(
+        requests=[
+            ApprovalRequest(
+                request_id="call-1",
+                tool_call_id="call-1",
+                tool_name="bash_execute",
+                args={"content": "npm test"},
+                decision=decision,
+            )
+        ]
+    )
+
+    session.record(True, remember=True)
+
+    assert session.to_resume_approvals()[0]["action_id"] == "allow_session"
+
+
+def test_remembered_legacy_approval_keeps_legacy_payload() -> None:
+    session = PendingApprovalSession(
+        requests=[
+            ApprovalRequest(
+                request_id="call-1",
+                tool_call_id="call-1",
+                tool_name="bash_execute",
+                args={"content": "npm test"},
+            )
+        ]
+    )
+
+    session.record(True, remember=True)
+
+    approval = session.to_resume_approvals()[0]
+    assert approval["remember"] == "session"
+    assert "action_id" not in approval

--- a/tests/core/test_approve_command_aliases.py
+++ b/tests/core/test_approve_command_aliases.py
@@ -1,0 +1,84 @@
+import pytest
+
+import suzent.core.commands  # noqa: F401 - register command handlers
+from suzent.core.commands import CommandContext, dispatch
+
+
+class _FakeSocialBrain:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def handle_approval_response(
+        self,
+        platform: str,
+        target_id: str,
+        approved: bool,
+        *,
+        sender_id: str | None = None,
+        remember: bool = False,
+    ) -> None:
+        self.calls.append(
+            {
+                "platform": platform,
+                "target_id": target_id,
+                "approved": approved,
+                "sender_id": sender_id,
+                "remember": remember,
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_ya_alias_remembers_social_tool_approval(monkeypatch) -> None:
+    brain = _FakeSocialBrain()
+    monkeypatch.setattr(
+        "suzent.core.social_brain.get_active_social_brain",
+        lambda: brain,
+    )
+
+    response = await dispatch(
+        CommandContext(
+            chat_id="social-wechat-room-1",
+            user_id="user-1",
+            surface="social",
+            platform="wechat",
+            sender_id="sender-1",
+            channel_manager=object(),
+        ),
+        "/ya",
+    )
+
+    assert response == ""
+    assert brain.calls == [
+        {
+            "platform": "wechat",
+            "target_id": "room-1",
+            "approved": True,
+            "sender_id": "sender-1",
+            "remember": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_y_alias_keeps_one_time_social_tool_approval(monkeypatch) -> None:
+    brain = _FakeSocialBrain()
+    monkeypatch.setattr(
+        "suzent.core.social_brain.get_active_social_brain",
+        lambda: brain,
+    )
+
+    response = await dispatch(
+        CommandContext(
+            chat_id="social-wechat-room-1",
+            user_id="user-1",
+            surface="social",
+            platform="wechat",
+            sender_id="sender-1",
+            channel_manager=object(),
+        ),
+        "/y",
+    )
+
+    assert response == ""
+    assert brain.calls[0]["remember"] is False

--- a/tests/core/test_social_approval_persistence.py
+++ b/tests/core/test_social_approval_persistence.py
@@ -1,0 +1,125 @@
+from types import SimpleNamespace
+
+from suzent.core.chat_processor import _resolve_resume_approval_actions
+from suzent.core.social_brain import (
+    _ensure_approval_decision,
+    _persist_pending_approval_session,
+)
+from suzent.core.stream_parser import ApprovalRequest
+from suzent.permissions.actions import build_approval_decision
+
+
+class FakeDatabase:
+    def __init__(self) -> None:
+        self.chat = SimpleNamespace(config={})
+
+    def get_chat(self, chat_id: str):
+        assert chat_id == "social-wechat-user-1"
+        return self.chat
+
+    def merge_chat_config(self, chat_id: str, updates: dict) -> bool:
+        assert chat_id == "social-wechat-user-1"
+        self.chat.config = {**self.chat.config, **updates}
+        return True
+
+
+def test_social_pending_approval_persistence_supports_ya_remember(
+    monkeypatch,
+) -> None:
+    decision = build_approval_decision(
+        "bash_execute",
+        {"content": "npm test"},
+    ).model_dump(mode="json", by_alias=True)
+    db = FakeDatabase()
+    monkeypatch.setattr("suzent.core.social_brain.get_database", lambda: db)
+    monkeypatch.setattr("suzent.core.chat_processor.get_database", lambda: db)
+
+    _persist_pending_approval_session(
+        "social-wechat-user-1",
+        [
+            ApprovalRequest(
+                request_id="call-1",
+                tool_call_id="call-1",
+                tool_name="bash_execute",
+                args={"content": "npm test"},
+                decision=decision,
+            )
+        ],
+    )
+
+    resolved = _resolve_resume_approval_actions(
+        "social-wechat-user-1",
+        [
+            {
+                "request_id": "call-1",
+                "tool_call_id": "call-1",
+                "action_id": "allow_session",
+            }
+        ],
+    )
+
+    assert resolved[0]["remember"] == "session"
+    assert resolved[0]["_permission_updates"][0]["payload"]["tool"] == "bash_execute"
+
+
+def test_social_pending_approval_persistence_deduplicates_by_tool_call_id(
+    monkeypatch,
+) -> None:
+    decision = build_approval_decision("write_file", {}).model_dump(
+        mode="json",
+        by_alias=True,
+    )
+    db = FakeDatabase()
+    db.chat.config = {
+        "_pending_approvals": [
+            {
+                "approvalId": "call-1",
+                "toolCallId": "call-1",
+                "toolName": "write_file",
+                "args": {},
+                "decision": {},
+            }
+        ]
+    }
+    monkeypatch.setattr("suzent.core.social_brain.get_database", lambda: db)
+
+    _persist_pending_approval_session(
+        "social-wechat-user-1",
+        [
+            ApprovalRequest(
+                request_id="call-1",
+                tool_call_id="call-1",
+                tool_name="write_file",
+                args={"file_path": "README.md"},
+                decision=decision,
+            )
+        ],
+    )
+
+    approvals = db.chat.config["_pending_approvals"]
+    assert len(approvals) == 1
+    assert approvals[0]["args"] == {"file_path": "README.md"}
+
+
+def test_social_missing_decision_is_hydrated_for_tool_wide_remember() -> None:
+    req = ApprovalRequest(
+        request_id="call-1",
+        tool_call_id="call-1",
+        tool_name="social_message",
+        args={
+            "channel": "wechat",
+            "recipient": "user-1@im.wechat",
+            "message": "volatile message text",
+        },
+    )
+
+    hydrated = _ensure_approval_decision(req)
+
+    allow_session = next(
+        action
+        for action in hydrated.decision["actions"]
+        if action["id"] == "allow_session"
+    )
+    update = allow_session["permissionUpdates"][0]
+    assert update["payload"]["tool"] == "social_message"
+    assert update["payload"]["matcher"] == {"type": "all"}

--- a/tests/permissions/test_permission_engine.py
+++ b/tests/permissions/test_permission_engine.py
@@ -28,6 +28,7 @@ def context(
     tmp_path: Path,
     *,
     mode: PermissionMode = PermissionMode.DEFAULT,
+    interaction_profile: str = "interactive",
     tool_approval_policy: dict[str, str] | None = None,
     tool_permission_policies: dict | None = None,
     permission_rules: list[dict] | None = None,
@@ -35,7 +36,7 @@ def context(
     return PermissionContext(
         chat_id="chat-1",
         mode=mode,
-        interaction_profile="interactive",
+        interaction_profile=interaction_profile,
         tool_approval_policy=tool_approval_policy or {},
         tool_permission_policies=tool_permission_policies or {},
         permission_rules=parse_rules(permission_rules or []),
@@ -176,7 +177,7 @@ async def test_auto_mode_classifies_unresolved_tool(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_auto_mode_blocks_risky_classifier_result(tmp_path: Path) -> None:
+async def test_auto_mode_prompts_for_risky_classifier_result(tmp_path: Path) -> None:
     decision = await PermissionEngine(
         classifier=Classifier(should_block=True)
     ).evaluate(
@@ -184,8 +185,45 @@ async def test_auto_mode_blocks_risky_classifier_result(tmp_path: Path) -> None:
         context(tmp_path, mode=PermissionMode.AUTO),
     )
 
+    assert decision.behavior == CommandDecision.ASK
+    assert decision.reason_code == "auto_classifier_high_risk"
+    assert decision.risk.value == "high"
+
+
+@pytest.mark.asyncio
+async def test_auto_mode_headless_blocks_risky_classifier_result(
+    tmp_path: Path,
+) -> None:
+    decision = await PermissionEngine(
+        classifier=Classifier(should_block=True)
+    ).evaluate(
+        ToolPermissionRequest("social_message", {"message": "hello"}),
+        context(
+            tmp_path,
+            mode=PermissionMode.AUTO,
+            interaction_profile="headless",
+        ),
+    )
+
     assert decision.behavior == CommandDecision.DENY
     assert decision.reason_code == "auto_classifier_block"
+
+
+@pytest.mark.asyncio
+async def test_auto_mode_prompts_for_high_risk_shell_policy(
+    tmp_path: Path,
+) -> None:
+    decision = await PermissionEngine().evaluate(
+        ToolPermissionRequest(
+            "bash_execute",
+            {"content": "chmod 777 secrets.txt", "language": "command"},
+        ),
+        context(tmp_path, mode=PermissionMode.AUTO),
+    )
+
+    assert decision.behavior == CommandDecision.ASK
+    assert decision.reason_code == "shell_policy_high_risk"
+    assert decision.risk.value == "critical"
 
 
 @pytest.mark.asyncio

--- a/tests/tools/shell/test_bash_permission_pipeline.py
+++ b/tests/tools/shell/test_bash_permission_pipeline.py
@@ -8,7 +8,7 @@ from suzent.config import CONFIG
 from suzent.tools.shell.bash_tool import BashTool
 
 
-def _ctx(tmp_path, sandbox_enabled=False):
+def _ctx(tmp_path, sandbox_enabled=False, approved=False):
     deps = SimpleNamespace(
         chat_id="chat-1",
         sandbox_enabled=sandbox_enabled,
@@ -18,10 +18,10 @@ def _ctx(tmp_path, sandbox_enabled=False):
         auto_approve_tools=False,
         tool_approval_policy={},
     )
-    return SimpleNamespace(deps=deps)
+    return SimpleNamespace(deps=deps, tool_call_approved=approved)
 
 
-def test_policy_blocks_dangerous_command_when_enabled(monkeypatch, tmp_path):
+def test_policy_prompts_for_dangerous_command_when_unapproved(monkeypatch, tmp_path):
     tool = BashTool()
 
     monkeypatch.setattr(
@@ -30,16 +30,44 @@ def test_policy_blocks_dangerous_command_when_enabled(monkeypatch, tmp_path):
         {"bash_execute": {"enabled": True, "mode": "accept_edits"}},
     )
 
+    with pytest.raises(ApprovalRequired):
+        tool.forward(
+            _ctx(tmp_path),
+            content="sudo ls",
+            description="List files with sudo",
+            language="command",
+        )
+
+
+def test_approved_dangerous_command_reaches_execution(monkeypatch, tmp_path):
+    tool = BashTool()
+
+    class _Process:
+        returncode = 0
+
+        def __init__(self, _cmd, **kwargs):
+            kwargs["stdout"].write(b"approved\n")
+            kwargs["stdout"].flush()
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+    monkeypatch.setattr("suzent.tools.shell.bash_tool.subprocess.Popen", _Process)
+    monkeypatch.setattr(
+        CONFIG,
+        "permission_policies",
+        {"bash_execute": {"enabled": True, "mode": "accept_edits"}},
+    )
+
     result = tool.forward(
-        _ctx(tmp_path),
+        _ctx(tmp_path, approved=True),
         content="sudo ls",
         description="List files with sudo",
         language="command",
     )
 
-    assert not result.success
-    assert result.error_code.value == "permission_denied"
-    assert "baseline guardrails" in result.message.lower()
+    assert result.success
+    assert "approved" in result.message
 
 
 def test_policy_asks_unknown_command_in_full_approval(monkeypatch, tmp_path):

--- a/tests/tools/shell/test_bash_tool_security.py
+++ b/tests/tools/shell/test_bash_tool_security.py
@@ -2,6 +2,9 @@ import os
 import subprocess
 from types import SimpleNamespace
 
+import pytest
+from pydantic_ai import ApprovalRequired
+
 from suzent.tools.shell.bash_tool import BashTool
 
 
@@ -161,14 +164,11 @@ def test_host_timeout_kills_process_tree_and_returns_tool_error(monkeypatch, tmp
     assert "background=True" in result.message
 
 
-def test_baseline_guardrails_block_dangerous_command(tmp_path):
-    result = BashTool().forward(
-        _ctx(tmp_path),
-        content="sudo ls",
-        language="command",
-        description="List files with elevated privileges",
-    )
-
-    assert not result.success
-    assert result.error_code.value == "permission_denied"
-    assert "baseline guardrails" in result.message
+def test_baseline_guardrails_require_approval_for_dangerous_command(tmp_path):
+    with pytest.raises(ApprovalRequired):
+        BashTool().forward(
+            _ctx(tmp_path),
+            content="sudo ls",
+            language="command",
+            description="List files with elevated privileges",
+        )


### PR DESCRIPTION
## Summary

Fixes the permission approval flow so interactive auto mode asks instead of hard-denying high-risk actions, and so social `/ya` approvals persist as session permission rules.

## Root Cause

Social approvals could fall back to the legacy resume payload when pending approval requests were restored without a full permission decision contract. Separately, the `/ya` slash command alias was normalized by Typer to the primary `/approve` command, so the approval handler did not recognize it as a remembered approval.

## Changes

- Treat interactive auto-mode high-risk classifier and shell policy results as approval prompts instead of final denials.
- Hydrate restored social approval requests with a modern approval decision contract.
- Persist social pending approvals before prompting, so `/ya` can resolve to `allow_session`.
- Preserve the exact slash-command alias during dispatch, so `/ya` sets `remember=True` while `/y` remains one-time.
- Allow previously approved shell guardrail actions to execute while preserving hard denies for explicit configured policy denies.
- Add focused tests for approval manager payloads, social approval persistence, `/ya` alias handling, permission engine behavior, and shell approval execution.

## Validation

- `uv run --no-sync pytest tests\core\test_approve_command_aliases.py tests\core\test_approval_manager.py tests\core\test_social_approval_persistence.py`
- `uv run --no-sync ruff check src\suzent\core\commands\base.py src\suzent\core\commands\approve.py tests\core\test_approve_command_aliases.py`
- Earlier focused permission/shell suites also passed during the fix pass.