### PR TITLE
fix: retry backend identity after refresh

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import { ProjectProvider } from './hooks/useProjects';
 import { useStatusStore } from './hooks/useStatusStore';
 import { useTheme } from './hooks/useTheme';
 import {
+  BackendVersionTimeoutError,
   drainCronNotifications,
   fetchHeartbeatStatus,
   fetchSystemVersion,
@@ -1153,8 +1154,12 @@ export default function App() {
         if (!cancelled) {
           setBackendError(tForLocale(
             getInitialLocale(),
-            'app.backendCompatibility.verifyFailed',
-            { error: String(error) },
+            error instanceof BackendVersionTimeoutError
+              ? 'app.backendCompatibility.verifyTimeout'
+              : 'app.backendCompatibility.verifyFailed',
+            error instanceof BackendVersionTimeoutError
+              ? undefined
+              : { error: String(error) },
           ));
           setBackendCompatible(false);
         }

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -36,6 +36,7 @@ export const en = {
       api: 'Frontend/backend API mismatch ({frontend} vs {backend}). Run suzent update.',
       build: 'Frontend/backend build mismatch ({frontend} vs {backend}). Run suzent update.',
       version: 'Frontend/backend version mismatch ({frontend} vs {backend}). Run suzent update.',
+      verifyTimeout: 'Backend version verification timed out. The backend may still be recovering; close and reopen Suzent.',
       verifyFailed: 'Failed to verify backend version: {error}',
     },
   },

--- a/frontend/src/i18n/messages/zh-CN.ts
+++ b/frontend/src/i18n/messages/zh-CN.ts
@@ -36,6 +36,7 @@ export const zhCN = {
       api: '前后端 API 版本不匹配（{frontend} 与 {backend}）。请运行 suzent update。',
       build: '前后端构建不匹配（{frontend} 与 {backend}）。请运行 suzent update。',
       version: '前后端版本不匹配（{frontend} 与 {backend}）。请运行 suzent update。',
+      verifyTimeout: '后端版本验证超时。后端可能仍在恢复，请关闭并重新打开 Suzent。',
       verifyFailed: '无法验证后端版本：{error}',
     },
   },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -50,17 +50,49 @@ export interface SystemVersionResponse {
   developmentMode: boolean;
 }
 
-export async function fetchSystemVersion(): Promise<SystemVersionResponse> {
-  const controller = new AbortController();
-  const timeout = window.setTimeout(() => controller.abort(), 5000);
-  let response: Response;
-  try {
-    response = await fetch(`${getApiBase()}/system/version`, {
-      signal: controller.signal,
-    });
-  } finally {
-    window.clearTimeout(timeout);
+export class BackendVersionTimeoutError extends Error {
+  constructor() {
+    super('Backend version verification timed out');
+    this.name = 'BackendVersionTimeoutError';
   }
+}
+
+interface FetchSystemVersionOptions {
+  attempts?: number;
+  timeoutMs?: number;
+  retryDelayMs?: number;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+export async function fetchSystemVersion(
+  options: FetchSystemVersionOptions = {},
+): Promise<SystemVersionResponse> {
+  const attempts = options.attempts ?? 2;
+  const timeoutMs = options.timeoutMs ?? 15000;
+  const retryDelayMs = options.retryDelayMs ?? 500;
+  let response: Response | null = null;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      response = await fetch(`${getApiBase()}/system/version`, {
+        signal: controller.signal,
+      });
+      break;
+    } catch (error) {
+      if (!isAbortError(error)) throw error;
+      if (attempt === attempts - 1) throw new BackendVersionTimeoutError();
+      await new Promise(resolve => window.setTimeout(resolve, retryDelayMs));
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  }
+
+  if (response === null) throw new BackendVersionTimeoutError();
   if (!response.ok) {
     throw new Error(`Failed to load backend version: ${response.status}`);
   }

--- a/frontend/src/lib/api.version.test.ts
+++ b/frontend/src/lib/api.version.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { getBackendCompatibilityIssue } from './api';
+import {
+  BackendVersionTimeoutError,
+  fetchSystemVersion,
+  getBackendCompatibilityIssue,
+} from './api';
 
 const frontend = {
   version: '1.2.3',
@@ -8,6 +12,45 @@ const frontend = {
   buildCommit: 'abcdef123456',
   enforceBuildCommit: true,
 };
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('backend version request', () => {
+  it('retries a transient abort during WebView refresh', async () => {
+    vi.stubGlobal('window', { setTimeout, clearTimeout });
+    const abortError = new Error('signal is aborted without reason');
+    abortError.name = 'AbortError';
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(abortError)
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        backend_version: '1.2.3',
+        api_version: 1,
+        build_commit: 'abcdef123456',
+        development_mode: false,
+      }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchSystemVersion({ retryDelayMs: 0 })).resolves.toEqual({
+      backendVersion: '1.2.3',
+      apiVersion: 1,
+      buildCommit: 'abcdef123456',
+      developmentMode: false,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns a typed timeout after repeated aborts', async () => {
+    vi.stubGlobal('window', { setTimeout, clearTimeout });
+    const abortError = new Error('aborted');
+    abortError.name = 'AbortError';
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortError));
+
+    await expect(fetchSystemVersion({ attempts: 2, retryDelayMs: 0 }))
+      .rejects.toBeInstanceOf(BackendVersionTimeoutError);
+  });
+});
 
 describe('backend compatibility', () => {
   it('accepts an exact release identity match', () => {


### PR DESCRIPTION
## What changed

- Retry backend identity requests that are aborted while the WebView is recovering from a refresh.
- Increase each identity-request window from 5 to 15 seconds, with two bounded attempts.
- Replace the raw `AbortError` with localized timeout guidance when both attempts expire.
- Add regression coverage for transient and repeated aborts.

## Why

On v0.7.6, right-click refresh can recover the persisted backend port successfully and then fail the compatibility gate because the single five-second `/system/version` request is aborted. The raw browser abort was incorrectly presented as a backend version mismatch/verification failure.

## Impact

WebView refresh now tolerates a transient backend identity timeout without becoming stuck on the compatibility screen. Genuine API, build, and version mismatches are still enforced.

## Validation

- `npm test` (80 passed)
- `npm run build`
- `uv run --no-sync pre-commit run --all-files`
