### PR TITLE
ci: replace retired macOS 13 release runner

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -117,7 +117,7 @@ jobs:
             binary: src-tauri/target/release/suzent
             installer_asset: suzent-installer-macos-aarch64
             installer_binary: apps/suzent-installer/target/release/suzent-installer
-          - os: macos-13
+          - os: macos-15-intel
             asset: suzent-macos-x86_64
             binary: src-tauri/target/release/suzent
             installer_asset: suzent-installer-macos-x86_64


### PR DESCRIPTION
## What changed

- Replace the retired `macos-13` release matrix runner with `macos-15-intel`.
- Keep the existing x86_64 artifact names and build paths unchanged.

## Why

Desktop release run #44 cannot finish because GitHub no longer assigns a runner to the `macos-13` job. Since `publish-release` depends on the complete build matrix, v0.7.2 remains a draft release.

## Impact

After this PR is merged, cancel run #44 and start a new **Build and Publish Desktop Release** workflow for tag `v0.7.2`. Re-running #44 is insufficient because reruns use the old workflow revision.

## Validation

- Parsed `.github/workflows/build-desktop.yml` successfully with PyYAML.
- Ran pre-commit for the changed workflow file.
- Verified `git diff --check` and confirmed no remaining `macos-13` workflow labels.