### PR TITLE
Improve provider bootstrap model defaults

### DIFF
--- a/src/suzent/core/dream_runner.py
+++ b/src/suzent/core/dream_runner.py
@@ -518,11 +518,18 @@ class DreamRunner(BaseBrain):
         by the time we get here, so a timed-out reindex is non-fatal — the indexer is
         idempotent and the next reconcile picks up whatever was missed.
         """
+        embedding_gen = getattr(mgr, "embedding_gen", None)
+        if not getattr(embedding_gen, "model", None):
+            logger.info(
+                "[dream] skipping search reindex: no embedding model configured"
+            )
+            return
+
         await asyncio.wait_for(
             mgr._core_indexer.check_and_update(
                 markdown_store=mgr.markdown_store,
                 lancedb_store=mgr.store,
-                embedding_gen=mgr.embedding_gen,
+                embedding_gen=embedding_gen,
                 user_id=CONFIG.user_id,
             ),
             timeout=CONFIG.memory_consolidation_timeout_seconds,

--- a/src/suzent/core/role_router.py
+++ b/src/suzent/core/role_router.py
@@ -176,6 +176,17 @@ class RoleRouter:
             if model_ids:
                 self.set_role(role, model_ids)
 
+    def replace_from_dict(self, role_models: Dict[str, Any]) -> None:
+        """Replace all role assignments with the supplied mapping.
+
+        Unlike ``load_from_dict``, empty lists intentionally clear roles. This
+        matches the Settings UI, where removing the last model from a role must
+        persist as "not configured" rather than leaving the old singleton value
+        alive.
+        """
+        self._roles = {}
+        self.load_from_dict(role_models)
+
     def load_from_db(self) -> None:
         """Load role assignments from the database."""
         try:
@@ -210,31 +221,12 @@ class RoleRouter:
             logger.warning("Failed to save role mappings to DB: {}", e)
 
     def load_from_config(self) -> None:
-        """Load role assignments from CONFIG.
-
-        Handles both new ``role_models`` dict and legacy flat fields:
-        ``tts_model``, ``embedding_model``, ``image_generation_model``,
-        ``extraction_model``.
-        """
+        """Load explicit role assignments from CONFIG."""
         from suzent.config import CONFIG
 
-        # New-style role_models dict
         role_models = getattr(CONFIG, "role_models", None)
         if role_models:
             self.load_from_dict(role_models)
-
-        # Legacy flat fields → role mapping (fallback if not set via role_models)
-        _legacy_map = {
-            ModelRole.TTS: "tts_model",
-            ModelRole.EMBEDDING: "embedding_model",
-            ModelRole.IMAGE_GENERATION: "image_generation_model",
-            ModelRole.CHEAP: "extraction_model",
-        }
-        for role, attr in _legacy_map.items():
-            if not self.has_role(role):
-                val = getattr(CONFIG, attr, None)
-                if val:
-                    self.set_role(role, [val])
 
 
 # ---------------------------------------------------------------------------

--- a/src/suzent/memory/lancedb_store.py
+++ b/src/suzent/memory/lancedb_store.py
@@ -509,7 +509,12 @@ class LanceDBMemoryStore:
     ) -> List[Dict[str, Any]]:
         """Public FTS-only search (no embedding API call, purely local)."""
         where = self._build_user_chat_filter(user_id, chat_id)
-        return await self._perform_fts_search(query_text, where, limit)
+        results = await self._perform_fts_search(query_text, where, limit)
+        formatted_results = [
+            self._format_memory_result(r, score=r.get("_score", 0.0)) for r in results
+        ]
+        self._schedule_access_recording(formatted_results)
+        return formatted_results
 
     @staticmethod
     def _normalize_fts_scores(fts_results: List[Dict[str, Any]]) -> float:

--- a/src/suzent/memory/lifecycle.py
+++ b/src/suzent/memory/lifecycle.py
@@ -266,15 +266,19 @@ async def init_memory_system() -> bool:
             CONFIG.tool_options.append("MemorySearchTool")
             logger.info("Added MemorySearchTool to config")
 
-        # Start background core-file watcher only when embedding is configured
+        # Start background core-file watcher only when embedding is configured.
+        # The watcher maintains the LanceDB search index, so it cannot do useful
+        # work without vectors.
         if markdown_store and _embedding_model:
             _watcher_task = asyncio.create_task(
                 _core_file_watch_loop(memory_manager, CONFIG.user_id),
                 name="core_memory_file_watcher",
             )
 
-            # Start the autonomous dream consolidation runner (gated; a safe no-op
-            # until enough daily logs accrue).
+        # Start the autonomous dream consolidation runner whenever markdown memory
+        # is available. Dream writes the notebook source of truth; vector reindexing
+        # is a best-effort follow-up that can be skipped when embeddings are unset.
+        if markdown_store:
             if getattr(CONFIG, "memory_consolidation_enabled", True):
                 try:
                     from suzent.core.dream_runner import DreamRunner

--- a/src/suzent/memory/manager.py
+++ b/src/suzent/memory/manager.py
@@ -410,9 +410,24 @@ class MemoryManager:
     ) -> List[Dict[str, Any]]:
         """
         Semantic search for memories (agent-facing tool).
