### PR TITLE
Accelerate grep search with ripgrep

### DIFF
--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -93,6 +93,22 @@ function Ensure-Git {
 Ensure-Git
 Write-Ok "git $(git --version)"
 
+# ── Optional accelerator: ripgrep ────────────────────────────────────────────
+if (Get-Command rg -ErrorAction SilentlyContinue) {
+    Write-Ok "ripgrep $((rg --version | Select-Object -First 1) -replace '^ripgrep ', '')"
+} elseif (Get-Command winget -ErrorAction SilentlyContinue) {
+    Write-Info "Installing optional ripgrep search accelerator..."
+    winget install --id BurntSushi.ripgrep.MSVC --source winget --accept-package-agreements --accept-source-agreements --silent
+    Refresh-Path
+    if (Get-Command rg -ErrorAction SilentlyContinue) {
+        Write-Ok "ripgrep installed"
+    } else {
+        Write-Warn "ripgrep install failed — grep_search will use its Python fallback."
+    }
+} else {
+    Write-Warn "ripgrep not found — grep_search will use its Python fallback."
+}
+
 # ── Check/install: Node.js ────────────────────────────────────────────────────
 function Get-NodeMajor {
     try {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -99,6 +99,19 @@ if ! command -v git &>/dev/null; then
 fi
 ok "git $(git --version | awk '{print $3}')"
 
+# ── Optional accelerator: ripgrep ────────────────────────────────────────────
+if command -v rg &>/dev/null; then
+    ok "ripgrep $(rg --version | awk 'NR==1 {print $2}')"
+elif [ "$OS" = "Darwin" ] && command -v brew &>/dev/null; then
+    info "Installing optional ripgrep search accelerator..."
+    brew install ripgrep || warn "ripgrep install failed — grep_search will use its Python fallback."
+elif [ "$(id -u)" -eq 0 ] && command -v apt-get &>/dev/null; then
+    info "Installing optional ripgrep search accelerator..."
+    apt-get update && apt-get install -y ripgrep || warn "ripgrep install failed — grep_search will use its Python fallback."
+else
+    warn "ripgrep not found — grep_search will use its Python fallback."
+fi
+
 # ── Check/install: Node.js ────────────────────────────────────────────────────
 install_node() {
     info "Installing Node.js via nvm..."

--- a/src/suzent/cli/main.py
+++ b/src/suzent/cli/main.py
@@ -1036,6 +1036,29 @@ def register_commands(app: typer.Typer):
                     typer.echo(f"  ❌ {name:<10} : Not installed")
                     all_ok = False
 
+        try:
+            ripgrep = subprocess.run(
+                ["rg", "--version"], capture_output=True, text=True
+            )
+            if ripgrep.returncode == 0:
+                typer.echo(
+                    f"  ✅ {'ripgrep':<10} : "
+                    f"{ripgrep.stdout.strip().splitlines()[0]} (optional accelerator)"
+                )
+            else:
+                raise FileNotFoundError
+        except (FileNotFoundError, OSError):
+            if IS_WINDOWS:
+                install_hint = "winget install --id BurntSushi.ripgrep.MSVC"
+            elif sys.platform == "darwin":
+                install_hint = "brew install ripgrep"
+            else:
+                install_hint = "install ripgrep with your system package manager"
+            typer.echo(
+                f"  ⚠️  {'ripgrep':<10} : Optional accelerator not installed; "
+                f"grep_search will use Python fallback. To enable it: {install_hint}"
+            )
+
         if all_ok:
             typer.echo("\n✨ System is ready for Suzent!")
         else:

--- a/src/suzent/tools/filesystem/grep_tool.py
+++ b/src/suzent/tools/filesystem/grep_tool.py
@@ -258,25 +258,40 @@ class GrepTool(Tool):
         ):
             return None
 
-        target = self._resolver.resolve(path or ".")
+        if path == "/" and hasattr(self._resolver, "get_virtual_roots"):
+            targets = []
+            seen_targets: set[Path] = set()
+            for _, root in self._resolver.get_virtual_roots():
+                target = Path(root).resolve()
+                if target.exists() and target not in seen_targets:
+                    seen_targets.add(target)
+                    targets.append(target)
+        else:
+            targets = [self._resolver.resolve(path or ".")]
+
+        if not targets:
+            return [], 0, 0, False
+
         args = [
             self._ripgrep_path or "rg",
             "--json",
             "--line-number",
             "--color",
             "never",
+            "--hidden",
+            "--no-ignore",
             "--max-filesize",
             "2M",
         ]
         if include:
             args.extend(["--glob", include])
         for excluded_dir in sorted(DEFAULT_EXCLUDED_DIRS):
-            args.extend(["--glob", f"!{excluded_dir}/**"])
+            args.extend(["--glob", f"!**/{excluded_dir}/**"])
         if case_insensitive:
             args.append("--ignore-case")
         if context_lines:
             args.extend(["--context", str(context_lines)])
-        args.extend(["--", pattern, str(target)])
+        args.extend(["--", pattern, *(str(target) for target in targets)])
 
         try:
             completed = subprocess.run(

--- a/src/suzent/tools/filesystem/grep_tool.py
+++ b/src/suzent/tools/filesystem/grep_tool.py
@@ -2,9 +2,12 @@
 GrepTool - Search file contents with regex.
 """
 
+import json
 import re
+import shutil
+import subprocess
 from pathlib import Path
-from typing import Annotated, Optional, List, Tuple
+from typing import Annotated, List, Optional, Tuple
 
 from pydantic import Field
 from pydantic_ai import RunContext
@@ -19,6 +22,8 @@ logger = get_logger(__name__)
 
 MAX_GREP_FILE_SIZE = 2 * 1024 * 1024  # 2 MiB
 MAX_GREP_FILES_SCANNED = 5000
+RIPGREP_TIMEOUT_SECONDS = 10
+RIPGREP_OUTPUT_LIMIT = 2 * 1024 * 1024
 # Shared with find_files' walk pruning; kept here as a defense for the case
 # where the caller explicitly targets a path inside a pruned dir.
 DEFAULT_EXCLUDED_DIRS = DEFAULT_PRUNED_DIRS
@@ -36,6 +41,8 @@ class GrepTool(Tool):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._resolver: Optional[PathResolver] = None
+        self._ripgrep_path: Optional[str] = None
+        self._ripgrep_checked = False
 
     def forward(
         self,
@@ -121,6 +128,31 @@ class GrepTool(Tool):
                     metadata={"pattern": pattern, "path": path, "include": include},
                 )
 
+            ripgrep_result = self._search_with_ripgrep(
+                pattern=pattern,
+                path=path,
+                include=include,
+                case_insensitive=bool(case_insensitive),
+                context_lines=context_lines or 0,
+            )
+            if ripgrep_result is not None:
+                results, files_with_matches, scanned_files, output_capped = (
+                    ripgrep_result
+                )
+                return self._format_results(
+                    pattern=pattern,
+                    path=path,
+                    include=include,
+                    context_lines=context_lines or 0,
+                    results=results,
+                    files_with_matches=files_with_matches,
+                    scanned_files=scanned_files,
+                    skipped_large_files=0,
+                    skipped_excluded_files=0,
+                    capped=output_capped,
+                    engine="ripgrep",
+                )
+
             # Collect files to search
             glob_pattern = include or "**/*"
 
@@ -175,58 +207,18 @@ class GrepTool(Tool):
                 except Exception as e:
                     logger.debug(f"Could not search {file_path}: {e}")
 
-            if not results:
-                message = f"No matches for '{pattern}' in {path or 'working directory'}"
-                if capped:
-                    message += (
-                        f" (scan capped at {MAX_GREP_FILES_SCANNED} files; "
-                        "use 'include' or a narrower 'path' to speed up search)"
-                    )
-                return ToolResult.success_result(
-                    message,
-                    metadata={
-                        "match_count": 0,
-                        "file_count": 0,
-                        "scanned_files": scanned_files,
-                        "skipped_large_files": skipped_large_files,
-                        "skipped_excluded_files": skipped_excluded_files,
-                        "capped": capped,
-                        "pattern": pattern,
-                        "path": path,
-                        "include": include,
-                        "context_lines": ctx_lines,
-                    },
-                )
-
-            # Format output
-            output_lines = [
-                f"Found {len(results)} match(es) in {files_with_matches} file(s):"
-            ]
-
-            current_file = None
-            for vpath, line_num, content in results[:50]:  # Limit output
-                if vpath != current_file:
-                    output_lines.append(f"\n{vpath}:")
-                    current_file = vpath
-                output_lines.append(f"  {line_num}: {content.rstrip()}")
-
-            if len(results) > 50:
-                output_lines.append(f"\n... and {len(results) - 50} more matches")
-
-            return ToolResult.success_result(
-                "\n".join(output_lines),
-                metadata={
-                    "match_count": len(results),
-                    "file_count": files_with_matches,
-                    "scanned_files": scanned_files,
-                    "skipped_large_files": skipped_large_files,
-                    "skipped_excluded_files": skipped_excluded_files,
-                    "capped": capped,
-                    "pattern": pattern,
-                    "path": path,
-                    "include": include,
-                    "context_lines": ctx_lines,
-                },
+            return self._format_results(
+                pattern=pattern,
+                path=path,
+                include=include,
+                context_lines=ctx_lines,
+                results=results,
+                files_with_matches=files_with_matches,
+                scanned_files=scanned_files,
+                skipped_large_files=skipped_large_files,
+                skipped_excluded_files=skipped_excluded_files,
+                capped=capped,
+                engine="python",
             )
 
         except ValueError as e:
@@ -242,6 +234,166 @@ class GrepTool(Tool):
                 str(e),
                 metadata={"pattern": pattern, "path": path, "include": include},
             )
+
+    def _check_ripgrep_available(self) -> bool:
+        if not self._ripgrep_checked:
+            self._ripgrep_path = shutil.which("rg")
+            self._ripgrep_checked = True
+        return self._ripgrep_path is not None
+
+    def _search_with_ripgrep(
+        self,
+        *,
+        pattern: str,
+        path: Optional[str],
+        include: Optional[str],
+        case_insensitive: bool,
+        context_lines: int,
+    ) -> Optional[tuple[List[Tuple[str, int, str]], int, int, bool]]:
+        """Run ripgrep, returning None when the Python fallback should be used."""
+        if (
+            not self._check_ripgrep_available()
+            or self._resolver is None
+            or not hasattr(self._resolver, "resolve")
+        ):
+            return None
+
+        target = self._resolver.resolve(path or ".")
+        args = [
+            self._ripgrep_path or "rg",
+            "--json",
+            "--line-number",
+            "--color",
+            "never",
+            "--max-filesize",
+            "2M",
+        ]
+        if include:
+            args.extend(["--glob", include])
+        for excluded_dir in sorted(DEFAULT_EXCLUDED_DIRS):
+            args.extend(["--glob", f"!{excluded_dir}/**"])
+        if case_insensitive:
+            args.append("--ignore-case")
+        if context_lines:
+            args.extend(["--context", str(context_lines)])
+        args.extend(["--", pattern, str(target)])
+
+        try:
+            completed = subprocess.run(
+                args,
+                capture_output=True,
+                check=False,
+                encoding="utf-8",
+                errors="replace",
+                timeout=RIPGREP_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            logger.warning(f"ripgrep unavailable during search; using Python: {exc}")
+            return None
+
+        if completed.returncode not in (0, 1):
+            logger.warning(
+                "ripgrep rejected or failed the search; using Python fallback"
+            )
+            return None
+
+        output = completed.stdout
+        output_capped = len(output.encode("utf-8")) > RIPGREP_OUTPUT_LIMIT
+        if output_capped:
+            output = output.encode("utf-8")[:RIPGREP_OUTPUT_LIMIT].decode(
+                "utf-8", errors="ignore"
+            )
+
+        results: List[Tuple[str, int, str]] = []
+        matched_files: set[str] = set()
+        scanned_files = 0
+        for raw_line in output.splitlines():
+            try:
+                event = json.loads(raw_line)
+            except json.JSONDecodeError:
+                continue
+            event_type = event.get("type")
+            data = event.get("data", {})
+            if event_type == "summary":
+                scanned_files = int(data.get("stats", {}).get("searches", 0))
+                continue
+            if event_type not in {"match", "context"}:
+                continue
+
+            raw_path = data.get("path", {}).get("text")
+            line_number = data.get("line_number")
+            text = data.get("lines", {}).get("text")
+            if not raw_path or not line_number or text is None:
+                continue
+            host_path = Path(raw_path).resolve()
+            display_path = str(host_path)
+            if self._resolver.sandbox_enabled:
+                display_path = self._resolver.to_virtual_path(host_path) or display_path
+            if event_type == "match":
+                matched_files.add(display_path)
+                if context_lines:
+                    text = f"> {text}"
+            elif context_lines:
+                text = f"  {text}"
+            results.append((display_path, int(line_number), text))
+            if len(results) >= 1000:
+                output_capped = True
+                break
+
+        return results, len(matched_files), scanned_files, output_capped
+
+    @staticmethod
+    def _format_results(
+        *,
+        pattern: str,
+        path: Optional[str],
+        include: Optional[str],
+        context_lines: int,
+        results: List[Tuple[str, int, str]],
+        files_with_matches: int,
+        scanned_files: int,
+        skipped_large_files: int,
+        skipped_excluded_files: int,
+        capped: bool,
+        engine: str,
+    ) -> ToolResult:
+        metadata = {
+            "match_count": len(results),
+            "file_count": files_with_matches,
+            "scanned_files": scanned_files,
+            "skipped_large_files": skipped_large_files,
+            "skipped_excluded_files": skipped_excluded_files,
+            "capped": capped,
+            "pattern": pattern,
+            "path": path,
+            "include": include,
+            "context_lines": context_lines,
+            "engine": engine,
+        }
+        if not results:
+            message = f"No matches for '{pattern}' in {path or 'working directory'}"
+            if capped:
+                if engine == "python":
+                    message += (
+                        f" (scan capped at {MAX_GREP_FILES_SCANNED} files; "
+                        "use 'include' or a narrower 'path' to speed up search)"
+                    )
+                else:
+                    message += " (search output was capped; narrow 'path' or 'include')"
+            return ToolResult.success_result(message, metadata=metadata)
+
+        output_lines = [
+            f"Found {len(results)} match(es) in {files_with_matches} file(s):"
+        ]
+        current_file = None
+        for display_path, line_number, content in results[:50]:
+            if display_path != current_file:
+                output_lines.append(f"\n{display_path}:")
+                current_file = display_path
+            output_lines.append(f"  {line_number}: {content.rstrip()}")
+        if len(results) > 50:
+            output_lines.append(f"\n... and {len(results) - 50} more matches")
+        return ToolResult.success_result("\n".join(output_lines), metadata=metadata)
 
     def _is_text_file(self, path: Path) -> bool:
         """Check if file is likely a text file."""

--- a/tests/cli/test_cli_nodes.py
+++ b/tests/cli/test_cli_nodes.py
@@ -2,6 +2,7 @@
 Unit tests for the CLI subcommands (nodes, agent, config).
 """
 
+import subprocess
 from unittest.mock import AsyncMock, patch, MagicMock
 
 from typer.testing import CliRunner
@@ -25,6 +26,25 @@ class TestCLIRoot:
         assert "nodes" in result.output
         assert "agent" in result.output
         assert "config" in result.output
+
+    @patch("suzent.cli.main.ensure_cargo_in_path")
+    @patch("suzent.cli.main.subprocess.run")
+    def test_doctor_treats_missing_ripgrep_as_optional(
+        self, mock_run, mock_ensure_cargo
+    ):
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[0] == "rg":
+                raise FileNotFoundError
+            return subprocess.CompletedProcess(cmd, 0, "tool version 1\n", "")
+
+        mock_run.side_effect = fake_run
+
+        result = runner.invoke(app, ["doctor"])
+
+        assert result.exit_code == 0
+        assert "ripgrep" in result.output
+        assert "Optional accelerator not installed" in result.output
+        assert "System is ready for Suzent" in result.output
 
 
 class TestNodesSubcommand:

--- a/tests/tools/test_tool_cleanup_smoke.py
+++ b/tests/tools/test_tool_cleanup_smoke.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -54,6 +55,24 @@ class _DummyRipgrepResolver(_DummyGrepResolver):
 
     def to_virtual_path(self, path):
         return f"/workspace/{path.name}"
+
+
+class _DummyVirtualRootResolver(_DummyRipgrepResolver):
+    def __init__(self, roots):
+        super().__init__([], sandbox_enabled=True)
+        self._roots = roots
+
+    def get_virtual_roots(self):
+        return self._roots
+
+    def to_virtual_path(self, path):
+        for virtual_root, host_root in self._roots:
+            try:
+                relative = path.relative_to(host_root)
+            except ValueError:
+                continue
+            return str((Path(virtual_root) / relative).as_posix())
+        return None
 
 
 @pytest.mark.asyncio
@@ -191,6 +210,92 @@ def test_grep_tool_uses_ripgrep_json_output(tmp_path, monkeypatch):
     assert result.metadata["match_count"] == 1
     assert result.metadata["scanned_files"] == 1
     assert str(source) in result.message
+
+
+def test_grep_tool_preserves_ripgrep_search_semantics(tmp_path, monkeypatch):
+    source = tmp_path / "example.py"
+    source.write_text("needle\n", encoding="utf-8")
+    tool = GrepTool()
+    tool._resolver = _DummyRipgrepResolver([(source, str(source))])
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            chat_id="chat-1",
+            sandbox_enabled=False,
+            custom_volumes=[],
+            workspace_root=str(tmp_path),
+            path_resolver=tool._resolver,
+        )
+    )
+    captured_args = []
+
+    def fake_run(args, **kwargs):
+        captured_args.extend(args)
+        return subprocess.CompletedProcess(args, 1, "", "")
+
+    monkeypatch.setattr(tool, "_ripgrep_checked", True)
+    monkeypatch.setattr(tool, "_ripgrep_path", "rg")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = tool.forward(ctx, pattern="needle", path=str(tmp_path))
+
+    assert result.success
+    assert result.metadata["engine"] == "ripgrep"
+    assert "--hidden" in captured_args
+    assert "--no-ignore" in captured_args
+    assert "!**/node_modules/**" in captured_args
+
+
+def test_grep_tool_searches_all_virtual_roots_for_slash_path(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    shared = tmp_path / "shared"
+    workspace.mkdir()
+    shared.mkdir()
+    shared_file = shared / "memory.md"
+    shared_file.write_text("needle\n", encoding="utf-8")
+
+    tool = GrepTool()
+    tool._resolver = _DummyVirtualRootResolver(
+        [("/workspace", workspace), ("/shared", shared)]
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            chat_id="chat-1",
+            sandbox_enabled=True,
+            custom_volumes=[],
+            workspace_root=str(workspace),
+            path_resolver=tool._resolver,
+        )
+    )
+    captured_args = []
+    events = [
+        {
+            "type": "match",
+            "data": {
+                "path": {"text": str(shared_file)},
+                "lines": {"text": "needle\n"},
+                "line_number": 1,
+            },
+        },
+        {"type": "summary", "data": {"stats": {"searches": 2}}},
+    ]
+
+    def fake_run(args, **kwargs):
+        captured_args.extend(args)
+        return subprocess.CompletedProcess(
+            args, 0, "\n".join(json.dumps(event) for event in events), ""
+        )
+
+    monkeypatch.setattr(tool, "_ripgrep_checked", True)
+    monkeypatch.setattr(tool, "_ripgrep_path", "rg")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = tool.forward(ctx, pattern="needle", path="/")
+
+    assert result.success
+    assert result.metadata["engine"] == "ripgrep"
+    assert str(workspace.resolve()) in captured_args
+    assert str(shared.resolve()) in captured_args
+    assert "/shared/memory.md" in result.message
 
 
 def test_grep_tool_falls_back_when_ripgrep_rejects_regex(tmp_path, monkeypatch):

--- a/tests/tools/test_tool_cleanup_smoke.py
+++ b/tests/tools/test_tool_cleanup_smoke.py
@@ -1,3 +1,5 @@
+import json
+import subprocess
 from types import SimpleNamespace
 
 import pytest
@@ -44,6 +46,14 @@ class _DummyGrepResolver:
 
     def find_files(self, pattern, path):
         return self._files
+
+
+class _DummyRipgrepResolver(_DummyGrepResolver):
+    def resolve(self, path):
+        return self._files[0][0].parent if self._files else path
+
+    def to_virtual_path(self, path):
+        return f"/workspace/{path.name}"
 
 
 @pytest.mark.asyncio
@@ -136,6 +146,80 @@ async def test_grep_tool_reports_capped_scan(tmp_path):
     assert result.success
     assert result.metadata["capped"] is True
     assert "scan capped" in result.message
+
+
+def test_grep_tool_uses_ripgrep_json_output(tmp_path, monkeypatch):
+    source = tmp_path / "example.py"
+    source.write_text("needle\n", encoding="utf-8")
+    tool = GrepTool()
+    tool._resolver = _DummyRipgrepResolver([(source, str(source))])
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            chat_id="chat-1",
+            sandbox_enabled=False,
+            custom_volumes=[],
+            workspace_root=str(tmp_path),
+            path_resolver=tool._resolver,
+        )
+    )
+    events = [
+        {
+            "type": "match",
+            "data": {
+                "path": {"text": str(source)},
+                "lines": {"text": "needle\n"},
+                "line_number": 1,
+            },
+        },
+        {"type": "summary", "data": {"stats": {"searches": 1}}},
+    ]
+
+    monkeypatch.setattr(tool, "_ripgrep_checked", True)
+    monkeypatch.setattr(tool, "_ripgrep_path", "rg")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0], 0, "\n".join(json.dumps(event) for event in events), ""
+        ),
+    )
+
+    result = tool.forward(ctx, pattern="needle", path=str(tmp_path))
+
+    assert result.success
+    assert result.metadata["engine"] == "ripgrep"
+    assert result.metadata["match_count"] == 1
+    assert result.metadata["scanned_files"] == 1
+    assert str(source) in result.message
+
+
+def test_grep_tool_falls_back_when_ripgrep_rejects_regex(tmp_path, monkeypatch):
+    source = tmp_path / "example.py"
+    source.write_text("needle\n", encoding="utf-8")
+    tool = GrepTool()
+    tool._resolver = _DummyRipgrepResolver([(source, str(source))])
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            chat_id="chat-1",
+            sandbox_enabled=False,
+            custom_volumes=[],
+            workspace_root=str(tmp_path),
+            path_resolver=tool._resolver,
+        )
+    )
+    monkeypatch.setattr(tool, "_ripgrep_checked", True)
+    monkeypatch.setattr(tool, "_ripgrep_path", "rg")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 2, "", "error"),
+    )
+
+    result = tool.forward(ctx, pattern="needle", path=str(tmp_path))
+
+    assert result.success
+    assert result.metadata["engine"] == "python"
+    assert result.metadata["match_count"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- add a cached ripgrep availability probe and JSON fast path
- preserve `/` searches across `/workspace`, `/shared`, and custom virtual roots
- keep hidden and ignored-file behavior consistent with the Python fallback
- apply excluded-directory globs beneath absolute search targets
- map include, case-insensitive, context, path, line-number, and size behavior
- cap execution time and parsed output
- fall back to the Python engine on missing binaries, process errors, timeouts, and incompatible regexes
- add optional ripgrep installation checks to setup scripts
- report missing ripgrep as a non-blocking optional accelerator in `suzent doctor`
- add fast-path, fallback, virtual-root, argument, and doctor regression tests

## Why

The Python scanner is single-threaded, capped at 5,000 files, and maintains a narrow text-extension list. The ripgrep fast path must retain the same search scope and filtering semantics so results do not depend on whether the optional binary is installed.

## Upgrade behavior

No data or database migration is required. Existing installations continue to use the Python fallback when ripgrep is absent; `suzent doctor` reports the optional accelerator and provides a platform-specific installation hint without failing system health.

## Validation

- `uv run --no-sync pytest tests/tools/test_tool_cleanup_smoke.py tests/cli/test_cli_nodes.py` (39 passed)
- `uv run --no-sync ruff check src/suzent/tools/filesystem/grep_tool.py src/suzent/cli/main.py tests/tools/test_tool_cleanup_smoke.py tests/cli/test_cli_nodes.py`
- `git diff --check`