### PR TITLE
Improve shell timeout diagnostics

### DIFF
--- a/src/suzent/sandbox/manager.py
+++ b/src/suzent/sandbox/manager.py
@@ -179,7 +179,7 @@ def _validate_volume_mount(host_path: str) -> None:
 class ExecutionResult:
     """Result from code execution in sandbox."""
 
-    __slots__ = ("success", "output", "error", "exit_code", "language")
+    __slots__ = ("success", "output", "error", "exit_code", "language", "timed_out")
 
     def __init__(
         self,
@@ -188,17 +188,31 @@ class ExecutionResult:
         error: Optional[str] = None,
         exit_code: int = 0,
         language: Optional[Language] = None,
+        timed_out: bool = False,
     ):
         self.success = success
         self.output = output
         self.error = error
         self.exit_code = exit_code
         self.language = language
+        self.timed_out = timed_out
 
     @classmethod
     def failure(cls, error: str) -> ExecutionResult:
         """Factory for failed execution."""
         return cls(success=False, output="", error=error)
+
+    @classmethod
+    def timeout(cls, error: str, language: Language) -> ExecutionResult:
+        """Factory for executions stopped by the sandbox timeout."""
+        return cls(
+            success=False,
+            output="",
+            error=error,
+            exit_code=124,
+            language=language,
+            timed_out=True,
+        )
 
 
 # =============================================================================
@@ -599,7 +613,7 @@ class DockerSession:
                     return self._execute_command(content, timeout)
                 return self._execute_code(content, language, timeout)
             except TimeoutError as e:
