### PR TITLE
feat: support secure peer file attachments

### DIFF
--- a/docs/02-concepts/nodes/nodes.md
+++ b/docs/02-concepts/nodes/nodes.md
@@ -278,7 +278,20 @@ your session and streams the reply back.
 ```bash
 # From device A, drive device B's agent (B must have granted A control):
 suzent nodes trigger "Device B" "summarize ~/notes"
+
+# Attach one or more files from device A for device B's agent:
+suzent nodes trigger "Device B" "summarize these" \
+  --file ./notes.txt --file ./report.pdf
 ```
+
+Peer attachments are pulled directly from the sending device over the same
+LAN or Tailscale network. Each transfer uses a random artifact-specific token,
+expires after five minutes, and is limited to two download attempts. No
+permanent reverse control grant is required. A trigger accepts up to eight
+files with a combined size of 50 MiB; the receiver rejects redirects, URLs that
+do not belong to the authenticated peer, mismatched sizes, and oversized
+streams. Downloaded files move into that peer chat's `/workspace/uploads`
+directory and the temporary staging directory is removed after the turn.
 
 On the **target**, the session behaves like any other channel conversation:
 

--- a/docs/02-concepts/nodes/nodes.md
+++ b/docs/02-concepts/nodes/nodes.md
@@ -309,7 +309,9 @@ The desktop app binds the server to **localhost only** by default
 (`SUZENT_HOST=127.0.0.1`), so peer devices can't reach it out of the box. To
 use cross-device nodes, enable **Settings → Devices → "Reachable by other
 devices"** (config `node_lan_bind`, default `false`) and **restart** the app —
-the server then binds `0.0.0.0` and is reachable on its LAN/Tailscale address.
+the server then binds `0.0.0.0` on the stable mesh port `25314` and is reachable
+on its LAN/Tailscale address. Desktop startup remains dynamically assigned when
+device reachability is disabled.
 
 ### Auth boundary (scoped tokens)
 

--- a/src/suzent/auth_boundary.py
+++ b/src/suzent/auth_boundary.py
@@ -35,6 +35,10 @@ _HTTP_EXEMPT_PREFIXES = (
     "/nodes/grant-request",
     "/nodes/grant-status/",
     "/channels/suzent/grant-changed",  # untrusted revoke hint; receiver re-verifies
+    # The route validates either a durable device grant or its own short-lived,
+    # artifact-specific bearer. This exception lets a one-way peer present the
+    # latter without requiring a permanent reverse grant.
+    "/nodes/peer-files/",
 )
 
 

--- a/src/suzent/cli/node.py
+++ b/src/suzent/cli/node.py
@@ -11,6 +11,7 @@ Usage:
 
 import json
 import asyncio
+from pathlib import Path
 from typing import Optional
 
 import typer
@@ -89,6 +90,16 @@ def node_trigger(
     peer: str = typer.Argument(help="Peer id or name from `suzent node list`"),
     prompt: str = typer.Argument(help="Prompt to run on the peer's agent"),
     chat_id: Optional[str] = typer.Option(None, "--chat-id", help="Reuse a chat"),
+    files: Optional[list[Path]] = typer.Option(
+        None,
+        "--file",
+        help="Attach a local file (repeat for multiple files)",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        resolve_path=True,
+    ),
 ):
     """Run a prompt on a peer device's agent and stream the reply."""
     import json as _json
