### PR TITLE
fix: always detach Windows self-updates

### DIFF
--- a/src/suzent/cli/main.py
+++ b/src/suzent/cli/main.py
@@ -770,7 +770,7 @@ def _windows_suzent_launcher_pid(root: Path) -> int | None:
         invoked_as = Path(sys.argv[0]).resolve()
         expected_launcher = root / ".venv" / "Scripts" / "suzent.exe"
         if invoked_as == expected_launcher.resolve():
-            return os.getppid()
+            return os.getpid()
     except OSError:
         pass
     return None
@@ -782,8 +782,7 @@ def _delegate_windows_update(root: Path, *, dev: bool) -> bool:
         return False
 
     launcher_pid = _windows_suzent_launcher_pid(root)
-    if launcher_pid is None:
-        return False
+    wait_pid = launcher_pid if launcher_pid is not None else os.getpid()
 
     python_exe = root / ".venv" / "Scripts" / "python.exe"
     if not python_exe.exists():
@@ -794,7 +793,7 @@ def _delegate_windows_update(root: Path, *, dev: bool) -> bool:
         "-m",
         "suzent.cli.update_helper",
         "--wait-pid",
-        str(launcher_pid),
+        str(wait_pid),
         "--root",
         str(root),
     ]

--- a/src/suzent/cli/update_helper.py
+++ b/src/suzent/cli/update_helper.py
@@ -5,6 +5,7 @@ import ctypes
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 
@@ -30,6 +31,10 @@ def main() -> int:
     args = parser.parse_args()
 
     _wait_for_process_exit(args.wait_pid)
+    # The uv-generated console launcher can outlive its Python child very
+    # briefly while it propagates the exit code. Give Windows time to release
+    # suzent.exe before the nested update replaces that file.
+    time.sleep(0.5)
 
     command = [sys.executable, "-m", "suzent.cli", "update"]
     if args.dev:

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -529,6 +529,27 @@ def test_windows_update_delegates_away_from_locked_launcher(monkeypatch, tmp_pat
     assert kwargs["env"][cli_main._UPDATE_HELPER_ENV] == "1"
 
 
+def test_windows_update_delegates_when_launcher_detection_misses(monkeypatch, tmp_path):
+    python_exe = tmp_path / ".venv" / "Scripts" / "python.exe"
+    python_exe.parent.mkdir(parents=True)
+    python_exe.write_bytes(b"")
+    popen_calls = []
+
+    monkeypatch.setattr(cli_main, "IS_WINDOWS", True)
+    monkeypatch.setattr(cli_main, "_windows_suzent_launcher_pid", lambda root: None)
+    monkeypatch.setattr(cli_main.os, "getpid", lambda: 9876)
+    monkeypatch.setattr(
+        cli_main.subprocess,
+        "Popen",
+        lambda command, **kwargs: popen_calls.append((command, kwargs)),
+    )
+    monkeypatch.delenv(cli_main._UPDATE_HELPER_ENV, raising=False)
+
+    assert cli_main._delegate_windows_update(tmp_path, dev=False)
+    command, _kwargs = popen_calls[0]
+    assert command[3:5] == ["--wait-pid", "9876"]
+
+
 def test_windows_update_helper_does_not_redelegate(monkeypatch, tmp_path):
     monkeypatch.setattr(cli_main, "IS_WINDOWS", True)
     monkeypatch.setenv(cli_main._UPDATE_HELPER_ENV, "1")
@@ -554,9 +575,9 @@ def test_windows_launcher_detection_falls_back_to_argv(monkeypatch, tmp_path):
         lambda *args, **kwargs: subprocess.CompletedProcess(args, 0, stdout=""),
     )
     monkeypatch.setattr(cli_main.sys, "argv", [str(launcher), "update"])
-    monkeypatch.setattr(cli_main.os, "getppid", lambda: 123)
+    monkeypatch.setattr(cli_main.os, "getpid", lambda: 456)
 
-    assert cli_main._windows_suzent_launcher_pid(tmp_path) == 123
+    assert cli_main._windows_suzent_launcher_pid(tmp_path) == 456
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

- Always hand Windows updates to the detached Python helper, even when the console-launcher PID lookup misses.
- Wait for the current updater PID as a safe fallback and allow the uv launcher time to release `suzent.exe`.
- Correct the argv-based launcher fallback to wait for the current process rather than its shell parent.

## Why

Some Windows process layouts do not expose `.venv\Scripts\suzent.exe` through the existing ancestor lookup. The update then ran inline, and `uv sync` could not replace the currently locked executable. The same lock also prevented rollback.

## Impact

`suzent update` now consistently leaves the locking console-script process before dependency synchronization, regardless of whether it was launched from PowerShell, the global cmd shim, or the venv executable.

## Validation

- `uv run pytest tests/cli/test_cli_main.py -q` (35 passed)
- `uv run pre-commit run --all-files`
