### PR TITLE
fix: hide Windows service autostart terminal

### DIFF
--- a/src/suzent/service/platforms/windows.py
+++ b/src/suzent/service/platforms/windows.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -20,6 +21,7 @@ except ImportError:  # pragma: no cover - imported by cross-platform unit tests
 RUN_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
 RUN_VALUE = "Suzent Service"
 SUPERVISOR_PATH = RUNTIME_DIR / "service-supervisor.cmd"
+LAUNCHER_PATH = RUNTIME_DIR / "service-launcher.pyw"
 STOP_REQUEST_PATH = RUNTIME_DIR / "service-stop.request"
 
 
@@ -27,6 +29,10 @@ class WindowsServiceManager(PlatformServiceManager):
     @property
     def definition_path(self) -> Path:
         return SUPERVISOR_PATH
+
+    @property
+    def launcher_path(self) -> Path:
+        return LAUNCHER_PATH
 
     def _read_autostart(self) -> str | None:
         if winreg is None:
@@ -60,6 +66,37 @@ class WindowsServiceManager(PlatformServiceManager):
     def is_installed(self) -> bool:
         return self.definition_path.exists() and self._read_autostart() is not None
 
+    def _autostart_command(self) -> str:
+        pythonw = self.python_executable.with_name("pythonw.exe")
+        if os.name == "nt" and not pythonw.is_file():
+            raise RuntimeError(f"Windowless Python launcher not found at {pythonw}")
+        return subprocess.list2cmdline([str(pythonw), str(self.launcher_path)])
+
+    def _write_hidden_launcher(self) -> None:
+        script = (
+            "import subprocess\n\n"
+            "creationflags = (\n"
+            '    getattr(subprocess, "CREATE_NO_WINDOW", 0)\n'
+            '    | getattr(subprocess, "DETACHED_PROCESS", 0)\n'
+            '    | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)\n'
+            ")\n"
+            "subprocess.Popen(\n"
+            f'    ["cmd.exe", "/d", "/c", {str(self.definition_path)!r}],\n'
+            "    stdin=subprocess.DEVNULL,\n"
+            "    stdout=subprocess.DEVNULL,\n"
+            "    stderr=subprocess.DEVNULL,\n"
+            "    close_fds=True,\n"
+            "    creationflags=creationflags,\n"
+            ")\n"
+        )
+        self.launcher_path.write_text(script, encoding="utf-8")
+
+    def _ensure_hidden_autostart(self) -> None:
+        command = self._autostart_command()
+        self._write_hidden_launcher()
+        if self._read_autostart() != command:
+            self._set_autostart(command)
+
     def install(self) -> None:
         self.definition_path.parent.mkdir(parents=True, exist_ok=True)
         python = subprocess.list2cmdline([str(self.python_executable)])
@@ -88,18 +125,18 @@ class WindowsServiceManager(PlatformServiceManager):
             "goto run\n"
         )
         self.definition_path.write_text(script, encoding="utf-8")
-        command = subprocess.list2cmdline(
-            ["cmd.exe", "/d", "/c", str(self.definition_path)]
-        )
-        self._set_autostart(command)
+        self._write_hidden_launcher()
+        self._set_autostart(self._autostart_command())
 
     def uninstall(self) -> None:
         self._delete_autostart()
         self.stop()
         self.definition_path.unlink(missing_ok=True)
+        self.launcher_path.unlink(missing_ok=True)
         STOP_REQUEST_PATH.unlink(missing_ok=True)
 
     def start(self) -> None:
+        self._ensure_hidden_autostart()
         if read_process_state() is not None:
             return
         STOP_REQUEST_PATH.unlink(missing_ok=True)

--- a/tests/service/test_platform_service_managers.py
+++ b/tests/service/test_platform_service_managers.py
@@ -49,11 +49,16 @@ def test_windows_service_uses_hkcu_autostart_and_bounded_restarts(
     tmp_path, monkeypatch
 ):
     manager = WindowsServiceManager()
-    definition = tmp_path / "service-supervisor.cmd"
+    runtime_dir = tmp_path / "Suzent Data"
+    definition = runtime_dir / "service-supervisor.cmd"
+    launcher = runtime_dir / "service-launcher.pyw"
     stop_request = tmp_path / "service-stop.request"
     autostart: list[str] = []
     monkeypatch.setattr(
         WindowsServiceManager, "definition_path", property(lambda _self: definition)
+    )
+    monkeypatch.setattr(
+        WindowsServiceManager, "launcher_path", property(lambda _self: launcher)
     )
     monkeypatch.setattr(windows_module, "STOP_REQUEST_PATH", stop_request)
     monkeypatch.setattr(manager, "_set_autostart", autostart.append)