@@ -116,7 +127,10 @@ def node_trigger(
 
         typer.echo(f"⚡ {match['name']}: ")
         try:
-            async for chunk in client.nodes.trigger(match["peer_id"], prompt, chat_id):
+            file_paths = [str(path) for path in (files or [])]
+            async for chunk in client.nodes.trigger(
+                match["peer_id"], prompt, chat_id, file_paths
+            ):
                 for line in chunk.decode("utf-8", "replace").splitlines():
                     if not line.startswith("data: "):
                         continue

--- a/src/suzent/client/api.py
+++ b/src/suzent/client/api.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import lru_cache
 
 from suzent.client.base import AsyncBaseClient
@@ -90,11 +92,19 @@ class NodesAPI:
             body["timeout"] = timeout
         return await self.client.post(f"/nodes/peers/{peer_id}/invoke", json=body)
 
-    async def trigger(self, peer_id: str, prompt: str, chat_id: str | None = None):
+    async def trigger(
+        self,
+        peer_id: str,
+        prompt: str,
+        chat_id: str | None = None,
+        files: list[str] | None = None,
+    ):
         """Stream a peer agent run; yields raw SSE chunks (bytes)."""
         payload: dict = {"prompt": prompt}
         if chat_id:
             payload["chat_id"] = chat_id
+        if files:
+            payload["attachments"] = [{"path": path} for path in files]
         async for chunk in self.client.stream_post(
             f"/nodes/peers/{peer_id}/trigger", json=payload, timeout=None
         ):

--- a/src/suzent/nodes/discovery.py
+++ b/src/suzent/nodes/discovery.py
@@ -16,6 +16,7 @@ Operator approval still gates the actual connection.
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import json
 import os
 import shutil
@@ -27,10 +28,54 @@ from suzent.logger import get_logger
 logger = get_logger(__name__)
 
 SERVICE_TYPE = "_suzent-node._tcp.local."
+TAILSCALE_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+VPN_BENCHMARK_NETWORK = ipaddress.ip_network("198.18.0.0/15")
+
+
+def resolve_mesh_bind(
+    host: str, port: int, *, enabled: bool, default_port: int
+) -> tuple[str, int]:
+    """Use a predictable externally reachable endpoint for the device mesh."""
+    if not enabled:
+        return host, port
+    return (host if host in ("0.0.0.0", "::") else "0.0.0.0", port or default_port)
 
 
 def _local_ip() -> str:
-    """Best-effort primary LAN IP (the default-route interface)."""
+    """Best-effort physical LAN IP, excluding overlays and VPN adapters."""
+    candidates: list[str] = []
+    try:
+        import psutil
+
+        stats = psutil.net_if_stats()
+        for interface, addresses in psutil.net_if_addrs().items():
+            if not stats.get(interface) or not stats[interface].isup:
+                continue
+            for address in addresses:
+                if address.family != socket.AF_INET:
+                    continue
+                ip = ipaddress.ip_address(address.address)
+                if not ip.is_private or ip.is_loopback or ip.is_link_local:
+                    continue
+                # Tailscale's CGNAT range and 198.18/15 VPN benchmark networks
+                # are routable overlays, not addresses a same-LAN peer can use.
+                if ip in TAILSCALE_NETWORK or ip in VPN_BENCHMARK_NETWORK:
+                    continue
+                candidates.append(str(ip))
+    except Exception:
+        pass
+
+    if candidates:
+
+        def rank(value: str) -> tuple[int, str]:
+            if value.startswith("192.168."):
+                return (0, value)
+            if value.startswith("10."):
+                return (1, value)
+            return (2, value)
+
+        return min(candidates, key=rank)
+
     try:
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         try:

--- a/src/suzent/nodes/peer_files.py
+++ b/src/suzent/nodes/peer_files.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import mimetypes
 import secrets
+from hashlib import sha256
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -14,6 +15,8 @@ from suzent.logger import get_logger
 logger = get_logger(__name__)
 
 DEFAULT_PEER_FILE_TTL_SECONDS = 3600
+TRANSFER_PEER_FILE_TTL_SECONDS = 300
+TRANSFER_PEER_FILE_DOWNLOADS = 2
 
 
 class PeerFileArtifact(BaseModel):
@@ -25,6 +28,8 @@ class PeerFileArtifact(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     expires_at: datetime
     producer: str = "unknown"
+    access_token_digest: str | None = Field(default=None, exclude=True)
+    remaining_downloads: int | None = Field(default=None, exclude=True)
 
     def to_reference(self) -> dict:
         return {
@@ -71,6 +76,44 @@ class PeerFileRegistry:
         self._artifacts[file_id] = artifact
         logger.debug("Registered peer file artifact {}", file_id)
         return artifact
+
+    def register_transfer(
+        self,
+        path: str | Path,
+        *,
+        name: str | None = None,
+        media_type: str | None = None,
+        ttl_seconds: int = TRANSFER_PEER_FILE_TTL_SECONDS,
+    ) -> tuple[PeerFileArtifact, str]:
+        """Register a file with a short-lived, artifact-specific download grant."""
+        artifact = self.register(
+            path,
+            producer="peer.attachment",
+            name=name,
+            media_type=media_type,
+            ttl_seconds=ttl_seconds,
+        )
+        token = secrets.token_urlsafe(32)
+        artifact.access_token_digest = sha256(token.encode("utf-8")).hexdigest()
+        artifact.remaining_downloads = TRANSFER_PEER_FILE_DOWNLOADS
+        return artifact, token
+
+    def authorize_transfer(self, file_id: str, token: str) -> PeerFileArtifact | None:
+        """Consume one use of an artifact-specific download grant."""
+        artifact = self.get(file_id)
+        if artifact is None or not token or artifact.access_token_digest is None:
+            return None
+        digest = sha256(token.encode("utf-8")).hexdigest()
+        if not secrets.compare_digest(digest, artifact.access_token_digest):
+            return None
+        remaining = artifact.remaining_downloads or 0
+        if remaining <= 0:
+            return None
+        artifact.remaining_downloads = remaining - 1
+        return artifact
+
+    def remove(self, file_id: str) -> None:
+        self._artifacts.pop(file_id, None)
 
     def get(self, file_id: str) -> PeerFileArtifact | None:
         artifact = self._artifacts.get(file_id)

--- a/src/suzent/routes/node_routes.py
+++ b/src/suzent/routes/node_routes.py
@@ -521,20 +521,9 @@ def _best_effort_lan_host() -> str:
 
     Falls back to the configured host when detection fails (e.g. offline).
     """
-    import socket
+    from suzent.nodes.discovery import _local_ip
 
-    from suzent.config import DEFAULT_HOST
-
-    try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        try:
-            # No packets are actually sent; this just picks the outbound iface.
-            s.connect(("8.8.8.8", 80))
-            return s.getsockname()[0]
-        finally:
-            s.close()
-    except Exception:
-        return DEFAULT_HOST
+    return _local_ip()
 
 
 def _tailscale_addresses() -> list[tuple[str, str]]:
@@ -583,10 +572,14 @@ def _tailscale_addresses() -> list[tuple[str, str]]:
     return out
 
 
-def _pairing_addresses() -> list[dict]:
-    """Candidate addresses a companion device can use to reach this server."""
+def _server_port(request: Request) -> int:
     from suzent.config import DEFAULT_PORT
 
+    return int(getattr(request.app.state, "server_port", DEFAULT_PORT))
+
+
+def _pairing_addresses(port: int) -> list[dict]:
+    """Candidate addresses a companion device can use to reach this server."""
     candidates: list[tuple[str, str]] = [("LAN", _best_effort_lan_host())]
     candidates.extend(_tailscale_addresses())
 
@@ -600,7 +593,7 @@ def _pairing_addresses() -> list[dict]:
             {
                 "label": label,
                 "host": host,
-                "gateway_url": f"ws://{host}:{DEFAULT_PORT}/ws/node",
+                "gateway_url": f"ws://{host}:{port}/ws/node",
             }
         )
     return result
@@ -608,15 +601,14 @@ def _pairing_addresses() -> list[dict]:
 
 async def get_node_config(request: Request) -> JSONResponse:
     """GET /nodes/config — Current node configuration + pairing addresses."""
-    from suzent.config import DEFAULT_PORT
-
-    addresses = _pairing_addresses()
+    port = _server_port(request)
+    addresses = _pairing_addresses(port)
     primary = addresses[0] if addresses else None
     return JSONResponse(
         {
             "nodes_enabled": bool(CONFIG.nodes_enabled),
             "node_lan_bind": bool(getattr(CONFIG, "node_lan_bind", False)),
-            "port": DEFAULT_PORT,
+            "port": port,
             # All reachable addresses (LAN + Tailscale if present) so the UI can
             # offer the right one per network. lan_host/gateway_url kept for
             # backward compatibility.
@@ -670,7 +662,6 @@ async def save_node_config(request: Request) -> JSONResponse:
 
 async def discover_nodes(request: Request) -> JSONResponse:
     """GET /nodes/discover — Find Suzent peers on the LAN (mDNS) and tailnet."""
-    from suzent.config import DEFAULT_PORT
     from suzent.nodes import discovery
 
     try:
@@ -680,7 +671,7 @@ async def discover_nodes(request: Request) -> JSONResponse:
     lan_timeout = max(0.5, min(lan_timeout, 5.0))
 
     result = await discovery.discover_all(
-        self_port=DEFAULT_PORT, lan_timeout=lan_timeout
+        self_port=_server_port(request), lan_timeout=lan_timeout
     )
     return JSONResponse(result)
 
@@ -894,19 +885,17 @@ def _is_tailscale_host(host: str) -> bool:
     return host.startswith("100.") or host.endswith(".ts.net")
 
 
-def _my_base_for_peer(peer_base_url: str) -> str:
+def _my_base_for_peer(peer_base_url: str, port: int) -> str:
     """Pick an address of *this* server reachable on the peer's network.
 
     If we reach the peer over Tailscale, offer our Tailscale address (a LAN IP
     wouldn't be reachable from their network), otherwise our LAN address.
     """
-    from suzent.config import DEFAULT_PORT
-
     if _is_tailscale_host(_host_of(peer_base_url)):
         for _label, host in _tailscale_addresses():
             if host.startswith("100."):
-                return f"http://{host}:{DEFAULT_PORT}"
-    return f"http://{_best_effort_lan_host()}:{DEFAULT_PORT}"
+                return f"http://{host}:{port}"
+    return f"http://{_best_effort_lan_host()}:{port}"
 
 
 async def request_control(request: Request) -> JSONResponse:
@@ -932,7 +921,7 @@ async def request_control(request: Request) -> JSONResponse:
     my_name = socket.gethostname()
     # Tell the grantor where to reach us (for revoke notifications), on the same
     # network we're reaching them.
-    my_addr = _my_base_for_peer(base)
+    my_addr = _my_base_for_peer(base, _server_port(request))
     try:
         async with httpx.AsyncClient(timeout=10) as client:
             r = await client.post(
@@ -1327,7 +1316,7 @@ async def set_peer_reverse(request: Request) -> JSONResponse:
             peer.get("name") or "peer", "peer", scope="agent"
         )
         # Offer an address reachable on the peer's network (Tailscale vs LAN).
-        my_base = _my_base_for_peer(peer["base_url"])
+        my_base = _my_base_for_peer(peer["base_url"], _server_port(request))
         try:
             async with httpx.AsyncClient(timeout=10) as client:
                 resp = await client.post(

--- a/src/suzent/routes/node_routes.py
+++ b/src/suzent/routes/node_routes.py
@@ -7,8 +7,10 @@ Provides:
 """
 
 import asyncio
+import mimetypes
 import time
 import uuid
+from pathlib import Path
 
 from pydantic import ValidationError
 from starlette.requests import Request
@@ -33,6 +35,9 @@ from suzent.nodes.models import (
 from suzent.nodes.ws_node import WebSocketNode
 
 logger = get_logger(__name__)
+
+MAX_PEER_ATTACHMENTS = 8
+MAX_PEER_ATTACHMENT_BYTES = 50 * 1024 * 1024
 
 # Cache of per-peer reachability + outbound status, keyed by peer_id. The Devices
 # tab polls GET /nodes/peers every few seconds; without this, each poll would fan
@@ -1084,11 +1089,28 @@ async def peer_invoke(request: Request) -> JSONResponse:
 
 async def serve_peer_file(request: Request):
     """GET /nodes/peer-files/{file_id} — serve a registered local artifact."""
+    from suzent.auth_boundary import extract_token, is_loopback, token_scope
+
     registry = _get_peer_file_registry(request)
     file_id = request.path_params.get("file_id", "")
-    artifact = registry.get(file_id) if registry else None
+    token = extract_token(request.headers.raw)
+    client_host = request.client.host if request.client else ""
+    artifact = None
+    if registry is not None:
+        if is_loopback(client_host):
+            artifact = registry.get(file_id)
+        else:
+            node_manager = _get_node_manager(request)
+            device_store = getattr(node_manager, "device_store", None)
+            if token_scope(token, device_store) in ("agent", "full"):
+                artifact = registry.get(file_id)
+            else:
+                artifact = registry.authorize_transfer(file_id, token)
     if artifact is None:
-        return JSONResponse({"error": "Peer file not found"}, status_code=404)
+        return JSONResponse(
+            {"error": "Peer file not found or download grant is invalid"},
+            status_code=404,
+        )
     return FileResponse(
         artifact.path,
         media_type=artifact.media_type,
@@ -1372,7 +1394,8 @@ async def remove_peer(request: Request) -> JSONResponse:
 async def trigger_peer(request: Request):
     """POST /nodes/peers/{peer_id}/trigger — run a prompt on the peer, stream SSE.
 
-    Body: {"prompt": str, "chat_id"?: str}. Sends through the peer's Suzent
+    Body: {"prompt": str, "chat_id"?: str, "attachments"?: [{"path": str}]}.
+    Sends through the peer's Suzent
     channel (/channels/suzent/inbound) — the peer keys the session by our
     authenticated identity and streams its agent's reply back.
     """
@@ -1395,9 +1418,56 @@ async def trigger_peer(request: Request):
     if not prompt:
         return JSONResponse({"error": "prompt is required"}, status_code=400)
 
+    raw_attachments = body.get("attachments") or []
+    if not isinstance(raw_attachments, list):
+        return JSONResponse({"error": "attachments must be a list"}, status_code=400)
+    if len(raw_attachments) > MAX_PEER_ATTACHMENTS:
+        return JSONResponse(
+            {"error": f"At most {MAX_PEER_ATTACHMENTS} attachments are allowed"},
+            status_code=400,
+        )
+
+    registry = _get_peer_file_registry(request)
+    registered: list[str] = []
+    attachment_refs: list[dict] = []
+    total_size = 0
+    try:
+        source_base = _my_base_for_peer(peer["base_url"], _server_port(request))
+        for item in raw_attachments:
+            if not isinstance(item, dict) or not isinstance(item.get("path"), str):
+                raise ValueError("Each attachment requires a path")
+            path = Path(item["path"]).expanduser().resolve(strict=True)
+            if not path.is_file():
+                raise ValueError(f"Attachment is not a file: {path.name}")
+            size = path.stat().st_size
+            total_size += size
+            if total_size > MAX_PEER_ATTACHMENT_BYTES:
+                raise ValueError("Peer attachments exceed the combined 50 MiB limit")
+            requested_name = item.get("name")
+            name = Path(str(requested_name)).name if requested_name else path.name
+            media_type = (
+                str(item.get("media_type") or "").strip()
+                or mimetypes.guess_type(name)[0]
+                or "application/octet-stream"
+            )
+            artifact, transfer_token = registry.register_transfer(
+                path, name=name, media_type=media_type
+            )
+            registered.append(artifact.file_id)
+            ref = artifact.to_reference()
+            ref["url"] = f"{source_base}{ref['url']}"
+            ref["token"] = transfer_token
+            attachment_refs.append(ref)
+    except (OSError, ValueError) as exc:
+        for file_id in registered:
+            registry.remove(file_id)
+        return JSONResponse({"error": str(exc)}, status_code=400)
+
     payload = {"content": prompt}
     if body.get("chat_id"):
         payload["chat_id"] = body["chat_id"]
+    if attachment_refs:
+        payload["attachments"] = attachment_refs
     headers = {"Authorization": f"Bearer {peer['token']}"}
     url = f"{peer['base_url']}/channels/suzent/inbound"
 

--- a/src/suzent/routes/suzent_channel_routes.py
+++ b/src/suzent/routes/suzent_channel_routes.py
@@ -8,6 +8,15 @@ queue. Transport is gated by the auth boundary (agent scope); the application
 allowlist is layered on in the pairing phase.
 """
 
+from __future__ import annotations
+
+import ipaddress
+import shutil
+import tempfile
+from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
 from starlette.requests import Request
 from starlette.responses import JSONResponse, StreamingResponse
 
@@ -16,11 +25,132 @@ from suzent.logger import get_logger
 
 logger = get_logger(__name__)
 
+MAX_PEER_ATTACHMENTS = 8
+MAX_PEER_ATTACHMENT_BYTES = 50 * 1024 * 1024
+PEER_ATTACHMENT_TIMEOUT_SECONDS = 300.0
+
+
+def _normalized_host(value: str | None) -> str:
+    host = (value or "").rstrip(".").lower()
+    try:
+        return str(ipaddress.ip_address(host))
+    except ValueError:
+        return host
+
+
+def _validate_attachment_source(
+    url: str,
+    file_id: str,
+    *,
+    client_host: str,
+    callback_url: str,
+) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        raise ValueError("Attachment URL must use HTTP or HTTPS")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError("Attachment URL contains unsupported components")
+    if parsed.path != f"/nodes/peer-files/{file_id}":
+        raise ValueError("Attachment URL does not match its file id")
+
+    allowed_hosts = {_normalized_host(client_host)}
+    callback_host = urlparse(callback_url).hostname if callback_url else None
+    if callback_host:
+        allowed_hosts.add(_normalized_host(callback_host))
+    if _normalized_host(parsed.hostname) not in allowed_hosts:
+        raise ValueError("Attachment URL does not belong to the authenticated peer")
+
+
+async def _download_peer_attachments(
+    items: object,
+    *,
+    client_host: str,
+    callback_url: str,
+) -> tuple[list[dict], Path | None]:
+    """Download authenticated peer artifacts into a disposable staging directory."""
+    if not items:
+        return [], None
+    if not isinstance(items, list):
+        raise ValueError("attachments must be a list")
+    if len(items) > MAX_PEER_ATTACHMENTS:
+        raise ValueError(f"At most {MAX_PEER_ATTACHMENTS} attachments are allowed")
+
+    staging_dir = Path(tempfile.mkdtemp(prefix="suzent-peer-"))
+    downloaded: list[dict] = []
+    total_received = 0
+    try:
+        async with httpx.AsyncClient(
+            timeout=PEER_ATTACHMENT_TIMEOUT_SECONDS,
+            follow_redirects=False,
+            trust_env=False,
+        ) as client:
+            for item in items:
+                if not isinstance(item, dict):
+                    raise ValueError("Invalid attachment metadata")
+                file_id = str(item.get("id") or "")
+                url = str(item.get("url") or "")
+                token = str(item.get("token") or "")
+                name = Path(str(item.get("name") or "attachment")).name
+                try:
+                    advertised_size = int(item.get("size") or 0)
+                except (TypeError, ValueError) as exc:
+                    raise ValueError("Invalid attachment size") from exc
+                if not file_id or not token or not name:
+                    raise ValueError("Incomplete attachment metadata")
+                if advertised_size < 0 or advertised_size > MAX_PEER_ATTACHMENT_BYTES:
+                    raise ValueError(f"Attachment '{name}' exceeds the 50 MiB limit")
+                _validate_attachment_source(
+                    url,
+                    file_id,
+                    client_host=client_host,
+                    callback_url=callback_url,
+                )
+
+                target = staging_dir / f"{file_id}_{name}"
+                received = 0
+                async with client.stream(
+                    "GET", url, headers={"Authorization": f"Bearer {token}"}
+                ) as response:
+                    response.raise_for_status()
+                    length = response.headers.get("content-length")
+                    try:
+                        content_length = int(length) if length else 0
+                    except ValueError as exc:
+                        raise ValueError("Invalid attachment Content-Length") from exc
+                    if total_received + content_length > MAX_PEER_ATTACHMENT_BYTES:
+                        raise ValueError(
+                            "Peer attachments exceed the combined 50 MiB limit"
+                        )
+                    with target.open("wb") as output:
+                        async for chunk in response.aiter_bytes():
+                            received += len(chunk)
+                            total_received += len(chunk)
+                            if total_received > MAX_PEER_ATTACHMENT_BYTES:
+                                raise ValueError(
+                                    "Peer attachments exceed the combined 50 MiB limit"
+                                )
+                            output.write(chunk)
+                if advertised_size and received != advertised_size:
+                    raise ValueError(f"Attachment '{name}' size did not match metadata")
+                media_type = str(item.get("media_type") or "application/octet-stream")
+                downloaded.append(
+                    {
+                        "path": str(target),
+                        "filename": name,
+                        "type": "image" if media_type.startswith("image/") else "file",
+                    }
+                )
+        return downloaded, staging_dir
+    except Exception:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        raise
+
 
 async def suzent_channel_inbound(request: Request):
     """POST /channels/suzent/inbound — run the agent for a peer, stream the reply.
 
-    Body: {"from_id": <peer id>, "content": str, "chat_id"?: str}
+    Body: {"from_id": <peer id>, "content": str, "chat_id"?: str,
+           "attachments"?: list[artifact reference]}
     """
     try:
         body = await request.json()
@@ -71,6 +201,21 @@ async def suzent_channel_inbound(request: Request):
     name = (rec or {}).get("display_name") if rec else None
     trigger_label = name or peer_id or "an unknown device"
 
+    attachment_files: list[dict] = []
+    attachment_staging_dir: Path | None = None
+    try:
+        attachment_files, attachment_staging_dir = await _download_peer_attachments(
+            body.get("attachments"),
+            client_host=request.client.host if request.client else "",
+            callback_url=str((rec or {}).get("callback_url") or ""),
+        )
+    except (httpx.HTTPError, OSError, ValueError) as exc:
+        logger.warning("Suzent channel: peer attachment download rejected: {}", exc)
+        return JSONResponse(
+            {"error": f"Could not retrieve peer attachment: {exc}"},
+            status_code=400,
+        )
+
     from suzent.agent_manager import build_agent_config
     from suzent.core.chat_processor import ChatProcessor
     from suzent.database import get_database
@@ -109,6 +254,7 @@ async def suzent_channel_inbound(request: Request):
         chat_id=chat_id,
         user_id=CONFIG.user_id,
         message_content=content,
+        files=attachment_files,
         config_override=config_override,
         system_reminders=[attribution],
     )
@@ -169,6 +315,8 @@ async def suzent_channel_inbound(request: Request):
                         logger.info(f"Suzent channel: removed empty chat {chat_id}")
                 except Exception:
                     pass
+            if attachment_staging_dir is not None:
+                shutil.rmtree(attachment_staging_dir, ignore_errors=True)
 
     return StreamingResponse(_teed(), media_type="text/event-stream")
 

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -609,7 +609,7 @@ async def startup():
             from suzent.nodes.discovery import SuzentAdvertiser
 
             node_advertiser = SuzentAdvertiser(
-                port=DEFAULT_PORT,
+                port=int(getattr(app.state, "server_port", DEFAULT_PORT)),
                 display_name=_socket.gethostname(),
             )
             app.state.node_advertiser = node_advertiser
@@ -1118,13 +1118,23 @@ if __name__ == "__main__":
     # node WebSocket (still reachable on loopback for the local app).
     try:
         from suzent.config import CONFIG as _CFG
+        from suzent.nodes.discovery import resolve_mesh_bind
 
-        if getattr(_CFG, "node_lan_bind", False) and host not in ("0.0.0.0", "::"):
-            logger.info(
-                f"node_lan_bind enabled: binding 0.0.0.0 instead of {host} "
-                f"so peer devices can reach this server"
-            )
-            host = "0.0.0.0"
+        mesh_enabled = bool(getattr(_CFG, "node_lan_bind", False))
+        resolved_host, resolved_port = resolve_mesh_bind(
+            host, port, enabled=mesh_enabled, default_port=DEFAULT_PORT
+        )
+        if mesh_enabled:
+            if resolved_host != host:
+                logger.info(
+                    f"node_lan_bind enabled: binding {resolved_host} instead of {host} "
+                    f"so peer devices can reach this server"
+                )
+            if resolved_port != port:
+                logger.info(
+                    f"node_lan_bind enabled: using stable mesh port {DEFAULT_PORT}"
+                )
+        host, port = resolved_host, resolved_port
     except Exception:
         pass
 
@@ -1184,6 +1194,7 @@ if __name__ == "__main__":
         _sock.set_inheritable(True)
         effective_port = _sock.getsockname()[1]
         report_port(effective_port)
+        app.state.server_port = effective_port
         if port == 0:
             logger.info(f"Dynamic port assigned: {effective_port}")
     except OSError as e:

--- a/tests/cli/test_cli_nodes.py
+++ b/tests/cli/test_cli_nodes.py
@@ -266,8 +266,9 @@ class TestNodesSubcommand:
             }
         )
 
-        async def fake_trigger(peer_id, prompt, chat_id=None):
+        async def fake_trigger(peer_id, prompt, chat_id=None, files=None):
             assert peer_id == "p1"
+            assert files == []
             yield b'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"Hi "}\n\n'
             yield b'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"there"}\n\n'
             yield b"data: [DONE]\n\n"
@@ -278,6 +279,31 @@ class TestNodesSubcommand:
         result = runner.invoke(app, ["nodes", "trigger", "Studio", "hello"])
         assert result.exit_code == 0
         assert "Hi there" in result.output
+
+    @patch("suzent.cli.node.get_client")
+    def test_nodes_trigger_passes_attached_file(self, mock_get_client, tmp_path):
+        attachment = tmp_path / "notes.txt"
+        attachment.write_text("hello", encoding="utf-8")
+        client = MagicMock()
+        client.nodes.peers = AsyncMock(
+            return_value={"peers": [{"peer_id": "p1", "name": "Studio"}]}
+        )
+
+        async def fake_trigger(peer_id, prompt, chat_id=None, files=None):
+            assert peer_id == "p1"
+            assert prompt == "read it"
+            assert files == [str(attachment.resolve())]
+            yield b"data: [DONE]\n\n"
+
+        client.nodes.trigger = fake_trigger
+        mock_get_client.return_value = client
+
+        result = runner.invoke(
+            app,
+            ["nodes", "trigger", "Studio", "read it", "--file", str(attachment)],
+        )
+
+        assert result.exit_code == 0
 
     @patch("suzent.cli.node.get_client")
     def test_nodes_trigger_unknown_peer(self, mock_get_client):

--- a/tests/nodes/test_auth_boundary.py
+++ b/tests/nodes/test_auth_boundary.py
@@ -11,6 +11,7 @@ from suzent.auth_boundary import (
     AuthBoundaryMiddleware,
     agent_path_allowed,
     extract_token,
+    is_http_exempt,
     is_loopback,
     scope_allows,
     token_scope,
@@ -64,6 +65,10 @@ def test_agent_path_allowed_peer_files_prefix_only():
     assert agent_path_allowed("/nodes/peer-files/pf_abc123")
     assert not agent_path_allowed("/nodes/peer-files")
     assert not agent_path_allowed("/sandbox/serve/chat/file.png")
+
+
+def test_peer_file_route_accepts_self_authenticating_transfer_grants():
+    assert is_http_exempt("/nodes/peer-files/pf_abc123")
 
 
 # ─── Middleware behavior ─────────────────────────────────────────────

--- a/tests/nodes/test_control_grant.py
+++ b/tests/nodes/test_control_grant.py
@@ -8,6 +8,24 @@ import pytest
 from suzent.nodes.device_store import DeviceTokenStore
 from suzent.nodes.manager import MAX_PENDING_GRANTS, NodeManager
 from suzent.nodes.peer_store import PeerGrantStore
+from suzent.routes import node_routes
+
+
+def test_pairing_and_callback_urls_use_actual_server_port(monkeypatch) -> None:
+    monkeypatch.setattr(node_routes, "_best_effort_lan_host", lambda: "192.168.1.8")
+    monkeypatch.setattr(
+        node_routes,
+        "_tailscale_addresses",
+        lambda: [("Tailscale", "100.64.0.8")],
+    )
+
+    addresses = node_routes._pairing_addresses(43123)
+
+    assert addresses[0]["gateway_url"] == "ws://192.168.1.8:43123/ws/node"
+    assert (
+        node_routes._my_base_for_peer("http://100.64.0.9:25314", 43123)
+        == "http://100.64.0.8:43123"
+    )
 
 
 def _mgr(tmp_path):

--- a/tests/nodes/test_discovery.py
+++ b/tests/nodes/test_discovery.py
@@ -5,11 +5,48 @@ the outbound connection manager.
 
 import asyncio
 import json
+import socket
+from collections import namedtuple
 
 import pytest
 
 from suzent.nodes import discovery
 from suzent.nodes.outbound import OutboundConnectionManager
+
+
+def test_mesh_bind_replaces_loopback_and_dynamic_port():
+    assert discovery.resolve_mesh_bind(
+        "127.0.0.1", 0, enabled=True, default_port=25314
+    ) == ("0.0.0.0", 25314)
+
+
+def test_mesh_bind_leaves_normal_desktop_start_dynamic():
+    assert discovery.resolve_mesh_bind(
+        "127.0.0.1", 0, enabled=False, default_port=25314
+    ) == ("127.0.0.1", 0)
+
+
+def test_local_ip_ignores_tailscale_and_vpn_ranges(monkeypatch):
+    address = namedtuple("address", "family address")
+    status = namedtuple("status", "isup")
+    monkeypatch.setattr(
+        "psutil.net_if_stats",
+        lambda: {
+            "VPN": status(True),
+            "Tailscale": status(True),
+            "Wi-Fi": status(True),
+        },
+    )
+    monkeypatch.setattr(
+        "psutil.net_if_addrs",
+        lambda: {
+            "VPN": [address(socket.AF_INET, "198.18.0.1")],
+            "Tailscale": [address(socket.AF_INET, "100.64.50.42")],
+            "Wi-Fi": [address(socket.AF_INET, "192.168.0.219")],
+        },
+    )
+
+    assert discovery._local_ip() == "192.168.0.219"
 
 
 # ─── Tailscale peer parsing ──────────────────────────────────────────

--- a/tests/nodes/test_peer_file_retrieval.py
+++ b/tests/nodes/test_peer_file_retrieval.py
@@ -1,20 +1,25 @@
 from __future__ import annotations
 
 from typing import Any
+from types import SimpleNamespace
 
 import httpx
+import pytest
 from starlette.applications import Starlette
+from starlette.requests import Request
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
 from suzent.nodes.base import NodeBase, NodeCapability
 from suzent.nodes.manager import NodeManager
 from suzent.nodes.peer_store import PeerGrantStore
+from suzent.nodes.peer_files import PeerFileRegistry
 from suzent.routes.node_routes import (
     invoke_peer,
     peer_invoke,
     proxy_peer_file,
     serve_peer_file,
+    trigger_peer,
 )
 
 
@@ -216,3 +221,120 @@ def test_proxy_peer_file_closes_client_when_send_fails(tmp_path, monkeypatch):
     assert response.status_code == 502
     assert clients
     assert clients[0].closed is True
+
+
+def test_transfer_grant_is_short_lived_and_use_limited(tmp_path):
+    path = tmp_path / "report.txt"
+    path.write_text("hello", encoding="utf-8")
+    registry = PeerFileRegistry()
+
+    artifact, token = registry.register_transfer(path)
+
+    assert registry.authorize_transfer(artifact.file_id, "wrong") is None
+    assert registry.authorize_transfer(artifact.file_id, token) == artifact
+    assert registry.authorize_transfer(artifact.file_id, token) == artifact
+    assert registry.authorize_transfer(artifact.file_id, token) is None
+
+
+@pytest.mark.asyncio
+async def test_serve_peer_file_accepts_transfer_token_from_remote(tmp_path):
+    path = tmp_path / "report.txt"
+    path.write_text("hello", encoding="utf-8")
+    registry = PeerFileRegistry()
+    artifact, token = registry.register_transfer(path)
+    app = SimpleNamespace(
+        state=SimpleNamespace(peer_file_registry=registry, node_manager=None)
+    )
+
+    wrong_request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": artifact.to_reference()["url"],
+            "headers": [(b"authorization", b"Bearer wrong")],
+            "path_params": {"file_id": artifact.file_id},
+            "client": ("192.168.1.20", 50000),
+            "app": app,
+        }
+    )
+    wrong_response = await serve_peer_file(wrong_request)
+    assert wrong_response.status_code == 404
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": artifact.to_reference()["url"],
+            "headers": [(b"authorization", f"Bearer {token}".encode("latin-1"))],
+            "path_params": {"file_id": artifact.file_id},
+            "client": ("192.168.1.20", 50000),
+            "app": app,
+        }
+    )
+    response = await serve_peer_file(request)
+    assert response.status_code == 200
+
+
+def test_trigger_peer_sends_ephemeral_attachment_reference(tmp_path, monkeypatch):
+    path = tmp_path / "notes.txt"
+    path.write_text("peer notes", encoding="utf-8")
+    store = PeerGrantStore(path=tmp_path / "peers.json")
+    peer_id = store.add("Peer", "http://peer.example", "peer-token")
+    sent: dict[str, Any] = {}
+
+    class FakeResponse:
+        status_code = 200
+
+        async def aread(self):
+            return b""
+
+        async def aiter_lines(self):
+            yield 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"ok"}'
+
+    class StreamContext:
+        async def __aenter__(self):
+            return FakeResponse()
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        def stream(self, method, url, json=None, headers=None):
+            sent.update(method=method, url=url, json=json, headers=headers)
+            return StreamContext()
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+    monkeypatch.setattr(
+        "suzent.routes.node_routes._my_base_for_peer",
+        lambda _peer_url, _port: "http://192.168.1.10:25314",
+    )
+    app = Starlette(
+        routes=[Route("/nodes/peers/{peer_id}/trigger", trigger_peer, methods=["POST"])]
+    )
+    app.state.peer_store = store
+    app.state.server_port = 25314
+    client = TestClient(app)
+
+    response = client.post(
+        f"/nodes/peers/{peer_id}/trigger",
+        json={"prompt": "Read this", "attachments": [{"path": str(path)}]},
+    )
+
+    assert response.status_code == 200
+    attachment = sent["json"]["attachments"][0]
+    assert attachment["name"] == "notes.txt"
+    assert attachment["size"] == len(b"peer notes")
+    assert attachment["url"].startswith(
+        "http://192.168.1.10:25314/nodes/peer-files/pf_"
+    )
+    assert attachment["token"]
+    assert str(path) not in str(sent["json"])

--- a/tests/nodes/test_peer_file_send.py
+++ b/tests/nodes/test_peer_file_send.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import httpx
+import pytest
+
+from suzent.routes.suzent_channel_routes import (
+    _download_peer_attachments,
+    _validate_attachment_source,
+)
+
+
+def test_attachment_source_must_belong_to_authenticated_peer():
+    with pytest.raises(ValueError, match="authenticated peer"):
+        _validate_attachment_source(
+            "http://169.254.169.254/nodes/peer-files/pf_123",
+            "pf_123",
+            client_host="192.168.1.10",
+            callback_url="http://192.168.1.10:25314",
+        )
+
+
+@pytest.mark.asyncio
+async def test_download_peer_attachment_to_staging_dir(monkeypatch):
+    class FakeResponse:
+        headers = {"content-length": "5"}
+
+        def raise_for_status(self):
+            return None
+
+        async def aiter_bytes(self):
+            yield b"hello"
+
+    class StreamContext:
+        async def __aenter__(self):
+            return FakeResponse()
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            assert kwargs["follow_redirects"] is False
+            assert kwargs["trust_env"] is False
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        def stream(self, method, url, headers=None):
+            assert method == "GET"
+            assert url == "http://192.168.1.10:25314/nodes/peer-files/pf_123"
+            assert headers == {"Authorization": "Bearer transfer-token"}
+            return StreamContext()
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+    files, staging = await _download_peer_attachments(
+        [
+            {
+                "id": "pf_123",
+                "url": "http://192.168.1.10:25314/nodes/peer-files/pf_123",
+                "token": "transfer-token",
+                "name": "hello.txt",
+                "media_type": "text/plain",
+                "size": 5,
+            }
+        ],
+        client_host="192.168.1.10",
+        callback_url="http://192.168.1.10:25314",
+    )
+
+    try:
+        assert staging is not None
+        assert files[0]["filename"] == "hello.txt"
+        assert files[0]["type"] == "file"
+        assert Path(files[0]["path"]).read_bytes() == b"hello"
+    finally:
+        if staging is not None:
+            shutil.rmtree(staging, ignore_errors=True)


### PR DESCRIPTION
## What changed

- improve LAN/Tailscale node discovery and stable mesh binding
- allow `suzent nodes trigger` to send one or more files with repeatable `--file`
- use short-lived artifact-specific download grants without requiring permanent reverse control
- validate peer source URLs, transfer sizes, redirects, count limits, and clean up staging files
- document the peer attachment workflow and security limits

## Why

Peers could retrieve capability-produced files such as camera snapshots, but a controller could not attach a local file to a remote peer-agent turn. The existing one-way grant also did not give the peer a safe credential for reading a controller file.

This adds a narrowly scoped, expiring transfer credential and reuses the existing peer file registry, so attachments work over LAN or Tailscale without broadening long-lived peer permissions.

## Impact

Users can now run, for example:

```text
suzent nodes trigger "Device B" "summarize this" --file ./report.pdf
```

Both peers must run a version containing this protocol update.

## Validation

- Ruff checks passed
- pre-commit Ruff check and format hooks passed
- `129 passed` across `tests/nodes` and `tests/cli/test_cli_nodes.py`
