### PR TITLE
fix: prevent desktop startup from hanging

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -938,7 +938,11 @@ async function isBackendPortReachable(port: number): Promise<boolean> {
 }
 
 async function waitForBackendPort(options?: { attempts?: number }): Promise<number | null> {
-  const attempts = options?.attempts ?? 12;
+  // Tauri may spend up to 45 seconds waiting for the port file and health
+  // check. Keep polling beyond that window so a persisted startup error is
+  // surfaced even when the original backend-error event fired before React
+  // registered its listener.
+  const attempts = options?.attempts ?? 24;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     const candidates: number[] = [];
     const remembered = getRememberedBackendPort();
@@ -956,6 +960,14 @@ async function waitForBackendPort(options?: { attempts?: number }): Promise<numb
         rememberBackendPort(port);
         return port;
       }
+    }
+
+    try {
+      const startupError = await invoke<string | null>('get_backend_startup_error');
+      if (startupError) throw new Error(startupError);
+    } catch (error) {
+      if (error instanceof Error && error.message) throw error;
+      // Older/dev shells may not expose startup error persistence yet.
     }
 
     await new Promise(resolve => window.setTimeout(resolve, Math.min(500 * Math.pow(1.35, attempt), 2500)));
@@ -1032,7 +1044,11 @@ export default function App() {
               setBackendError(null);
               setBackendStartingAtStartup(false);
             })
-            .catch(() => {});
+            .catch((error: unknown) => {
+              if (cancelled) return;
+              setBackendStartingAtStartup(false);
+              setBackendError(String(error));
+            });
         }
         setBootstrapChecked(true);
       })
@@ -1061,6 +1077,12 @@ export default function App() {
           setBackendError(null);
           setBackendStartingAtStartup(false);
           setBackendStartingAfterInstall(false);
+        }
+      }).catch((error: unknown) => {
+        if (!cancelled) {
+          setBackendStartingAtStartup(false);
+          setBackendStartingAfterInstall(false);
+          setBackendError(String(error));
         }
       });
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,6 +17,7 @@ const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 struct AppState {
     backend: Mutex<Option<BackendProcess>>,
+    backend_startup_error: Mutex<Option<String>>,
 }
 
 #[derive(Clone, Serialize)]
