### PR TITLE
fix: show the Suzent icon for the macOS UI

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -432,6 +432,21 @@ try {{ localStorage.setItem('SUZENT_PORT', '{port}'); }} catch (e) {{}}
 }
 
 fn find_relaunch_exe(repo_dir: &Path) -> Result<PathBuf, std::io::Error> {
+    // The CLI wraps the released binary in a .app so macOS shows the Suzent
+    // icon; relaunch through the bundle to keep it after an update.
+    #[cfg(target_os = "macos")]
+    {
+        let bundled = repo_dir
+            .join("bin")
+            .join("SUZENT.app")
+            .join("Contents")
+            .join("MacOS")
+            .join("suzent-ui");
+        if bundled.exists() {
+            return Ok(bundled);
+        }
+    }
+
     let bundled = if cfg!(windows) {
         repo_dir.join("bin").join("suzent-ui.exe")
     } else {

--- a/src/suzent/cli/main.py
+++ b/src/suzent/cli/main.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import platform
+import plistlib
 import re
 import signal
 import shutil
@@ -31,6 +32,7 @@ _UPDATE_CHANNEL_FILE = ".suzent/update-channel"
 _STABLE_CHANNEL = "stable"
 _DEV_CHANNEL = "dev"
 _UPDATE_HELPER_ENV = "SUZENT_UPDATE_HELPER"
+_MACOS_UI_BUNDLE = "SUZENT.app"
 
 
 def _is_development_workspace(root: Path) -> bool:
@@ -104,6 +106,82 @@ def _write_update_channel(root: Path, channel: str) -> None:
 def _is_ui_binary_current(root: Path, binary: Path) -> bool:
     """Return True when a discovered UI binary can be launched."""
     return binary.exists()
+
+
+def _macos_bundle_plist(executable: str, version: str) -> bytes:
+    info: dict[str, object] = {
+        "CFBundleDevelopmentRegion": "en",
+        "CFBundleExecutable": executable,
+        "CFBundleIconFile": "icon.icns",
+        "CFBundleIdentifier": "com.suzent.app",
+        "CFBundleInfoDictionaryVersion": "6.0",
+        "CFBundleName": "SUZENT",
+        "CFBundlePackageType": "APPL",
+        "CFBundleSignature": "????",
+        "LSMinimumSystemVersion": "10.13",
+        "NSHighResolutionCapable": True,
+    }
+    if re.fullmatch(r"\d+(\.\d+){0,2}", version):
+        info["CFBundleShortVersionString"] = version
+        info["CFBundleVersion"] = version
+    return plistlib.dumps(info, sort_keys=True)
+
+
+def _write_bundle_file(path: Path, data: bytes) -> None:
+    """Write bundle metadata, leaving the mtime alone when nothing changed."""
+    if path.exists() and path.read_bytes() == data:
+        return
+    path.write_bytes(data)
+
+
+def _link_bundle_executable(binary: Path, executable: Path) -> None:
+    """Point the bundle at the current binary, refreshing it after an update."""
+    if executable.exists() and executable.stat().st_ino == binary.stat().st_ino:
+        return
+    executable.unlink(missing_ok=True)
+    try:
+        os.link(binary, executable)
+    except OSError:
+        shutil.copy2(binary, executable)
+        executable.chmod(0o755)
+
+
+def _macos_launch_target(root: Path, binary: Path) -> Path:
+    """Return a path that launches the UI with the Suzent icon and name.
+
+    Releases publish a bare Mach-O executable, but macOS reads an app's icon,
+    name and activation policy from the enclosing bundle — a loose binary only
+    ever gets the generic executable icon. Generating the bundle around the
+    downloaded binary keeps the single-file release format intact.
+    """
+    if sys.platform != "darwin" or not binary.exists():
+        return binary
+    if any(part.endswith(".app") for part in binary.parts):
+        return binary
+
+    try:
+        bundle = binary.parent / _MACOS_UI_BUNDLE
+        contents = bundle / "Contents"
+        macos_dir = contents / "MacOS"
+        resources = contents / "Resources"
+        macos_dir.mkdir(parents=True, exist_ok=True)
+        resources.mkdir(parents=True, exist_ok=True)
+
+        _write_bundle_file(
+            contents / "Info.plist",
+            _macos_bundle_plist(
+                binary.name, _normalize_version_tag(_current_version(root))
+            ),
+        )
+        icon = root / "src-tauri" / "icons" / "icon.icns"
+        if icon.exists():
+            _write_bundle_file(resources / "icon.icns", icon.read_bytes())
+
+        executable = macos_dir / binary.name
+        _link_bundle_executable(binary, executable)
+    except OSError:
+        return binary
+    return executable
 
 
 def _ui_launch_env(extra: dict[str, str] | None = None) -> dict[str, str]:
@@ -1103,7 +1181,7 @@ def register_commands(app: typer.Typer):
             typer.echo(f"  • Launching UI binary ({ui_bin.name})...")
             try:
                 subprocess.run(
-                    [str(ui_bin)],
+                    [str(_macos_launch_target(root, ui_bin))],
                     env=_ui_launch_env({"SUZENT_DIR": str(root)}),
                 )
             except (subprocess.CalledProcessError, KeyboardInterrupt):

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -852,3 +852,59 @@ def test_check_update_json_command(monkeypatch):
     assert payload["current_version"] == "0.6.2"
     assert payload["latest_version"] == "v0.6.3"
     assert payload["update_available"] is True
+
+
+def _macos_workspace(tmp_path: Path) -> Path:
+    (tmp_path / "pyproject.toml").write_text('version = "0.7.13"\n', encoding="utf-8")
+    icons = tmp_path / "src-tauri" / "icons"
+    icons.mkdir(parents=True)
+    (icons / "icon.icns").write_bytes(b"icns-payload")
+    binary = tmp_path / "bin" / "suzent-ui"
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(b"mach-o")
+    return binary
+
+
+def test_macos_launch_target_wraps_bare_binary_in_app_bundle(monkeypatch, tmp_path):
+    """Regression: a loose executable only ever gets the generic macOS icon."""
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    binary = _macos_workspace(tmp_path)
+
+    launch = cli_main._macos_launch_target(tmp_path, binary)
+
+    bundle = tmp_path / "bin" / "SUZENT.app"
+    assert launch == bundle / "Contents" / "MacOS" / "suzent-ui"
+    assert launch.stat().st_ino == binary.stat().st_ino
+    assert (bundle / "Contents" / "Resources" / "icon.icns").read_bytes() == (
+        b"icns-payload"
+    )
+
+    info = cli_main.plistlib.loads((bundle / "Contents" / "Info.plist").read_bytes())
+    assert info["CFBundleExecutable"] == "suzent-ui"
+    assert info["CFBundleIconFile"] == "icon.icns"
+    assert info["CFBundleIdentifier"] == "com.suzent.app"
+    assert info["CFBundlePackageType"] == "APPL"
+    assert info["CFBundleShortVersionString"] == "0.7.13"
+
+
+def test_macos_launch_target_relinks_bundle_after_update(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    binary = _macos_workspace(tmp_path)
+    launch = cli_main._macos_launch_target(tmp_path, binary)
+
+    # `suzent update` swaps the binary by rename, leaving the old inode behind.
+    replacement = binary.with_name(".suzent-ui.new")
+    replacement.write_bytes(b"mach-o-v2")
+    replacement.replace(binary)
+
+    assert cli_main._macos_launch_target(tmp_path, binary) == launch
+    assert launch.read_bytes() == b"mach-o-v2"
+    assert launch.stat().st_ino == binary.stat().st_ino
+
+
+def test_macos_launch_target_skips_non_macos_platforms(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+    binary = _macos_workspace(tmp_path)
+
+    assert cli_main._macos_launch_target(tmp_path, binary) == binary
+    assert not (tmp_path / "bin" / "SUZENT.app").exists()


### PR DESCRIPTION
## Problem

On macOS the running app shows the generic green **exec** icon in the Dock and app switcher instead of the Suzent logo.

The icon assets are fine — the cause is the release format. `tauri build` produces both `src-tauri/target/release/suzent` (a bare Mach-O executable) and `src-tauri/target/release/bundle/macos/SUZENT.app`, and [`build-desktop.yml`](.github/workflows/build-desktop.yml) ships the former. `setup.sh` drops it at `bin/suzent-ui` and the CLI execs it directly. macOS reads an app's icon, name and version from the enclosing bundle's `Info.plist`, never from the binary, so a loose executable can only get the generic icon.

Verified against LaunchServices — the currently shipped binary registers as:

```
"suzent-ui"  bundleID=[ NULL ]  fileType="????"  Version=[ NULL ]
  bundle path="…/bin/suzent-ui"
```

## Fix

Generate the bundle client-side instead of changing what the release publishes. Before launching, `suzent start` builds `bin/SUZENT.app` around the downloaded binary — `Info.plist` plus a copy of `src-tauri/icons/icon.icns` — and launches `SUZENT.app/Contents/MacOS/suzent-ui`.

- The executable is **hard-linked**, not copied, so the bundle costs no extra disk, and it is relinked whenever `suzent update` swaps the binary (inode comparison).
- Release assets, `SHA256SUMS`, and both the Python and Rust update paths are untouched, so there is no backwards-compat break for already-installed clients.
- Any failure falls back to launching the bare binary exactly as before.
- `find_relaunch_exe` in the Tauri app prefers the bundle so the icon survives a post-update relaunch.
- Non-macOS platforms return the binary unchanged.

After the fix, the same LaunchServices query reports:

```
"SUZENT"  bundleID="com.suzent.app"  fileType="APPL"  Version="0.7.13"
  bundle path="…/SUZENT.app"
```

and `NSWorkspace iconForFile:` returns the Suzent logo instead of the exec icon.

## Testing

- `uv run pytest tests/cli` — 74 passed (3 new tests: bundle generation, relink after update, non-macOS no-op)
- `cargo check` in `src-tauri`
- `pre-commit run` on the changed files
- Manually launched the generated bundle on macOS 15 and confirmed the bundle identity and icon above

## Not covered

`suzent-installer` is shipped the same way and still shows the exec icon while an update runs. It resolves its own staging path from `current_exe()`, so wrapping it needs a closer look — left for a follow-up.