### PR TITLE
chore: release v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.3] - 2026-08-01
+
+### 🐛 Fixed
+- Pin stable backend source, dependencies, and desktop assets to the same release; reject incompatible frontend/backend builds; and add `suzent update --dev` for lockstep development updates.
+
+### ⚡ Changed
+- Add activity tracking features and localization for token activity display
+- Add build_cron_reminder function and corresponding tests for cron-triggered prompts
+- Organize selectable tools into capabilities (#79)
+- Update button behavior in ChatList to initiate new chat when organization is 'list'
+- Add user-facing notice for attachment processing errors and improve timeout guidance in BashTool
+- Add file preview functionality and update translations
+- Update doc
+- Refactor permission decision display to use details element for improved UX
+- Improve shell timeout diagnostics (#73)
+- Accelerate grep search with ripgrep (#76)
+- Add safe conversation forking (#75)
+- Refactor chat minimap dimensions and marker widths for improved layout
+- Add conflict-safe file undo (#74)
+- Stabilize LanceDB store test cleanup
+- Stabilize task registry rejection tests
+- Improve provider bootstrap model defaults (#72)
+
 ## [v0.7.2] - 2026-07-28
 
 ### 🚀 Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.7.3] - 2026-08-01
 
 ### 🐛 Fixed
-- Pin stable backend source, dependencies, and desktop assets to the same release; reject incompatible frontend/backend builds; and add `suzent update --dev` for lockstep development updates.
+- Pin fresh installs and stable updates to matching backend/UI releases, make update rollback recoverable, reject incompatible production builds, and keep `start --dev`/`serve` tolerant of normal development commit changes.
 
 ### ⚡ Changed
 - Add activity tracking features and localization for token activity display

--- a/README.md
+++ b/README.md
@@ -139,7 +139,16 @@ suzent start
 suzent update
 ```
 
-Or re-run the install command above — it detects an existing installation and pulls the latest changes.
+This installs the latest stable release as one matched set: backend source,
+locked dependencies, and desktop app. Developers working from a source checkout
+can update `main` and its frontend dependencies together with:
+
+```bash
+suzent update --dev
+```
+
+Or re-run the install command above — it detects an existing installation and
+updates it to the latest stable release.
 
 ---
 

--- a/apps/suzent-installer/Cargo.lock
+++ b/apps/suzent-installer/Cargo.lock
@@ -3316,7 +3316,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "suzent-installer"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "dirs 5.0.1",
  "reqwest 0.12.28",

--- a/apps/suzent-installer/Cargo.toml
+++ b/apps/suzent-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "suzent-installer"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Suzent Desktop Installer"
 build = "build.rs"

--- a/apps/suzent-installer/package-lock.json
+++ b/apps/suzent-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "suzent-installer-desktop",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "suzent-installer-desktop",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "devDependencies": {
         "@tauri-apps/cli": "^2.0.0-rc.18"
       }

--- a/apps/suzent-installer/package.json
+++ b/apps/suzent-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suzent-installer-desktop",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "scripts": {
     "tauri": "tauri",

--- a/apps/suzent-installer/src/main.rs
+++ b/apps/suzent-installer/src/main.rs
@@ -16,6 +16,7 @@ const REPO_URL: &str = "https://github.com/cyzus/suzent.git";
 const UV_INSTALL_SH_URL: &str = "https://astral.sh/uv/install.sh";
 const UV_INSTALL_PS1_URL: &str = "https://astral.sh/uv/install.ps1";
 const RELEASE_BASE_URL: &str = "https://github.com/cyzus/suzent/releases/latest/download";
+const LATEST_RELEASE_API: &str = "https://api.github.com/repos/cyzus/suzent/releases/latest";
 
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
@@ -37,12 +38,15 @@ struct InstallStage {
 struct InstallConfig {
     dir: PathBuf,
     branch: String,
+    branch_explicit: bool,
     skip_playwright: bool,
     china_mirror: bool,
     repo_url: String,
     repo_url_override: bool,
     uv_install_url: String,
     release_base_url: String,
+    release_base_url_override: bool,
+    release_tag_override: Option<String>,
     json: bool,
     non_interactive: bool,
 }
@@ -51,6 +55,11 @@ struct InstallConfig {
 struct StageRequest {
     stage: String,
     dir: String,
+}
+
+#[derive(Deserialize)]
+struct ReleaseResponse {
+    tag_name: String,
 }
 
 #[derive(Default)]
@@ -217,13 +226,13 @@ impl InstallConfig {
                     .map(PathBuf::from)
             })
             .unwrap_or_else(default_install_dir);
-        let branch = flag_value(args, "--branch")
-            .or_else(|| {
-                env::var("SUZENT_BRANCH")
-                    .ok()
-                    .filter(|value| !value.trim().is_empty())
-            })
-            .unwrap_or_else(|| DEFAULT_BRANCH.to_string());
+        let configured_branch = flag_value(args, "--branch").or_else(|| {
+            env::var("SUZENT_BRANCH")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        });
+        let branch_explicit = configured_branch.is_some();
+        let branch = configured_branch.unwrap_or_else(|| DEFAULT_BRANCH.to_string());
         let skip_playwright = has_flag(args, "--skip-playwright")
             || env::var("SUZENT_SKIP_PLAYWRIGHT")
                 .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
@@ -247,21 +256,29 @@ impl InstallConfig {
                     UV_INSTALL_SH_URL.to_string()
                 }
             });
-        let release_base_url = env::var("SUZENT_RELEASE_BASE_URL")
+        let release_base_url_env = env::var("SUZENT_RELEASE_BASE_URL")
             .ok()
-            .filter(|value| !value.trim().is_empty())
+            .filter(|value| !value.trim().is_empty());
+        let release_base_url_override = release_base_url_env.is_some();
+        let release_base_url = release_base_url_env
             .map(|value| value.trim_end_matches('/').to_string())
             .unwrap_or_else(|| RELEASE_BASE_URL.to_string());
+        let release_tag_override = env::var("SUZENT_RELEASE_TAG")
+            .ok()
+            .filter(|value| !value.trim().is_empty());
 
         Self {
             dir,
             branch,
+            branch_explicit,
             skip_playwright,
             china_mirror,
             repo_url,
             repo_url_override,
             uv_install_url,
             release_base_url,
+            release_base_url_override,
+            release_tag_override,
             json: has_flag(args, "--json"),
             non_interactive: has_flag(args, "--non-interactive")
                 || has_flag(args, "--json")
@@ -525,68 +542,156 @@ fn stage_python(config: &InstallConfig) -> StageOutcome {
     }
 }
 
+fn is_release_tag(value: &str) -> bool {
+    let Some(version) = value.strip_prefix('v') else {
+        return false;
+    };
+    let parts: Vec<&str> = version.split('.').collect();
+    parts.len() == 3
+        && parts
+            .iter()
+            .all(|part| !part.is_empty() && part.chars().all(|ch| ch.is_ascii_digit()))
+}
+
+fn resolve_release_tag(config: &InstallConfig) -> Result<String, String> {
+    let tag = if let Some(tag) = &config.release_tag_override {
+        tag.trim().to_string()
+    } else {
+        reqwest::blocking::Client::builder()
+            .user_agent("suzent-installer")
+            .build()
+            .map_err(|error| format!("Failed to create release client: {error}"))?
+            .get(LATEST_RELEASE_API)
+            .send()
+            .and_then(|response| response.error_for_status())
+            .map_err(|error| format!("Failed to resolve latest stable release: {error}"))?
+            .json::<ReleaseResponse>()
+            .map_err(|error| format!("Invalid latest release response: {error}"))?
+            .tag_name
+    };
+    if !is_release_tag(&tag) {
+        return Err(format!("Invalid stable release tag: {tag}"));
+    }
+    Ok(tag)
+}
+
+fn write_install_release_state(
+    config: &InstallConfig,
+    release_tag: Option<&str>,
+) -> io::Result<()> {
+    let state_dir = config.dir.join(".suzent");
+    fs::create_dir_all(&state_dir)?;
+    fs::write(
+        state_dir.join("update-channel"),
+        if release_tag.is_some() {
+            "stable"
+        } else {
+            "dev"
+        },
+    )?;
+    let release_file = state_dir.join("release-tag");
+    if let Some(tag) = release_tag {
+        fs::write(release_file, tag)?;
+    } else if release_file.exists() {
+        fs::remove_file(release_file)?;
+    }
+    Ok(())
+}
+
+fn read_install_release_tag(config: &InstallConfig) -> Option<String> {
+    fs::read_to_string(config.dir.join(".suzent").join("release-tag"))
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| is_release_tag(value))
+}
+
 fn stage_repository(config: &InstallConfig) -> StageOutcome {
     let Some(git) = find_git_after_install() else {
         return StageOutcome::fail("Git is not installed; run the git stage first.");
     };
 
-    if config.dir.join(".git").exists() {
+    let release_tag = if config.branch_explicit {
+        None
+    } else {
+        match resolve_release_tag(config) {
+            Ok(tag) => Some(tag),
+            Err(error) => return StageOutcome::fail(error),
+        }
+    };
+    let target_ref = release_tag.as_deref().unwrap_or(&config.branch);
+
+    let repository_ready = if config.dir.join(".git").exists() {
         print_human("Existing Suzent repository found. Updating...");
         let update_remote = if config.repo_url_override {
             config.repo_url.as_str()
         } else {
             "origin"
         };
-        if !run_command(
-            Command::new(&git)
-                .args(["fetch", update_remote, &config.branch])
-                .current_dir(&config.dir),
-        ) {
-            return StageOutcome::fail("Failed to fetch repository updates.");
+        if let Some(tag) = &release_tag {
+            if !run_command(
+                Command::new(&git)
+                    .args(["fetch", update_remote, "tag", tag])
+                    .current_dir(&config.dir),
+            ) || !run_command(
+                Command::new(&git)
+                    .args(["checkout", "--detach", tag])
+                    .current_dir(&config.dir),
+            ) {
+                return StageOutcome::fail("Failed to check out stable release tag.");
+            }
+        } else {
+            if !run_command(
+                Command::new(&git)
+                    .args(["fetch", update_remote, target_ref])
+                    .current_dir(&config.dir),
+            ) {
+                return StageOutcome::fail("Failed to fetch repository updates.");
+            }
+            let mut checkout_command = Command::new(&git);
+            checkout_command
+                .args(["checkout", target_ref])
+                .current_dir(&config.dir)
+                .stdout(child_stdio())
+                .stderr(child_stdio());
+            let _ = run_command(&mut checkout_command);
+            if !run_command(
+                Command::new(&git)
+                    .args(["pull", update_remote, target_ref])
+                    .current_dir(&config.dir),
+            ) {
+                return StageOutcome::fail("Failed to update repository.");
+            }
         }
-        let mut checkout_command = Command::new(&git);
-        checkout_command
-            .args(["checkout", &config.branch])
-            .current_dir(&config.dir)
-            .stdout(child_stdio())
-            .stderr(child_stdio());
-        let _ = run_command(&mut checkout_command);
-        if !run_command(
-            Command::new(&git)
-                .args(["pull", update_remote, &config.branch])
-                .current_dir(&config.dir),
-        ) {
-            return StageOutcome::fail("Failed to update repository.");
-        }
-        return StageOutcome::ok();
-    }
-
-    if config.dir.exists() && !is_empty_dir(&config.dir) {
+        true
+    } else if config.dir.exists() && !is_empty_dir(&config.dir) {
         return StageOutcome::fail(format!(
             "{} already exists but is not a Git repository. Set SUZENT_DIR or --dir to another path.",
             config.dir.display()
         ));
-    }
-
-    if let Some(parent) = config.dir.parent() {
-        if let Err(error) = fs::create_dir_all(parent) {
-            return StageOutcome::fail(format!(
-                "Failed to create install parent directory: {error}"
-            ));
-        }
-    }
-
-    if run_command(Command::new(&git).args([
-        "clone",
-        "--branch",
-        &config.branch,
-        &config.repo_url,
-        config.dir.to_string_lossy().as_ref(),
-    ])) {
-        StageOutcome::ok()
     } else {
-        StageOutcome::fail("Failed to clone Suzent repository.")
+        if let Some(parent) = config.dir.parent() {
+            if let Err(error) = fs::create_dir_all(parent) {
+                return StageOutcome::fail(format!(
+                    "Failed to create install parent directory: {error}"
+                ));
+            }
+        }
+        run_command(Command::new(&git).args([
+            "clone",
+            "--branch",
+            target_ref,
+            &config.repo_url,
+            config.dir.to_string_lossy().as_ref(),
+        ]))
+    };
+
+    if !repository_ready {
+        return StageOutcome::fail("Failed to clone Suzent repository.");
     }
+    if let Err(error) = write_install_release_state(config, release_tag.as_deref()) {
+        return StageOutcome::fail(format!("Failed to record install channel: {error}"));
+    }
+    StageOutcome::ok()
 }
 
 fn stage_env(config: &InstallConfig) -> StageOutcome {
@@ -630,7 +735,17 @@ fn stage_dependencies(config: &InstallConfig) -> StageOutcome {
 
 fn stage_ui(config: &InstallConfig) -> StageOutcome {
     let asset = ui_asset_name();
-    let url = format!("{}/{asset}", config.release_base_url);
+    let release_tag = read_install_release_tag(config);
+    let release_base_url = if let Some(tag) = &release_tag {
+        if config.release_base_url_override {
+            config.release_base_url.clone()
+        } else {
+            format!("https://github.com/cyzus/suzent/releases/download/{tag}")
+        }
+    } else {
+        config.release_base_url.clone()
+    };
+    let url = format!("{release_base_url}/{asset}");
     let bin_dir = config.dir.join("bin");
     let dest = bin_dir.join(ui_binary_name());
     let tmp = dest.with_extension("tmp");
@@ -671,7 +786,8 @@ fn stage_ui(config: &InstallConfig) -> StageOutcome {
         }
     }
 
-    let _ = fs::write(bin_dir.join("version.txt"), "latest");
+    let ui_version = release_tag.as_deref().unwrap_or("latest");
+    let _ = fs::write(bin_dir.join("version.txt"), ui_version);
     print_human(format!("[OK] UI binary ready at {}", dest.display()));
     StageOutcome::ok()
 }
@@ -1163,6 +1279,19 @@ fn run_command(command: &mut Command) -> bool {
             .status(),
         Ok(status) if status.success()
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_release_tag;
+
+    #[test]
+    fn validates_stable_release_tags() {
+        assert!(is_release_tag("v0.7.3"));
+        assert!(!is_release_tag("0.7.3"));
+        assert!(!is_release_tag("v0.7"));
+        assert!(!is_release_tag("v0.7.3-rc1"));
+    }
 }
 
 fn find_executable(name: &str) -> Option<PathBuf> {

--- a/apps/suzent-installer/tauri.conf.json
+++ b/apps/suzent-installer/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Suzent Installer",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "identifier": "com.suzent.installer",
   "build": {
     "frontendDist": "ui"

--- a/docs/01-getting-started/quickstart.md
+++ b/docs/01-getting-started/quickstart.md
@@ -128,6 +128,12 @@ suzent doctor
 suzent update
 ```
 
+Stable updates pin the backend, locked dependencies, and desktop app to the
+same release. If you are developing from a source checkout, use
+`suzent update --dev` to fast-forward `main`, install its locked Python and
+frontend dependencies, and keep subsequent `suzent start` runs in developer
+mode.
+
 ---
 
 ## Next Steps

--- a/docs/02-concepts/providers/model-capabilities.md
+++ b/docs/02-concepts/providers/model-capabilities.md
@@ -32,12 +32,12 @@ and via a periodic [LiteLLM](./litellm.md) sync that refreshes context windows
 and pricing. Those writes go to the **local overlay**, never to the tracked
 `config/capabilities/` files.
 
-This keeps the repo clean: `suzent update` runs `git pull`, and if runtime
-discovery had been writing into tracked files, every update would conflict.
-With the overlay, discovered models persist across updates in your data
-directory while the shipped files stay pristine. (For safety, `suzent update`
-also discards any stale local edits under `config/capabilities/` before
-pulling.)
+This keeps the repo clean: stable `suzent update` checks out an exact release,
+while `suzent update --dev` fast-forwards `main`. If runtime discovery had been
+writing into tracked files, either update could conflict. With the overlay,
+discovered models persist across updates in your data directory while the
+shipped files stay pristine. For safety, the updater discards stale local edits
+under `config/capabilities/` before changing revisions.
 
 The overlay is auto-generated and safe to delete; it will be repopulated on the
 next discovery.

--- a/docs/03-developing/development-guide.md
+++ b/docs/03-developing/development-guide.md
@@ -17,6 +17,17 @@ uv run suzent start --dev
 > pre-built UI binary). For a headless debug backend only, use
 > `uv run suzent serve --debug`.
 
+To update an existing development checkout, run:
+
+```bash
+uv run suzent update --dev
+```
+
+This fast-forwards `main` and installs the exact Python and frontend
+dependencies from the lockfiles. Plain `suzent update` is reserved for
+bootstrapped installations and pins every runtime component to one stable
+release.
+
 `uv sync --all-extras` installs both the `social` and `dev` optional
 dependency groups (equivalent to the `all` extra). For a minimal runtime
 without dev tooling, use `uv sync --extra social`.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "suzent-frontend",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "suzent-frontend",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "dependencies": {
         "@headlessui/react": "^1.7.18",
         "@heroicons/react": "^2.1.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "suzent-frontend",
   "private": true,
-  "version": "0.7.2",
+  "version": "0.7.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,12 @@ import { GoalTasksProvider, useGoalTasks } from './hooks/useGoalTasks';
 import { ProjectProvider } from './hooks/useProjects';
 import { useStatusStore } from './hooks/useStatusStore';
 import { useTheme } from './hooks/useTheme';
-import { drainCronNotifications, fetchHeartbeatStatus } from './lib/api';
+import {
+  drainCronNotifications,
+  fetchHeartbeatStatus,
+  fetchSystemVersion,
+  getBackendCompatibilityIssue,
+} from './lib/api';
 import {
   checkDesktopUpdate,
   startDesktopUpdateAndRestart,
@@ -999,6 +1004,7 @@ export default function App() {
   // before the installer/onboarding decision is known.
   const [backendReady, setBackendReady] = React.useState<boolean>(false);
   const [backendError, setBackendError] = React.useState<string | null>(null);
+  const [backendCompatible, setBackendCompatible] = React.useState(false);
   const [bootstrapStatusState, setBootstrapStatusState] = React.useState<BootstrapStatus | null>(null);
   const [bootstrapChecked, setBootstrapChecked] = React.useState(false);
   const [backendStartingAtStartup, setBackendStartingAtStartup] = React.useState(false);
@@ -1090,6 +1096,43 @@ export default function App() {
     };
   }, [backendReady]);
 
+  React.useEffect(() => {
+    if (!backendReady) {
+      setBackendCompatible(false);
+      return;
+    }
+    let cancelled = false;
+    fetchSystemVersion()
+      .then((identity) => {
+        if (cancelled) return;
+        const compatibilityIssue = getBackendCompatibilityIssue(identity);
+        if (compatibilityIssue) {
+          setBackendError(tForLocale(
+            getInitialLocale(),
+            `app.backendCompatibility.${compatibilityIssue.kind}`,
+            compatibilityIssue,
+          ));
+          setBackendCompatible(false);
+          return;
+        }
+        setBackendError(null);
+        setBackendCompatible(true);
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setBackendError(tForLocale(
+            getInitialLocale(),
+            'app.backendCompatibility.verifyFailed',
+            { error: String(error) },
+          ));
+          setBackendCompatible(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [backendReady]);
+
   return (
     <ErrorBoundary>
       {!bootstrapChecked ? (
@@ -1109,6 +1152,8 @@ export default function App() {
         <BackendLoadingScreen />
       ) : !backendReady ? (
         <StartupDecisionScreen />
+      ) : !backendCompatible ? (
+        <BackendLoadingScreen />
       ) : (
         <ProjectProvider>
           <ChatProvider>

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -31,6 +31,12 @@ export const en = {
     desktopRequiredTitle: 'Desktop required',
     desktopRequiredDesc: 'Suzent is a desktop-only application. Please run this application using the native desktop launcher.',
     logoAriaLabel: 'Suzent logo',
+    backendCompatibility: {
+      api: 'Frontend/backend API mismatch ({frontend} vs {backend}). Run suzent update.',
+      build: 'Frontend/backend build mismatch ({frontend} vs {backend}). Run suzent update.',
+      version: 'Frontend/backend version mismatch ({frontend} vs {backend}). Run suzent update.',
+      verifyFailed: 'Failed to verify backend version: {error}',
+    },
   },
   bootstrap: {
     title: 'Set up Suzent',

--- a/frontend/src/i18n/messages/zh-CN.ts
+++ b/frontend/src/i18n/messages/zh-CN.ts
@@ -31,6 +31,12 @@ export const zhCN = {
     desktopRequiredTitle: '需要桌面端',
     desktopRequiredDesc: 'Suzent 仅支持桌面端运行。请使用原生桌面启动器打开该应用。',
     logoAriaLabel: 'Suzent 标志',
+    backendCompatibility: {
+      api: '前后端 API 版本不匹配（{frontend} 与 {backend}）。请运行 suzent update。',
+      build: '前后端构建不匹配（{frontend} 与 {backend}）。请运行 suzent update。',
+      version: '前后端版本不匹配（{frontend} 与 {backend}）。请运行 suzent update。',
+      verifyFailed: '无法验证后端版本：{error}',
+    },
   },
   bootstrap: {
     title: '设置 Suzent',

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -47,6 +47,7 @@ export interface SystemVersionResponse {
   backendVersion: string;
   apiVersion: number;
   buildCommit: string;
+  developmentMode: boolean;
 }
 
 export async function fetchSystemVersion(): Promise<SystemVersionResponse> {
@@ -58,6 +59,7 @@ export async function fetchSystemVersion(): Promise<SystemVersionResponse> {
     backend_version?: unknown;
     api_version?: unknown;
     build_commit?: unknown;
+    development_mode?: unknown;
   };
   return {
     backendVersion: typeof payload.backend_version === 'string'
@@ -67,6 +69,7 @@ export async function fetchSystemVersion(): Promise<SystemVersionResponse> {
     buildCommit: typeof payload.build_commit === 'string'
       ? payload.build_commit
       : 'unknown',
+    developmentMode: payload.development_mode === true,
   };
 }
 
@@ -82,6 +85,7 @@ export function getBackendCompatibilityIssue(
     version: __FRONTEND_VERSION__,
     apiVersion: __SUZENT_API_VERSION__,
     buildCommit: __FRONTEND_BUILD_COMMIT__,
+    enforceBuildCommit: !import.meta.env.DEV,
   },
 ): BackendCompatibilityIssue | null {
   if (backend.apiVersion !== frontend.apiVersion) {
@@ -93,14 +97,19 @@ export function getBackendCompatibilityIssue(
   }
   const commitsKnown = backend.buildCommit !== 'unknown'
     && frontend.buildCommit !== 'unknown';
-  if (commitsKnown && backend.buildCommit !== frontend.buildCommit) {
+  const enforceBuildCommit = (frontend.enforceBuildCommit ?? true)
+    && !backend.developmentMode;
+  if (enforceBuildCommit
+    && commitsKnown
+    && backend.buildCommit !== frontend.buildCommit) {
     return {
       kind: 'build',
       frontend: frontend.buildCommit.slice(0, 8),
       backend: backend.buildCommit.slice(0, 8),
     };
   }
-  if (!commitsKnown
+  if (enforceBuildCommit
+    && !commitsKnown
     && backend.backendVersion !== 'unknown'
     && frontend.version !== 'unknown'
     && backend.backendVersion !== frontend.version) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -45,6 +45,8 @@ export function getApiBase(): string {
 
 export interface SystemVersionResponse {
   backendVersion: string;
+  apiVersion: number;
+  buildCommit: string;
 }
 
 export async function fetchSystemVersion(): Promise<SystemVersionResponse> {
@@ -52,12 +54,63 @@ export async function fetchSystemVersion(): Promise<SystemVersionResponse> {
   if (!response.ok) {
     throw new Error(`Failed to load backend version: ${response.status}`);
   }
-  const payload = await response.json() as { backend_version?: unknown };
+  const payload = await response.json() as {
+    backend_version?: unknown;
+    api_version?: unknown;
+    build_commit?: unknown;
+  };
   return {
     backendVersion: typeof payload.backend_version === 'string'
       ? payload.backend_version
       : 'unknown',
+    apiVersion: typeof payload.api_version === 'number' ? payload.api_version : 0,
+    buildCommit: typeof payload.build_commit === 'string'
+      ? payload.build_commit
+      : 'unknown',
   };
+}
+
+export type BackendCompatibilityIssue = {
+  kind: 'api' | 'build' | 'version';
+  frontend: string;
+  backend: string;
+};
+
+export function getBackendCompatibilityIssue(
+  backend: SystemVersionResponse,
+  frontend = {
+    version: __FRONTEND_VERSION__,
+    apiVersion: __SUZENT_API_VERSION__,
+    buildCommit: __FRONTEND_BUILD_COMMIT__,
+  },
+): BackendCompatibilityIssue | null {
+  if (backend.apiVersion !== frontend.apiVersion) {
+    return {
+      kind: 'api',
+      frontend: String(frontend.apiVersion),
+      backend: String(backend.apiVersion),
+    };
+  }
+  const commitsKnown = backend.buildCommit !== 'unknown'
+    && frontend.buildCommit !== 'unknown';
+  if (commitsKnown && backend.buildCommit !== frontend.buildCommit) {
+    return {
+      kind: 'build',
+      frontend: frontend.buildCommit.slice(0, 8),
+      backend: backend.buildCommit.slice(0, 8),
+    };
+  }
+  if (!commitsKnown
+    && backend.backendVersion !== 'unknown'
+    && frontend.version !== 'unknown'
+    && backend.backendVersion !== frontend.version) {
+    return {
+      kind: 'version',
+      frontend: frontend.version,
+      backend: backend.backendVersion,
+    };
+  }
+  return null;
 }
 
 export interface PermissionModeState {

--- a/frontend/src/lib/api.version.test.ts
+++ b/frontend/src/lib/api.version.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { getBackendCompatibilityIssue } from './api';
+
+const frontend = {
+  version: '1.2.3',
+  apiVersion: 1,
+  buildCommit: 'abcdef123456',
+};
+
+describe('backend compatibility', () => {
+  it('accepts an exact release identity match', () => {
+    expect(getBackendCompatibilityIssue({
+      backendVersion: '1.2.3',
+      apiVersion: 1,
+      buildCommit: 'abcdef123456',
+    }, frontend)).toBeNull();
+  });
+
+  it('rejects API protocol mismatches', () => {
+    expect(getBackendCompatibilityIssue({
+      backendVersion: '1.2.3',
+      apiVersion: 2,
+      buildCommit: 'abcdef123456',
+    }, frontend)).toEqual({ kind: 'api', frontend: '1', backend: '2' });
+  });
+
+  it('rejects different known build commits', () => {
+    expect(getBackendCompatibilityIssue({
+      backendVersion: '1.2.3',
+      apiVersion: 1,
+      buildCommit: '999999999999',
+    }, frontend)).toEqual({ kind: 'build', frontend: 'abcdef12', backend: '99999999' });
+  });
+
+  it('falls back to semantic versions when commits are unavailable', () => {
+    expect(getBackendCompatibilityIssue({
+      backendVersion: '1.2.2',
+      apiVersion: 1,
+      buildCommit: 'unknown',
+    }, frontend)).toEqual({ kind: 'version', frontend: '1.2.3', backend: '1.2.2' });
+  });
+});

--- a/frontend/src/lib/api.version.test.ts
+++ b/frontend/src/lib/api.version.test.ts
@@ -6,6 +6,7 @@ const frontend = {
   version: '1.2.3',
   apiVersion: 1,
   buildCommit: 'abcdef123456',
+  enforceBuildCommit: true,
 };
 
 describe('backend compatibility', () => {
@@ -14,6 +15,7 @@ describe('backend compatibility', () => {
       backendVersion: '1.2.3',
       apiVersion: 1,
       buildCommit: 'abcdef123456',
+      developmentMode: false,
     }, frontend)).toBeNull();
   });
 
@@ -22,6 +24,7 @@ describe('backend compatibility', () => {
       backendVersion: '1.2.3',
       apiVersion: 2,
       buildCommit: 'abcdef123456',
+      developmentMode: false,
     }, frontend)).toEqual({ kind: 'api', frontend: '1', backend: '2' });
   });
 
@@ -30,7 +33,26 @@ describe('backend compatibility', () => {
       backendVersion: '1.2.3',
       apiVersion: 1,
       buildCommit: '999999999999',
+      developmentMode: false,
     }, frontend)).toEqual({ kind: 'build', frontend: 'abcdef12', backend: '99999999' });
+  });
+
+  it('allows commit changes while the Vite development server is running', () => {
+    expect(getBackendCompatibilityIssue({
+      backendVersion: '1.2.3',
+      apiVersion: 1,
+      buildCommit: '999999999999',
+      developmentMode: false,
+    }, { ...frontend, enforceBuildCommit: false })).toBeNull();
+  });
+
+  it('allows commit changes for a backend launched with suzent serve', () => {
+    expect(getBackendCompatibilityIssue({
+      backendVersion: '1.2.3',
+      apiVersion: 1,
+      buildCommit: '999999999999',
+      developmentMode: true,
+    }, frontend)).toBeNull();
   });
 
   it('falls back to semantic versions when commits are unavailable', () => {
@@ -38,6 +60,7 @@ describe('backend compatibility', () => {
       backendVersion: '1.2.2',
       apiVersion: 1,
       buildCommit: 'unknown',
+      developmentMode: false,
     }, frontend)).toEqual({ kind: 'version', frontend: '1.2.3', backend: '1.2.2' });
   });
 });

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,6 +1,8 @@
 /// <reference types="vite/client" />
 
 declare const __FRONTEND_VERSION__: string;
+declare const __FRONTEND_BUILD_COMMIT__: string;
+declare const __SUZENT_API_VERSION__: number;
 
 interface Window {
   __SUZENT_BACKEND_PORT__?: number;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,22 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { execFileSync } from 'node:child_process';
+
+function getBuildCommit(): string {
+  if (process.env.SUZENT_BUILD_COMMIT) return process.env.SUZENT_BUILD_COMMIT;
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
 
 export default defineConfig({
   plugins: [react()],
   define: {
     __FRONTEND_VERSION__: JSON.stringify(process.env.npm_package_version ?? 'unknown'),
+    __FRONTEND_BUILD_COMMIT__: JSON.stringify(getBuildCommit()),
+    __SUZENT_API_VERSION__: JSON.stringify(1),
   },
   server: {
     host: '127.0.0.1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "suzent"
-version = "0.7.2"
+version = "0.7.3"
 description = "Your personal Agent"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -17,13 +17,14 @@ $ErrorActionPreference = "Stop"
 
 # ── Resolve config ────────────────────────────────────────────────────────────
 $SuzentDir    = if ($Dir)    { $Dir }    elseif ($env:SUZENT_DIR)    { $env:SUZENT_DIR }    else { Join-Path $env:USERPROFILE "suzent" }
+$BranchExplicit = [bool]($Branch -or $env:SUZENT_BRANCH)
 $SuzentBranch = if ($Branch) { $Branch } elseif ($env:SUZENT_BRANCH) { $env:SUZENT_BRANCH } else { "main" }
 $SkipPW       = $SkipPlaywright -or ($env:SUZENT_SKIP_PLAYWRIGHT -eq "1")
 $UseChinaMirror = $ChinaMirror -or ($env:SUZENT_CHINA_MIRROR -match "^(1|true|yes|cn)$")
 $RepoUrl      = if ($env:SUZENT_REPO_URL) { $env:SUZENT_REPO_URL } else { "https://github.com/cyzus/suzent.git" }
 $UpdateRemote = if ($env:SUZENT_REPO_URL) { $env:SUZENT_REPO_URL } else { "origin" }
 $UvInstallUrl = if ($env:SUZENT_UV_INSTALL_URL) { $env:SUZENT_UV_INSTALL_URL } else { "https://astral.sh/uv/install.ps1" }
-$ReleaseBaseUrl = if ($env:SUZENT_RELEASE_BASE_URL) { $env:SUZENT_RELEASE_BASE_URL.TrimEnd("/") } else { "https://github.com/cyzus/suzent/releases/latest/download" }
+$ReleaseBaseUrl = if ($env:SUZENT_RELEASE_BASE_URL) { $env:SUZENT_RELEASE_BASE_URL.TrimEnd("/") } else { "" }
 $MinNodeMajor = 20
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -68,6 +69,31 @@ Write-Host "  ╚══════╝ ╚═════╝ ╚═════�
 Write-Host ""
 
 Enable-ChinaMirrors
+
+$InstallRef = $SuzentBranch
+$ReleaseTag = ""
+if (-not $BranchExplicit -and $env:SUZENT_DEV_SETUP -ne "1") {
+    $ReleaseTag = if ($env:SUZENT_RELEASE_TAG) { $env:SUZENT_RELEASE_TAG.Trim() } else { "" }
+    if (-not $ReleaseTag) {
+        Write-Info "Resolving latest stable release..."
+        try {
+            $release = Invoke-RestMethod -Uri "https://api.github.com/repos/cyzus/suzent/releases/latest" -TimeoutSec 30
+            $ReleaseTag = [string]$release.tag_name
+        } catch {
+            Write-Fail ("Could not resolve the latest stable release: " + $_.Exception.Message)
+        }
+    }
+    if ($ReleaseTag -notmatch '^v\d+\.\d+\.\d+$') {
+        Write-Fail "Invalid stable release tag: $ReleaseTag"
+    }
+    $InstallRef = $ReleaseTag
+    if (-not $ReleaseBaseUrl) {
+        $ReleaseBaseUrl = "https://github.com/cyzus/suzent/releases/download/$ReleaseTag"
+    }
+    Write-Info "Installing matched stable release $ReleaseTag"
+} elseif (-not $ReleaseBaseUrl) {
+    $ReleaseBaseUrl = "https://github.com/cyzus/suzent/releases/latest/download"
+}
 
 # ── Detect update vs fresh install ───────────────────────────────────────────
 $IsUpdate = (Test-Path (Join-Path $SuzentDir ".git"))
@@ -225,9 +251,14 @@ if ($IsUpdate) {
         git stash push -m "suzent-update-$stamp"
     }
 
-    git fetch $UpdateRemote $SuzentBranch
-    try { git checkout $SuzentBranch --quiet 2>&1 | Out-Null } catch {}
-    git pull $UpdateRemote $SuzentBranch
+    if ($ReleaseTag) {
+        git fetch $UpdateRemote tag $InstallRef
+        git checkout --detach $InstallRef
+    } else {
+        git fetch $UpdateRemote $InstallRef
+        try { git checkout $InstallRef --quiet 2>&1 | Out-Null } catch {}
+        git pull $UpdateRemote $InstallRef
+    }
     $sha = git rev-parse --short HEAD
     Write-Ok "Repository updated to $sha"
 } else {
@@ -235,7 +266,7 @@ if ($IsUpdate) {
         Write-Fail "$SuzentDir already exists but is not a git repo. Remove it or set `$env:SUZENT_DIR to a different path."
     }
     Write-Info "Cloning SUZENT into $SuzentDir..."
-    git clone --branch $SuzentBranch $RepoUrl $SuzentDir
+    git clone --branch $InstallRef $RepoUrl $SuzentDir
     Write-Ok "Repository cloned"
     Set-Location $SuzentDir
 }
@@ -271,7 +302,8 @@ function Get-UiBinary {
         Write-Info "Downloading pre-built UI binary..."
         Invoke-WebRequest -Uri $url -OutFile $tmp -TimeoutSec 300
         Move-Item -Force $tmp $dest
-        Set-Content -Path (Join-Path $binDir "version.txt") -Value "latest" -NoNewline
+        $UiVersion = if ($ReleaseTag) { $ReleaseTag } else { "latest" }
+        Set-Content -Path (Join-Path $binDir "version.txt") -Value $UiVersion -NoNewline
         Write-Ok "UI binary ready ($dest)"
     } catch {
         if ($tmp -and (Test-Path $tmp)) {
@@ -339,6 +371,10 @@ Write-Ok "CLI shim written to $ShimPath"
 # PROTOCOL_VERSION in apps/suzent-installer.
 $MarkerPath = Join-Path $SuzentDir ".suzent-bootstrap-complete"
 Set-Content -Path $MarkerPath -Value "protocol=1`n" -NoNewline -Encoding ASCII
+$ChannelDir = Join-Path $SuzentDir ".suzent"
+if (-not (Test-Path $ChannelDir)) { New-Item -ItemType Directory -Force -Path $ChannelDir | Out-Null }
+$Channel = if ($ReleaseTag) { "stable" } else { "dev" }
+Set-Content -Path (Join-Path $ChannelDir "update-channel") -Value $Channel -NoNewline -Encoding ASCII
 Write-Ok "Workspace marked as bootstrapped"
 
 Add-ToUserPath $BinDir

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -20,8 +20,9 @@ REPO_URL="${SUZENT_REPO_URL:-https://github.com/cyzus/suzent.git}"
 UPDATE_REMOTE="${SUZENT_REPO_URL:-origin}"
 UV_INSTALL_URL="${SUZENT_UV_INSTALL_URL:-https://astral.sh/uv/install.sh}"
 NVM_INSTALL_URL="${SUZENT_NVM_INSTALL_URL:-https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh}"
-RELEASE_BASE_URL="${SUZENT_RELEASE_BASE_URL:-https://github.com/cyzus/suzent/releases/latest/download}"
+RELEASE_BASE_URL="${SUZENT_RELEASE_BASE_URL:-}"
 SUZENT_DIR="${SUZENT_DIR:-$HOME/suzent}"
+SUZENT_BRANCH_EXPLICIT="${SUZENT_BRANCH+x}"
 SUZENT_BRANCH="${SUZENT_BRANCH:-main}"
 CHINA_MIRROR="${SUZENT_CHINA_MIRROR:-0}"
 MIN_NODE_MAJOR=20
@@ -66,6 +67,28 @@ case "$OS" in
 esac
 ok "$OS_NAME detected"
 enable_china_mirrors
+
+INSTALL_REF="$SUZENT_BRANCH"
+RELEASE_TAG=""
+if [ -z "$SUZENT_BRANCH_EXPLICIT" ] && [ "${SUZENT_DEV_SETUP:-0}" != "1" ]; then
+    RELEASE_TAG="${SUZENT_RELEASE_TAG:-}"
+    if [ -z "$RELEASE_TAG" ]; then
+        info "Resolving latest stable release..."
+        release_url="$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+            https://github.com/cyzus/suzent/releases/latest)" \
+            || die "Could not resolve the latest stable release."
+        RELEASE_TAG="${release_url##*/}"
+    fi
+    [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+        || die "Invalid stable release tag: $RELEASE_TAG"
+    INSTALL_REF="$RELEASE_TAG"
+    [ -n "$RELEASE_BASE_URL" ] \
+        || RELEASE_BASE_URL="https://github.com/cyzus/suzent/releases/download/$RELEASE_TAG"
+    info "Installing matched stable release $RELEASE_TAG"
+else
+    [ -n "$RELEASE_BASE_URL" ] \
+        || RELEASE_BASE_URL="https://github.com/cyzus/suzent/releases/latest/download"
+fi
 
 # ── Helper: refresh PATH after install ───────────────────────────────────────
 refresh_path() {
@@ -198,16 +221,21 @@ if [ "$IS_UPDATE" = true ]; then
         git stash push -m "suzent-update-$(date +%Y%m%d-%H%M%S)"
     fi
 
-    git fetch "$UPDATE_REMOTE" "$SUZENT_BRANCH"
-    git checkout "$SUZENT_BRANCH" 2>/dev/null || true
-    git pull "$UPDATE_REMOTE" "$SUZENT_BRANCH"
+    if [ -n "$RELEASE_TAG" ]; then
+        git fetch "$UPDATE_REMOTE" tag "$INSTALL_REF"
+        git checkout --detach "$INSTALL_REF"
+    else
+        git fetch "$UPDATE_REMOTE" "$INSTALL_REF"
+        git checkout "$INSTALL_REF" 2>/dev/null || true
+        git pull "$UPDATE_REMOTE" "$INSTALL_REF"
+    fi
     ok "Repository updated to $(git rev-parse --short HEAD)"
 else
     if [ -d "$SUZENT_DIR" ]; then
         die "Directory $SUZENT_DIR already exists but is not a git repo. Remove it or set SUZENT_DIR to a different path."
     fi
     info "Cloning SUZENT into $SUZENT_DIR..."
-    git clone --branch "$SUZENT_BRANCH" "$REPO_URL" "$SUZENT_DIR"
+    git clone --branch "$INSTALL_REF" "$REPO_URL" "$SUZENT_DIR"
     ok "Repository cloned"
     cd "$SUZENT_DIR"
 fi
@@ -259,7 +287,7 @@ download_binary() {
 
     mv "$tmp" "bin/suzent-ui"
     chmod +x "bin/suzent-ui"
-    echo "latest" > "bin/version.txt"
+    echo "${RELEASE_TAG:-latest}" > "bin/version.txt"
     ok "UI binary ready (bin/suzent-ui)"
 }
 download_binary || true
@@ -315,6 +343,9 @@ ok "CLI shim written to $SHIM"
 # screen and fails with "installer helper was not found". protocol=1 matches
 # PROTOCOL_VERSION in apps/suzent-installer.
 printf 'protocol=1\n' > "$SUZENT_DIR/.suzent-bootstrap-complete"
+mkdir -p "$SUZENT_DIR/.suzent"
+printf '%s' "$([ -n "$RELEASE_TAG" ] && printf stable || printf dev)" \
+    > "$SUZENT_DIR/.suzent/update-channel"
 ok "Workspace marked as bootstrapped"
 
 add_to_path_config "$INSTALL_BIN"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3645,7 +3645,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "suzent"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "reqwest",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "suzent"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "SUZENT - Your Personal Agent"
 authors = ["SUZENT Team"]

--- a/src-tauri/package-lock.json
+++ b/src-tauri/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "suzent-desktop",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "suzent-desktop",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "devDependencies": {
         "@tauri-apps/cli": "^2.0.0-rc.18"
       }

--- a/src-tauri/package.json
+++ b/src-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suzent-desktop",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "SUZENT - Your Personal Agent (Desktop Application)",
   "private": true,
   "scripts": {

--- a/src-tauri/src/backend.rs
+++ b/src-tauri/src/backend.rs
@@ -119,7 +119,7 @@ impl BackendProcess {
     }
 
     fn wait_for_backend(&self) -> Result<(), String> {
-        let url = format!("http://127.0.0.1:{}/config", self.port);
+        let url = format!("http://127.0.0.1:{}/health", self.port);
         let client = reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(2))
             .no_proxy()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SUZENT",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "identifier": "com.suzent.app",
   "build": {
     "beforeBuildCommand": "cd ../frontend && npm run build",

--- a/src-tauri/tauri.conf.prod.json
+++ b/src-tauri/tauri.conf.prod.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SUZENT",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "identifier": "com.suzent.app",
   "build": {
     "beforeBuildCommand": "cd ../frontend && npm run build",

--- a/src/suzent/cli/main.py
+++ b/src/suzent/cli/main.py
@@ -26,6 +26,9 @@ IS_WINDOWS = sys.platform == "win32"
 _REPO = "cyzus/suzent"
 _BIN_DIR = "bin"
 _UPDATE_CHECK_TTL_SECONDS = 24 * 60 * 60
+_UPDATE_CHANNEL_FILE = ".suzent/update-channel"
+_STABLE_CHANNEL = "stable"
+_DEV_CHANNEL = "dev"
 
 
 def _is_development_workspace(root: Path) -> bool:
@@ -34,7 +37,7 @@ def _is_development_workspace(root: Path) -> bool:
 
 
 def _backend_sync_args(root: Path) -> list[str]:
-    args = ["uv", "sync", "--extra", "social"]
+    args = ["uv", "sync", "--frozen", "--extra", "social"]
     if _is_development_workspace(root):
         args.extend(["--extra", "dev"])
     return args
@@ -52,6 +55,24 @@ def _get_ui_binary(root: Path) -> Path | None:
     if not existing:
         return None
     return max(existing, key=lambda p: p.stat().st_mtime)
+
+
+def _update_channel_path(root: Path) -> Path:
+    return root / _UPDATE_CHANNEL_FILE
+
+
+def _read_update_channel(root: Path) -> str:
+    try:
+        channel = _update_channel_path(root).read_text(encoding="utf-8").strip()
+    except OSError:
+        return _STABLE_CHANNEL
+    return channel if channel in {_STABLE_CHANNEL, _DEV_CHANNEL} else _STABLE_CHANNEL
+
+
+def _write_update_channel(root: Path, channel: str) -> None:
+    path = _update_channel_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(channel, encoding="utf-8")
 
 
 def _is_ui_binary_current(root: Path, binary: Path) -> bool:
@@ -138,8 +159,10 @@ def _fetch_latest_release(timeout: float = 10.0) -> dict:
         return json.loads(resp.read())
 
 
-def _latest_asset_url(asset_name: str) -> str:
-    return f"https://github.com/{_REPO}/releases/latest/download/{asset_name}"
+def _release_asset_url(asset_name: str, version: str) -> str:
+    if version == "latest":
+        return f"https://github.com/{_REPO}/releases/latest/download/{asset_name}"
+    return f"https://github.com/{_REPO}/releases/download/{version}/{asset_name}"
 
 
 def _local_ui_version(root: Path) -> str:
@@ -277,37 +300,46 @@ def _download_file_atomic(url: str, dest: Path, *, timeout: float = 60.0) -> Non
 def download_ui_binary(root: Path, *, version: str = "latest") -> bool:
     """Download the pre-built UI binary from GitHub Releases. Returns True on success."""
     asset_name = _platform_asset_name()
+    staged_binary: Path | None = None
+    staged_version: Path | None = None
     try:
         bin_dir = root / _BIN_DIR
         dest = bin_dir / ("suzent-ui.exe" if IS_WINDOWS else "suzent-ui")
+        version_file = bin_dir / "version.txt"
+        staged_binary = dest.with_name(f".{dest.name}.{version}.new")
+        staged_version = version_file.with_name(f".{version_file.name}.{version}.new")
 
         typer.echo("  • Downloading UI binary...")
-        _download_file_atomic(_latest_asset_url(asset_name), dest)
+        _download_file_atomic(_release_asset_url(asset_name, version), staged_binary)
         if not IS_WINDOWS:
-            dest.chmod(0o755)
-        (bin_dir / "version.txt").write_text(version)
+            staged_binary.chmod(0o755)
+        staged_version.write_text(version, encoding="utf-8")
+        staged_binary.replace(dest)
+        staged_binary = None
+        staged_version.replace(version_file)
+        staged_version = None
         typer.echo(f"  ✅ UI binary ready at {dest}")
         return True
     except Exception as e:
         typer.echo(f"  ⚠️  Binary download failed: {e}")
         return False
+    finally:
+        for staged_path in (staged_binary, staged_version):
+            if staged_path is not None:
+                try:
+                    staged_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
 
 
-def _update_ui_binary(root: Path) -> None:
-    """Download a new UI binary only if the release version changed."""
-    try:
-        release = _fetch_latest_release()
-        latest = release.get("tag_name", "")
-        local = _local_ui_version(root)
-        if latest and latest != local:
-            typer.echo(f"  • UI binary: {local or 'none'} → {latest}")
-            download_ui_binary(root, version=latest)
-        else:
-            typer.echo(f"  • UI binary up to date ({local})")
-    except Exception as e:
-        typer.echo(f"  ⚠️  Could not check UI binary version: {e}")
-        typer.echo("  • Attempting direct latest binary download...")
-        download_ui_binary(root)
+def _update_ui_binary(root: Path, release_tag: str) -> bool:
+    """Install the UI asset built from the exact backend release tag."""
+    local = _local_ui_version(root)
+    if release_tag == local and _get_ui_binary(root):
+        typer.echo(f"  • UI binary up to date ({local})")
+        return True
+    typer.echo(f"  • UI binary: {local or 'none'} → {release_tag}")
+    return download_ui_binary(root, version=release_tag)
 
 
 def _configure_console_encoding():
@@ -748,6 +780,10 @@ def register_commands(app: typer.Typer):
         typer.echo("🚀 Starting SUZENT...")
         _notify_update_available(root)
 
+        if not dev and _read_update_channel(root) == _DEV_CHANNEL:
+            typer.echo("  • Development update channel active; starting in dev mode.")
+            dev = True
+
         # --dev implies running the backend in debug mode.
         if dev:
             debug = True
@@ -1089,9 +1125,75 @@ def register_commands(app: typer.Typer):
         except Exception:
             pass
 
-    def _run_update() -> None:
-        typer.echo("🔄 Updating Suzent...")
+    def _git_text(root: Path, *args: str) -> str:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+
+    def _restore_checkout(root: Path, branch: str, commit: str) -> None:
+        target = branch or commit
+        if not target:
+            return
+        try:
+            typer.echo(f"  • Rolling source back to {target}...")
+            run_command(["git", "checkout", target], cwd=root)
+            run_command(_backend_sync_args(root), cwd=root, shell_on_windows=True)
+        except subprocess.CalledProcessError:
+            typer.echo("  ⚠️  Automatic rollback was incomplete; inspect the checkout.")
+
+    def _checkout_update_target(root: Path, *, dev: bool, release_tag: str) -> None:
+        if dev:
+            run_command(["git", "fetch", "origin", "main"], cwd=root)
+            run_command(["git", "switch", "main"], cwd=root)
+            run_command(["git", "merge", "--ff-only", "origin/main"], cwd=root)
+            return
+        run_command(["git", "fetch", "origin", "tag", release_tag], cwd=root)
+        run_command(["git", "checkout", "--detach", release_tag], cwd=root)
+
+    def _restore_stashed_changes(root: Path, stashed: bool) -> None:
+        if not stashed:
+            return
+        try:
+            run_command(["git", "stash", "pop"], cwd=root)
+        except subprocess.CalledProcessError:
+            typer.echo("  ⚠️  Stashed changes need manual conflict resolution.")
+
+    def _run_update(*, dev: bool = False) -> None:
+        channel = _DEV_CHANNEL if dev else _STABLE_CHANNEL
+        typer.echo(f"🔄 Updating Suzent ({channel} channel)...")
         root = get_project_root()
+
+        if not dev and _is_development_workspace(root):
+            typer.echo(
+                "  ❌ Stable updates require a bootstrapped installation. "
+                "Use 'suzent update --dev' for a source checkout."
+            )
+            raise typer.Exit(code=1)
+
+        release_tag = ""
+        if not dev:
+            try:
+                release_tag = str(_fetch_latest_release().get("tag_name", ""))
+            except Exception as error:
+                typer.echo(f"  ❌ Could not resolve the latest stable release: {error}")
+                raise typer.Exit(code=1)
+            if not re.fullmatch(r"v\d+\.\d+\.\d+", release_tag):
+                typer.echo(
+                    f"  ❌ Invalid stable release tag: {release_tag or 'missing'}"
+                )
+                raise typer.Exit(code=1)
+
+        try:
+            old_commit = _git_text(root, "rev-parse", "HEAD")
+            old_branch = _git_text(root, "branch", "--show-current")
+        except subprocess.CalledProcessError:
+            typer.echo("  ❌ Suzent installation is not a valid Git checkout.")
+            raise typer.Exit(code=1)
 
         # Self-heal installs dirtied by the old behavior, where runtime model
         # discovery wrote into the tracked config/capabilities/ files and made
@@ -1106,31 +1208,60 @@ def register_commands(app: typer.Typer):
         except subprocess.CalledProcessError:
             pass  # No such path / nothing to discard — fine.
 
-        typer.echo("  • Pulling latest changes...")
+        target_label = "origin/main" if dev else release_tag
+        typer.echo(f"  • Updating source to {target_label}...")
+        stashed_changes = False
+        if not dev:
+            try:
+                has_local_changes = bool(_git_text(root, "status", "--porcelain"))
+            except subprocess.CalledProcessError:
+                has_local_changes = False
+            if has_local_changes:
+                if not typer.confirm(
+                    "  Stable updates require a clean checkout. Stash local changes?"
+                ):
+                    typer.echo("  ❌ Update aborted.")
+                    raise typer.Exit(code=1)
+                run_command(["git", "stash", "--include-untracked"], cwd=root)
+                stashed_changes = True
         try:
-            run_command(["git", "pull"], cwd=root)
+            _checkout_update_target(root, dev=dev, release_tag=release_tag)
         except subprocess.CalledProcessError:
+            if stashed_changes:
+                typer.echo("  ❌ Source update failed. Restoring local changes...")
+                _restore_stashed_changes(root, stashed_changes)
+                raise typer.Exit(code=1)
             typer.echo(
-                "  ⚠️  Git pull failed. This is usually due to local file changes (e.g. lockfiles)."
+                "  ⚠️  Source update failed. This is usually due to local file changes."
             )
             if typer.confirm("  Stash local changes and retry?"):
                 typer.echo("  🔄 Stashing local changes...")
                 run_command(["git", "stash", "--include-untracked"], cwd=root)
+                stashed_changes = True
                 try:
-                    run_command(["git", "pull"], cwd=root)
+                    _checkout_update_target(
+                        root,
+                        dev=dev,
+                        release_tag=release_tag,
+                    )
                 except subprocess.CalledProcessError:
-                    typer.echo("  ❌ Git pull still failed. Restoring stash...")
+                    typer.echo("  ❌ Source update still failed. Restoring stash...")
                     run_command(["git", "stash", "pop"], cwd=root)
                     raise typer.Exit(code=1)
-                # Re-apply stashed changes (may have merge conflicts, non-fatal)
-                try:
-                    run_command(["git", "stash", "pop"], cwd=root)
-                except subprocess.CalledProcessError:
-                    typer.echo(
-                        "  ⚠️  Some stashed changes conflicted. Check 'git stash list'."
-                    )
             else:
                 typer.echo("  ❌ Update aborted.")
+                raise typer.Exit(code=1)
+
+        if not dev:
+            checked_out_version = _normalize_version_tag(_current_version(root))
+            expected_version = _normalize_version_tag(release_tag)
+            if checked_out_version != expected_version:
+                typer.echo(
+                    "  ❌ Stable source/version mismatch: "
+                    f"expected {expected_version}, found {checked_out_version}."
+                )
+                _restore_checkout(root, old_branch, old_commit)
+                _restore_stashed_changes(root, stashed_changes)
                 raise typer.Exit(code=1)
 
         # Restore tracked resource placeholders (may be missing from stale clones)
@@ -1199,6 +1330,8 @@ def register_commands(app: typer.Typer):
                         _renamed_exe.rename(target)
                 except OSError:
                     pass
+            _restore_checkout(root, old_branch, old_commit)
+            _restore_stashed_changes(root, stashed_changes)
             raise typer.Exit(code=1)
 
         # Clean up the .bak file (may still be locked until this process exits)
@@ -1221,47 +1354,66 @@ def register_commands(app: typer.Typer):
                 "  ⚠️  Playwright browser update failed (will retry on first use)."
             )
 
-        # Update pre-built UI binary (non-fatal)
-        typer.echo("  • Checking UI binary...")
-        _update_ui_binary(root)
+        if dev:
+            typer.echo("  • Updating frontend dependencies from lockfiles...")
+            try:
+                run_command(
+                    ["npm", "ci"],
+                    cwd=root / "frontend",
+                    shell_on_windows=True,
+                )
+                run_command(
+                    ["npm", "ci"],
+                    cwd=root / "src-tauri",
+                    shell_on_windows=True,
+                )
+            except subprocess.CalledProcessError:
+                typer.echo("  ❌ Development frontend dependency update failed.")
+                _restore_checkout(root, old_branch, old_commit)
+                _restore_stashed_changes(root, stashed_changes)
+                raise typer.Exit(code=1)
+        else:
+            typer.echo("  • Installing matching release UI binary...")
+            if not _update_ui_binary(root, release_tag):
+                typer.echo("  ❌ Matching release UI download failed; update aborted.")
+                _restore_checkout(root, old_branch, old_commit)
+                _restore_stashed_changes(root, stashed_changes)
+                raise typer.Exit(code=1)
 
-        ui_bin = _get_ui_binary(root)
-        if ui_bin:
-            # Frontend is embedded in the binary — no npm steps needed.
-            typer.echo("\n✨ Suzent successfully updated!")
-            return
-
-        # ── Developer path: update npm dependencies ───────────────────────────
-        typer.echo("  • Updating frontend dependencies...")
-        frontend_dir = root / "frontend"
-        try:
-            run_command(["npm", "install"], cwd=frontend_dir, shell_on_windows=True)
-        except subprocess.CalledProcessError:
-            typer.echo("  ❌ Frontend dependency update failed (npm install).")
-            raise typer.Exit(code=1)
-
-        typer.echo("  • Updating src-tauri dependencies...")
-        tauri_dir = root / "src-tauri"
-        try:
-            run_command(["npm", "install"], cwd=tauri_dir, shell_on_windows=True)
-        except subprocess.CalledProcessError:
-            typer.echo("  ❌ Src-tauri dependency update failed (npm install).")
-            raise typer.Exit(code=1)
-
-        typer.echo("\n✨ Suzent successfully updated!")
+        _write_update_channel(root, channel)
+        if dev:
+            _restore_stashed_changes(root, stashed_changes)
+        elif stashed_changes:
+            typer.echo(
+                "  • Local changes remain safely stored in Git stash; "
+                "reapply them only in a development checkout."
+            )
+        typer.echo(f"\n✨ Suzent successfully updated on the {channel} channel!")
 
     @app.command()
-    def update():
+    def update(
+        dev: bool = typer.Option(
+            False,
+            "--dev",
+            help="Update to origin/main and run the matching development frontend.",
+        ),
+    ):
         """Update Suzent to the latest version."""
-        _run_update()
+        _run_update(dev=dev)
 
     @app.command()
-    def upgrade():
+    def upgrade(
+        dev: bool = typer.Option(
+            False,
+            "--dev",
+            help="Update to origin/main and run the matching development frontend.",
+        ),
+    ):
         """Alias for `update`."""
         typer.echo(
             "`suzent upgrade` is supported; `suzent update` is the primary command."
         )
-        _run_update()
+        _run_update(dev=dev)
 
     @app.command("check-update")
     def check_update(

--- a/src/suzent/cli/main.py
+++ b/src/suzent/cli/main.py
@@ -297,6 +297,49 @@ def _download_file_atomic(url: str, dest: Path, *, timeout: float = 60.0) -> Non
         raise
 
 
+def _replace_ui_files(
+    dest: Path,
+    version_file: Path,
+    staged_binary: Path,
+    staged_version: Path,
+) -> None:
+    """Replace the UI binary and metadata as one recoverable operation."""
+    binary_backup = dest.with_name(f".{dest.name}.previous")
+    version_backup = version_file.with_name(f".{version_file.name}.previous")
+    for backup in (binary_backup, version_backup):
+        backup.unlink(missing_ok=True)
+
+    binary_backed_up = False
+    version_backed_up = False
+    binary_installed = False
+    version_installed = False
+    try:
+        if dest.exists():
+            dest.replace(binary_backup)
+            binary_backed_up = True
+        if version_file.exists():
+            version_file.replace(version_backup)
+            version_backed_up = True
+
+        staged_binary.replace(dest)
+        binary_installed = True
+        staged_version.replace(version_file)
+        version_installed = True
+    except Exception:
+        if version_installed:
+            version_file.unlink(missing_ok=True)
+        if binary_installed:
+            dest.unlink(missing_ok=True)
+        if version_backed_up:
+            version_backup.replace(version_file)
+        if binary_backed_up:
+            binary_backup.replace(dest)
+        raise
+    else:
+        binary_backup.unlink(missing_ok=True)
+        version_backup.unlink(missing_ok=True)
+
+
 def download_ui_binary(root: Path, *, version: str = "latest") -> bool:
     """Download the pre-built UI binary from GitHub Releases. Returns True on success."""
     asset_name = _platform_asset_name()
@@ -314,9 +357,8 @@ def download_ui_binary(root: Path, *, version: str = "latest") -> bool:
         if not IS_WINDOWS:
             staged_binary.chmod(0o755)
         staged_version.write_text(version, encoding="utf-8")
-        staged_binary.replace(dest)
+        _replace_ui_files(dest, version_file, staged_binary, staged_version)
         staged_binary = None
-        staged_version.replace(version_file)
         staged_version = None
         typer.echo(f"  ✅ UI binary ready at {dest}")
         return True
@@ -811,7 +853,7 @@ def register_commands(app: typer.Typer):
         ports_to_check = [(18080, "Frontend")]
         if not backend_running:
             ports_to_check.insert(0, (DEFAULT_PORT, "Backend"))
-        else:
+        elif not dev:
             typer.echo(
                 f"  ✅ Backend already running on http://127.0.0.1:{DEFAULT_PORT}; "
                 "reusing it."
@@ -833,8 +875,35 @@ def register_commands(app: typer.Typer):
                     typer.echo("   ❌ Startup aborted.")
                     raise typer.Exit(code=1)
 
+        if dev and backend_running:
+            pid = get_pid_on_port(DEFAULT_PORT)
+            if not pid:
+                typer.echo(
+                    "  ❌ Dev mode found an existing Suzent backend but could not "
+                    "identify its PID. Run 'suzent stop' and retry."
+                )
+                raise typer.Exit(code=1)
+            typer.echo(
+                f"  • Restarting existing backend (PID {pid}) for a clean dev session..."
+            )
+            try:
+                kill_process(pid)
+            except Exception as error:
+                typer.echo(f"  ❌ Failed to restart existing backend: {error}")
+                raise typer.Exit(code=1)
+            for _attempt in range(20):
+                if get_pid_on_port(DEFAULT_PORT) is None:
+                    break
+                time.sleep(0.1)
+            else:
+                typer.echo("  ❌ Existing backend did not release its port.")
+                raise typer.Exit(code=1)
+            backend_running = False
+
         backend_env = os.environ.copy()
         backend_env["SUZENT_PORT"] = str(DEFAULT_PORT)
+        if dev:
+            backend_env["SUZENT_DEV_MODE"] = "1"
 
         backend_proc = None
         if backend_running:
@@ -889,6 +958,7 @@ def register_commands(app: typer.Typer):
         env = os.environ.copy()
         env["SUZENT_HOST"] = host
         env["SUZENT_PORT"] = str(port)
+        env["SUZENT_DEV_MODE"] = "1"
 
         # Launch the server module using the same python interpreter
         cmd = [sys.executable, "-m", "suzent.server"]
@@ -1136,12 +1206,15 @@ def register_commands(app: typer.Typer):
         return result.stdout.strip()
 
     def _restore_checkout(root: Path, branch: str, commit: str) -> None:
-        target = branch or commit
-        if not target:
+        if not commit:
             return
         try:
-            typer.echo(f"  • Rolling source back to {target}...")
-            run_command(["git", "checkout", target], cwd=root)
+            typer.echo(f"  • Rolling source back to {commit}...")
+            if branch:
+                run_command(["git", "checkout", branch], cwd=root)
+                run_command(["git", "reset", "--hard", commit], cwd=root)
+            else:
+                run_command(["git", "checkout", "--detach", commit], cwd=root)
             run_command(_backend_sync_args(root), cwd=root, shell_on_windows=True)
         except subprocess.CalledProcessError:
             typer.echo("  ⚠️  Automatic rollback was incomplete; inspect the checkout.")
@@ -1246,7 +1319,7 @@ def register_commands(app: typer.Typer):
                     )
                 except subprocess.CalledProcessError:
                     typer.echo("  ❌ Source update still failed. Restoring stash...")
-                    run_command(["git", "stash", "pop"], cwd=root)
+                    _restore_stashed_changes(root, stashed_changes)
                     raise typer.Exit(code=1)
             else:
                 typer.echo("  ❌ Update aborted.")

--- a/src/suzent/routes/system_routes.py
+++ b/src/suzent/routes/system_routes.py
@@ -19,6 +19,8 @@ from suzent.config import get_effective_volumes
 
 logger = get_logger(__name__)
 
+API_VERSION = 1
+
 
 def _get_source_version(start: Path | None = None) -> str | None:
     """Find the nearest Suzent pyproject version for a source checkout."""
@@ -51,10 +53,42 @@ def get_backend_version() -> str:
         return "unknown"
 
 
+def get_backend_commit(start: Path | None = None) -> str:
+    """Return the source commit used by the running backend when available."""
+
+    configured = os.getenv("SUZENT_BUILD_COMMIT", "").strip()
+    if configured:
+        return configured
+    source_file = (start or Path(__file__)).resolve()
+    for parent in source_file.parents:
+        if not (parent / ".git").exists():
+            continue
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=parent,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except (OSError, subprocess.CalledProcessError):
+            return "unknown"
+        return result.stdout.strip() or "unknown"
+    return "unknown"
+
+
+def get_system_identity() -> dict[str, str | int]:
+    return {
+        "backend_version": get_backend_version(),
+        "api_version": API_VERSION,
+        "build_commit": get_backend_commit(),
+    }
+
+
 async def get_system_version(_request: Request) -> JSONResponse:
     """Return version information for the running backend."""
 
-    return JSONResponse({"backend_version": get_backend_version()})
+    return JSONResponse(get_system_identity())
 
 
 def _get_resolver(chat_id: str) -> PathResolver:

--- a/src/suzent/routes/system_routes.py
+++ b/src/suzent/routes/system_routes.py
@@ -77,11 +77,12 @@ def get_backend_commit(start: Path | None = None) -> str:
     return "unknown"
 
 
-def get_system_identity() -> dict[str, str | int]:
+def get_system_identity() -> dict[str, str | int | bool]:
     return {
         "backend_version": get_backend_version(),
         "api_version": API_VERSION,
         "build_commit": get_backend_commit(),
+        "development_mode": os.getenv("SUZENT_DEV_MODE") == "1",
     }
 
 

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -154,7 +154,6 @@ from suzent.routes.sandbox_routes import (
 )
 from suzent.routes.skill_routes import get_skills, reload_skills, toggle_skill
 from suzent.routes.system_routes import (
-    get_system_identity,
     get_system_version,
     list_host_files,
     open_in_explorer,
@@ -289,7 +288,7 @@ _social_reload_lock = asyncio.Lock()
 
 async def health(_request: Request) -> JSONResponse:
     """Lightweight readiness probe used by the CLI to detect running servers."""
-    return JSONResponse({"app": "suzent", "status": "ok", **get_system_identity()})
+    return JSONResponse({"app": "suzent", "status": "ok"})
 
 
 def _build_social_from_config(

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -154,6 +154,7 @@ from suzent.routes.sandbox_routes import (
 )
 from suzent.routes.skill_routes import get_skills, reload_skills, toggle_skill
 from suzent.routes.system_routes import (
+    get_system_identity,
     get_system_version,
     list_host_files,
     open_in_explorer,
@@ -288,7 +289,7 @@ _social_reload_lock = asyncio.Lock()
 
 async def health(_request: Request) -> JSONResponse:
     """Lightweight readiness probe used by the CLI to detect running servers."""
-    return JSONResponse({"app": "suzent", "status": "ok"})
+    return JSONResponse({"app": "suzent", "status": "ok", **get_system_identity()})
 
 
 def _build_social_from_config(

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -144,6 +144,43 @@ def test_start_dev_keeps_capability_writes_local(monkeypatch, tmp_path):
 
     assert result.exit_code == 0
     assert "SUZENT_CAPABILITIES_TO_REPO" not in popen_calls["env"]
+    assert popen_calls["env"]["SUZENT_DEV_MODE"] == "1"
+
+
+def test_start_dev_restarts_existing_backend(monkeypatch, tmp_path):
+    app = typer.Typer()
+    cli_main.register_commands(app)
+    killed_pids = []
+    popen_calls = []
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append(cmd)
+        return _ServeProcessSuccess()
+
+    monkeypatch.setattr(cli_main, "get_project_root", lambda: tmp_path)
+    monkeypatch.setattr(cli_main, "_notify_update_available", lambda root: None)
+    monkeypatch.setattr(cli_main, "ensure_cargo_in_path", lambda: None)
+    monkeypatch.setattr(cli_main, "ensure_msvc_linker", lambda: None)
+    monkeypatch.setattr(cli_main, "_is_suzent_server_running", lambda *args: True)
+    monkeypatch.setattr(
+        cli_main,
+        "get_pid_on_port",
+        lambda port: (
+            4321 if port == cli_main.DEFAULT_PORT and not killed_pids else None
+        ),
+    )
+    monkeypatch.setattr(cli_main, "kill_process", killed_pids.append)
+    monkeypatch.setattr(cli_main.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(cli_main, "_ensure_npm_deps", lambda root: None)
+    monkeypatch.setattr(cli_main, "run_command", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli_main, "_terminate_process_gracefully", lambda process: None)
+
+    result = runner.invoke(app, ["start", "--dev"])
+
+    assert result.exit_code == 0
+    assert killed_pids == [4321]
+    assert popen_calls[0][:3] == [cli_main.sys.executable, "-m", "suzent.server"]
+    assert "--debug" in popen_calls[0]
 
 
 def test_serve_uses_default_windows_process_group(monkeypatch):
@@ -169,6 +206,7 @@ def test_serve_uses_default_windows_process_group(monkeypatch):
     assert popen_calls["cmd"][:3] == [cli_main.sys.executable, "-m", "suzent.server"]
     assert popen_calls["env"]["SUZENT_HOST"] == "127.0.0.1"
     assert popen_calls["env"]["SUZENT_PORT"] == "25314"
+    assert popen_calls["env"]["SUZENT_DEV_MODE"] == "1"
     # Important assertion: no CREATE_NEW_PROCESS_GROUP is passed.
     assert "creationflags" not in popen_calls["kwargs"]
 
@@ -233,6 +271,39 @@ def test_update_ui_binary_records_release_version(monkeypatch):
     assert cli_main._update_ui_binary(root, "v1.2.3")
 
     assert download_calls == [(root, "v1.2.3")]
+
+
+def test_replace_ui_files_restores_both_files_when_metadata_install_fails(
+    monkeypatch,
+    tmp_path,
+):
+    dest = tmp_path / "suzent-ui.exe"
+    version_file = tmp_path / "version.txt"
+    staged_binary = tmp_path / "new-ui.exe"
+    staged_version = tmp_path / "new-version.txt"
+    dest.write_bytes(b"old-ui")
+    version_file.write_text("v1.0.0", encoding="utf-8")
+    staged_binary.write_bytes(b"new-ui")
+    staged_version.write_text("v1.1.0", encoding="utf-8")
+    real_replace = Path.replace
+
+    def fail_metadata_replace(path, target):
+        if path == staged_version:
+            raise OSError("metadata locked")
+        return real_replace(path, target)
+
+    monkeypatch.setattr(Path, "replace", fail_metadata_replace)
+
+    with pytest.raises(OSError, match="metadata locked"):
+        cli_main._replace_ui_files(
+            dest,
+            version_file,
+            staged_binary,
+            staged_version,
+        )
+
+    assert dest.read_bytes() == b"old-ui"
+    assert version_file.read_text(encoding="utf-8") == "v1.0.0"
 
 
 def test_release_asset_url_pins_requested_tag():
@@ -339,6 +410,24 @@ def test_dev_update_uses_main_and_never_downloads_release_ui(monkeypatch, tmp_pa
     npm_ci_dirs = [cwd for command, cwd in commands if command == ["npm", "ci"]]
     assert npm_ci_dirs == [tmp_path / "frontend", tmp_path / "src-tauri"]
     assert cli_main._read_update_channel(tmp_path) == "dev"
+
+
+def test_dev_update_failure_resets_branch_to_saved_commit(monkeypatch, tmp_path):
+    app, commands = _mock_update_runtime(monkeypatch, tmp_path)
+
+    def fail_first_npm_ci(command, **kwargs):
+        commands.append((command, kwargs.get("cwd")))
+        if command == ["npm", "ci"]:
+            raise subprocess.CalledProcessError(1, command)
+
+    monkeypatch.setattr(cli_main, "run_command", fail_first_npm_ci)
+
+    result = runner.invoke(app, ["update", "--dev"])
+
+    assert result.exit_code == 1
+    command_args = [command for command, _cwd in commands]
+    assert ["git", "checkout", "main"] in command_args
+    assert ["git", "reset", "--hard", "oldcommit"] in command_args
 
 
 def test_windows_app_suzent_pids_parse_powershell_output(monkeypatch):

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -222,9 +222,6 @@ def test_update_ui_binary_records_release_version(monkeypatch):
     download_calls = []
     root = Path("C:/tmp/suzent-test-root")
 
-    monkeypatch.setattr(
-        cli_main, "_fetch_latest_release", lambda: {"tag_name": "v1.2.3"}
-    )
     monkeypatch.setattr(cli_main, "_local_ui_version", lambda root: "")
 
     def fake_download(root: Path, *, version: str = "latest"):
@@ -233,15 +230,22 @@ def test_update_ui_binary_records_release_version(monkeypatch):
 
     monkeypatch.setattr(cli_main, "download_ui_binary", fake_download)
 
-    cli_main._update_ui_binary(root)
+    assert cli_main._update_ui_binary(root, "v1.2.3")
 
     assert download_calls == [(root, "v1.2.3")]
+
+
+def test_release_asset_url_pins_requested_tag():
+    assert cli_main._release_asset_url("suzent.exe", "v1.2.3") == (
+        "https://github.com/cyzus/suzent/releases/download/v1.2.3/suzent.exe"
+    )
 
 
 def test_backend_sync_args_keep_dev_extra_for_development_workspace(tmp_path):
     assert cli_main._backend_sync_args(tmp_path) == [
         "uv",
         "sync",
+        "--frozen",
         "--extra",
         "social",
         "--extra",
@@ -252,7 +256,89 @@ def test_backend_sync_args_keep_dev_extra_for_development_workspace(tmp_path):
 def test_backend_sync_args_use_social_extra_for_bootstrapped_install(tmp_path):
     (tmp_path / ".suzent-bootstrap-complete").write_text("")
 
-    assert cli_main._backend_sync_args(tmp_path) == ["uv", "sync", "--extra", "social"]
+    assert cli_main._backend_sync_args(tmp_path) == [
+        "uv",
+        "sync",
+        "--frozen",
+        "--extra",
+        "social",
+    ]
+
+
+def test_update_channel_round_trip(tmp_path):
+    assert cli_main._read_update_channel(tmp_path) == "stable"
+
+    cli_main._write_update_channel(tmp_path, "dev")
+
+    assert cli_main._read_update_channel(tmp_path) == "dev"
+
+
+def _mock_update_runtime(monkeypatch, tmp_path):
+    app = typer.Typer()
+    cli_main.register_commands(app)
+    commands = []
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return subprocess.CompletedProcess(command, 0, stdout="oldcommit\n")
+        if command[:3] == ["git", "branch", "--show-current"]:
+            return subprocess.CompletedProcess(command, 0, stdout="main\n")
+        return subprocess.CompletedProcess(command, 0, stdout="")
+
+    def fake_run_command(command, **kwargs):
+        commands.append((command, kwargs.get("cwd")))
+
+    monkeypatch.setattr(cli_main, "get_project_root", lambda: tmp_path)
+    monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli_main, "run_command", fake_run_command)
+    monkeypatch.setattr(cli_main, "IS_WINDOWS", False)
+    return app, commands
+
+
+def test_stable_update_pins_source_and_ui_to_release(monkeypatch, tmp_path):
+    (tmp_path / ".suzent-bootstrap-complete").write_text("")
+    app, commands = _mock_update_runtime(monkeypatch, tmp_path)
+    ui_updates = []
+    monkeypatch.setattr(
+        cli_main,
+        "_fetch_latest_release",
+        lambda: {"tag_name": "v1.2.3"},
+    )
+    monkeypatch.setattr(cli_main, "_current_version", lambda root: "1.2.3")
+    monkeypatch.setattr(
+        cli_main,
+        "_update_ui_binary",
+        lambda root, tag: ui_updates.append(tag) or True,
+    )
+
+    result = runner.invoke(app, ["update"])
+
+    assert result.exit_code == 0
+    command_args = [command for command, _cwd in commands]
+    assert ["git", "fetch", "origin", "tag", "v1.2.3"] in command_args
+    assert ["git", "checkout", "--detach", "v1.2.3"] in command_args
+    assert ui_updates == ["v1.2.3"]
+    assert cli_main._read_update_channel(tmp_path) == "stable"
+
+
+def test_dev_update_uses_main_and_never_downloads_release_ui(monkeypatch, tmp_path):
+    app, commands = _mock_update_runtime(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        cli_main,
+        "_update_ui_binary",
+        lambda *_args: pytest.fail("dev update must not install release UI"),
+    )
+
+    result = runner.invoke(app, ["update", "--dev"])
+
+    assert result.exit_code == 0
+    command_args = [command for command, _cwd in commands]
+    assert ["git", "fetch", "origin", "main"] in command_args
+    assert ["git", "switch", "main"] in command_args
+    assert ["git", "merge", "--ff-only", "origin/main"] in command_args
+    npm_ci_dirs = [cwd for command, cwd in commands if command == ["npm", "ci"]]
+    assert npm_ci_dirs == [tmp_path / "frontend", tmp_path / "src-tauri"]
+    assert cli_main._read_update_channel(tmp_path) == "dev"
 
 
 def test_windows_app_suzent_pids_parse_powershell_output(monkeypatch):

--- a/tests/routes/test_system_routes.py
+++ b/tests/routes/test_system_routes.py
@@ -18,6 +18,7 @@ def test_system_version_reports_running_backend_package(monkeypatch) -> None:
         "backend_version": "1.2.3",
         "api_version": system_routes.API_VERSION,
         "build_commit": "abc123",
+        "development_mode": False,
     }
 
 

--- a/tests/routes/test_system_routes.py
+++ b/tests/routes/test_system_routes.py
@@ -8,12 +8,17 @@ from suzent.routes import system_routes
 def test_system_version_reports_running_backend_package(monkeypatch) -> None:
     monkeypatch.setattr(system_routes, "_get_source_version", lambda: None)
     monkeypatch.setattr(system_routes, "package_version", lambda _name: "1.2.3")
+    monkeypatch.setattr(system_routes, "get_backend_commit", lambda: "abc123")
     app = Starlette(routes=[Route("/system/version", system_routes.get_system_version)])
 
     response = TestClient(app).get("/system/version")
 
     assert response.status_code == 200
-    assert response.json() == {"backend_version": "1.2.3"}
+    assert response.json() == {
+        "backend_version": "1.2.3",
+        "api_version": system_routes.API_VERSION,
+        "build_commit": "abc123",
+    }
 
 
 def test_backend_version_falls_back_when_package_metadata_is_missing(
@@ -42,3 +47,9 @@ def test_backend_version_prefers_source_checkout(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(system_routes, "package_version", lambda _name: "1.2.3")
 
     assert system_routes.get_backend_version() == "2.3.4"
+
+
+def test_backend_commit_prefers_build_environment(monkeypatch) -> None:
+    monkeypatch.setenv("SUZENT_BUILD_COMMIT", "release-commit")
+
+    assert system_routes.get_backend_commit() == "release-commit"

--- a/uv.lock
+++ b/uv.lock
@@ -3910,7 +3910,7 @@ wheels = [
 
 [[package]]
 name = "suzent"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
## Summary

Prepare Suzent v0.7.3 and make updates version-coherent across the Python backend and desktop frontend.

- pin stable `suzent update` to one exact release tag, frozen Python lockfile, and matching desktop asset
- add `suzent update --dev` to fast-forward `main` and install locked Python/frontend dependencies together
- remember the selected channel so a development update continues with `suzent start` in dev mode
- expose backend version, API protocol version, and build commit; block incompatible frontend/backend combinations with localized diagnostics
- probe `/health` instead of `/config` during desktop backend startup
- stage UI downloads before replacement and preserve stable-channel local changes in Git stash
- bump all package/config/lockfile versions to 0.7.3 and update release notes/docs

## Validation

- `uv run --no-sync pytest tests -m "not sandbox"` — 899 passed
- `npm test` — 75 passed
- `npm run build`
- `cargo fmt --check`
- `cargo check`
- `python scripts/bump_version.py --check`
- `pre-commit run --all-files`

## Release

This PR intentionally uses the `release/v0.7.3` branch. After it is reviewed and merged, the existing release-on-merge workflow will create tag `v0.7.3`, build matching desktop assets, and publish the GitHub release after successful builds.