### PR TITLE
fix: recover backend state after WebView refresh

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -944,22 +944,23 @@ async function waitForBackendPort(options?: { attempts?: number }): Promise<numb
   // registered its listener.
   const attempts = options?.attempts ?? 24;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
-    const candidates: number[] = [];
-    const remembered = getRememberedBackendPort();
-    if (remembered) candidates.push(remembered);
-
     try {
       const tauriPort = await invoke<number>('get_backend_port');
-      candidates.unshift(tauriPort);
+      if (Number.isFinite(tauriPort) && tauriPort > 0) {
+        // Rust only stores the BackendProcess after its /health check passes,
+        // so this port is authoritative. This also makes WebView refreshes
+        // recover without a second browser-side request that can race startup.
+        rememberBackendPort(tauriPort);
+        return tauriPort;
+      }
     } catch {
       // A dev backend may only be discoverable from storage after a WebView refresh.
     }
 
-    for (const port of Array.from(new Set(candidates))) {
-      if (await isBackendPortReachable(port)) {
-        rememberBackendPort(port);
-        return port;
-      }
+    const remembered = getRememberedBackendPort();
+    if (remembered && await isBackendPortReachable(remembered)) {
+      rememberBackendPort(remembered);
+      return remembered;
     }
 
     try {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -51,7 +51,16 @@ export interface SystemVersionResponse {
 }
 
 export async function fetchSystemVersion(): Promise<SystemVersionResponse> {
-  const response = await fetch(`${getApiBase()}/system/version`);
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), 5000);
+  let response: Response;
+  try {
+    response = await fetch(`${getApiBase()}/system/version`, {
+      signal: controller.signal,
+    });
+  } finally {
+    window.clearTimeout(timeout);
+  }
   if (!response.ok) {
     throw new Error(`Failed to load backend version: ${response.status}`);
   }


### PR DESCRIPTION
## Summary

- trust `get_backend_port` as an authoritative ready signal after a WebView refresh
- reserve browser-side `/health` probing for persisted-port fallback when the Tauri shell has not reported readiness
- bound the backend compatibility request to five seconds so failures surface instead of showing INITIALIZING forever

## Root cause

The Rust shell only stores and exposes `BackendProcess` after `/health` succeeds. After a right-click refresh, however, the frontend discarded that authoritative ready state and performed another browser HTTP probe. A delayed or stuck probe prevented the refreshed WebView from restoring the already-running backend and left the UI on INITIALIZING.

## Validation

- `npm run build`
- `uv run pre-commit run --all-files`
- `git diff --check`