-                return ExecutionResult.failure(str(e))
+                return ExecutionResult.timeout(str(e), language)
             except Exception as e:
                 if self._should_auto_heal(str(e)):
                     logger.warning(

--- a/src/suzent/tools/shell/bash_tool.py
+++ b/src/suzent/tools/shell/bash_tool.py
@@ -16,6 +16,7 @@ import os
 import re
 import subprocess
 import tempfile
+from math import ceil
 from pathlib import Path
 from typing import Annotated, Literal, Optional
 
@@ -86,8 +87,20 @@ class BashTool(Tool):
 
     @classmethod
     def default_timeout_seconds(cls) -> int:
-        """Return the execution timeout used when the caller omits timeout."""
-        return cls.DEFAULT_TIMEOUT_SECONDS
+        """Return the configured timeout used when the caller omits timeout."""
+        raw_timeout_ms = os.getenv("SUZENT_SHELL_TIMEOUT_MS", "").strip()
+        if not raw_timeout_ms:
+            return cls.DEFAULT_TIMEOUT_SECONDS
+        try:
+            timeout_ms = int(raw_timeout_ms)
+            if timeout_ms <= 0:
+                raise ValueError
+        except ValueError:
+            logger.warning(
+                "Ignoring invalid SUZENT_SHELL_TIMEOUT_MS; expected a positive integer"
+            )
+            return cls.DEFAULT_TIMEOUT_SECONDS
+        return max(1, ceil(timeout_ms / 1000))
 
     @classmethod
     def stream_wait_timeout_seconds(
@@ -533,6 +546,29 @@ class BashTool(Tool):
                     background=False,
                 )
 
+        except TimeoutError as e:
+            logger.warning(f"Sandbox execution timed out after {timeout}s")
+            self._audit_execution(
+                "timeout",
+                description=description,
+                mode="sandbox",
+                language=language,
+                timeout=timeout,
+                background=False,
+            )
+            return self._error_result(
+                ToolErrorCode.TIMEOUT,
+                (
+                    f"{e}\n[SYSTEM REMINDER: The sandbox command timed out. "
+                    "Do not blindly retry the same command; inspect the likely "
+                    "bottleneck, increase timeout, or use background=True.]"
+                ),
+                mode="sandbox",
+                language=language,
+                timeout=timeout,
+                background=False,
+                returncode=124,
+            )
         except Exception as e:
             logger.error(f"Sandbox tool error: {e}")
             self._audit_execution(
@@ -719,9 +755,25 @@ class BashTool(Tool):
         except subprocess.TimeoutExpired:
             if process is not None:
                 self._kill_host_process_tree(process)
+            stdout = self._read_output_file(stdout_path) if stdout_path else ""
+            stderr = self._read_output_file(stderr_path) if stderr_path else ""
+            partial_parts = []
+            if stdout.strip():
+                partial_parts.append(stdout)
+            if stderr.strip():
+                partial_parts.append(f"[stderr]\n{stderr}")
+            partial_output = "\n".join(partial_parts)
+            reminder = (
+                f"[SYSTEM REMINDER: Process timed out after {effective_timeout}s "
+                "and was terminated. Do not blindly retry the same command; "
+                "inspect the partial output, increase timeout, or use "
+                "background=True.]"
+            )
+            message = "\n".join(part for part in (partial_output, reminder) if part)
             logger.warning(f"Host execution timed out after {effective_timeout}s")
             self._audit_execution(
                 "timeout",
+                description=description,
                 mode="host",
                 language=language,
                 timeout=effective_timeout,
@@ -729,15 +781,15 @@ class BashTool(Tool):
             )
             return self._error_result(
                 ToolErrorCode.TIMEOUT,
-                (
-                    f"Command timed out after {effective_timeout} seconds and was "
-                    "terminated. Continue with a different approach, set a larger "
-                    "timeout, or use background=True for expected long-running work."
-                ),
+                message,
                 mode="host",
                 language=language,
                 timeout=effective_timeout,
                 background=False,
+                returncode=124,
+                stdout=stdout,
+                stderr=stderr,
+                cwd=str(working_dir),
             )
         except FileNotFoundError as e:
             logger.error(f"Host execution command not found: {e}")

--- a/src/suzent/tools/shell/bash_tool.py
+++ b/src/suzent/tools/shell/bash_tool.py
@@ -56,6 +56,7 @@ class BashTool(Tool):
     _SUPPORTED_LANGUAGES = {"python", "nodejs", "command"}
     DEFAULT_TIMEOUT_SECONDS = 120
     TOOL_STREAM_TIMEOUT_GRACE_SECONDS = 30
+    TIMEOUT_OUTPUT_BYTES_PER_STREAM = 12_000
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -527,6 +528,31 @@ class BashTool(Tool):
                     background=False,
                 )
             else:
+                if result.timed_out:
+                    error = result.error or "Sandbox execution timed out"
+                    logger.warning(f"Sandbox execution timed out: {error}")
+                    self._audit_execution(
+                        "timeout",
+                        description=description,
+                        mode="sandbox",
+                        language=language,
+                        timeout=timeout,
+                        background=False,
+                    )
+                    return self._error_result(
+                        ToolErrorCode.TIMEOUT,
+                        (
+                            f"{error}\n"
+                            "[SYSTEM REMINDER: The sandbox command timed out. "
+                            "Do not blindly retry the same command; inspect the likely "
+                            "bottleneck, increase timeout, or use background=True.]"
+                        ),
+                        mode="sandbox",
+                        language=language,
+                        timeout=timeout,
+                        background=False,
+                        returncode=124,
+                    )
                 logger.warning(f"Sandbox execution error: {result.error}")
                 self._audit_execution(
                     "error",
@@ -755,8 +781,14 @@ class BashTool(Tool):
         except subprocess.TimeoutExpired:
             if process is not None:
                 self._kill_host_process_tree(process)
-            stdout = self._read_output_file(stdout_path) if stdout_path else ""
-            stderr = self._read_output_file(stderr_path) if stderr_path else ""
+            stdout = self._read_output_file(
+                stdout_path,
+                max_bytes=self.TIMEOUT_OUTPUT_BYTES_PER_STREAM,
+            )
+            stderr = self._read_output_file(
+                stderr_path,
+                max_bytes=self.TIMEOUT_OUTPUT_BYTES_PER_STREAM,
+            )
             partial_parts = []
             if stdout.strip():
                 partial_parts.append(stdout)
@@ -832,11 +864,39 @@ class BashTool(Tool):
             self._unlink_temp_output(stderr_path)
 
     @staticmethod
-    def _read_output_file(path: Optional[Path]) -> str:
+    def _read_output_file(
+        path: Optional[Path],
+        max_bytes: Optional[int] = None,
+    ) -> str:
         if path is None:
             return ""
         try:
-            return path.read_text(encoding="utf-8", errors="replace")
+            with path.open("rb") as output_file:
+                truncated = False
+                if max_bytes is not None:
+                    output_file.seek(0, os.SEEK_END)
+                    size = output_file.tell()
+                    truncated = size > max_bytes
+                    if truncated:
+                        head_bytes = max_bytes // 3
+                        tail_bytes = max_bytes - head_bytes
+                        output_file.seek(0)
+                        head = output_file.read(head_bytes)
+                        output_file.seek(-tail_bytes, os.SEEK_END)
+                        tail = output_file.read(tail_bytes)
+                        omitted_bytes = size - len(head) - len(tail)
+                        return (
+                            head.decode("utf-8", errors="replace")
+                            + f"\n... [{omitted_bytes} bytes omitted] ...\n"
+                            + tail.decode("utf-8", errors="replace")
+                        )
+                    else:
+                        output_file.seek(0)
+                    data = output_file.read(max_bytes)
+                else:
+                    data = output_file.read()
+            text = data.decode("utf-8", errors="replace")
+            return text
         except FileNotFoundError:
             return ""
 

--- a/tests/sandbox/test_sandbox_manager_unit.py
+++ b/tests/sandbox/test_sandbox_manager_unit.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from suzent.sandbox.manager import DockerSession, SandboxManager
+from suzent.sandbox.manager import DockerSession, Language, SandboxManager
 
 
 class _FakeContainers:
@@ -53,6 +53,33 @@ def test_docker_session_build_env_exposes_project_paths():
     assert env["PROJECT_SLUG"] == "default"
     assert env["PROJECT_PATH"] == "/workspace"
     assert env["SHARED_PATH"] == "/shared"
+
+
+def test_docker_session_timeout_returns_exit_code_124(monkeypatch):
+    session = DockerSession(
+        session_id="chat-timeout",
+        client=None,
+        data_path="unused",
+        image="python:3.11-slim",
+        memory_mb=512,
+        cpus=1,
+        network="bridge",
+        project_slug="default",
+    )
+    session._is_running = True
+
+    def raise_timeout(content, timeout):
+        raise TimeoutError("Execution timed out after 1s")
+
+    monkeypatch.setattr(session, "_execute_command", raise_timeout)
+
+    result = session.execute("sleep 10", Language.COMMAND, timeout=1)
+
+    assert not result.success
+    assert result.timed_out
+    assert result.exit_code == 124
+    assert result.error == "Execution timed out after 1s"
+    assert result.language == Language.COMMAND
 
 
 def test_sandbox_manager_singleton_per_volume_key(monkeypatch):

--- a/tests/tools/shell/test_bash_tool_security.py
+++ b/tests/tools/shell/test_bash_tool_security.py
@@ -137,7 +137,10 @@ def test_host_timeout_kills_process_tree_and_returns_tool_error(monkeypatch, tmp
         returncode = None
 
         def __init__(self, cmd, **kwargs):
-            pass
+            kwargs["stdout"].write(b"Fetching packages... 45%\n")
+            kwargs["stdout"].flush()
+            kwargs["stderr"].write(b"waiting for registry\n")
+            kwargs["stderr"].flush()
 
         def wait(self, timeout=None):
             raise subprocess.TimeoutExpired(cmd="slow", timeout=timeout)
@@ -160,8 +163,25 @@ def test_host_timeout_kills_process_tree_and_returns_tool_error(monkeypatch, tmp
     assert killed["called"]
     assert not result.success
     assert result.error_code.value == "timeout"
-    assert "Command timed out after 1 seconds" in result.message
+    assert "Fetching packages... 45%" in result.message
+    assert "waiting for registry" in result.message
+    assert "Process timed out after 1s" in result.message
     assert "background=True" in result.message
+    assert result.metadata["returncode"] == 124
+    assert result.metadata["stdout"] == "Fetching packages... 45%\n"
+    assert result.metadata["stderr"] == "waiting for registry\n"
+
+
+def test_default_timeout_uses_environment_override(monkeypatch):
+    monkeypatch.setenv("SUZENT_SHELL_TIMEOUT_MS", "2501")
+
+    assert BashTool.default_timeout_seconds() == 3
+
+
+def test_default_timeout_ignores_invalid_environment_override(monkeypatch):
+    monkeypatch.setenv("SUZENT_SHELL_TIMEOUT_MS", "not-a-number")
+
+    assert BashTool.default_timeout_seconds() == BashTool.DEFAULT_TIMEOUT_SECONDS
 
 
 def test_baseline_guardrails_require_approval_for_dangerous_command(tmp_path):

--- a/tests/tools/shell/test_bash_tool_security.py
+++ b/tests/tools/shell/test_bash_tool_security.py
@@ -172,6 +172,101 @@ def test_host_timeout_kills_process_tree_and_returns_tool_error(monkeypatch, tmp
     assert result.metadata["stderr"] == "waiting for registry\n"
 
 
+def test_host_timeout_bounds_captured_output(monkeypatch, tmp_path):
+    tool = BashTool()
+    limit = tool.TIMEOUT_OUTPUT_BYTES_PER_STREAM
+
+    class _Process:
+        pid = 123
+        returncode = None
+
+        def __init__(self, cmd, **kwargs):
+            kwargs["stdout"].write(b"a" * (limit + 100) + b"stdout-tail\n")
+            kwargs["stdout"].flush()
+            kwargs["stderr"].write(b"b" * (limit + 100) + b"stderr-tail\n")
+            kwargs["stderr"].flush()
+
+        def wait(self, timeout=None):
+            raise subprocess.TimeoutExpired(cmd="verbose", timeout=timeout)
+
+    monkeypatch.setattr("suzent.tools.shell.bash_tool.subprocess.Popen", _Process)
+    monkeypatch.setattr(
+        BashTool, "_kill_host_process_tree", staticmethod(lambda _: None)
+    )
+
+    result = tool.forward(
+        _ctx(tmp_path),
+        content="verbose-command",
+        language="command",
+        timeout=1,
+        description="Run a verbose command",
+    )
+
+    stdout = result.metadata["stdout"]
+    stderr = result.metadata["stderr"]
+    assert stdout.startswith("a" * (limit // 3))
+    assert stderr.startswith("b" * (limit // 3))
+    assert "bytes omitted" in stdout
+    assert "bytes omitted" in stderr
+    assert stdout.endswith("stdout-tail\n")
+    assert stderr.endswith("stderr-tail\n")
+    assert len(stdout.encode()) <= limit + 40
+    assert len(stderr.encode()) <= limit + 40
+    assert "Process timed out after 1s" in result.message
+
+
+def test_sandbox_timeout_result_is_classified(monkeypatch, tmp_path):
+    tool = BashTool()
+    tool._manager = SimpleNamespace(
+        execute=lambda **kwargs: SimpleNamespace(
+            success=False,
+            output="",
+            error="Execution timed out after 1s",
+            exit_code=124,
+            timed_out=True,
+        )
+    )
+
+    result = tool.forward(
+        _ctx(tmp_path, sandbox_enabled=True),
+        content="sleep 10",
+        language="command",
+        timeout=1,
+        description="Run a slow sandbox command",
+    )
+
+    assert not result.success
+    assert result.error_code.value == "timeout"
+    assert result.metadata["returncode"] == 124
+    assert "Execution timed out after 1s" in result.message
+    assert "background=True" in result.message
+
+
+def test_sandbox_exit_code_124_is_not_assumed_to_be_timeout(monkeypatch, tmp_path):
+    tool = BashTool()
+    tool._manager = SimpleNamespace(
+        execute=lambda **kwargs: SimpleNamespace(
+            success=False,
+            output="",
+            error="Command exited with status 124",
+            exit_code=124,
+            timed_out=False,
+        )
+    )
+
+    result = tool.forward(
+        _ctx(tmp_path, sandbox_enabled=True),
+        content="exit 124",
+        language="command",
+        timeout=1,
+        description="Exit with status 124",
+    )
+
+    assert not result.success
+    assert result.error_code.value == "execution_failed"
+    assert "SYSTEM REMINDER" not in result.message
+
+
 def test_default_timeout_uses_environment_override(monkeypatch):
     monkeypatch.setenv("SUZENT_SHELL_TIMEOUT_MS", "2501")
 


### PR DESCRIPTION
## What changed

- preserve host-command stdout and stderr when execution times out
- return structured timeout metadata with exit code 124
- classify sandbox timeouts as recoverable tool timeouts
- support `SUZENT_SHELL_TIMEOUT_MS` as the user-configured default
- add regression tests for timeout output and configuration precedence

## Why

Previously a timed-out host command discarded the output produced before it hung, leaving the agent without diagnostic context. The hard-coded default also could not be tuned for a user's environment.

## Impact

Agents can diagnose timeouts from partial output, avoid blind retries, and honor a user-configured default while explicit per-call timeouts retain precedence.

## Validation

- `uv run --no-sync pytest tests/test_streaming_timeout.py tests/tools/shell/test_bash_tool_security.py` (23 passed)
- `ruff check src/suzent/tools/shell/bash_tool.py tests/tools/shell/test_bash_tool_security.py`
