### PR TITLE
docs: complete v0.7.8 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🚀 Added
 - Add transactional standalone updates (#91)
+- Add guided installer and updater experience with recoverable progress and per-step timing (#93)
 
 ### 🐛 Fixed
 - Retry backend identity after refresh (#90)


### PR DESCRIPTION
Adds the already-merged guided installer/updater experience from #93 to the v0.7.8 changelog before recreating the unpublished release tag. This keeps the tagged changelog and generated GitHub Release notes consistent.

Validation: `git diff --check`; content-only changelog change.