### PR TITLE
fix: stabilize updater progress and headless fallback

### DIFF
--- a/apps/suzent-installer/src/updater.rs
+++ b/apps/suzent-installer/src/updater.rs
@@ -3,11 +3,11 @@ use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::env;
 use std::fs::{self, OpenOptions};
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const LATEST_RELEASE_API: &str = "https://api.github.com/repos/cyzus/suzent/releases/latest";
 const RELEASE_BASE_URL: &str = "https://github.com/cyzus/suzent/releases/download";
@@ -28,6 +28,10 @@ struct UpdateStatus {
     phase_started_at: u64,
     #[serde(default)]
     phase_durations_ms: BTreeMap<String, u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    downloaded_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    total_bytes: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -252,7 +256,12 @@ fn prepare_target(paths: &UpdatePaths, target_tag: &str) -> Result<(), String> {
     }
     fs::create_dir_all(&paths.staging_dir)
         .map_err(display_io("create update staging directory"))?;
-    download_file(&release_asset_url(target_tag), &paths.staged_ui())?;
+    download_file(
+        &release_asset_url(target_tag),
+        &paths.staged_ui(),
+        paths,
+        target_tag,
+    )?;
     verify_release_asset(&paths.staged_ui(), target_tag, ui_asset_name())?;
     set_executable(&paths.staged_ui())?;
 
@@ -569,19 +578,59 @@ fn ui_asset_name() -> &'static str {
     }
 }
 
