### PR TITLE
fix: make Windows startup and updates resilient

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -928,7 +928,7 @@ async function isBackendPortReachable(port: number): Promise<boolean> {
   const controller = new AbortController();
   const timeout = window.setTimeout(() => controller.abort(), 1500);
   try {
-    const res = await fetch(`http://127.0.0.1:${port}/config`, { signal: controller.signal });
+    const res = await fetch(`http://127.0.0.1:${port}/health`, { signal: controller.signal });
     return res.ok;
   } catch {
     return false;
@@ -1039,7 +1039,15 @@ export default function App() {
           setBackendStartingAtStartup(true);
           waitForBackendPort()
             .then((port) => {
-              if (cancelled || port === null) return;
+              if (cancelled) return;
+              if (port === null) {
+                setBackendStartingAtStartup(false);
+                setBackendError(tForLocale(
+                  getInitialLocale(),
+                  'app.backendStartTimeout',
+                ));
+                return;
+              }
               setBackendReady(true);
               setBackendError(null);
               setBackendStartingAtStartup(false);

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -28,6 +28,7 @@ export const en = {
     systemIdentity: 'SUZENT / SYSTEM',
     systemStartup: 'System startup',
     backendErrorTitle: 'CONNECTION FAILED',
+    backendStartTimeout: 'Backend startup timed out. Check ~/.suzent/runtime/server.log for details.',
     desktopRequiredTitle: 'Desktop required',
     desktopRequiredDesc: 'Suzent is a desktop-only application. Please run this application using the native desktop launcher.',
     logoAriaLabel: 'Suzent logo',

--- a/frontend/src/i18n/messages/zh-CN.ts
+++ b/frontend/src/i18n/messages/zh-CN.ts
@@ -28,6 +28,7 @@ export const zhCN = {
     systemIdentity: 'SUZENT / 系统',
     systemStartup: '系统启动',
     backendErrorTitle: '连接失败',
+    backendStartTimeout: '后端启动超时。请检查 ~/.suzent/runtime/server.log 获取详细信息。',
     desktopRequiredTitle: '需要桌面端',
     desktopRequiredDesc: 'Suzent 仅支持桌面端运行。请使用原生桌面启动器打开该应用。',
     logoAriaLabel: 'Suzent 标志',

--- a/src-tauri/src/backend.rs
+++ b/src-tauri/src/backend.rs
@@ -100,7 +100,7 @@ impl BackendProcess {
     }
 
     fn poll_port_file(
-        &self,
+        &mut self,
         port_file: &std::path::Path,
         timeout: Duration,
     ) -> Result<u16, String> {
@@ -112,6 +112,19 @@ impl BackendProcess {
             if let Ok(contents) = std::fs::read_to_string(port_file) {
                 if let Ok(port) = contents.trim().parse::<u16>() {
                     return Ok(port);
+                }
+            }
+            if let Some(child) = self.child.as_mut() {
+                if let Ok(Some(status)) = child.try_wait() {
+                    return Err(format!(
+                        "Backend exited with {} before reporting a port. Check {} for details.",
+                        status,
+                        port_file
+                            .parent()
+                            .unwrap_or_else(|| std::path::Path::new("."))
+                            .join("server.log")
+                            .display()
+                    ));
                 }
             }
             thread::sleep(Duration::from_millis(200));

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -412,12 +412,13 @@ fn write_update_script(repo_dir: &Path, uv_exe: &Path, ui_exe: &Path) -> Result<
 
     if cfg!(windows) {
         let script = runtime_dir.join("suzent-update-and-restart.cmd");
+        let python_exe = repo_dir.join(".venv").join("Scripts").join("python.exe");
         let contents = format!(
             "@echo off\r\n\
 title Suzent Update\r\n\
 timeout /t 1 /nobreak >nul\r\n\
 cd /d \"{}\"\r\n\
-\"{}\" run --no-sync suzent update\r\n\
+\"{}\" -m suzent.cli update\r\n\
 if errorlevel 1 (\r\n\
   echo.\r\n\
   echo Suzent update failed. Press any key to close.\r\n\
@@ -427,7 +428,7 @@ if errorlevel 1 (\r\n\
 start \"\" \"{}\"\r\n\
 exit /b 0\r\n",
             repo_dir.display(),
-            uv_exe.display(),
+            python_exe.display(),
             ui_exe.display()
         );
         std::fs::File::create(&script)

--- a/src/suzent/cli/main.py
+++ b/src/suzent/cli/main.py
@@ -29,6 +29,7 @@ _UPDATE_CHECK_TTL_SECONDS = 24 * 60 * 60
 _UPDATE_CHANNEL_FILE = ".suzent/update-channel"
 _STABLE_CHANNEL = "stable"
 _DEV_CHANNEL = "dev"
+_UPDATE_HELPER_ENV = "SUZENT_UPDATE_HELPER"
 
 
 def _is_development_workspace(root: Path) -> bool:
@@ -738,6 +739,83 @@ def _windows_suzent_backend_pids(root: Path, *, exclude_pids: set[int]) -> list[
     return pids
 
 
+def _windows_suzent_launcher_pid(root: Path) -> int | None:
+    """Return the running venv console-shim PID in our ancestor chain."""
+    if not IS_WINDOWS:
+        return None
+    launcher = str((root / ".venv" / "Scripts" / "suzent.exe").resolve())
+    escaped_launcher = launcher.replace("'", "''")
+    script = (
+        "$ErrorActionPreference = 'SilentlyContinue'; "
+        f"$launcher = '{escaped_launcher}'; "
+        "Get-CimInstance Win32_Process | Where-Object { "
+        "$_.ExecutablePath -eq $launcher "
+        "} | ForEach-Object { $_.ProcessId }"
+    )
+    result = subprocess.run(
+        ["powershell", "-NoProfile", "-Command", script],
+        capture_output=True,
+        text=True,
+    )
+    ancestors = _windows_ancestor_pids()
+    for line in result.stdout.splitlines():
+        try:
+            pid = int(line.strip())
+        except ValueError:
+            continue
+        if pid in ancestors:
+            return pid
+
+    try:
+        invoked_as = Path(sys.argv[0]).resolve()
+        expected_launcher = root / ".venv" / "Scripts" / "suzent.exe"
+        if invoked_as == expected_launcher.resolve():
+            return os.getppid()
+    except OSError:
+        pass
+    return None
+
+
+def _delegate_windows_update(root: Path, *, dev: bool) -> bool:
+    """Relaunch updates outside the locked Windows console-script shim."""
+    if not IS_WINDOWS or os.environ.get(_UPDATE_HELPER_ENV) == "1":
+        return False
+
+    launcher_pid = _windows_suzent_launcher_pid(root)
+    if launcher_pid is None:
+        return False
+
+    python_exe = root / ".venv" / "Scripts" / "python.exe"
+    if not python_exe.exists():
+        raise RuntimeError(f"Python environment not found at {python_exe}")
+
+    command = [
+        str(python_exe),
+        "-m",
+        "suzent.cli.update_helper",
+        "--wait-pid",
+        str(launcher_pid),
+        "--root",
+        str(root),
+    ]
+    if dev:
+        command.append("--dev")
+
+    helper_env = os.environ.copy()
+    helper_env[_UPDATE_HELPER_ENV] = "1"
+    creationflags = getattr(subprocess, "CREATE_NEW_CONSOLE", 0) | getattr(
+        subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+    )
+    subprocess.Popen(
+        command,
+        cwd=root,
+        env=helper_env,
+        creationflags=creationflags,
+    )
+    typer.echo("  • Update will continue in a separate window...")
+    return True
+
+
 def _stop_windows_process(pid: int, label: str) -> None:
     typer.echo(f"  • Stopping running {label} (PID {pid})...")
     subprocess.run(["taskkill", "/F", "/PID", str(pid)], capture_output=True)
@@ -1251,6 +1329,9 @@ def register_commands(app: typer.Typer):
         channel = _DEV_CHANNEL if dev else _STABLE_CHANNEL
         typer.echo(f"🔄 Updating Suzent ({channel} channel)...")
         root = get_project_root()
+
+        if _delegate_windows_update(root, dev=dev):
+            return
 
         if not dev and _is_development_workspace(root):
             typer.echo(

--- a/src/suzent/cli/update_helper.py
+++ b/src/suzent/cli/update_helper.py
@@ -1,0 +1,44 @@
+"""Windows helper that waits for the locked Suzent launcher before updating."""
+
+import argparse
+import ctypes
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _wait_for_process_exit(pid: int) -> None:
+    """Wait for a Windows process, returning immediately if it already exited."""
+    synchronize = 0x00100000
+    infinite = 0xFFFFFFFF
+    kernel32 = ctypes.windll.kernel32
+    handle = kernel32.OpenProcess(synchronize, False, pid)
+    if not handle:
+        return
+    try:
+        kernel32.WaitForSingleObject(handle, infinite)
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--wait-pid", type=int, required=True)
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--dev", action="store_true")
+    args = parser.parse_args()
+
+    _wait_for_process_exit(args.wait_pid)
+
+    command = [sys.executable, "-m", "suzent.cli", "update"]
+    if args.dev:
+        command.append("--dev")
+    result = subprocess.run(command, cwd=args.root, env=os.environ.copy())
+    if result.returncode != 0 and sys.stdin.isatty():
+        input("\nSuzent update failed. Press Enter to close.")
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/suzent/core/providers/chatgpt.py
+++ b/src/suzent/core/providers/chatgpt.py
@@ -23,9 +23,9 @@ class ChatGPTProvider(BaseProvider):
     def _authenticator(self):
         return create_authenticator()
 
-    def is_authenticated(self) -> bool:
+    def is_authenticated(self, *, refresh: bool = True) -> bool:
         auth = self._authenticator()
-        return bool(get_valid_access_token(auth))
+        return bool(get_valid_access_token(auth, refresh=refresh))
 
     def fetch_models(self) -> List[Model]:
         auth = self._authenticator()

--- a/src/suzent/core/providers/helpers.py
+++ b/src/suzent/core/providers/helpers.py
@@ -111,7 +111,17 @@ def _provider_is_configured(spec) -> bool:
                 "ChatGPT provider unavailable while checking default model: {}", exc
             )
             return False
-        return bool(getattr(provider, "is_authenticated", lambda: False)())
+        try:
+            # /config is part of desktop startup. Never perform an OAuth refresh
+            # (and therefore a network request) while choosing its default model.
+            return bool(provider.is_authenticated(refresh=False))
+        except Exception as exc:
+            logger.warning(
+                "ChatGPT credentials could not be checked while choosing the "
+                "default model: {}",
+                exc,
+            )
+            return False
     return False
 
 

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -502,6 +502,63 @@ def test_windows_suzent_backend_pids_parse_powershell_output(monkeypatch, tmp_pa
     assert cli_main._windows_suzent_backend_pids(tmp_path, exclude_pids={111}) == [222]
 
 
+def test_windows_update_delegates_away_from_locked_launcher(monkeypatch, tmp_path):
+    python_exe = tmp_path / ".venv" / "Scripts" / "python.exe"
+    python_exe.parent.mkdir(parents=True)
+    python_exe.write_bytes(b"")
+    popen_calls = []
+
+    monkeypatch.setattr(cli_main, "IS_WINDOWS", True)
+    monkeypatch.setattr(cli_main, "_windows_suzent_launcher_pid", lambda root: 4321)
+    monkeypatch.setattr(
+        cli_main.subprocess,
+        "Popen",
+        lambda command, **kwargs: popen_calls.append((command, kwargs)),
+    )
+    monkeypatch.delenv(cli_main._UPDATE_HELPER_ENV, raising=False)
+
+    assert cli_main._delegate_windows_update(tmp_path, dev=True)
+
+    command, kwargs = popen_calls[0]
+    assert command[:3] == [
+        str(python_exe),
+        "-m",
+        "suzent.cli.update_helper",
+    ]
+    assert command[-1] == "--dev"
+    assert kwargs["env"][cli_main._UPDATE_HELPER_ENV] == "1"
+
+
+def test_windows_update_helper_does_not_redelegate(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli_main, "IS_WINDOWS", True)
+    monkeypatch.setenv(cli_main._UPDATE_HELPER_ENV, "1")
+    monkeypatch.setattr(
+        cli_main,
+        "_windows_suzent_launcher_pid",
+        lambda root: pytest.fail("helper must not inspect the launcher"),
+    )
+
+    assert not cli_main._delegate_windows_update(tmp_path, dev=False)
+
+
+def test_windows_launcher_detection_falls_back_to_argv(monkeypatch, tmp_path):
+    launcher = tmp_path / ".venv" / "Scripts" / "suzent.exe"
+    launcher.parent.mkdir(parents=True)
+    launcher.write_bytes(b"")
+
+    monkeypatch.setattr(cli_main, "IS_WINDOWS", True)
+    monkeypatch.setattr(cli_main, "_windows_ancestor_pids", lambda: {123})
+    monkeypatch.setattr(
+        cli_main.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args, 0, stdout=""),
+    )
+    monkeypatch.setattr(cli_main.sys, "argv", [str(launcher), "update"])
+    monkeypatch.setattr(cli_main.os, "getppid", lambda: 123)
+
+    assert cli_main._windows_suzent_launcher_pid(tmp_path) == 123
+
+
 @pytest.mark.parametrize(
     ("latest", "current", "expected"),
     [

--- a/tests/cli/test_update_helper.py
+++ b/tests/cli/test_update_helper.py
@@ -1,0 +1,41 @@
+"""Tests for the detached Windows update helper."""
+
+import importlib
+import subprocess
+import sys
+
+
+update_helper = importlib.import_module("suzent.cli.update_helper")
+
+
+def test_update_helper_waits_then_runs_cli_module(monkeypatch, tmp_path):
+    events = []
+
+    def fake_run(command, **kwargs):
+        events.append(("run", command, kwargs))
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(
+        update_helper,
+        "_wait_for_process_exit",
+        lambda pid: events.append(("wait", pid)),
+    )
+    monkeypatch.setattr(update_helper.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "update_helper",
+            "--wait-pid",
+            "4321",
+            "--root",
+            str(tmp_path),
+            "--dev",
+        ],
+    )
+
+    assert update_helper.main() == 0
+    assert events[0] == ("wait", 4321)
+    _, command, kwargs = events[1]
+    assert command == [sys.executable, "-m", "suzent.cli", "update", "--dev"]
+    assert kwargs["cwd"] == tmp_path

--- a/tests/core/test_default_chat_model.py
+++ b/tests/core/test_default_chat_model.py
@@ -167,6 +167,47 @@ def test_provider_is_configured_uses_resolve_api_key_for_keyed_providers(
     assert helpers._provider_is_configured(catalog[1]) is False
 
 
+def test_provider_is_configured_does_not_refresh_chatgpt_token(monkeypatch):
+    spec = _spec(
+        "chatgpt",
+        env_key=None,
+        api_type="chatgpt_subscription",
+        models=["chatgpt/gpt-5"],
+    )
+
+    class _Provider:
+        def is_authenticated(self, *, refresh: bool = True) -> bool:
+            assert refresh is False
+            return True
+
+    monkeypatch.setattr(
+        "suzent.core.providers.factory.ProviderFactory.get_provider",
+        lambda provider_id, config: _Provider(),
+    )
+
+    assert helpers._provider_is_configured(spec) is True
+
+
+def test_provider_is_configured_tolerates_chatgpt_auth_failure(monkeypatch):
+    spec = _spec(
+        "chatgpt",
+        env_key=None,
+        api_type="chatgpt_subscription",
+        models=["chatgpt/gpt-5"],
+    )
+
+    class _Provider:
+        def is_authenticated(self, *, refresh: bool = True) -> bool:
+            raise RuntimeError("refresh token rejected")
+
+    monkeypatch.setattr(
+        "suzent.core.providers.factory.ProviderFactory.get_provider",
+        lambda provider_id, config: _Provider(),
+    )
+
+    assert helpers._provider_is_configured(spec) is False
+
+
 def test_load_user_provider_config_tolerates_malformed_blob(monkeypatch):
     class _FakeDB:
         def get_api_keys(self):


### PR DESCRIPTION
## Summary

- move Windows self-updates into a detached Python helper so the running `suzent.exe` shim can exit before `uv sync` replaces it
- make desktop-triggered updates invoke Python directly
- use `/health` for frontend backend-readiness checks and surface startup timeouts/errors
- keep `/config` startup-safe when a stale ChatGPT OAuth refresh token is rejected

## Root cause confirmed from v0.7.4 logs

The backend was healthy and listening, but frontend readiness probed `/config`. Default-model discovery tried to refresh an expired ChatGPT subscription token; the OAuth endpoint returned 403, `/config` returned 500, and the UI remained on INITIALIZING.

## Validation

- `uv run pytest tests/core/test_default_chat_model.py tests/cli/test_cli_main.py tests/cli/test_update_helper.py` (47 passed)
- `uv run ruff check ...`
- `uv run pre-commit run --all-files`
- `npm run build`
- `cargo fmt -- --check`
- `cargo check`