@@ -65,6 +70,76 @@ def test_windows_service_uses_hkcu_autostart_and_bounded_restarts(
     assert "retries" in script
     assert "%code% EQU 73" in script
     assert str(stop_request) in script
+    launcher_script = launcher.read_text(encoding="utf-8")
+    assert "subprocess.Popen" in launcher_script
+    assert "CREATE_NO_WINDOW" in launcher_script
+    assert "DETACHED_PROCESS" in launcher_script
+    assert "CREATE_NEW_PROCESS_GROUP" in launcher_script
+    assert repr(str(definition)) in launcher_script
+    compile(launcher_script, str(launcher), "exec")
     assert len(autostart) == 1
-    assert "cmd.exe" in autostart[0]
-    assert str(definition) in autostart[0]
+    assert "pythonw.exe" in autostart[0]
+    assert str(launcher) in autostart[0]
+    assert "cmd.exe" not in autostart[0]
+
+
+def test_windows_start_migrates_visible_autostart_before_process_check(
+    tmp_path, monkeypatch
+):
+    manager = WindowsServiceManager()
+    runtime_dir = tmp_path / "Suzent Data"
+    runtime_dir.mkdir()
+    definition = runtime_dir / "service-supervisor.cmd"
+    launcher = runtime_dir / "service-launcher.pyw"
+    autostart: list[str] = []
+    definition.write_text("@echo off\n", encoding="utf-8")
+    monkeypatch.setattr(
+        WindowsServiceManager, "definition_path", property(lambda _self: definition)
+    )
+    monkeypatch.setattr(
+        WindowsServiceManager, "launcher_path", property(lambda _self: launcher)
+    )
+    monkeypatch.setattr(
+        manager,
+        "_read_autostart",
+        lambda: f'cmd.exe /d /c "{definition}"',
+    )
+    monkeypatch.setattr(manager, "_set_autostart", autostart.append)
+    monkeypatch.setattr(windows_module, "read_process_state", lambda: object())
+
+    manager.start()
+
+    assert launcher.exists()
+    assert autostart == [manager._autostart_command()]
+    assert "pythonw.exe" in autostart[0]
+
+
+def test_windows_uninstall_removes_supervisor_and_hidden_launcher(
+    tmp_path, monkeypatch
+):
+    manager = WindowsServiceManager()
+    definition = tmp_path / "service-supervisor.cmd"
+    launcher = tmp_path / "service-launcher.pyw"
+    stop_request = tmp_path / "service-stop.request"
+    definition.write_text("@echo off\n", encoding="utf-8")
+    launcher.write_text("# launcher\n", encoding="utf-8")
+    stop_request.touch()
+    deleted_autostart: list[bool] = []
+    monkeypatch.setattr(
+        WindowsServiceManager, "definition_path", property(lambda _self: definition)
+    )
+    monkeypatch.setattr(
+        WindowsServiceManager, "launcher_path", property(lambda _self: launcher)
+    )
+    monkeypatch.setattr(windows_module, "STOP_REQUEST_PATH", stop_request)
+    monkeypatch.setattr(
+        manager, "_delete_autostart", lambda: deleted_autostart.append(True)
+    )
+    monkeypatch.setattr(manager, "stop", lambda: None)
+
+    manager.uninstall()
+
+    assert deleted_autostart == [True]
+    assert not definition.exists()
+    assert not launcher.exists()
+    assert not stop_request.exists()


### PR DESCRIPTION
## What changed

- replace the visible Windows `HKCU\\...\\Run` `cmd.exe` entry with a `pythonw.exe` launcher
- launch the existing lightweight supervisor with `CREATE_NO_WINDOW`, `DETACHED_PROCESS`, and `CREATE_NEW_PROCESS_GROUP`
- migrate existing `0.8.0` autostart entries whenever the Service starts, including the updater restart path
- remove the generated launcher during Service uninstall
- cover paths containing spaces, migration while already running, generated-script syntax, and uninstall cleanup

## Why

Windows started the long-lived `service-supervisor.cmd` directly from the Run key. Because the supervisor intentionally remains alive, its console window also remained visible. Manual Service starts were already hidden, but login autostart did not use the same process flags.

The new `pythonw` launcher is transient and exits immediately after spawning the existing low-overhead supervisor, so it adds no resident Python process.

## Validation

- `uv run pytest -p no:cacheprovider ... -m "not sandbox"` — 1036 passed
- focused Service and CLI suite — 23 passed
- `pre-commit run --all-files` — passed
- actual Windows migration changed the Run entry from `cmd.exe` to `pythonw.exe ... service-launcher.pyw`
- actual login-equivalent launch restored `ready=true` on port 25314
- the live supervisor reported `MainWindowHandle=0`