-fn download_file(url: &str, destination: &Path) -> Result<(), String> {
-    let response = reqwest::blocking::Client::builder()
+fn download_file(
+    url: &str,
+    destination: &Path,
+    paths: &UpdatePaths,
+    tag: &str,
+) -> Result<(), String> {
+    let mut response = reqwest::blocking::Client::builder()
         .user_agent("suzent-installer")
+        .connect_timeout(Duration::from_secs(30))
         .build()
         .map_err(|error| format!("failed to create download client: {error}"))?
         .get(url)
         .send()
         .and_then(|response| response.error_for_status())
         .map_err(|error| format!("failed to download {url}: {error}"))?;
-    let bytes = response
-        .bytes()
-        .map_err(|error| format!("failed to read {url}: {error}"))?;
-    fs::write(destination, bytes).map_err(display_io("write downloaded asset"))
+    let total = response.content_length();
+    let temporary = destination.with_extension("download");
+    let result = (|| {
+        let mut file = fs::File::create(&temporary).map_err(display_io("create download"))?;
+        let mut buffer = [0_u8; 256 * 1024];
+        let mut downloaded = 0_u64;
+        let mut last_report = Instant::now() - Duration::from_secs(1);
+        loop {
+            let count = response
+                .read(&mut buffer)
+                .map_err(|error| format!("failed to read {url}: {error}"))?;
+            if count == 0 {
+                break;
+            }
+            file.write_all(&buffer[..count])
+                .map_err(display_io("write downloaded asset"))?;
+            downloaded += count as u64;
+            if last_report.elapsed() >= Duration::from_millis(250)
+                || total.is_some_and(|size| downloaded >= size)
+            {
+                write_download_status(paths, tag, downloaded, total)?;
+                last_report = Instant::now();
+            }
+        }
+        file.sync_all()
+            .map_err(display_io("flush downloaded asset"))?;
+        if total.is_some_and(|size| downloaded != size) {
+            return Err(format!(
+                "incomplete download: received {downloaded} of {} bytes",
+                total.unwrap()
+            ));
+        }
+        fs::rename(&temporary, destination).map_err(display_io("finish downloaded asset"))
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
 }
 
 fn verify_release_asset(path: &Path, tag: &str, asset_name: &str) -> Result<(), String> {
@@ -636,6 +685,61 @@ fn write_status(
     tag: &str,
 ) -> Result<(), String> {
     println!("[{progress:>3}%] {message}");
+    write_status_details(paths, phase, progress, message, tag, None, None)
+}
+
+fn write_download_status(
+    paths: &UpdatePaths,
+    tag: &str,
+    downloaded_bytes: u64,
+    total_bytes: Option<u64>,
+) -> Result<(), String> {
+    let percent = total_bytes
+        .filter(|total| *total > 0)
+        .map(|total| (downloaded_bytes.saturating_mul(100) / total).min(100));
+    let progress = percent
+        .map(|value| 15 + (value.saturating_mul(9) / 100) as u8)
+        .unwrap_or(15);
+    let message = match total_bytes {
+        Some(total) => format!(
+            "Downloading desktop application ({:.1} / {:.1} MiB, {}%)",
+            downloaded_bytes as f64 / 1024.0 / 1024.0,
+            total as f64 / 1024.0 / 1024.0,
+            percent.unwrap_or(0)
+        ),
+        None => format!(
+            "Downloading desktop application ({:.1} MiB)",
+            downloaded_bytes as f64 / 1024.0 / 1024.0
+        ),
+    };
+    print!("\r[{progress:>3}%] {message}");
+    io::stdout()
+        .flush()
+        .map_err(display_io("flush download progress"))?;
+    if percent == Some(100) {
+        println!();
+    }
+    write_status_details(
+        paths,
+        "download",
+        progress,
+        &message,
+        tag,
+        Some(downloaded_bytes),
+        total_bytes,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_status_details(
+    paths: &UpdatePaths,
+    phase: &str,
+    progress: u8,
+    message: &str,
+    tag: &str,
+    downloaded_bytes: Option<u64>,
+    total_bytes: Option<u64>,
+) -> Result<(), String> {
     let now = now_epoch_millis();
     let previous = fs::read(&paths.status)
         .ok()
@@ -670,6 +774,8 @@ fn write_status(
         updated_at: now / 1_000,
         phase_started_at,
         phase_durations_ms,
+        downloaded_bytes,
+        total_bytes,
     };
     write_json_atomic(&paths.status, &payload, "write update status")
 }
@@ -793,7 +899,7 @@ fn set_executable(_path: &Path) -> Result<(), String> {
 mod tests {
     use super::{
         acquire_lock, backup_current_ui, is_release_tag, parse_release_checksum, restore_ui_backup,
-        write_status, UpdatePaths, UpdateStatus,
+        write_download_status, write_status, UpdatePaths, UpdateStatus,
     };
     use std::fs;
     use std::thread;
@@ -863,5 +969,23 @@ mod tests {
         assert_eq!(status.phase, "download");
         assert!(status.phase_durations_ms.contains_key("preflight"));
         assert!(status.phase_started_at > 0);
+    }
+
+    #[test]
+    fn records_download_byte_progress_in_status() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let paths = UpdatePaths::new(temp.path().to_path_buf(), "v1.2.3");
+        fs::create_dir_all(&paths.state_dir).expect("state dir");
+
+        write_download_status(&paths, "v1.2.3", 5 * 1024 * 1024, Some(10 * 1024 * 1024))
+            .expect("download status");
+
+        let status: UpdateStatus =
+            serde_json::from_slice(&fs::read(&paths.status).expect("status file"))
+                .expect("valid status");
+        assert_eq!(status.phase, "download");
+        assert_eq!(status.downloaded_bytes, Some(5 * 1024 * 1024));
+        assert_eq!(status.total_bytes, Some(10 * 1024 * 1024));
+        assert_eq!(status.progress, 19);
     }
 }

--- a/apps/suzent-installer/ui/index.html
+++ b/apps/suzent-installer/ui/index.html
@@ -320,6 +320,10 @@
       .stage.running { color: #fff; background: #111; box-shadow: 3px 3px 0 #737373; }
       .stage.running .stage-icon { border-color: #fff; color: #111; background: #fff; }
       .stage.running .state { color: #d4d4d4; }
+      body[data-mode="update"] .progress-bar.running::after { display: none; }
+      body[data-mode="update"] .stage { animation: none; }
+      body[data-mode="update"] .stage.running .stage-icon,
+      body[data-mode="update"] .live-dot.running::before { animation: none; }
       @media (max-width: 820px) {
         .shell { grid-template-columns: 205px minmax(0, 1fr); }
         .workspace { grid-template-columns: minmax(0, 1fr); }
@@ -427,7 +431,7 @@
         install: '安装', launch: '启动 Suzent', activity: '实时状态', channel: '通道', target: '目标版本', recovery: '恢复策略', rollback: '自动回滚',
         latest: '最新版本', live: '进行中', local: '仅本机', action: '需要处理', retry: '安全重试', copy: '复制详情', allSet: '已完成',
         footerInstall: '安装期间可以继续使用这台电脑。', footerUpdate: '准备阶段可安全恢复。', footerCritical: '正在替换运行环境，请勿关闭电脑。', protected: '事务保护已开启',
-        preparing: '正在准备', verifying: '校验下载与版本', completed: '操作完成', failed: '操作未完成', details: '详情', secure: ['资产校验', '保留当前版本', '自动恢复'], updatePlan: '更新进度',
+        preparing: '正在准备', downloading: '正在下载桌面端', verifying: '校验下载与版本', completed: '操作完成', failed: '操作未完成', details: '详情', secure: ['资产校验', '保留当前版本', '自动恢复'], updatePlan: '更新进度',
         showAll: '展开全部', showLess: '收起', completedCount: count => `已完成 ${count} 项`, waitingActivity: '等待活动',
       } : {
         installer: 'Installer', updater: 'Safe updater', installEyebrow: 'Guided setup', updateEyebrow: 'Transactional update', installTitle: 'Your agent, ready in one place.',
@@ -437,7 +441,7 @@
         install: 'Install', launch: 'Launch Suzent', activity: 'Activity', channel: 'Channel', target: 'Target', recovery: 'Recovery', rollback: 'Automatic rollback',
         latest: 'Latest release', live: 'Live', local: 'local only', action: 'Action needed', retry: 'Retry safely', copy: 'Copy details', allSet: 'All set',
         footerInstall: 'You can continue using this computer during setup.', footerUpdate: 'Preparation is recoverable.', footerCritical: 'Replacing the runtime. Do not shut down this computer.', protected: 'Transaction protected',
-        preparing: 'Preparing', verifying: 'Verifying download and version', completed: 'Operation complete', failed: 'Operation incomplete', details: 'Details', secure: ['Asset verification', 'Keep current version', 'Automatic recovery'], updatePlan: 'Update progress',
+        preparing: 'Preparing', downloading: 'Downloading desktop app', verifying: 'Verifying download and version', completed: 'Operation complete', failed: 'Operation incomplete', details: 'Details', secure: ['Asset verification', 'Keep current version', 'Automatic recovery'], updatePlan: 'Update progress',
         showAll: 'Show all', showLess: 'Show less', completedCount: count => `${count} completed`, waitingActivity: 'Waiting for activity',
       };
 
@@ -457,6 +461,7 @@
       let startedAt = null;
       let lastError = '';
       let lastStatusKey = '';
+      let lastStageRenderKey = '';
       let pollTimer = null;
       let showAllStages = false;
       let currentPhase = '';
@@ -465,14 +470,16 @@
       const states = new Map();
 
       function translateStage(title) { return isZh ? (stageTranslations[title] || title) : title; }
-      function setText(id, value) { const node = $(id); if (node) node.textContent = value; }
+      function setNodeText(node, value) { if (node && node.textContent !== value) node.textContent = value; }
+      function setText(id, value) { setNodeText($(id), value); }
       function log(message) { if (!message) return; els.recent.textContent = message; const line = document.createElement('div'); line.textContent = message; els.log.appendChild(line); els.log.scrollTop = els.log.scrollHeight; }
-      function setProgress(value, label, displayValue = null) { const pct = Math.max(0, Math.min(100, Math.round(value))); els.bar.style.width = `${pct}%`; els.bar.classList.toggle('running', running && pct < 100); els.percent.textContent = displayValue || `${pct}%`; els.progressLabel.textContent = label || text.waiting; document.querySelector('.progress-track').setAttribute('aria-valuenow', String(pct)); }
+      function setProgress(value, label, displayValue = null) { const pct = Math.max(0, Math.min(100, Math.round(value))); if (els.bar.style.width !== `${pct}%`) els.bar.style.width = `${pct}%`; els.bar.classList.toggle('running', running && pct < 100); setNodeText(els.percent, displayValue || `${pct}%`); setNodeText(els.progressLabel, label || text.waiting); const track = document.querySelector('.progress-track'); if (track.getAttribute('aria-valuenow') !== String(pct)) track.setAttribute('aria-valuenow', String(pct)); }
       function setRunning(value) { running = value; els.live.classList.toggle('running', value); els.live.textContent = value ? text.live : text.ready; els.start.disabled = value; els.browse.disabled = value; els.dir.readOnly = context?.mode === 'update'; els.dir.disabled = value && context?.mode !== 'update'; }
       function setError(message) { lastError = message || ''; els.error.style.display = message ? 'block' : 'none'; els.errorMessage.textContent = message || ''; if (message) { els.complete.style.display = 'none'; els.statusKicker.textContent = text.action; els.statusTitle.textContent = text.failed; } }
       function setComplete(message) { els.complete.style.display = message ? 'block' : 'none'; els.completeMessage.textContent = message || ''; if (message) { els.error.style.display = 'none'; els.statusKicker.textContent = text.allSet; els.statusTitle.textContent = text.completed; } }
 
       function applyStaticCopy() {
+        document.body.dataset.mode = context.mode;
         setText('product-kind', context.mode === 'update' ? text.updater : text.installer);
         setText('rail-eyebrow', context.mode === 'update' ? text.updateEyebrow : text.installEyebrow);
         setText('rail-title', context.mode === 'update' ? text.updateTitle : text.installTitle);
@@ -505,12 +512,35 @@
         return `${Math.floor(seconds / 60)}m ${String(seconds % 60).padStart(2, '0')}s`;
       }
 
+      function formatBytes(bytes) {
+        const value = Number(bytes || 0);
+        return value >= 1024 * 1024 ? `${(value / 1024 / 1024).toFixed(1)} MiB` : `${Math.round(value / 1024)} KiB`;
+      }
+
       function stageDuration(name, state) {
         if (state === 'skipped' || state === 'pending') return null;
         const aliases = name === 'download' ? ['download', 'fetch'] : [name];
         let total = aliases.reduce((sum, phase) => sum + Number(phaseDurations[phase] || 0), 0);
         if (aliases.includes(currentPhase) && phaseStartedAt) total += Math.max(0, Date.now() - phaseStartedAt);
         return total || null;
+      }
+
+      function stageRenderKey(activeName) {
+        const source = context.mode === 'update' ? updateStages.map(([name]) => name) : (manifest?.stages || []).map(stage => stage.name);
+        return `${showAllStages}:${activeName || ''}:${source.map(name => `${name}:${states.get(name) || 'pending'}`).join('|')}`;
+      }
+
+      function refreshStageDurations() {
+        for (const row of els.stages.querySelectorAll('.stage[data-stage]')) {
+          const name = row.dataset.stage;
+          const timing = row.querySelector('.duration');
+          if (!timing) continue;
+          const state = [...row.classList].find(value => ['succeeded','running','failed','skipped','pending'].includes(value)) || 'pending';
+          const duration = name === '__completed' ? Object.values(phaseDurations).reduce((sum, value) => sum + Number(value || 0), 0) : stageDuration(name, state);
+          const nextText = duration == null ? '' : formatDuration(duration);
+          if (timing.hidden !== (duration == null)) timing.hidden = duration == null;
+          if (timing.textContent !== nextText) timing.textContent = nextText;
+        }
       }
 
       function renderStages(activeName = null) {
@@ -526,17 +556,18 @@
         els.stages.innerHTML = '';
         for (const stage of list) {
           const state = stage.summaryState || states.get(stage.name) || 'pending';
-          const row = document.createElement('div'); row.className = `stage ${state} ${activeName === stage.name ? 'running' : ''}`;
+          const row = document.createElement('div'); row.className = `stage ${state} ${activeName === stage.name ? 'running' : ''}`; row.dataset.stage = stage.name;
           const icon = document.createElement('span'); icon.className = 'stage-icon'; icon.textContent = state === 'succeeded' ? '✓' : state === 'failed' ? '!' : String(stage.originalIndex + 1).padStart(2,'0');
           const title = document.createElement('span'); title.className = 'stage-title'; title.textContent = context.mode === 'install' ? translateStage(stage.title) : stage.title;
           const status = document.createElement('span'); status.className = 'state';
           const statusLabel = document.createElement('span'); statusLabel.textContent = state === 'succeeded' ? (isZh ? '完成' : 'done') : state === 'running' ? (isZh ? '进行中' : 'working') : state === 'failed' ? (isZh ? '失败' : 'failed') : state === 'skipped' ? (isZh ? '跳过' : 'skipped') : (isZh ? '等待' : 'queued'); status.appendChild(statusLabel);
-          const duration = stage.name === '__completed' ? Object.values(phaseDurations).reduce((sum, value) => sum + Number(value || 0), 0) : stageDuration(stage.name, state);
-          if (duration != null) { const timing = document.createElement('span'); timing.className = 'duration'; timing.textContent = formatDuration(duration); status.appendChild(timing); }
+          const timing = document.createElement('span'); timing.className = 'duration'; status.appendChild(timing);
           row.append(icon,title,status); els.stages.appendChild(row);
         }
         setText('stage-count', context.mode === 'update' ? `${done} / ${fullList.length}` : `${fullList.length} ${text.steps}`);
         els.toggleStages.textContent = showAllStages ? text.showLess : text.showAll;
+        lastStageRenderKey = stageRenderKey(activeName);
+        refreshStageDurations();
       }
 
       function phaseIndex(phase) { const aliases = { fetch:'download', switching:'source', rollback:'verify', rolled_back:'complete', repair_required:'complete' }; const key = aliases[phase] || phase; return updateStages.findIndex(([name]) => name === key); }
@@ -553,16 +584,23 @@
         });
         if (status.phase === 'complete') updateStages.forEach(([name]) => states.set(name, 'succeeded'));
         if (['repair_required'].includes(status.phase)) states.set(updateStages[Math.max(0,index)]?.[0] || 'verify', 'failed');
-        renderStages(index >= 0 ? updateStages[index][0] : null);
-        els.statusKicker.textContent = status.phase === 'complete' ? text.allSet : text.preparing;
-        els.statusTitle.textContent = status.message || text.verifying;
+        const activeName = index >= 0 ? updateStages[index][0] : null;
+        const nextRenderKey = stageRenderKey(activeName);
+        if (nextRenderKey !== lastStageRenderKey) renderStages(activeName); else refreshStageDurations();
+        setNodeText(els.statusKicker, status.phase === 'complete' ? text.allSet : text.preparing);
+        const downloading = status.phase === 'download' && Number(status.downloaded_bytes || 0) > 0;
+        setNodeText(els.statusTitle, downloading ? text.downloading : (status.message || text.verifying));
         const critical = ['source', 'dependencies', 'desktop', 'verify', 'switching', 'rollback'].includes(status.phase);
-        els.statusMessage.textContent = critical ? text.footerCritical : (isZh ? `目标 ${status.target_version || context.target} · 每一步都会写入恢复记录` : `Target ${status.target_version || context.target} · every step is journaled for recovery`);
+        const downloadDetail = downloading
+          ? `${formatBytes(status.downloaded_bytes)}${status.total_bytes ? ` / ${formatBytes(status.total_bytes)} · ${Math.min(100, Math.round(status.downloaded_bytes * 100 / status.total_bytes))}%` : ''}`
+          : '';
+        setNodeText(els.statusMessage, downloadDetail || (critical ? text.footerCritical : (isZh ? `目标 ${status.target_version || context.target} · 每一步都会写入恢复记录` : `Target ${status.target_version || context.target} · every step is journaled for recovery`)));
         setText('footer-note', critical ? text.footerCritical : text.footerUpdate);
         els.close.disabled = critical;
         els.close.title = critical ? text.footerCritical : '';
         setProgress(status.progress || 0, status.phase || text.preparing, `${Math.max(1, index + 1)} / ${updateStages.length}`);
-        const statusKey = `${status.phase}:${status.progress}:${status.message}`;
+        setNodeText(els.recent, status.message || text.waitingActivity);
+        const statusKey = status.phase === 'download' ? status.phase : `${status.phase}:${status.message}`;
         if (statusKey !== lastStatusKey) { log(status.message); lastStatusKey = statusKey; }
       }
 
@@ -598,6 +636,8 @@
             ? {phase:'repair_required',progress:100,message:isZh ? '更新未完成，旧版本已保留' : 'Update did not complete; the working version was kept',target_version:'v0.7.8'}
             : preview === 'complete'
               ? {phase:'complete',progress:100,message:isZh ? '更新完成，正在重新启动' : 'Update complete; relaunching Suzent',target_version:'v0.7.8'}
+              : preview === 'download'
+                ? {phase:'download',progress:20,message:isZh ? '正在下载桌面端' : 'Downloading desktop application',target_version:'v0.7.8',downloaded_bytes:10485760,total_bytes:16777216,phase_started_at:Date.now()-18400,phase_durations_ms:{preflight:620}}
               : {phase:'dependencies',progress:65,message:isZh ? '正在同步后端环境' : 'Synchronizing backend environment',target_version:'v0.7.8',phase_started_at:Date.now()-12700,phase_durations_ms:{preflight:620,download:5300,fetch:2400,stopping:900,source:1300}};
           applyUpdateStatus(previewStatus);
           if (preview === 'error') { setRunning(false); setError(isZh ? '依赖同步失败。旧版本已恢复，可以安全重试。' : 'Dependency sync failed. The previous version was restored and it is safe to retry.'); }
@@ -649,7 +689,7 @@
       $('window-maximize').addEventListener('click', () => tauri?.window?.getCurrentWindow?.().toggleMaximize());
       $('window-close').addEventListener('click', () => { if (!els.close.disabled) closeInstaller(); });
       els.browse.addEventListener('click', async () => { if (!openDialog) return; const selected = await openDialog({directory:true,multiple:false,defaultPath:els.dir.value || undefined}); if (typeof selected === 'string') { const trimmed = selected.replace(/[\\/]+$/,''); els.dir.value = trimmed.toLowerCase().endsWith(`${navigator.platform.includes('Win')?'\\':'/'}suzent`) ? trimmed : `${trimmed}${selected.includes('\\')?'\\':'/'}suzent`; } });
-      window.setInterval(() => { if (!startedAt) return; const seconds = Math.floor((Date.now() - startedAt) / 1000); els.elapsed.textContent = `${String(Math.floor(seconds/60)).padStart(2,'0')}:${String(seconds%60).padStart(2,'0')}`; if (running) renderStages(); },1000);
+      window.setInterval(() => { if (!startedAt) return; const seconds = Math.floor((Date.now() - startedAt) / 1000); els.elapsed.textContent = `${String(Math.floor(seconds/60)).padStart(2,'0')}:${String(seconds%60).padStart(2,'0')}`; if (running) refreshStageDurations(); },1000);
 
       (async () => {
         context = await loadContext(); document.documentElement.lang = isZh ? 'zh-CN' : 'en'; applyStaticCopy();

--- a/src/suzent/cli/main.py
+++ b/src/suzent/cli/main.py
@@ -196,6 +196,13 @@ def _persistent_updater_path() -> Path:
     return Path.home() / ".suzent" / "updater" / name
 
 
+def _graphical_update_available() -> bool:
+    """Return whether the current session can show the updater window."""
+    if IS_WINDOWS or sys.platform == "darwin":
+        return True
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
 def _fetch_latest_release(timeout: float = 10.0) -> dict:
     url = f"https://api.github.com/repos/{_REPO}/releases/latest"
     req = urllib.request.Request(url, headers={"User-Agent": "suzent-updater"})
@@ -356,7 +363,12 @@ def _notify_update_available(root: Path) -> None:
     typer.echo(f"  • Update available: {current} -> {latest}. Run 'suzent update'.")
 
 
-def _download_file_atomic(url: str, dest: Path, *, timeout: float = 60.0) -> None:
+def _download_file_atomic(
+    url: str,
+    dest: Path,
+    *,
+    inactivity_timeout: float = 300.0,
+) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(
         prefix=f".{dest.name}.", suffix=".tmp", dir=dest.parent
@@ -365,8 +377,27 @@ def _download_file_atomic(url: str, dest: Path, *, timeout: float = 60.0) -> Non
     try:
         with os.fdopen(fd, "wb") as file:
             req = urllib.request.Request(url, headers={"User-Agent": "suzent-updater"})
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
-                shutil.copyfileobj(resp, file)
+            with urllib.request.urlopen(req, timeout=inactivity_timeout) as resp:
+                total = int(resp.headers.get("Content-Length") or 0)
+                downloaded = 0
+                last_report = 0.0
+                while chunk := resp.read(256 * 1024):
+                    file.write(chunk)
+                    downloaded += len(chunk)
+                    now = time.monotonic()
+                    if now - last_report >= 0.25 or (total and downloaded >= total):
+                        if total:
+                            percent = min(100, round(downloaded * 100 / total))
+                            detail = (
+                                f"{downloaded / 1024 / 1024:.1f} / "
+                                f"{total / 1024 / 1024:.1f} MiB ({percent}%)"
+                            )
+                        else:
+                            detail = f"{downloaded / 1024 / 1024:.1f} MiB"
+                        typer.echo(f"\r  • Downloading {detail}", nl=False)
+                        last_report = now
+                if downloaded:
+                    typer.echo()
         tmp_path.replace(dest)
     except Exception:
         try:
@@ -407,6 +438,7 @@ def _delegate_installer_update(
     release_tag: str,
     relaunch: Path | None,
     repair: bool = False,
+    headless: bool = False,
 ) -> None:
     typer.echo("  • Preparing standalone updater...")
     try:
@@ -429,6 +461,10 @@ def _delegate_installer_update(
     if relaunch is not None:
         command.extend(["--relaunch", str(relaunch)])
 
+    use_headless = headless or not _graphical_update_available()
+    if use_headless:
+        command.append("--headless")
+
     kwargs: dict = {"cwd": root, "env": os.environ.copy()}
     if IS_WINDOWS:
         kwargs["creationflags"] = getattr(
@@ -436,9 +472,15 @@ def _delegate_installer_update(
         ) | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
     else:
         kwargs["start_new_session"] = True
-    subprocess.Popen(command, **kwargs)
+    process = subprocess.Popen(command, **kwargs)
+    if not use_headless and process is not None:
+        time.sleep(0.75)
+        if process.poll() is not None:
+            typer.echo("  ⚠️  Updater window unavailable; continuing in the terminal.")
+            subprocess.Popen([*command, "--headless"], **kwargs)
     action = "Repair" if repair else "Update"
-    typer.echo(f"  • {action} continues in the standalone Suzent Installer.")
+    destination = "terminal" if use_headless else "standalone Suzent Installer"
+    typer.echo(f"  • {action} continues in the {destination}.")
 
 
 def _replace_ui_files(
@@ -1464,7 +1506,12 @@ def register_commands(app: typer.Typer):
         except subprocess.CalledProcessError:
             typer.echo("  ⚠️  Stashed changes need manual conflict resolution.")
 
-    def _run_update(*, dev: bool = False, relaunch: Path | None = None) -> None:
+    def _run_update(
+        *,
+        dev: bool = False,
+        relaunch: Path | None = None,
+        headless: bool = False,
+    ) -> None:
         root = get_project_root()
 
         if not dev and _is_development_workspace(root):
@@ -1495,6 +1542,7 @@ def register_commands(app: typer.Typer):
                 root,
                 release_tag=release_tag,
                 relaunch=relaunch,
+                headless=headless,
             )
             return
 
@@ -1712,9 +1760,14 @@ def register_commands(app: typer.Typer):
             "--relaunch",
             hidden=True,
         ),
+        headless: bool = typer.Option(
+            False,
+            "--headless",
+            help="Run the standalone updater in the terminal without a window.",
+        ),
     ):
         """Update Suzent to the latest version."""
-        _run_update(dev=dev, relaunch=relaunch)
+        _run_update(dev=dev, relaunch=relaunch, headless=headless)
 
     @app.command()
     def upgrade(
@@ -1723,15 +1776,26 @@ def register_commands(app: typer.Typer):
             "--dev",
             help="Update to origin/main and run the matching development frontend.",
         ),
+        headless: bool = typer.Option(
+            False,
+            "--headless",
+            help="Run the standalone updater in the terminal without a window.",
+        ),
     ):
         """Alias for `update`."""
         typer.echo(
             "`suzent upgrade` is supported; `suzent update` is the primary command."
         )
-        _run_update(dev=dev)
+        _run_update(dev=dev, headless=headless)
 
     @app.command()
-    def repair() -> None:
+    def repair(
+        headless: bool = typer.Option(
+            False,
+            "--headless",
+            help="Run the standalone updater in the terminal without a window.",
+        ),
+    ) -> None:
         """Repair the installed stable release with the standalone updater."""
         root = get_project_root()
         release_file = root / ".suzent" / "release-tag"
@@ -1752,6 +1816,7 @@ def register_commands(app: typer.Typer):
             release_tag=release_tag,
             relaunch=None,
             repair=True,
+            headless=headless,
         )
 
     @app.command("check-update")

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -433,9 +433,28 @@ def test_stable_update_delegates_to_release_installer(monkeypatch, tmp_path):
     assert delegated == [
         (
             tmp_path,
-            {"release_tag": "v1.2.3", "relaunch": None},
+            {"release_tag": "v1.2.3", "relaunch": None, "headless": False},
         )
     ]
+
+
+def test_stable_update_accepts_headless_mode(monkeypatch, tmp_path):
+    (tmp_path / ".suzent-bootstrap-complete").write_text("")
+    app, _commands = _mock_update_runtime(monkeypatch, tmp_path)
+    delegated = []
+    monkeypatch.setattr(
+        cli_main, "_fetch_latest_release", lambda: {"tag_name": "v1.2.3"}
+    )
+    monkeypatch.setattr(
+        cli_main,
+        "_delegate_installer_update",
+        lambda root, **kwargs: delegated.append((root, kwargs)),
+    )
+
+    result = runner.invoke(app, ["update", "--headless"])
+
+    assert result.exit_code == 0
+    assert delegated[0][1]["headless"] is True
 
 
 def test_parse_release_checksum_selects_exact_asset():
@@ -598,6 +617,96 @@ def test_stable_update_launches_standalone_installer(monkeypatch, tmp_path):
         str(tmp_path / "bin" / "suzent-ui.exe"),
     ]
     assert kwargs["cwd"] == tmp_path
+
+
+def test_stable_update_uses_headless_mode_without_graphical_session(
+    monkeypatch, tmp_path
+):
+    updater = tmp_path / "updater" / "suzent-installer"
+    updater.parent.mkdir()
+    updater.write_bytes(b"")
+    popen_calls = []
+
+    monkeypatch.setattr(cli_main, "IS_WINDOWS", False)
+    monkeypatch.setattr(cli_main, "_graphical_update_available", lambda: False)
+    monkeypatch.setattr(cli_main, "_install_release_updater", lambda tag: updater)
+    monkeypatch.setattr(
+        cli_main.subprocess,
+        "Popen",
+        lambda command, **kwargs: popen_calls.append((command, kwargs)),
+    )
+
+    cli_main._delegate_installer_update(
+        tmp_path,
+        release_tag="v1.2.3",
+        relaunch=None,
+    )
+
+    assert "--headless" in popen_calls[0][0]
+
+
+def test_stable_update_falls_back_when_window_exits_immediately(monkeypatch, tmp_path):
+    updater = tmp_path / "updater" / "suzent-installer.exe"
+    updater.parent.mkdir()
+    updater.write_bytes(b"")
+    popen_calls = []
+
+    class FailedWindow:
+        def poll(self):
+            return 1
+
+    def fake_popen(command, **kwargs):
+        popen_calls.append((command, kwargs))
+        return FailedWindow() if len(popen_calls) == 1 else None
+
+    monkeypatch.setattr(cli_main, "IS_WINDOWS", True)
+    monkeypatch.setattr(cli_main, "_graphical_update_available", lambda: True)
+    monkeypatch.setattr(cli_main, "_install_release_updater", lambda tag: updater)
+    monkeypatch.setattr(cli_main.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(cli_main.time, "sleep", lambda _seconds: None)
+
+    cli_main._delegate_installer_update(
+        tmp_path,
+        release_tag="v1.2.3",
+        relaunch=None,
+    )
+
+    assert "--headless" not in popen_calls[0][0]
+    assert "--headless" in popen_calls[1][0]
+
+
+def test_atomic_download_streams_with_progress(monkeypatch, tmp_path, capsys):
+    destination = tmp_path / "asset.exe"
+    observed_timeout = []
+
+    class Response:
+        headers = {"Content-Length": "6"}
+
+        def __init__(self):
+            self.chunks = iter((b"abc", b"def", b""))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, _size):
+            return next(self.chunks)
+
+    response = Response()
+
+    def fake_urlopen(_request, *, timeout):
+        observed_timeout.append(timeout)
+        return response
+
+    monkeypatch.setattr(cli_main.urllib.request, "urlopen", fake_urlopen)
+
+    cli_main._download_file_atomic("https://example.test/asset", destination)
+
+    assert destination.read_bytes() == b"abcdef"
+    assert observed_timeout == [300.0]
+    assert "100%" in capsys.readouterr().out
 
 
 def test_windows_update_delegates_when_launcher_detection_misses(monkeypatch, tmp_path):


### PR DESCRIPTION
## What changed

- add `suzent update --headless`, `suzent upgrade --headless`, and `suzent repair --headless`
- automatically use terminal mode on Linux sessions without `DISPLAY`/`WAYLAND_DISPLAY`
- retry in headless mode when the updater window exits immediately
- stream bootstrap and desktop downloads to disk with byte/percentage progress
- remove the short download deadline; retain a connection timeout and atomic partial-file cleanup
- persist download byte totals in updater status for GUI recovery
- stop rebuilding the stage DOM on every poll and update timing text only when it changes
- remove looping updater animations that made the interface appear to flash

## Root cause

The updater UI polled status every 350 ms and reconstructed all stage rows, while several infinite CSS animations ran concurrently. The CLI also did not expose the installer's existing headless mode, and the bootstrap download used a short socket timeout without visible progress.

## Validation

- `uv run --no-sync pytest tests/cli/test_cli_main.py -q` — 43 passed
- `uv run --no-sync pre-commit run --all-files`
- `cargo fmt --check`
- `cargo check`
- `cargo test` — 7 passed
- browser preview confirmed byte progress and no stage/icon/progress/live animations; console clean