-        Uses hybrid search: semantic + full-text + importance ranking.
+        Uses hybrid search when embeddings are configured; otherwise falls back
+        to local full-text search so memory remains useful without an embedding
+        provider.
         """
         try:
+            if not self.embedding_gen.model:
+                results = await self.store.fts_search(
+                    query_text=query,
+                    user_id=user_id or "",
+                    chat_id=chat_id,
+                    limit=limit,
+                )
+                self._log_recalls(results)
+                logger.info(
+                    f"Keyword memory search for '{query}': found {len(results)} results"
+                )
+                return results
+
             # Generate query embedding
             query_embedding = await self.embedding_gen.generate(query)
 

--- a/src/suzent/routes/config_routes.py
+++ b/src/suzent/routes/config_routes.py
@@ -60,6 +60,70 @@ def _schedule_volume_metadata_refresh(volumes: list[str]) -> None:
             logger.warning("Volume metadata refresh failed: {}", exc)
 
 
+def _parse_role_models_blob(blob: str | None) -> dict[str, list[str]]:
+    if not blob:
+        return {}
+    try:
+        parsed = json.loads(blob)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+
+    roles: dict[str, list[str]] = {}
+    for role, value in parsed.items():
+        if isinstance(value, dict):
+            models = value.get("models", [])
+        elif isinstance(value, list):
+            models = value
+        else:
+            continue
+        if isinstance(models, list):
+            roles[role] = [m for m in models if isinstance(m, str) and m]
+    return roles
+
+
+def _save_role_models_blob(db: Any, roles: dict[str, list[str]]) -> None:
+    blob = json.dumps({role: {"models": models} for role, models in roles.items()})
+    db.save_api_key("_ROLE_MODELS_", blob)
+    os.environ["_ROLE_MODELS_"] = blob
+
+    from suzent.core.role_router import get_role_router
+
+    get_role_router().replace_from_dict(roles)
+
+
+def _autofill_chat_roles_from_models(db: Any, model_ids: list[str]) -> bool:
+    """Fill empty chat roles after a provider is connected."""
+    if not model_ids:
+        return False
+
+    api_keys = db.get_api_keys() or {}
+    roles = _parse_role_models_blob(api_keys.get("_ROLE_MODELS_"))
+
+    changed = False
+    for role in ("primary", "cheap"):
+        if not roles.get(role):
+            roles[role] = list(model_ids)
+            changed = True
+
+    if not roles.get("vision"):
+        try:
+            from suzent.core.model_registry import get_model_registry
+
+            registry = get_model_registry()
+            vision_models = [m for m in model_ids if registry.supports_vision(m)]
+        except Exception:
+            vision_models = []
+        if vision_models:
+            roles["vision"] = vision_models
+            changed = True
+
+    if changed:
+        _save_role_models_blob(db, roles)
+    return changed
+
+
 async def get_config(request: Request) -> JSONResponse:
     """Return frontend-consumable configuration merged with user preferences."""
     db = get_database()
@@ -445,31 +509,37 @@ async def save_api_keys(request: Request) -> JSONResponse:
             except json.JSONDecodeError:
                 custom_config = {}
 
-            # Build a map of provider field keys → provider id
-            key_to_provider: dict[str, str] = {}
             provider_defaults: dict[str, list[str]] = {}
             for p in PROVIDER_REGISTRY:
                 pid = p.id
                 provider_defaults[pid] = [m["id"] for m in p.default_models]
-                for field in p.fields:
-                    key_to_provider[field["key"]] = pid
 
             # For each provider whose key was newly set and has no enabled_models,
             # auto-populate with default_models so the UI shows options immediately.
-            for env_key in newly_set_keys:
-                pid = key_to_provider.get(env_key)
-                if pid and not custom_config.get(pid, {}).get("enabled_models"):
+            models_for_role_autofill: list[str] = []
+            for provider in PROVIDER_REGISTRY:
+                pid = provider.id
+                provider_key_was_set = any(
+                    field["key"] in newly_set_keys for field in provider.fields
+                )
+                if provider_key_was_set and not custom_config.get(pid, {}).get(
+                    "enabled_models"
+                ):
                     defaults = provider_defaults.get(pid, [])
                     if defaults:
                         if pid not in custom_config:
                             custom_config[pid] = {}
                         custom_config[pid]["enabled_models"] = defaults
+                        if not models_for_role_autofill:
+                            models_for_role_autofill = defaults
 
             updated_blob = json.dumps(custom_config)
             db.save_api_key("_PROVIDER_CONFIG_", updated_blob)
             os.environ["_PROVIDER_CONFIG_"] = updated_blob
             count += 1
             invalidate_default_model_cache()
+            if _autofill_chat_roles_from_models(db, models_for_role_autofill):
+                count += 1
 
         return JSONResponse({"success": True, "updated": count})
     except Exception as e:
@@ -830,7 +900,7 @@ async def save_role_models(request: Request) -> JSONResponse:
         roles = data.get("roles", {})
 
         router = get_role_router()
-        router.load_from_dict(roles)
+        router.replace_from_dict(roles)
         router.save_to_db()
 
         return JSONResponse({"success": True, "roles": router.list_roles()})

--- a/src/suzent/routes/config_routes.py
+++ b/src/suzent/routes/config_routes.py
@@ -124,6 +124,19 @@ def _autofill_chat_roles_from_models(db: Any, model_ids: list[str]) -> bool:
     return changed
 
 
+def _first_newly_enabled_provider_models(
+    old_config: dict[str, Any], new_config: dict[str, Any]
+) -> list[str]:
+    """Return enabled models for the first provider that just gained models."""
+    for provider in PROVIDER_REGISTRY:
+        pid = provider.id
+        old_models = old_config.get(pid, {}).get("enabled_models") or []
+        new_models = new_config.get(pid, {}).get("enabled_models") or []
+        if not old_models and new_models:
+            return [m for m in new_models if isinstance(m, str) and m]
+    return []
+
+
 async def get_config(request: Request) -> JSONResponse:
     """Return frontend-consumable configuration merged with user preferences."""
     db = get_database()
@@ -504,6 +517,19 @@ async def save_api_keys(request: Request) -> JSONResponse:
         # Process _PROVIDER_CONFIG_ with auto-population of default_models
         provider_config_blob = keys.get("_PROVIDER_CONFIG_")
         if isinstance(provider_config_blob, str) and provider_config_blob:
+            existing_provider_config: dict[str, Any] = {}
+            try:
+                existing_blob = (db.get_api_keys() or {}).get("_PROVIDER_CONFIG_")
+                existing_provider_config = (
+                    json.loads(existing_blob)
+                    if isinstance(existing_blob, str) and existing_blob
+                    else {}
+                )
+                if not isinstance(existing_provider_config, dict):
+                    existing_provider_config = {}
+            except json.JSONDecodeError:
+                existing_provider_config = {}
+
             try:
                 custom_config: dict[str, Any] = json.loads(provider_config_blob)
             except json.JSONDecodeError:
@@ -516,7 +542,6 @@ async def save_api_keys(request: Request) -> JSONResponse:
 
             # For each provider whose key was newly set and has no enabled_models,
             # auto-populate with default_models so the UI shows options immediately.
-            models_for_role_autofill: list[str] = []
             for provider in PROVIDER_REGISTRY:
                 pid = provider.id
                 provider_key_was_set = any(
@@ -530,14 +555,15 @@ async def save_api_keys(request: Request) -> JSONResponse:
                         if pid not in custom_config:
                             custom_config[pid] = {}
                         custom_config[pid]["enabled_models"] = defaults
-                        if not models_for_role_autofill:
-                            models_for_role_autofill = defaults
 
             updated_blob = json.dumps(custom_config)
             db.save_api_key("_PROVIDER_CONFIG_", updated_blob)
             os.environ["_PROVIDER_CONFIG_"] = updated_blob
             count += 1
             invalidate_default_model_cache()
+            models_for_role_autofill = _first_newly_enabled_provider_models(
+                existing_provider_config, custom_config
+            )
             if _autofill_chat_roles_from_models(db, models_for_role_autofill):
                 count += 1
 

--- a/tests/core/test_dream_runner_without_embedding.py
+++ b/tests/core/test_dream_runner_without_embedding.py
@@ -1,0 +1,30 @@
+from suzent.core.dream_runner import DreamRunner
+
+
+class FakeEmbedding:
+    model = None
+
+
+class FakeIndexer:
+    def __init__(self):
+        self.called = False
+
+    async def check_and_update(self, **kwargs):
+        self.called = True
+
+
+class FakeManager:
+    def __init__(self):
+        self.embedding_gen = FakeEmbedding()
+        self._core_indexer = FakeIndexer()
+        self.markdown_store = object()
+        self.store = object()
+
+
+async def test_dream_reindex_skips_without_embedding_model():
+    manager = FakeManager()
+    runner = DreamRunner()
+
+    await runner._reindex(manager)
+
+    assert manager._core_indexer.called is False

--- a/tests/core/test_role_router.py
+++ b/tests/core/test_role_router.py
@@ -107,3 +107,34 @@ class TestRoleRouter:
         )
         assert router.has_role("primary") is False
         assert router.has_role("cheap") is False
+
+    def test_replace_from_dict_clears_existing_roles(self):
+        router = RoleRouter()
+        router.set_role("primary", ["openai/gpt-4.1"])
+        router.set_role("cheap", ["openai/gpt-4.1-mini"])
+
+        router.replace_from_dict({"primary": []})
+
+        assert router.list_roles() == {}
+
+    def test_load_from_config_ignores_legacy_model_fields(self, monkeypatch):
+        from suzent import config as config_mod
+
+        monkeypatch.setattr(config_mod.CONFIG, "role_models", {}, raising=False)
+        monkeypatch.setattr(
+            config_mod.CONFIG,
+            "embedding_model",
+            "gemini/gemini-embedding-001",
+            raising=False,
+        )
+        monkeypatch.setattr(
+            config_mod.CONFIG,
+            "extraction_model",
+            "gemini/gemini-2.5-flash",
+            raising=False,
+        )
+
+        router = RoleRouter()
+        router.load_from_config()
+
+        assert router.list_roles() == {}

--- a/tests/memory/test_search_without_embedding.py
+++ b/tests/memory/test_search_without_embedding.py
@@ -1,0 +1,46 @@
+from suzent.memory.manager import MemoryManager
+
+
+class FakeStore:
+    def __init__(self):
+        self.calls = []
+
+    async def fts_search(self, query_text, user_id, chat_id=None, limit=10):
+        self.calls.append(
+            {
+                "query_text": query_text,
+                "user_id": user_id,
+                "chat_id": chat_id,
+                "limit": limit,
+            }
+        )
+        return [
+            {
+                "id": "m1",
+                "content": "likes local keyword search",
+                "metadata": {},
+                "importance": 0.7,
+                "created_at": None,
+                "updated_at": None,
+                "access_count": 0,
+                "score": 1.0,
+            }
+        ]
+
+
+async def test_search_memories_uses_keyword_fallback_without_embedding():
+    store = FakeStore()
+    manager = MemoryManager(store=store, embedding_model=None, embedding_dimension=2)
+    manager.embedding_gen.model = None
+
+    results = await manager.search_memories("keyword", user_id="user-1", limit=3)
+
+    assert results[0]["content"] == "likes local keyword search"
+    assert store.calls == [
+        {
+            "query_text": "keyword",
+            "user_id": "user-1",
+            "chat_id": None,
+            "limit": 3,
+        }
+    ]

--- a/tests/routes/test_config_role_autofill.py
+++ b/tests/routes/test_config_role_autofill.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 
 from suzent.routes import config_routes
 from suzent.core.role_router import get_role_router
@@ -72,3 +73,24 @@ def test_autofill_noops_without_models():
 
     assert config_routes._autofill_chat_roles_from_models(db, []) is False
     assert "_ROLE_MODELS_" not in db.api_keys
+
+
+def test_detects_models_enabled_for_fieldless_provider(monkeypatch):
+    monkeypatch.setattr(
+        config_routes,
+        "PROVIDER_REGISTRY",
+        [
+            SimpleNamespace(id="openai"),
+            SimpleNamespace(id="chatgpt"),
+        ],
+    )
+
+    models = config_routes._first_newly_enabled_provider_models(
+        {"openai": {"enabled_models": ["openai/gpt-4.1"]}},
+        {
+            "openai": {"enabled_models": ["openai/gpt-4.1"]},
+            "chatgpt": {"enabled_models": ["chatgpt/gpt-5"]},
+        },
+    )
+
+    assert models == ["chatgpt/gpt-5"]

--- a/tests/routes/test_config_role_autofill.py
+++ b/tests/routes/test_config_role_autofill.py
@@ -1,0 +1,74 @@
+import json
+
+from suzent.routes import config_routes
+from suzent.core.role_router import get_role_router
+
+
+class FakeDB:
+    def __init__(self, api_keys=None):
+        self.api_keys = dict(api_keys or {})
+
+    def get_api_keys(self):
+        return dict(self.api_keys)
+
+    def save_api_key(self, key, value):
+        self.api_keys[key] = value
+
+
+class FakeRegistry:
+    def supports_vision(self, model_id: str) -> bool:
+        return model_id.endswith("vision")
+
+
+def _saved_roles(db: FakeDB) -> dict:
+    return json.loads(db.api_keys["_ROLE_MODELS_"])
+
+
+def test_autofill_chat_roles_from_connected_provider(monkeypatch):
+    monkeypatch.setattr(
+        "suzent.core.model_registry.get_model_registry", lambda: FakeRegistry()
+    )
+    router = get_role_router()
+    router.replace_from_dict({})
+    db = FakeDB()
+
+    changed = config_routes._autofill_chat_roles_from_models(
+        db, ["openai/gpt-4.1-vision", "openai/gpt-4.1-mini"]
+    )
+
+    assert changed is True
+    assert _saved_roles(db) == {
+        "primary": {"models": ["openai/gpt-4.1-vision", "openai/gpt-4.1-mini"]},
+        "cheap": {"models": ["openai/gpt-4.1-vision", "openai/gpt-4.1-mini"]},
+        "vision": {"models": ["openai/gpt-4.1-vision"]},
+    }
+
+
+def test_autofill_preserves_existing_roles(monkeypatch):
+    monkeypatch.setattr(
+        "suzent.core.model_registry.get_model_registry", lambda: FakeRegistry()
+    )
+    router = get_role_router()
+    router.replace_from_dict({})
+    db = FakeDB(
+        {
+            "_ROLE_MODELS_": json.dumps(
+                {"primary": {"models": ["anthropic/claude-sonnet"]}}
+            )
+        }
+    )
+
+    changed = config_routes._autofill_chat_roles_from_models(db, ["openai/gpt-4.1"])
+
+    assert changed is True
+    assert _saved_roles(db) == {
+        "primary": {"models": ["anthropic/claude-sonnet"]},
+        "cheap": {"models": ["openai/gpt-4.1"]},
+    }
+
+
+def test_autofill_noops_without_models():
+    db = FakeDB()
+
+    assert config_routes._autofill_chat_roles_from_models(db, []) is False
+    assert "_ROLE_MODELS_" not in db.api_keys


### PR DESCRIPTION
## Summary

- Keep model roles empty on fresh installs instead of backfilling legacy Gemini-flavored config fields.
- Auto-fill empty chat roles from the provider that was just connected and enabled.
- Let DreamRunner run without an embedding model, while skipping only vector reindexing.
- Fall back to local keyword/FTS memory search when no embedding model is configured.

## Why

Fresh bootstrap was too Gemini-biased for users who connect another provider first. The role router also preserved removed roles in-memory, and memory features degraded more than necessary when embeddings were unset.

## Validation

- `uv run --no-sync pytest tests/core/test_role_router.py tests/routes/test_config_role_autofill.py tests/core/test_default_chat_model.py tests/memory/test_search_without_embedding.py tests/core/test_dream_runner_without_embedding.py`
- pre-commit: `ruff check`, `ruff format`