### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Let the desktop app attach to an existing Service instead of launching a duplicate backend
 - Make desktop shutdown, updates, rollbacks, and uninstall service-aware and graceful
 - Bound streaming queues, pending approvals, background process metadata, and captured command output
+- Defer memory subsystem initialization until first use to reduce idle Service memory usage
 
 ### 🐛 Fixed
 - Prevent stale runtime locks and recycled process IDs from being treated as a healthy Service


### PR DESCRIPTION
Automated release preparation for **v0.8.0**.

This release introduces the opt-in cross-platform Background Service, a dedicated Service settings tab, lifecycle-safe desktop attachment and updates, bounded background resources, and lazy memory initialization.

The implementation PR (#107) passed CI before merge. Version synchronization has been revalidated locally with `scripts/bump_version.py --check`.

Merging this PR creates the `v0.8.0` tag and starts the draft multi-platform desktop build and publication workflow.