@@ -57,6 +58,15 @@ async fn check_for_update() -> Result<String, String> {
     tauri::async_runtime::spawn_blocking(check_for_update_blocking)
         .await
         .map_err(|error| format!("Update check task failed: {}", error))?
+}
+
+#[tauri::command]
+fn get_backend_startup_error(state: State<AppState>) -> Result<Option<String>, String> {
+    let error_guard = state
+        .backend_startup_error
+        .lock()
+        .map_err(|e| format!("Lock error: {}", e))?;
+    Ok(error_guard.clone())
 }
 
 fn check_for_update_blocking() -> Result<String, String> {
@@ -330,6 +340,12 @@ fn spawn_backend_start(app_handle: tauri::AppHandle) {
             return;
         };
 
+        if let Some(state) = app_handle.try_state::<AppState>() {
+            if let Ok(mut error_guard) = state.backend_startup_error.lock() {
+                *error_guard = None;
+            }
+        }
+
         match get_backend_config(&app_handle) {
             Ok((port, backend)) => {
                 println!("Backend configured on port {}", port);
@@ -359,6 +375,11 @@ try {{ localStorage.setItem('SUZENT_PORT', '{port}'); }} catch (e) {{}}
             }
             Err(e) => {
                 eprintln!("Failed to start backend: {}", e);
+                if let Some(state) = app_handle.try_state::<AppState>() {
+                    if let Ok(mut error_guard) = state.backend_startup_error.lock() {
+                        *error_guard = Some(e.clone());
+                    }
+                }
                 if e == "bootstrap-required" {
                     let _ = app_handle.emit(
                         "bootstrap-required",
@@ -518,6 +539,7 @@ fn main() {
         .setup(|app| {
             app.manage(AppState {
                 backend: Mutex::new(None),
+                backend_startup_error: Mutex::new(None),
             });
 
             let status = build_bootstrap_status(Some(app.handle()));
@@ -534,6 +556,7 @@ fn main() {
         })
         .invoke_handler(tauri::generate_handler![
             get_backend_port,
+            get_backend_startup_error,
             check_for_update,
             start_update_and_restart,
             bootstrap_status,

--- a/src/suzent/cli/main.py
+++ b/src/suzent/cli/main.py
@@ -44,11 +44,19 @@ def _backend_sync_args(root: Path) -> list[str]:
 
 
 def _get_ui_binary(root: Path) -> Path | None:
-    """Return a compatible UI binary: newest local/release build wins."""
+    """Return the managed release UI, falling back to a local release build."""
     name = "suzent-ui.exe" if IS_WINDOWS else "suzent-ui"
     release_name = "suzent.exe" if IS_WINDOWS else "suzent"
+    managed_release = root / _BIN_DIR / name
+
+    # `suzent update` installs the UI and its version marker atomically. Prefer
+    # that managed pair over a locally-built executable whose newer mtime does
+    # not imply compatibility with the checked-out backend.
+    if managed_release.exists() and (root / _BIN_DIR / "version.txt").exists():
+        return managed_release
+
     candidates = [
-        root / _BIN_DIR / name,
+        managed_release,
         root / "src-tauri" / "target" / "release" / release_name,
     ]
     existing = [p for p in candidates if p.exists() and _is_ui_binary_current(root, p)]
@@ -835,7 +843,10 @@ def register_commands(app: typer.Typer):
             # Pre-built binary manages both backend and webview internally.
             typer.echo(f"  • Launching UI binary ({ui_bin.name})...")
             try:
-                subprocess.run([str(ui_bin)], env=_ui_launch_env())
+                subprocess.run(
+                    [str(ui_bin)],
+                    env=_ui_launch_env({"SUZENT_DIR": str(root)}),
+                )
             except (subprocess.CalledProcessError, KeyboardInterrupt):
                 pass
             return
@@ -1027,7 +1038,7 @@ def register_commands(app: typer.Typer):
 
         ui_bin = _get_ui_binary(root)
         if ui_bin:
-            env = _ui_launch_env({"SUZENT_PORT": str(port)})
+            env = _ui_launch_env({"SUZENT_DIR": str(root), "SUZENT_PORT": str(port)})
             try:
                 subprocess.run([str(ui_bin)], env=env)
             except (subprocess.CalledProcessError, KeyboardInterrupt):

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -183,6 +183,52 @@ def test_start_dev_restarts_existing_backend(monkeypatch, tmp_path):
     assert "--debug" in popen_calls[0]
 
 
+def test_get_ui_binary_prefers_managed_release_over_newer_local_build(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(cli_main, "IS_WINDOWS", True)
+    managed = tmp_path / "bin" / "suzent-ui.exe"
+    local_build = tmp_path / "src-tauri" / "target" / "release" / "suzent.exe"
+    managed.parent.mkdir(parents=True)
+    local_build.parent.mkdir(parents=True)
+    managed.write_bytes(b"managed")
+    (managed.parent / "version.txt").write_text("v1.2.3", encoding="utf-8")
+    local_build.write_bytes(b"local")
+    local_build.touch()
+
+    assert cli_main._get_ui_binary(tmp_path) == managed
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_port"), [("start", None), ("ui", "25314")]
+)
+def test_release_ui_receives_workspace_directory(
+    monkeypatch, tmp_path, command, expected_port
+):
+    app = typer.Typer()
+    cli_main.register_commands(app)
+    ui_binary = tmp_path / "bin" / "suzent-ui.exe"
+    launched = {}
+
+    def fake_run(args, env=None, **kwargs):
+        launched["args"] = args
+        launched["env"] = env
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(cli_main, "get_project_root", lambda: tmp_path)
+    monkeypatch.setattr(cli_main, "_notify_update_available", lambda root: None)
+    monkeypatch.setattr(cli_main, "_get_ui_binary", lambda root: ui_binary)
+    monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+
+    result = runner.invoke(app, [command])
+
+    assert result.exit_code == 0
+    assert launched["args"] == [str(ui_binary)]
+    assert launched["env"]["SUZENT_DIR"] == str(tmp_path)
+    if expected_port is not None:
+        assert launched["env"]["SUZENT_PORT"] == expected_port
+
+
 def test_serve_uses_default_windows_process_group(monkeypatch):
     """Regression: `suzent serve` should not create a new process group on Windows."""
     app = typer.Typer()


### PR DESCRIPTION
## What changed

- pass the resolved Suzent workspace to release UI launches
- prefer the update-managed UI binary over a newer local release build
- persist backend startup errors in Tauri and surface them after frontend event-listener races
- add CLI regression coverage for managed UI selection and workspace propagation

## Root cause

`start` could launch a stale local UI binary or resolve the backend from a stale install marker. Separately, a backend failure emitted before React registered `backend-error` could leave the loading state active forever.

## Impact

After updating, `suzent start` consistently launches the matching UI/backend pair. Startup failures now show their actual error instead of remaining on `INITIALIZING` indefinitely.

## Validation

- `uv run pytest tests/cli/test_cli_main.py` (31 passed)
- `uv run ruff check src/suzent/cli/main.py tests/cli/test_cli_main.py`
- `npm test -- src/lib/api.version.test.ts` (6 passed)
- `npm run build`
- `cargo fmt -- --check`
- `cargo check`