### PR TITLE
fix(memory): stop archival memory from filling with duplicates

### DIFF
--- a/docs/02-concepts/memory/README.md
+++ b/docs/02-concepts/memory/README.md
@@ -25,6 +25,7 @@ Suzent remembers things across conversations — facts you've shared, preference
 
 - [Memory Consolidation](./consolidation.md): How daily logs become consolidated notebook memory.
 - [Memory Internals](./internals.md): Implementation-level architecture and data flow.
+- [Upgrade Notes](./upgrade-notes.md): What changes on an existing install after the deduplication work — read before deleting anything.
 
 ## Configuration
 

--- a/docs/02-concepts/memory/architecture.md
+++ b/docs/02-concepts/memory/architecture.md
@@ -215,7 +215,17 @@ The **revisit queue** is a deterministic frontmatter scan by the runner, handed 
 dream alongside the confirmations: vault pages past their `stale_after`, soonest first,
 to be re-confirmed against the logs being ingested — never deleted. Both queues are
 runner-owned for the same reason the watermark is: index and lifecycle mutation stays
-out of the agent's hands. The confirmations sidecar is truncated only by the number of
+out of the agent's hands.
+
+A `3_Personal/` page with no `stale_after` *at all* is queued too, after every genuinely
+expired one. Every page written before `07f24c4b` is in that state — 6 of the live vault's
+personal pages — and selecting strictly on the field would mean they are never queued, so
+the dream never visits them, so the field is never written: the pages most in need of a
+first pass would be the only ones permanently exempt from one. Letting the dream backfill
+the field beats a script guessing it, because a wrong `stale_after` actively damps a good
+claim in step 6's ranking and only the dream can see which category a claim belongs to.
+The undated branch is scoped to `3_Personal/`: a wiki or project page having no expiry is
+correct, not a backlog item. The confirmations sidecar is truncated only by the number of
 lines the agent was actually shown, since conversations keep appending to it while the
 dream runs.
 

--- a/docs/02-concepts/memory/architecture.md
+++ b/docs/02-concepts/memory/architecture.md
@@ -115,6 +115,11 @@ those days on its own.
    disappears. Every tombstone write must be paired with an explicit reindex.
 5. **Recall enrichment must never block a write.** A search outage degrades extraction
    quality, never durability.
+5b. **The write path may recognise a repeat, never an update.** The one case it is
+   allowed to divert is a word-for-word restatement of a claim already recorded in an
+   append-only store, adding no new specifics. Anything else — a new detail, a
+   contradiction, a match found only in a transcript — is written exactly as before.
+   Issue #34 was this line being crossed.
 6. **Only the generated zone of `MEMORY.md` is generated.** The file has two generators
    and an agent editing it directly; everything after the `<!-- /memory:generated -->`
    marker is copied through untouched, and a file with no marker that we cannot prove we
@@ -144,7 +149,8 @@ marker survive either of them.
 | `2af08c7b` | Every append to a daily log re-embedded the whole file — 28.5x amplification over the real corpus, quadratic in appends per day, and ~374k single-row inserts fragmenting the table. Archive reindex is now a diff, falling back to full replace if the diff query fails. |
 | `7842c41d` | `MEMORY.md` was a blind overwrite with three writers, and the per-turn refresh filtered on an importance column the indexer stamps with a constant — so it rebuilt the file exclusively from pre-June legacy rows. |
 | `d1067d4e` | The confirmation counts, `status`, and `stale_after` the dream writes were read by nothing; retrieval scored every row identically. |
-| _this_ | A dry-run harness for the dream, and a ranker that reads the status the live vault actually writes (`active`, not `stable`). |
+| `5b21f156` | A dry-run harness for the dream, and a ranker that reads the status the live vault actually writes (`active`, not `stable`). |
+| _this_ | Every re-statement of a known claim became another row competing with the original. The write path now recognises a word-for-word repeat of a durably recorded claim and records the recurrence instead. |
 
 ## Next steps
 
@@ -157,7 +163,7 @@ flowchart LR
     D4 --> D5["✓ claim lifecycle (writer)"]
     D5 --> N6["✓ rank on the new signals"]
     N6 --> N7["✓ catch-up dream<br/>(completed itself)"]
-    N7 --> N8["8 · write-path classifier<br/>+ revisit queue"]
+    N7 --> N8["✓ write-path classifier<br/>+ revisit queue"]
     N7 --> N9["9 · retire 2,833 legacy rows"]
 ```
 
@@ -187,11 +193,31 @@ under the pre-`07f24c4b` prompts: of the 18 `3_Personal` pages, 8 carry frontmat
 nothing to read on existing pages — the lint pass is the backfill, and it should be
 exercised against a clone before the real vault.
 
-**8 — Write-path classifier and revisit queue.** Classify each extracted fact against the
-recalled set: ≥0.97 with no new specifics is a confirmation (one line to a
-`confirmations.jsonl` sidecar, folded in by the dream), 0.90–0.97 a revision, below that
-new. The revisit queue selects vault claims past their `stale_after`. Unblocked: step 7
-finished, so there is a populated claim set to compare against.
+**8 — Write-path classifier and revisit queue.** Done. `memory/classifier.py` compares
+each extracted fact against the recall set already assembled for the extraction prompt,
+so it costs no extra retrieval and no extra model call — the comparison is lexical on
+purpose, because the only band that changes behaviour is "practically the same
+sentence", which is what a lexical measure is good at and what a semantic one is too
+generous about.
+
+Three outcomes. A **confirmation** (≥0.97 similar, no new specifics, matched against a
+*durable* source) is not written to the daily log; it becomes a line in
+`.state/confirmations.jsonl`, and the dream folds the count into the claim's
+`(confirmed Nx)` marker. A **revision** (similar, or a strict superset carrying a new
+specific) is written exactly as before and tagged `revision`. Everything else is
+**new**. Two guards do the real work: a match found only in a chat transcript or in the
+generated `MEMORY.md` can never divert a write, because neither is a record the write
+path can defer to; and any new number, date, quote, path, or version in the restatement
+makes it a revision however similar the surrounding prose (`moved to Berlin in 2024` is
+not a repeat of `moved to Berlin`).
+
+The **revisit queue** is a deterministic frontmatter scan by the runner, handed to the
+dream alongside the confirmations: vault pages past their `stale_after`, soonest first,
+to be re-confirmed against the logs being ingested — never deleted. Both queues are
+runner-owned for the same reason the watermark is: index and lifecycle mutation stays
+out of the agent's hands. The confirmations sidecar is truncated only by the number of
+lines the agent was actually shown, since conversations keep appending to it while the
+dream runs.
 
 **9 — Retire the legacy rows.** 2,833 pre-June rows predate the current write path and
 carry no source file, so they cannot be reindexed, only deleted. Deleting them is now

--- a/docs/02-concepts/memory/architecture.md
+++ b/docs/02-concepts/memory/architecture.md
@@ -140,7 +140,7 @@ marker survive either of them.
 
 | commit | what it fixes |
 | --- | --- |
-| `70994416` | The dream barely ran. Retry counters were in-memory, so retry-then-skip never fired across restarts and the watermark sat at `2026-03-11` for five months. |
+| `70994416` | Retry counters were in-memory, so retry-then-skip never fired across restarts and a wedged batch stranded the watermark at `2026-02-22`. (The original "barely ran" reading was measured against the wrong vault — see the correction in `deduplication.md`.) |
 | `50621860` | Indexer state was keyed by absolute path in a synced directory — 436 entries from two machines, and only 18 of 129 logs actually indexed. Now `label:filename`, versioned, pre-v2 discarded. |
 | `ca421b74` | Extraction was context-free. The prompt now carries the nearest known facts, with an explicit rule permitting updates. |
 | `5fc97850` | The dream resolved duplicates by doing nothing. It now retires folded-in log lines through the tombstone hand-off. |

--- a/docs/02-concepts/memory/architecture.md
+++ b/docs/02-concepts/memory/architecture.md
@@ -173,6 +173,18 @@ is derived from its confirmation count (log-scaled, capped at +0.25), its `statu
 Daily-log facts keep the neutral 0.5 — raw capture has no lifecycle. A person's edit to the
 `facts` block is recorded as a `human:` verification in the manual zone of `MEMORY.md`.
 
+A person editing the `facts` block is the one claim in the system that did not come from
+extraction — it is the claim's subject stating it directly — so `write_memory_manual_zone`
+stamps the manual zone with a `human:` actor and retrieval now reads that stamp. It takes
+an importance *floor* (`HUMAN_VERIFIED_FLOOR`, 0.9) rather than a bonus, so a low base
+score cannot dilute it, and it skips the `stale_after` decay: an expiry means nobody has
+re-confirmed the claim lately, which is exactly the question a human verification answers.
+`deprecated` still wins — a person retiring a claim is also a person — and only a `human:`
+actor qualifies, or an agent stamping itself would launder its own output into the
+strongest evidence class there is. Because the floor applies per row, MEMORY.md is now
+chunked per zone instead of per file: paragraph merging otherwise produced a single row
+spanning the generated half and the human half, which is neither.
+
 **7 — The catch-up dream.** Done, and not by us. The backlog was 129 logs because the
 dream advanced the watermark by at most one day per run; the pacing fix in `70994416`
 removed that ceiling and the backlog drained itself in the field. Measured on the live

--- a/docs/02-concepts/memory/architecture.md
+++ b/docs/02-concepts/memory/architecture.md
@@ -115,6 +115,21 @@ those days on its own.
    disappears. Every tombstone write must be paired with an explicit reindex.
 5. **Recall enrichment must never block a write.** A search outage degrades extraction
    quality, never durability.
+6. **Only the generated zone of `MEMORY.md` is generated.** The file has two generators
+   and an agent editing it directly; everything after the `<!-- /memory:generated -->`
+   marker is copied through untouched, and a file with no marker that we cannot prove we
+   wrote is treated as entirely manual.
+
+### Who owns MEMORY.md
+
+Two writers regenerate the same file. `refresh_core_memory_facts` (per turn, from the top
+archival rows) is the legacy path; `promote_memory_md` (per productive dream, from
+consolidated `3_Personal/` pages plus recall signal) is its replacement. The hand-over
+needs no flag day: the legacy path stands down as soon as the vault has any personal page,
+so as the dream fills the vault it simply stops firing.
+
+Both write through the same marked zone, so an agent's or user's own notes below the
+marker survive either of them.
 
 ## What landed in PR #118
 
@@ -125,6 +140,9 @@ those days on its own.
 | `ca421b74` | Extraction was context-free. The prompt now carries the nearest known facts, with an explicit rule permitting updates. |
 | `5fc97850` | The dream resolved duplicates by doing nothing. It now retires folded-in log lines through the tombstone hand-off. |
 | `07f24c4b` | Repeats had nowhere to go but the bin. Personal claims now carry `(confirmed 12x, last YYYY-MM-DD)` and a category-derived `stale_after`. |
+| `fb47218d` | This document. |
+| `2af08c7b` | Every append to a daily log re-embedded the whole file — 28.5x amplification over the real corpus, quadratic in appends per day, and ~374k single-row inserts fragmenting the table. Archive reindex is now a diff, falling back to full replace if the diff query fails. |
+| _this_ | `MEMORY.md` was a blind overwrite with three writers, and the per-turn refresh filtered on an importance column the indexer stamps with a constant — so it rebuilt the file exclusively from pre-June legacy rows. |
 
 ## Next steps
 
@@ -160,4 +178,6 @@ new. The revisit queue selects vault claims past their `stale_after`. Neither sh
 before step 7 — a classifier is only as good as the claims it compares against.
 
 **9 — Retire the legacy rows.** 2,833 pre-June rows predate the current write path and
-carry no source file, so they cannot be reindexed, only deleted.
+carry no source file, so they cannot be reindexed, only deleted. Deleting them is now
+safe: `MEMORY.md` no longer depends on them being the only rows above the old importance
+gate.

--- a/docs/02-concepts/memory/architecture.md
+++ b/docs/02-concepts/memory/architecture.md
@@ -143,7 +143,8 @@ marker survive either of them.
 | `fb47218d` | This document. |
 | `2af08c7b` | Every append to a daily log re-embedded the whole file — 28.5x amplification over the real corpus, quadratic in appends per day, and ~374k single-row inserts fragmenting the table. Archive reindex is now a diff, falling back to full replace if the diff query fails. |
 | `7842c41d` | `MEMORY.md` was a blind overwrite with three writers, and the per-turn refresh filtered on an importance column the indexer stamps with a constant — so it rebuilt the file exclusively from pre-June legacy rows. |
-| _this_ | The confirmation counts, `status`, and `stale_after` the dream writes were read by nothing; retrieval scored every row identically. |
+| `d1067d4e` | The confirmation counts, `status`, and `stale_after` the dream writes were read by nothing; retrieval scored every row identically. |
+| _this_ | A dry-run harness for the dream, and a ranker that reads the status the live vault actually writes (`active`, not `stable`). |
 
 ## Next steps
 
@@ -155,7 +156,7 @@ flowchart LR
     D3 --> D4["✓ retire duplicates"]
     D4 --> D5["✓ claim lifecycle (writer)"]
     D5 --> N6["✓ rank on the new signals"]
-    N6 --> N7["7 · catch-up dream<br/>over 129 logs"]
+    N6 --> N7["✓ catch-up dream<br/>(completed itself)"]
     N7 --> N8["8 · write-path classifier<br/>+ revisit queue"]
     N7 --> N9["9 · retire 2,833 legacy rows"]
 ```
@@ -166,17 +167,31 @@ is derived from its confirmation count (log-scaled, capped at +0.25), its `statu
 Daily-log facts keep the neutral 0.5 — raw capture has no lifecycle. A person's edit to the
 `facts` block is recorded as a `human:` verification in the manual zone of `MEMORY.md`.
 
-**7 — The catch-up dream.** 129 logs sit above the watermark. This is the first step that
-*mutates live memory* — it rewrites vault pages and tombstones archival rows across five
-months of backlog, driven by an LLM, and it is where a bad `superseded.txt` line costs
-real facts. It should run against a copy of `~/.suzent` first, with the diff reviewed
-before anything touches the real vault.
+**7 — The catch-up dream.** Done, and not by us. The backlog was 129 logs because the
+dream advanced the watermark by at most one day per run; the pacing fix in `70994416`
+removed that ceiling and the backlog drained itself in the field. Measured on the live
+system: watermark `2026-08-22`, 47 advances recorded in `log.md`, 130 archive logs
+spanning `2026-02-09`–`2026-08-23`, and exactly one date pending — today's, which the
+dream never ingests while it is still being appended to.
+
+`scripts/dream_dry_run.py` remains, because the next mutating pass deserves the same
+caution this one would have: it clones `~/.suzent`, redirects the `/mnt/notebook` volume
+at a copy of the vault, and drives the real `DreamRunner` over the clone, leaving a
+unified diff to review. The redirect is the point — the vault is a host path mounted into
+the sandbox, *not* a directory inside the data dir, so cloning `~/.suzent` alone isolates
+everything except the one thing the dream rewrites.
+
+What the catch-up left behind is a gap, not a backlog. Those 309 pages were consolidated
+under the pre-`07f24c4b` prompts: of the 18 `3_Personal` pages, 8 carry frontmatter and
+**none carry a confirmation marker or a `stale_after`**. Step 6's ranking is live but has
+nothing to read on existing pages — the lint pass is the backfill, and it should be
+exercised against a clone before the real vault.
 
 **8 — Write-path classifier and revisit queue.** Classify each extracted fact against the
 recalled set: ≥0.97 with no new specifics is a confirmation (one line to a
 `confirmations.jsonl` sidecar, folded in by the dream), 0.90–0.97 a revision, below that
-new. The revisit queue selects vault claims past their `stale_after`. Neither should land
-before step 7 — a classifier is only as good as the claims it compares against.
+new. The revisit queue selects vault claims past their `stale_after`. Unblocked: step 7
+finished, so there is a populated claim set to compare against.
 
 **9 — Retire the legacy rows.** 2,833 pre-June rows predate the current write path and
 carry no source file, so they cannot be reindexed, only deleted. Deleting them is now

--- a/docs/02-concepts/memory/architecture.md
+++ b/docs/02-concepts/memory/architecture.md
@@ -142,7 +142,8 @@ marker survive either of them.
 | `07f24c4b` | Repeats had nowhere to go but the bin. Personal claims now carry `(confirmed 12x, last YYYY-MM-DD)` and a category-derived `stale_after`. |
 | `fb47218d` | This document. |
 | `2af08c7b` | Every append to a daily log re-embedded the whole file — 28.5x amplification over the real corpus, quadratic in appends per day, and ~374k single-row inserts fragmenting the table. Archive reindex is now a diff, falling back to full replace if the diff query fails. |
-| _this_ | `MEMORY.md` was a blind overwrite with three writers, and the per-turn refresh filtered on an importance column the indexer stamps with a constant — so it rebuilt the file exclusively from pre-June legacy rows. |
+| `7842c41d` | `MEMORY.md` was a blind overwrite with three writers, and the per-turn refresh filtered on an importance column the indexer stamps with a constant — so it rebuilt the file exclusively from pre-June legacy rows. |
+| _this_ | The confirmation counts, `status`, and `stale_after` the dream writes were read by nothing; retrieval scored every row identically. |
 
 ## Next steps
 
@@ -153,17 +154,17 @@ flowchart LR
     D2 --> D3["✓ context-aware extraction"]
     D3 --> D4["✓ retire duplicates"]
     D4 --> D5["✓ claim lifecycle (writer)"]
-    D5 --> N6["6 · rank on the new signals"]
+    D5 --> N6["✓ rank on the new signals"]
     N6 --> N7["7 · catch-up dream<br/>over 129 logs"]
     N7 --> N8["8 · write-path classifier<br/>+ revisit queue"]
     N7 --> N9["9 · retire 2,833 legacy rows"]
 ```
 
-**6 — Rank on the signals now being written.** Confirmation count, `stale_after`, and
-`status` are produced but nothing reads them. Retrieval still treats a claim confirmed
-twelve times exactly like a one-off. Also open here: recording a user's own edit to a core
-memory block as a `human:` `verified` actor, so a person's correction outranks anything the
-extractor produced.
+**6 — Rank on the signals now being written.** Done. A vault chunk's indexed `importance`
+is derived from its confirmation count (log-scaled, capped at +0.25), its `status`
+(`deprecated` drops it to 0.1, `draft` −0.05), and its `stale_after` (×0.6 once passed).
+Daily-log facts keep the neutral 0.5 — raw capture has no lifecycle. A person's edit to the
+`facts` block is recorded as a `human:` verification in the manual zone of `MEMORY.md`.
 
 **7 — The catch-up dream.** 129 logs sit above the watermark. This is the first step that
 *mutates live memory* — it rewrites vault pages and tombstones archival rows across five

--- a/docs/02-concepts/memory/architecture.md
+++ b/docs/02-concepts/memory/architecture.md
@@ -164,7 +164,7 @@ flowchart LR
     D5 --> N6["✓ rank on the new signals"]
     N6 --> N7["✓ catch-up dream<br/>(completed itself)"]
     N7 --> N8["✓ write-path classifier<br/>+ revisit queue"]
-    N7 --> N9["9 · retire 2,833 legacy rows"]
+    N7 --> N9["9 · export, then retire 2,833 legacy rows"]
 ```
 
 **6 — Rank on the signals now being written.** Done. A vault chunk's indexed `importance`
@@ -219,7 +219,21 @@ out of the agent's hands. The confirmations sidecar is truncated only by the num
 lines the agent was actually shown, since conversations keep appending to it while the
 dream runs.
 
-**9 — Retire the legacy rows.** 2,833 pre-June rows predate the current write path and
-carry no source file, so they cannot be reindexed, only deleted. Deleting them is now
-safe: `MEMORY.md` no longer depends on them being the only rows above the old importance
-gate.
+**9 — Retire the legacy rows: export first, then delete.** 2,833 pre-June rows predate
+the current write path and carry no source file, so no reindex can replace them and no
+tombstone can retire them. The plan said deleting them was safe once `MEMORY.md` stopped
+depending on them. Measuring rather than assuming overturned that: `scripts/retire_legacy_rows.py`
+checked every legacy row's first 90 characters against every daily log and every vault
+page, and **2,832 of 2,833 appear nowhere in markdown**. A separate 120-row random sample
+found zero matches — not reworded, not summarised, not at all. These rows predate the
+markdown tier, so the index is the only place that content exists; deleting them is data
+loss, not index cleanup.
+
+So the sequence is `--export` then `--apply`. The export appends each row to the daily
+log for its `created_at` date, which puts it in the append-only tier, gives it a
+`source_file` the indexer owns, and makes it something the dream can consolidate — only
+then is the delete removing a duplicate. `--apply` copies the table directory to a
+timestamped backup first, and refuses outright while any row is recorded nowhere else.
+Neither has been run against the live index: the delete is irreversible beyond that
+backup and the export writes 2,833 lines into the user's memory directory, so both are
+the user's call.

--- a/docs/02-concepts/memory/architecture.md
+++ b/docs/02-concepts/memory/architecture.md
@@ -1,0 +1,163 @@
+# Memory Architecture
+
+How memory is written, consolidated, indexed, and read — and what is still missing.
+Companions: [Consolidation](./consolidation.md) for the dream's design intent,
+[Deduplication](./deduplication.md) for the duplicate problem and its fixes.
+
+## Three tiers, one job each
+
+| tier | location | job | who writes it |
+| --- | --- | --- | --- |
+| Capture buffer | `sandbox/shared/memory/archive/YYYY-MM-DD.md` | Lossless and fast. Never reasoned over at write time. | write path, append only |
+| Knowledge base | `~/.suzent/notebook/**/*.md` | Consolidated claims with provenance and lifecycle | the dream, via file tools |
+| Search index | `~/.suzent/memory` (LanceDB) | Derived. Rebuilt per file, never authored. | the indexer, exclusively |
+
+The direction of travel is one-way: logs feed the vault, both feed the index, and the
+index feeds retrieval. Nothing reads back up the chain.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+flowchart LR
+    subgraph capture["Capture"]
+        LOG[("archive/<br/>YYYY-MM-DD.md")]
+    end
+    subgraph knowledge["Knowledge"]
+        VAULT[("notebook/<br/>vault pages")]
+        STATE[".state/<br/>tombstones · superseded<br/>dream_state"]
+    end
+    subgraph derived["Derived"]
+        DB[("LanceDB<br/>archival_memories<br/>memory_blocks")]
+    end
+
+    TURN["chat turn"] --> WRITE["write path"]
+    WRITE -->|append| LOG
+    LOG -->|read-only| DREAM["dream"]
+    DREAM -->|create / update| VAULT
+    DREAM -->|hand-off| STATE
+    LOG --> IDX["indexer"]
+    VAULT --> IDX
+    STATE -->|filter| IDX
+    IDX -->|delete-then-add| DB
+    DB --> RECALL["retrieval"]
+    RECALL --> TURN
+```
+
+## Write path, per conversation turn
+
+Runs after the assistant response completes, in
+`MemoryManager.process_conversation_turn_for_memories`.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+flowchart TD
+    A["turn text"] --> B["recall 10 nearest known facts<br/>(best-effort — failure means<br/>extraction runs as before)"]
+    B --> C["LLM extraction<br/>prompt carries 'already in memory'"]
+    C -->|nothing new| Z["stop"]
+    C --> D["append to today's log"]
+    D --> E["reindex_file_now(archive, today)"]
+    E --> F[("LanceDB")]
+    D --> G{"any fact important?"}
+    G -->|yes| H["refresh MEMORY.md"]
+```
+
+There is deliberately **no write-time deduplication**. A 0.85 cosine threshold used to
+sit here and silently dropped *updates* to facts (#34). Repetition is suppressed one step
+earlier instead — the extractor is shown what memory already holds and told that a fact
+which *changes* a known one must still be emitted.
+
+## The dream
+
+A background loop ticking every `memory_consolidation_interval_seconds`. It has one gate
+and two phases.
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+flowchart TD
+    T["tick"] --> P{"logs above<br/>the watermark?"}
+    P -->|no| L{"lint due?"}
+    L -->|yes| LINT["lint pass<br/>editorial audit of the vault"]
+    L -->|no| IDLE["idle"]
+    P -->|yes| B{"far behind?"}
+    B -->|yes| RUN["ingest batch"]
+    B -->|no| G{"enough new facts<br/>+ enough time passed?"}
+    G -->|no| IDLE
+    G -->|yes| RUN
+    RUN --> AGENT["forked agent:<br/>fold logs into vault pages"]
+    AGENT --> WM["advance watermark"]
+    WM --> REC["reconcile (runner-owned)"]
+    REC --> R1["retire superseded:<br/>tombstone + reindex those days"]
+    REC --> R2["check_and_update:<br/>mtime sweep of vault"]
+    REC --> R3["optimize: compact LanceDB"]
+```
+
+Ingest is always preferred over lint, so an editorial audit can never starve
+consolidation of new logs.
+
+### Why the reconcile belongs to the runner
+
+The agent's only declared capability is writing files. It hands the runner a list of log
+facts it has folded into pages, in `notebook/.state/superseded.txt`; the runner
+tombstones each line, reindexes each affected day, and truncates the file last so a crash
+replays rather than loses.
+
+The explicit reindex is not a belt-and-braces measure. **Appending a tombstone does not
+change the log's mtime**, so the watcher — which triggers on mtime — would never revisit
+those days on its own.
+
+## Invariants worth not breaking
+
+1. **Daily logs are append-only.** Never rewritten, so nothing races the live write path
+   appending to today's file.
+2. **The indexer is the only writer to LanceDB.** Every other component asks it.
+3. **The indexer is not append-only.** Only the markdown history is. `_reindex_file` is
+   delete-then-add per file, which is what makes reindexing idempotent and safe to repeat.
+4. **Tombstones are the only removal mechanism.** History stays intact; the derived row
+   disappears. Every tombstone write must be paired with an explicit reindex.
+5. **Recall enrichment must never block a write.** A search outage degrades extraction
+   quality, never durability.
+
+## What landed in PR #118
+
+| commit | what it fixes |
+| --- | --- |
+| `70994416` | The dream barely ran. Retry counters were in-memory, so retry-then-skip never fired across restarts and the watermark sat at `2026-03-11` for five months. |
+| `50621860` | Indexer state was keyed by absolute path in a synced directory — 436 entries from two machines, and only 18 of 129 logs actually indexed. Now `label:filename`, versioned, pre-v2 discarded. |
+| `ca421b74` | Extraction was context-free. The prompt now carries the nearest known facts, with an explicit rule permitting updates. |
+| `5fc97850` | The dream resolved duplicates by doing nothing. It now retires folded-in log lines through the tombstone hand-off. |
+| `07f24c4b` | Repeats had nowhere to go but the bin. Personal claims now carry `(confirmed 12x, last YYYY-MM-DD)` and a category-derived `stale_after`. |
+
+## Next steps
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+flowchart LR
+    D1["✓ dream runs"] --> D2["✓ index repaired"]
+    D2 --> D3["✓ context-aware extraction"]
+    D3 --> D4["✓ retire duplicates"]
+    D4 --> D5["✓ claim lifecycle (writer)"]
+    D5 --> N6["6 · rank on the new signals"]
+    N6 --> N7["7 · catch-up dream<br/>over 129 logs"]
+    N7 --> N8["8 · write-path classifier<br/>+ revisit queue"]
+    N7 --> N9["9 · retire 2,833 legacy rows"]
+```
+
+**6 — Rank on the signals now being written.** Confirmation count, `stale_after`, and
+`status` are produced but nothing reads them. Retrieval still treats a claim confirmed
+twelve times exactly like a one-off. Also open here: recording a user's own edit to a core
+memory block as a `human:` `verified` actor, so a person's correction outranks anything the
+extractor produced.
+
+**7 — The catch-up dream.** 129 logs sit above the watermark. This is the first step that
+*mutates live memory* — it rewrites vault pages and tombstones archival rows across five
+months of backlog, driven by an LLM, and it is where a bad `superseded.txt` line costs
+real facts. It should run against a copy of `~/.suzent` first, with the diff reviewed
+before anything touches the real vault.
+
+**8 — Write-path classifier and revisit queue.** Classify each extracted fact against the
+recalled set: ≥0.97 with no new specifics is a confirmation (one line to a
+`confirmations.jsonl` sidecar, folded in by the dream), 0.90–0.97 a revision, below that
+new. The revisit queue selects vault claims past their `stale_after`. Neither should land
+before step 7 — a classifier is only as good as the claims it compares against.
+
+**9 — Retire the legacy rows.** 2,833 pre-June rows predate the current write path and
+carry no source file, so they cannot be reindexed, only deleted.

--- a/docs/02-concepts/memory/deduplication.md
+++ b/docs/02-concepts/memory/deduplication.md
@@ -45,16 +45,34 @@ explicitly prefers — emitting a fact that *changes* one of them. Recall is bes
 a search failure returns nothing and extraction proceeds exactly as before, because
 enriching the prompt must never be able to block a memory write.
 
-### Nothing deduplicates the archival index
+### Nothing deduplicates the archival index (fixed)
 
 Write-time deduplication was removed in `98a39a3b` (fixes #34) because a 0.85 cosine
 threshold silently dropped *updates* to facts. The intended replacement was the dream
 consolidation pass — but the dream consolidates into the notebook vault, while
 `DREAM_SYSTEM_PROMPT` declares the daily logs read-only and `DREAM_INSTRUCTIONS` step 3b
-resolves a duplicate by doing nothing. The lint pass audits the vault only.
+resolved a duplicate by doing nothing. The lint pass audits the vault only.
 
-The archival index is derived from the logs. A duplicate written today is therefore
-permanent.
+The archival index is derived from the logs, so a duplicate written today was permanent.
+
+Step 3b now ends in a retirement: after folding a log line into a page, the dream appends
+the fact text to `notebook/.state/superseded.txt`. That file is the hand-off. The runner —
+not the agent — reads it in `_retire_superseded`, tombstones each line, reindexes every
+day whose log contains it, and only then truncates it. Ordering is deliberate: a crash
+before the truncate replays the same lines, which is idempotent, while clearing first
+would lose them.
+
+The split keeps each side to what it is good at. The agent writes files, which is its only
+declared capability; index mutation stays with the runner. And the logs are still never
+rewritten, so the race with the live write path appending to today's log cannot happen.
+
+Two guards worth knowing about:
+
+- Lines shorter than `MIN_SUPERSEDED_CHARS` (24) are refused. Date lookup is a normalized
+  substring match, so a fragment like "dark mode" would match logs it never came from.
+- The match is deliberately loose in the other direction. A false positive costs one
+  redundant reindex, which is delete-then-add and therefore harmless; a *missed* date
+  would strand the row in the index with no mtime change to ever bring the watcher back.
 
 ### The dream barely runs (fixed)
 
@@ -140,12 +158,12 @@ The dream gains two queues beyond its current one:
 - **Confirm** — fold `confirmations.jsonl` into claim counters, then truncate it.
 - **Revisit** — vault claims past their `stale_after`.
 
-The duplicate rule in ingest changes from "do nothing" to four outcomes: increment the
-claim's confirmation count, supersede it, sharpen it (replace the body with the more
-specific wording, keep the accumulated counters), or add it as novel.
+The duplicate rule in ingest is no longer "do nothing": keep the richest wording on the
+page and retire the weaker log lines. Incrementing a confirmation count and sharpening in
+place both need the claim frontmatter from step 4; the retire half is live now.
 
-A reconcile phase then runs **in the runner, not the agent**: collect every date and
-page the run touched and call `reindex_file_now` for each.
+The reconcile phase runs **in the runner, not the agent** — `_retire_superseded` reads the
+hand-off file, tombstones, and calls `reindex_file_now` per affected date.
 
 ### Borrowed from the Open Knowledge Format
 
@@ -183,10 +201,13 @@ formal `okf_version` conformance.
    state costs one full reindex, which doubles as the backfill for the window above the
    watermark), and retire the legacy pre-June rows.
 3. ~~Add the already-known context to extraction.~~ Done.
-4. Add OKF frontmatter to vault pages: writer first, then ranking.
-5. Run a catch-up dream over the backlog with ingest and confirm enabled.
-6. Add the write-path classifier and the revisit queue, once there is a populated claim
+4. ~~Stop the dream from resolving duplicates by doing nothing — retire folded-in log
+   lines via the tombstone hand-off.~~ Done.
+5. Add OKF frontmatter to vault pages: writer first, then ranking. This is what unlocks
+   the remaining two duplicate outcomes (confirm, sharpen in place).
+6. Run a catch-up dream over the backlog with ingest and confirm enabled.
+7. Add the write-path classifier and the revisit queue, once there is a populated claim
    set for them to work against.
 
-Steps 3 and 4 are independent. Step 6 should not land before step 5 — the classifier is
+Steps 3 and 5 are independent. Step 7 should not land before step 6 — the classifier is
 only as good as the claims it compares against.

--- a/docs/02-concepts/memory/deduplication.md
+++ b/docs/02-concepts/memory/deduplication.md
@@ -158,9 +158,30 @@ The dream gains two queues beyond its current one:
 - **Confirm** — fold `confirmations.jsonl` into claim counters, then truncate it.
 - **Revisit** — vault claims past their `stale_after`.
 
-The duplicate rule in ingest is no longer "do nothing": keep the richest wording on the
-page and retire the weaker log lines. Incrementing a confirmation count and sharpening in
-place both need the claim frontmatter from step 4; the retire half is live now.
+The duplicate rule in ingest is no longer "do nothing". All four outcomes are live:
+confirm (bump the count), sharpen in place (replace the wording, keep the count), supersede,
+or add as novel.
+
+Confirmation is recorded on the bullet, not in frontmatter:
+
+```markdown
+- Wants to be reminded to drink water hourly from 9 AM to 9 PM. (confirmed 12x, last 2026-08-20)
+```
+
+This is OKF's `sources[].usage_count` in the only place it can go: OKF frontmatter is
+per-document, and these claims are bullets sharing a page rather than a document each. The
+marker's absence means confirmed once, so no page needs migrating. A repeat that
+*contradicts* the bullet is explicitly not a confirmation — it resets the count and takes
+the correction path, or a reversal would count as evidence for the thing it reverses.
+
+`stale_after` on `3_Personal/` pages is derived from the fact category rather than guessed:
+identity never, `preference` a year, `technical` six months, `goal` three months, `context`
+three weeks. Lint honours it by re-confirming or deprecating, never deleting.
+
+These rules are stated in `DREAM_INSTRUCTIONS` as well as in `schema_example.md`, because
+`schema.md` is copied into a vault once at bootstrap and is user-editable afterwards — every
+existing vault predates them. `verified:` is defined in the profile but nothing writes it
+yet; wiring a user's core-memory edit to a `human:` actor is still open.
 
 The reconcile phase runs **in the runner, not the agent** — `_retire_superseded` reads the
 hand-off file, tombstones, and calls `reindex_file_now` per affected date.
@@ -203,8 +224,9 @@ formal `okf_version` conformance.
 3. ~~Add the already-known context to extraction.~~ Done.
 4. ~~Stop the dream from resolving duplicates by doing nothing — retire folded-in log
    lines via the tombstone hand-off.~~ Done.
-5. Add OKF frontmatter to vault pages: writer first, then ranking. This is what unlocks
-   the remaining two duplicate outcomes (confirm, sharpen in place).
+5. ~~Add OKF frontmatter to vault pages (writer side): the personal-page contract, the
+   confirmation marker, and category-derived `stale_after`.~~ Done. Ranking on those
+   signals is not wired yet.
 6. Run a catch-up dream over the backlog with ingest and confirm enabled.
 7. Add the write-path classifier and the revisit queue, once there is a populated claim
    set for them to work against.

--- a/docs/02-concepts/memory/deduplication.md
+++ b/docs/02-concepts/memory/deduplication.md
@@ -239,9 +239,18 @@ formal `okf_version` conformance.
 5b. ~~Read those signals back: derive a vault chunk's indexed importance from its
    confirmation count, `status`, and `stale_after`, and record a human's core-memory edit
    as a `human:` verification.~~ Done.
-6. Run a catch-up dream over the backlog with ingest and confirm enabled.
-7. Add the write-path classifier and the revisit queue, once there is a populated claim
-   set for them to work against.
+6. ~~Run a catch-up dream over the backlog with ingest and confirm enabled.~~ Done, in
+   the field: once step 1 lifted the one-day-per-run ceiling the backlog drained itself
+   (watermark `2026-08-22`, 47 advances). What it left behind is a *backfill* gap, not a
+   backlog — the resulting pages were consolidated under the pre-step-5 prompts, so of
+   the 18 `3_Personal` pages none carries a confirmation marker or a `stale_after` yet.
+   The lint pass is the mechanism; `scripts/dream_dry_run.py` runs it against a clone
+   first.
+7. ~~Add the write-path classifier and the revisit queue.~~ Done. A restatement of a
+   durably recorded claim now goes to `.state/confirmations.jsonl` instead of becoming
+   another row; anything carrying a new specific, or matched only in a transcript, is
+   written exactly as before. See `memory/classifier.py` and the architecture doc.
+8. Retire the 2,833 legacy pre-June rows (the top row of the table above).
 
-Steps 3 and 5 are independent. Step 7 should not land before step 6 — the classifier is
+Steps 3 and 5 are independent. Step 7 did not land before step 6, because a classifier is
 only as good as the claims it compares against.

--- a/docs/02-concepts/memory/deduplication.md
+++ b/docs/02-concepts/memory/deduplication.md
@@ -174,14 +174,24 @@ marker's absence means confirmed once, so no page needs migrating. A repeat that
 *contradicts* the bullet is explicitly not a confirmation — it resets the count and takes
 the correction path, or a reversal would count as evidence for the thing it reverses.
 
+Retrieval reads all three. A vault chunk's indexed `importance` — already a term in
+hybrid search — is now derived from its confirmation count (log-scaled, capped), its
+`status` (`deprecated` demotes hard, `draft` slightly), and whether its `stale_after` has
+passed (a discount, not a veto). Daily-log facts stay at the neutral default: they are raw
+capture and carry no lifecycle. Nothing here can remove a claim from retrieval; deletion
+stays with tombstones, where it is reversible and auditable.
+
+A person editing the `facts` block is `human:` evidence and outranks anything the
+extractor produced, so it is written to the manual zone of `MEMORY.md` with a
+`<!-- verified: human:<id> at <ts> -->` stamp, where no generator can overwrite it.
+
 `stale_after` on `3_Personal/` pages is derived from the fact category rather than guessed:
 identity never, `preference` a year, `technical` six months, `goal` three months, `context`
 three weeks. Lint honours it by re-confirming or deprecating, never deleting.
 
 These rules are stated in `DREAM_INSTRUCTIONS` as well as in `schema_example.md`, because
 `schema.md` is copied into a vault once at bootstrap and is user-editable afterwards — every
-existing vault predates them. `verified:` is defined in the profile but nothing writes it
-yet; wiring a user's core-memory edit to a `human:` actor is still open.
+existing vault predates them.
 
 The reconcile phase runs **in the runner, not the agent** — `_retire_superseded` reads the
 hand-off file, tombstones, and calls `reindex_file_now` per affected date.
@@ -225,8 +235,10 @@ formal `okf_version` conformance.
 4. ~~Stop the dream from resolving duplicates by doing nothing — retire folded-in log
    lines via the tombstone hand-off.~~ Done.
 5. ~~Add OKF frontmatter to vault pages (writer side): the personal-page contract, the
-   confirmation marker, and category-derived `stale_after`.~~ Done. Ranking on those
-   signals is not wired yet.
+   confirmation marker, and category-derived `stale_after`.~~ Done.
+5b. ~~Read those signals back: derive a vault chunk's indexed importance from its
+   confirmation count, `status`, and `stale_after`, and record a human's core-memory edit
+   as a `human:` verification.~~ Done.
 6. Run a catch-up dream over the backlog with ingest and confirm enabled.
 7. Add the write-path classifier and the revisit queue, once there is a populated claim
    set for them to work against.

--- a/docs/02-concepts/memory/deduplication.md
+++ b/docs/02-concepts/memory/deduplication.md
@@ -250,7 +250,8 @@ formal `okf_version` conformance.
    durably recorded claim now goes to `.state/confirmations.jsonl` instead of becoming
    another row; anything carrying a new specific, or matched only in a transcript, is
    written exactly as before. See `memory/classifier.py` and the architecture doc.
-8. Retire the 2,833 legacy pre-June rows (the top row of the table above).
+8. Export the 2,833 legacy pre-June rows (the top row of the table above) into daily
+   logs, then delete them. Not the other way round: they are recorded nowhere else.
 
 Steps 3 and 5 are independent. Step 7 did not land before step 6, because a classifier is
 only as good as the claims it compares against.

--- a/docs/02-concepts/memory/deduplication.md
+++ b/docs/02-concepts/memory/deduplication.md
@@ -1,0 +1,182 @@
+# Memory Deduplication
+
+Companion to [Memory Consolidation](./consolidation.md). That page describes how the
+append-only write path and the dream runner are *meant* to work. This page records
+what the live data actually looks like, why duplicates accumulate, and the plan for
+fixing it.
+
+## The measurement
+
+Near-duplicate rate in the archival index, cosine over the stored embeddings. A row
+counts as redundant when an earlier row exceeds the threshold.
+
+| write path | rows | ≥0.995 | ≥0.95 | ≥0.92 |
+| --- | ---: | ---: | ---: | ---: |
+| `legacy_direct` (pre-June, had write-time dedup) | 2833 | 0.0% | 0.0% | 0.0% |
+| `archive_log` (current path) | 615 | 0.3% | 10.1% | 25.4% |
+| `notebook` (dream output) | 1342 | 14.7% | 15.6% | 17.6% |
+
+On disk the backlog is larger than the index suggests: 13,102 fact lines across 129
+daily logs, 340 exact repeats, and 581 token-set near-duplicates in 279 clusters. The
+largest cluster is a single identity fact written 64 times across 26 distinct days.
+
+Most duplication is a paraphrase where one side is strictly less informative:
+
+```text
+0.982  A: [preference] The user wants to be reminded to drink water hourly from 9 AM to 9 PM daily.
+       B: [preference] User wants to be reminded to drink water daily.
+```
+
+Exact-match deduplication keeps both. Similarity deduplication alone would keep the
+wrong one half the time.
+
+## Why duplicates accumulate
+
+### Extraction is context-free
+
+`FACT_EXTRACTION_SYSTEM_PROMPT` and `format_fact_extraction_user_prompt` pass only the
+current conversation turn. The extraction model never sees existing memory and is never
+told to skip what is already known, so stable identity and preference facts are
+re-extracted every time they are mentioned.
+
+### Nothing deduplicates the archival index
+
+Write-time deduplication was removed in `98a39a3b` (fixes #34) because a 0.85 cosine
+threshold silently dropped *updates* to facts. The intended replacement was the dream
+consolidation pass — but the dream consolidates into the notebook vault, while
+`DREAM_SYSTEM_PROMPT` declares the daily logs read-only and `DREAM_INSTRUCTIONS` step 3b
+resolves a duplicate by doing nothing. The lint pass audits the vault only.
+
+The archival index is derived from the logs. A duplicate written today is therefore
+permanent.
+
+### The dream barely runs
+
+`DreamRunner._failures` is documented as ephemeral pacing state and lives only in
+memory. It is the counter behind retry-then-skip, which exists so that a batch which
+keeps producing nothing cannot wedge the backlog.
+
+Because the counter resets on every process start, retry-then-skip only fires if the
+app stays up long enough for `memory_consolidation_max_retries` consecutive attempts on
+the same batch. On a desktop app that restarts regularly, a batch that fails once keeps
+failing from a fresh counter forever, and the watermark never advances.
+
+## The indexer is not append-only
+
+Worth stating explicitly, because it is easy to assume otherwise: only the markdown
+history is append-only.
+
+`MarkdownIndexer._reindex_file` is delete-then-add, per file — `delete_memories_by_source_date`
+for archive logs, `delete_memories_by_source_file` for notebook and core files — and its
+trigger is mtime. Rewriting a daily log would converge the index with no new machinery.
+
+Log rewriting is still the wrong tool, for three reasons:
+
+1. Duplication is cross-day, so a useful pass must edit many files, not one.
+2. Today's log is appended to by the live write path; read-modify-write races with it.
+3. Logs at or below the watermark are dropped from the index anyway.
+
+### Tombstones are the right tool
+
+`read_tombstones()` filters by normalized content at index time for archive facts and
+notebook chunks alike, and the delete route already implements the full flow:
+
+```text
+append_tombstone(content) → reindex_file_now(that day's log) → row is gone
+```
+
+History stays intact; the derived row disappears. The trap — and the reason that route
+calls reindex explicitly — is that appending a tombstone does not change the log's
+mtime, so the watcher never notices on its own. **Every tombstone write must be paired
+with an explicit reindex of the affected dates.**
+
+## Target workflow
+
+### Tiers get one job each
+
+Today the log and the vault compete: both are indexed at equal weight, so repeated raw
+extractions drown out consolidated pages.
+
+| tier | file | job | writer |
+| --- | --- | --- | --- |
+| Capture buffer | `archive/YYYY-MM-DD.md` | Lossless, fast, never reasoned over at write time | write path (append only) |
+| Knowledge base | `notebook/**/*.md` | Deduplicated claims with provenance and lifecycle | dream only |
+| Index | LanceDB | Derived; rebuilt per file | indexer only |
+
+### Write path
+
+Two new steps around the existing extraction call:
+
+1. Retrieve roughly ten nearest known claims and inject them into the extraction prompt
+   under an "already known — emit a fact only if it is new, or changes one of these"
+   heading. This removes the repetition at its source without reintroducing #34: the
+   model can still emit a revision, it just has to know it is writing one.
+2. Classify each extracted fact against that retrieved set:
+
+   | similarity | outcome | written |
+   | --- | --- | --- |
+   | ≥ 0.97, no new specifics | confirmation | one line to `confirmations.jsonl` |
+   | 0.90 – 0.97 | revision | new fact line, tagged as revising |
+   | < 0.90 | new | new fact line |
+
+   The confirmation sidecar exists for the same reason tombstones do: the write path
+   must never edit the vault, and appending to JSONL is race-free.
+
+### Dream
+
+The dream gains two queues beyond its current one:
+
+- **Ingest** — logs in `(watermark, yesterday]`. Never today's log.
+- **Confirm** — fold `confirmations.jsonl` into claim counters, then truncate it.
+- **Revisit** — vault claims past their `stale_after`.
+
+The duplicate rule in ingest changes from "do nothing" to four outcomes: increment the
+claim's confirmation count, supersede it, sharpen it (replace the body with the more
+specific wording, keep the accumulated counters), or add it as novel.
+
+A reconcile phase then runs **in the runner, not the agent**: collect every date and
+page the run touched and call `reindex_file_now` for each.
+
+### Borrowed from the Open Knowledge Format
+
+[OKF v0.2](https://github.com/GoogleCloudPlatform/open-knowledge-format/blob/main/SPEC.md)
+frontmatter is per-document, so it maps onto notebook vault pages — which today carry no
+frontmatter at all — and not onto individual log fact lines. Daily logs stay dumb.
+
+Adopted field names, used as the spec defines them (producer-defined keys are explicitly
+permitted, so partial adoption is within its rules):
+
+- `status: draft | stable | deprecated` — `deprecated` is a softer tombstone: the claim
+  stays readable and linkable but leaves retrieval ranking, and it is reversible.
+- `stale_after` — an absolute instant that gives the dream a revisit queue. Defaults are
+  derived from the existing fact `category` rather than guessed per fact by the
+  extractor: identity effectively never, `preference` a year, `technical` six months,
+  `goal` three months, `context` three weeks.
+- `verified: [{by, at}]` — with OKF's actor convention, so a user editing a core memory
+  block is a `human:` verification that outranks anything the extractor produced. This
+  also supplies the contradiction-resolution rule the system currently lacks.
+- `generated: {by, at}` — uniform provenance across logs, vault, and core files.
+- `sources[].usage_count` — the most useful borrowing for this problem. A fact extracted
+  64 times is not 64 facts; it is one claim confirmed 64 times. Collapsing repeats into
+  a counter turns the worst noise source into a ranking signal.
+
+Not adopted: the Attested Computation family (`runtime`, `parameters`, `computation`,
+`executor`, `attester`), `resource` URIs (the vault already uses `[[wikilinks]]`), and
+formal `okf_version` conformance.
+
+## Sequence
+
+1. Make the dream actually run — persist the retry counter so retry-then-skip survives
+   restarts. Everything below assumes consolidation happens.
+2. Repair the index: backfill the window above the watermark, retire the legacy
+   pre-June rows, and key the indexer state on paths relative to the memory base dir so
+   it stops leaking between machines.
+3. Add the already-known context to extraction. No schema change, independently
+   valuable.
+4. Add OKF frontmatter to vault pages: writer first, then ranking.
+5. Run a catch-up dream over the backlog with ingest and confirm enabled.
+6. Add the write-path classifier and the revisit queue, once there is a populated claim
+   set for them to work against.
+
+Steps 3 and 4 are independent. Step 6 should not land before step 5 — the classifier is
+only as good as the claims it compares against.

--- a/docs/02-concepts/memory/deduplication.md
+++ b/docs/02-concepts/memory/deduplication.md
@@ -168,9 +168,10 @@ formal `okf_version` conformance.
 
 1. Make the dream actually run — persist the retry counter so retry-then-skip survives
    restarts. Everything below assumes consolidation happens.
-2. Repair the index: backfill the window above the watermark, retire the legacy
-   pre-June rows, and key the indexer state on paths relative to the memory base dir so
-   it stops leaking between machines.
+2. Repair the index: key the indexer state on `label:filename` rather than absolute
+   paths so it stops leaking between machines, and retire the legacy pre-June rows.
+   Discarding the old path-keyed state costs one full reindex, which doubles as the
+   backfill for the window above the watermark.
 3. Add the already-known context to extraction. No schema change, independently
    valuable.
 4. Add OKF frontmatter to vault pages: writer first, then ranking.

--- a/docs/02-concepts/memory/deduplication.md
+++ b/docs/02-concepts/memory/deduplication.md
@@ -32,12 +32,18 @@ wrong one half the time.
 
 ## Why duplicates accumulate
 
-### Extraction is context-free
+### Extraction is context-free (fixed)
 
-`FACT_EXTRACTION_SYSTEM_PROMPT` and `format_fact_extraction_user_prompt` pass only the
-current conversation turn. The extraction model never sees existing memory and is never
-told to skip what is already known, so stable identity and preference facts are
-re-extracted every time they are mentioned.
+`FACT_EXTRACTION_SYSTEM_PROMPT` and `format_fact_extraction_user_prompt` passed only the
+current conversation turn. The extraction model never saw existing memory and was never
+told to skip what is already known, so stable identity and preference facts were
+re-extracted every time they were mentioned.
+
+The write path now retrieves the nearest `KNOWN_FACTS_LIMIT` facts and renders them into
+the prompt under an "already in memory" heading, with a rule that permits — and
+explicitly prefers — emitting a fact that *changes* one of them. Recall is best-effort:
+a search failure returns nothing and extraction proceeds exactly as before, because
+enriching the prompt must never be able to block a memory write.
 
 ### Nothing deduplicates the archival index
 
@@ -50,23 +56,27 @@ resolves a duplicate by doing nothing. The lint pass audits the vault only.
 The archival index is derived from the logs. A duplicate written today is therefore
 permanent.
 
-### The dream barely runs
+### The dream barely runs (fixed)
 
-`DreamRunner._failures` is documented as ephemeral pacing state and lives only in
-memory. It is the counter behind retry-then-skip, which exists so that a batch which
-keeps producing nothing cannot wedge the backlog.
+`DreamRunner._failures` was ephemeral pacing state, held only in memory. It is the
+counter behind retry-then-skip, which exists so that a batch which keeps producing
+nothing cannot wedge the backlog.
 
-Because the counter resets on every process start, retry-then-skip only fires if the
-app stays up long enough for `memory_consolidation_max_retries` consecutive attempts on
-the same batch. On a desktop app that restarts regularly, a batch that fails once keeps
-failing from a fresh counter forever, and the watermark never advances.
+Because the counter reset on every process start, retry-then-skip only fired if the app
+stayed up long enough for `memory_consolidation_max_retries` consecutive attempts on the
+same batch. On a desktop app that restarts regularly, a batch that failed once kept
+failing from a fresh counter forever, and the watermark never advanced — locally it sat
+at `2026-03-11` for five months.
+
+The counters now live in the vault's `.state/dream_state.json`, hydrated once per
+process and written back on every mutation.
 
 ## The indexer is not append-only
 
 Worth stating explicitly, because it is easy to assume otherwise: only the markdown
 history is append-only.
 
-`MarkdownIndexer._reindex_file` is delete-then-add, per file — `delete_memories_by_source_date`
+`CoreMemoryFileIndexer._reindex_file` is delete-then-add, per file — `delete_memories_by_source_date`
 for archive logs, `delete_memories_by_source_file` for notebook and core files — and its
 trigger is mtime. Rewriting a daily log would converge the index with no new machinery.
 
@@ -166,14 +176,13 @@ formal `okf_version` conformance.
 
 ## Sequence
 
-1. Make the dream actually run — persist the retry counter so retry-then-skip survives
-   restarts. Everything below assumes consolidation happens.
-2. Repair the index: key the indexer state on `label:filename` rather than absolute
-   paths so it stops leaking between machines, and retire the legacy pre-June rows.
-   Discarding the old path-keyed state costs one full reindex, which doubles as the
-   backfill for the window above the watermark.
-3. Add the already-known context to extraction. No schema change, independently
-   valuable.
+1. ~~Make the dream actually run — persist the retry counter so retry-then-skip
+   survives restarts.~~ Done. Everything below assumes consolidation happens.
+2. Repair the index: ~~key the indexer state on `label:filename` rather than absolute
+   paths so it stops leaking between machines~~ (done — discarding the old path-keyed
+   state costs one full reindex, which doubles as the backfill for the window above the
+   watermark), and retire the legacy pre-June rows.
+3. ~~Add the already-known context to extraction.~~ Done.
 4. Add OKF frontmatter to vault pages: writer first, then ranking.
 5. Run a catch-up dream over the backlog with ingest and confirm enabled.
 6. Add the write-path classifier and the revisit queue, once there is a populated claim

--- a/docs/02-concepts/memory/deduplication.md
+++ b/docs/02-concepts/memory/deduplication.md
@@ -83,8 +83,21 @@ nothing cannot wedge the backlog.
 Because the counter reset on every process start, retry-then-skip only fired if the app
 stayed up long enough for `memory_consolidation_max_retries` consecutive attempts on the
 same batch. On a desktop app that restarts regularly, a batch that failed once kept
-failing from a fresh counter forever, and the watermark never advanced — locally it sat
-at `2026-03-11` for five months.
+failing from a fresh counter forever.
+
+**Correction to the original diagnosis.** That first read said the watermark had sat at
+`2026-03-11` for five months and the dream "barely ran". It was measured against
+`CONFIG.notebook_dir`, which on this machine is a stale bootstrap skeleton — the real
+vault is mounted at `/mnt/notebook` and holds 91 consolidation entries, not 2. Read
+correctly, the live history is: daily ingest through April, **no ingest at all between
+2026-05-01 and 2026-06-11** (lint kept running on its own pacing), then a catch-up burst
+on 06-12/13 that walked the watermark from `2026-02-22` up to `2026-05-26`, and daily
+ingest since. So the wedge was real and did strand the watermark from February — but it
+cleared itself in June, before any of this work, and the current healthy cadence is not
+evidence that this fix works. The fix is verified by
+`tests/memory/test_dream_failures_persist.py`, not by production behaviour.
+
+`resolve_notebook_dir()` now exists so nothing else repeats that measurement mistake.
 
 The counters now live in the vault's `.state/dream_state.json`, hydrated once per
 process and written back on every mutation.

--- a/docs/02-concepts/memory/upgrade-notes.md
+++ b/docs/02-concepts/memory/upgrade-notes.md
@@ -1,0 +1,108 @@
+# Memory dedup: what changes for an existing install
+
+Notes for anyone upgrading a running install across the memory-deduplication work.
+Nothing here needs action on a fresh install — every item is about state that already
+exists on disk before the upgrade.
+
+Ordered by how likely it is to surprise you.
+
+## 1. The first run re-embeds everything, once
+
+`.index_state.json` is now versioned and keyed on `label:filename` instead of the
+absolute path. Pre-v2 state is **discarded rather than migrated**, so the first pass
+after the upgrade treats every daily log and vault page as new and re-embeds it.
+
+That is deliberate — the old absolute-path keys were why files got skipped forever, so
+the discard doubles as the backfill — but it is not free. Budget one embedding call per
+chunk across your whole corpus, and expect the first pass to take noticeably longer than
+a steady-state one. If you pay per embedding call, this is the line item to expect.
+
+## 2. Check `CONFIG.notebook_dir` before you assume it's empty
+
+If you mount your own vault at `/mnt/notebook` (an Obsidian folder, say), the *default*
+vault path under the data dir still gets created, and any run where the mount failed to
+resolve will have consolidated into it. That directory can therefore hold real pages
+that exist nowhere else — orphaned output from a misrouted run, not a skeleton.
+
+On the machine this work was done on, the default path held 14 consolidated pages —
+including a personal profile and a contacts page — written during a single misrouted run
+months after the vault had moved. None of them exist in the live vault. They read like a
+leftover bootstrap skeleton, and deleting them on that assumption would have been the
+only irreversible mistake in this whole body of work.
+
+`resolve_notebook_dir()` stops code from reading the wrong vault from now on. It does not
+retroactively rescue anything already stranded there. **Before deleting that directory,
+diff it against your real vault.** It will look like a leftover. It may not be one.
+
+## 3. Legacy rows are not redundant copies — export before deleting
+
+If your install predates the markdown tier, your archival index holds rows with no
+`source_file`. Nothing can reindex them, no tombstone can retire them, and no
+consolidation will fold them in; they sit in retrieval permanently.
+
+The obvious move is to delete them. Measure first. On this install, **2,831 of 2,833 such
+rows appear nowhere in any daily log or vault page** — they predate the markdown tier, so
+the index is the only copy of that content, and deleting them is data loss.
+
+```bash
+python scripts/retire_legacy_rows.py            # report only
+python scripts/retire_legacy_rows.py --export   # append them to daily logs
+python scripts/retire_legacy_rows.py --apply    # delete, after a backup
+```
+
+`--apply` refuses while any row is recorded nowhere else. Re-indexing the exported logs
+costs one embedding call per chunk, and the dream will not consolidate dates below its
+watermark without a rewind.
+
+## 4. An existing `MEMORY.md` will not be regenerated until it has markers
+
+`MEMORY.md` is now split into a generated zone and a manual zone by HTML comment
+markers. A file with no markers cannot be proven to be generator output, so it is treated
+as **entirely manual and never overwritten** — the safe default, since the alternative is
+destroying notes someone typed.
+
+The practical consequence: if you have an existing `MEMORY.md`, automatic refresh stays
+off for it until markers appear. Let a consolidation write the file, or add the markers by
+hand, if you want the generated half back.
+
+## 5. Restated facts stop appearing in the daily logs
+
+A fact that restates something already durably recorded, word for word and with no new
+specifics, is no longer written to the daily log. It goes to
+`notebook/.state/confirmations.jsonl` and reaches the next dream as a confirmation count.
+
+If you audit what memory captured by grepping daily logs, that file is now part of the
+picture. A *revision* — anything adding a new number, date, path, quote, or version — is
+still written to the log as before, tagged `revision`.
+
+## 6. Expect vault churn on the first few dreams
+
+Two changes rewrite frontmatter on pages that predate them:
+
+- `3_Personal/` pages with no `stale_after` are queued for revisit and given one from the
+  fact-category table.
+- Claims that recur pick up `(confirmed Nx, last YYYY-MM-DD)` markers.
+
+If your vault is in git or a sync folder, the first few dreams after upgrading will look
+like a large diff touching many personal pages. That is the backfill, not a bug.
+
+## 7. Retrieval order will change
+
+Indexed `importance` used to be a constant `0.5` for every row. It now varies: repeated
+confirmations lift a claim, an expiry in the past damps it, `deprecated` sinks it to a
+floor, and a claim you verified yourself in `MEMORY.md` takes a floor of `0.9`.
+
+Since `importance` is already a term in hybrid search, results will re-order after the
+first reindex. Nothing is removed from retrieval — `deprecated` demotes, it does not
+delete, and deletion stays with tombstones so it remains reversible and auditable.
+
+## 8. Stop the app before running the scripts
+
+`scripts/retire_legacy_rows.py` and `scripts/dream_dry_run.py` both assume nothing else
+is writing. A concurrent reindex can race a delete. Stop the app, or accept the race.
+
+## 9. Tombstones do not change a file's mtime
+
+Worth knowing if you write tooling against this: the indexer is delete-then-add keyed on
+mtime, so appending a tombstone will not cause the affected file to be reindexed. Every
+tombstone write must be paired with an explicit reindex of the dates it touches.

--- a/docs/02-concepts/memory/upgrade-notes.md
+++ b/docs/02-concepts/memory/upgrade-notes.md
@@ -75,6 +75,10 @@ If you audit what memory captured by grepping daily logs, that file is now part 
 picture. A *revision* — anything adding a new number, date, path, quote, or version — is
 still written to the log as before, tagged `revision`.
 
+The dreaming panel gained a **pending confirmations** tile for the same reason, and a
+dream can now run on that queue alone. So an install that is caught up on logs may still
+start a consolidation, and it will not move the watermark when it does.
+
 ## 6. Expect vault churn on the first few dreams
 
 Two changes rewrite frontmatter on pages that predate them:

--- a/frontend/src/components/memory/DreamingPanel.tsx
+++ b/frontend/src/components/memory/DreamingPanel.tsx
@@ -232,10 +232,11 @@ export function DreamingPanel(): React.ReactElement {
                     disabled={!canRunDream}
                     busy={runningIngest || (dreamStatus?.phase === 'running_agent')}
                 >
-                    <div className="grid grid-cols-3 gap-2">
+                    <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
                         <StatCard label={t('settings.memoryConfig.consolidatedThrough')} value={dreamStatus?.watermark || '—'} accent="green" />
                         <StatCard label={t('settings.memoryConfig.pendingLogs')} value={String(pendingCount)} accent={pendingCount > 0 ? 'amber' : 'neutral'} />
                         <StatCard label={t('settings.memoryConfig.pendingFacts')} value={String(dreamStatus?.pending_facts ?? 0)} accent={(dreamStatus?.pending_facts ?? 0) > 0 ? 'amber' : 'neutral'} />
+                        <StatCard label={t('settings.memoryConfig.pendingConfirmations')} value={String(dreamStatus?.pending_confirmations ?? 0)} accent={(dreamStatus?.pending_confirmations ?? 0) > 0 ? 'amber' : 'neutral'} />
                     </div>
                 </LastResultBox>
                 <LastResultBox

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -222,6 +222,7 @@ export const en = {
       consolidatedThrough: 'Consolidated through',
       pendingLogs: 'Pending logs',
       pendingFacts: 'Pending facts',
+      pendingConfirmations: 'Pending confirmations',
       backlogProgress: 'Backlog progress',
       progressCount: '{current}/{total} logs',
       complete: 'complete',

--- a/frontend/src/i18n/messages/zh-CN.ts
+++ b/frontend/src/i18n/messages/zh-CN.ts
@@ -262,6 +262,7 @@ export const zhCN = {
       consolidatedThrough: '已整理至',
       pendingLogs: '待处理日志',
       pendingFacts: '待处理事实',
+      pendingConfirmations: '待处理确认',
       backlogProgress: '积压进度',
       progressCount: '{current}/{total} 条日志',
       complete: '完成',

--- a/frontend/src/types/memory.ts
+++ b/frontend/src/types/memory.ts
@@ -130,6 +130,7 @@ export interface DreamStatus {
   pending_dates?: string[];
   pending_count?: number;
   pending_facts?: number;
+  pending_confirmations?: number;
   archive_count?: number;
   consolidated_count?: number;
   progress_percent?: number;

--- a/scripts/dream_dry_run.py
+++ b/scripts/dream_dry_run.py
@@ -1,0 +1,231 @@
+"""Run the catch-up dream against a *copy* of the user's data directory.
+
+The backlog is five months of daily logs. Consolidating it is the first step in this
+work that mutates live memory: the agent rewrites vault pages and retires archival rows,
+and a bad `superseded.txt` line costs real facts. That is not something to try for the
+first time on the only copy of someone's memory.
+
+This script clones `~/.suzent` into a scratch directory, points the whole app at the
+clone through `SUZENT_DATA_DIR`, drives the real `DreamRunner` over it, and prints a
+reviewable diff of what the dream did to the vault.
+
+    python scripts/dream_dry_run.py --cycles 1
+    python scripts/dream_dry_run.py --cycles 30 --keep
+
+Nothing here writes to the real data directory. The clone is created fresh each run
+unless `--target` names an existing one, and the LLM calls are real — a full backlog
+pass is many agent runs and costs real money and hours, which is why `--cycles`
+defaults to 1.
+"""
+
+import argparse
+import asyncio
+import difflib
+import os
+import re
+import shutil
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Everything the app reads is derived from SUZENT_DATA_DIR at import time, so the
+# override has to be in place before any suzent module is imported.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# What the dream actually touches. Deliberately not the whole data directory:
+# `chats.db` alone is ~560MB of conversation history the dream never reads, and
+# copying it would dominate the run.
+CLONE_ALWAYS = (
+    "notebook",
+    "sandbox",
+    "config",
+    "skills",
+    "capabilities",
+    ".secret_key",
+)
+
+# The LanceDB index (~800MB). The ingest phase reads markdown, not the index — the
+# index only matters for observing the reindex that follows. Skippable for a fast pass.
+CLONE_INDEX = "memory"
+
+
+def clone_data_dir(source: Path, target: Path, with_index: bool) -> Path:
+    """Copy the parts of the data dir the dream reads or writes."""
+    if target.exists():
+        print(f"reusing existing clone at {target}")
+        return target
+
+    target.mkdir(parents=True)
+    names = list(CLONE_ALWAYS) + ([CLONE_INDEX] if with_index else [])
+    for name in names:
+        src = source / name
+        if not src.exists():
+            continue
+        dst = target / name
+        print(f"  copying {name} ...", flush=True)
+        if src.is_dir():
+            shutil.copytree(src, dst, dirs_exist_ok=True)
+        else:
+            shutil.copy2(src, dst)
+    return target
+
+
+def redirect_notebook_volume(target: Path) -> Path:
+    """Point the clone's `/mnt/notebook` mapping at a copy of the real vault.
+
+    This is the trap the whole script exists to catch. The vault is usually NOT inside
+    the data directory — it is a host path mounted at `/mnt/notebook` (here, a folder
+    under OneDrive), so cloning `~/.suzent` alone isolates everything *except* the one
+    thing the dream rewrites. Without this redirect a "dry run" edits the real vault.
+
+    Returns the path the dry run's vault now lives at.
+    """
+    cfg_path = target / "config" / "local.yaml"
+    fallback = target / "notebook"
+    if not cfg_path.exists():
+        return fallback
+
+    text = cfg_path.read_text(encoding="utf-8")
+    m = re.search(r"^(\s*-\s*)(.+?):(/mnt/notebook)\s*$", text, re.MULTILINE)
+    if not m:
+        return fallback
+
+    real_vault = Path(m.group(2))
+    clone_vault = target / "notebook-vault"
+    if real_vault.exists() and not clone_vault.exists():
+        print(f"  copying vault {real_vault} ...", flush=True)
+        shutil.copytree(real_vault, clone_vault)
+    clone_vault.mkdir(parents=True, exist_ok=True)
+
+    text = text.replace(m.group(0), f"{m.group(1)}{clone_vault}:/mnt/notebook")
+    # notebook_dir is the non-sandbox fallback for the same vault; keep them agreed.
+    if re.search(r"^notebook_dir:", text, re.MULTILINE):
+        text = re.sub(
+            r"^notebook_dir:.*$",
+            f"notebook_dir: {clone_vault}",
+            text,
+            flags=re.MULTILINE,
+        )
+    else:
+        text += f"\nnotebook_dir: {clone_vault}\n"
+    cfg_path.write_text(text, encoding="utf-8")
+    print(f"  vault redirected to {clone_vault}")
+    return clone_vault
+
+
+def snapshot_vault(notebook: Path) -> dict:
+    """Path → text for every page in the vault, so the run can be diffed."""
+    pages = {}
+    for p in sorted(notebook.rglob("*.md")):
+        if ".state" in p.parts:
+            continue
+        try:
+            pages[p.relative_to(notebook).as_posix()] = p.read_text(
+                encoding="utf-8", errors="replace"
+            )
+        except OSError:
+            continue
+    return pages
+
+
+def render_diff(before: dict, after: dict) -> str:
+    out = []
+    for name in sorted(set(before) | set(after)):
+        old = before.get(name, "").splitlines(keepends=True)
+        new = after.get(name, "").splitlines(keepends=True)
+        if old == new:
+            continue
+        out.extend(
+            difflib.unified_diff(old, new, fromfile=f"a/{name}", tofile=f"b/{name}")
+        )
+    return "".join(out) or "(no page changes)\n"
+
+
+async def drive(cycles: int) -> list[dict]:
+    """Run the real DreamRunner over the clone, one forced ingest per cycle.
+
+    The memory stack is booted through the app's own initializer rather than
+    hand-assembled, so the dry run exercises the same wiring the product does --
+    including model routing, the vault bootstrap, and the background watcher.
+    """
+    from suzent.core.dream_runner import DreamRunner
+    from suzent.memory.lifecycle import init_memory_system
+
+    if not await init_memory_system():
+        print("memory system failed to initialize (is memory_enabled set?)")
+        return []
+
+    runner = DreamRunner()
+    results = []
+    for i in range(1, cycles + 1):
+        print(f"\n--- cycle {i}/{cycles} ---", flush=True)
+        result = await runner.force_run()
+        print(
+            f"  ran={result.get('ran')} advanced={result.get('advanced')} "
+            f"watermark={result.get('watermark')} "
+            f"reason={result.get('reason') or result.get('summary', '')[:120]}",
+            flush=True,
+        )
+        results.append(result)
+        if not result.get("advanced"):
+            print("  watermark did not advance; stopping early", flush=True)
+            break
+    return results
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--cycles", type=int, default=1, help="forced ingest runs")
+    ap.add_argument("--source", type=Path, default=Path.home() / ".suzent")
+    ap.add_argument("--target", type=Path, default=None, help="clone location")
+    ap.add_argument("--keep", action="store_true", help="do not delete the clone")
+    ap.add_argument(
+        "--skip-index",
+        action="store_true",
+        help="do not copy the ~800MB LanceDB index (ingest does not read it)",
+    )
+    args = ap.parse_args()
+
+    if not args.source.exists():
+        print(f"no data directory at {args.source}", file=sys.stderr)
+        return 1
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    target = args.target or Path(tempfile.gettempdir()) / f"suzent-dream-{stamp}"
+
+    print(f"cloning {args.source} -> {target}")
+    clone_data_dir(args.source, target, with_index=not args.skip_index)
+
+    os.environ["SUZENT_DATA_DIR"] = str(target)
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+    notebook = redirect_notebook_volume(target)
+    before = snapshot_vault(notebook)
+    print(f"vault before: {len(before)} pages")
+
+    try:
+        results = asyncio.run(drive(args.cycles))
+    except KeyboardInterrupt:
+        print("interrupted", file=sys.stderr)
+        results = []
+
+    after = snapshot_vault(notebook)
+    diff = render_diff(before, after)
+
+    report = target / "dry-run-report.diff"
+    report.write_text(diff, encoding="utf-8")
+
+    print(f"\nvault after: {len(after)} pages ({len(after) - len(before):+d})")
+    print(f"cycles that advanced: {sum(1 for r in results if r.get('advanced'))}")
+    print(f"diff written to {report}")
+
+    if not args.keep and args.target is None:
+        print(f"clone left at {target} (use --keep to silence this note)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/retire_legacy_rows.py
+++ b/scripts/retire_legacy_rows.py
@@ -97,10 +97,14 @@ def count_unrecorded(rows: list) -> int:
     the question is "is this literally written down somewhere", not "is it implied".
     """
     from suzent.config import CONFIG
+    from suzent.memory.lifecycle import resolve_notebook_dir
 
+    # Not CONFIG.notebook_dir: when the user mounts their own vault at /mnt/notebook,
+    # that default path holds a stale bootstrap skeleton, and checking against it would
+    # report every row as unrecorded no matter what the real vault contains.
     corpus = _markdown_corpus(
         Path(CONFIG.sandbox_data_path) / "shared" / "memory" / "archive",
-        Path(CONFIG.notebook_dir),
+        Path(resolve_notebook_dir()),
     )
     if not corpus:
         return len(rows)

--- a/scripts/retire_legacy_rows.py
+++ b/scripts/retire_legacy_rows.py
@@ -1,0 +1,273 @@
+"""Report on — and optionally delete — archival rows that can never be reindexed.
+
+The archival table is a *derived* index: every current row is produced by reindexing a
+markdown file, and `_reindex_file` is delete-then-add keyed on that file. Rows written
+by the pre-June direct-insert path carry no `source_file`, so no file will ever replace
+them, no tombstone can retire them, and no consolidation will ever fold them in. They
+sit in retrieval permanently, at the same importance as everything else.
+
+What the dry run found, and why the order below matters: these rows are not redundant
+copies of anything. A 120-row sample checked against every daily log and every vault
+page found **zero** of them recorded in markdown — not reworded, not summarised, not at
+all. They predate the markdown tier, so the index is the only place that content exists.
+Deleting them is data loss, not index cleanup.
+
+So the safe sequence is export first, delete second:
+
+    python scripts/retire_legacy_rows.py                 # report only
+    python scripts/retire_legacy_rows.py --export        # write them to daily logs
+    python scripts/retire_legacy_rows.py --apply         # delete, after a backup
+
+`--export` appends each row to the daily log for the date it was created, which puts it
+in the append-only tier where everything else lives; the indexer then owns it through a
+`source_file` like every other row, and the dream can consolidate it. Only after that is
+`--apply` merely deleting a duplicate. `--apply` copies the table directory next to
+itself first, so it is reversible by restoring that copy.
+
+Note that re-indexing exported logs costs one embedding call per chunk, and that the
+dream will not consolidate dates below its watermark without a rewind.
+
+Nothing here is safe to run while the app is writing: stop it, or accept that a
+concurrent reindex may race the delete.
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import shutil
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+
+def _classify(metadata: dict) -> str:
+    """Which write path produced this row.
+
+    `source_file` is the reindexable key. Its absence is the whole problem: such a row
+    is unreachable from every mechanism that maintains the index.
+    """
+    source_type = metadata.get("source_type") or ""
+    if metadata.get("source_file"):
+        return source_type or "indexed (no source_type)"
+    if source_type:
+        return f"orphaned: {source_type}"
+    return "legacy_direct"
+
+
+async def load_rows(table) -> list:
+    """Every archival row as a dict, minus the vector column.
+
+    The vector is thousands of floats per row; reading it just to count metadata would
+    pull the whole index off disk for nothing.
+    """
+    query = table.query().select(
+        ["id", "content", "metadata", "importance", "created_at"]
+    )
+    return (await query.to_arrow()).to_pylist()
+
+
+def _markdown_corpus(archive_dir: Path, vault_dir: Path) -> str:
+    """Every daily log and vault page, normalised, as one searchable blob."""
+    parts = []
+    for root in (archive_dir, vault_dir):
+        if not root or not root.exists():
+            continue
+        for path in root.rglob("*.md"):
+            if ".state" in path.parts:
+                continue
+            try:
+                parts.append(
+                    " ".join(path.read_text(encoding="utf-8", errors="replace").split())
+                )
+            except OSError:
+                continue
+    return " ".join(parts).lower()
+
+
+def count_unrecorded(rows: list) -> int:
+    """How many rows' text cannot be found in the markdown tier.
+
+    Matched on a 90-character prefix: long enough that a hit is not a coincidence,
+    short enough to survive a trailing edit. Substring rather than similarity, because
+    the question is "is this literally written down somewhere", not "is it implied".
+    """
+    from suzent.config import CONFIG
+
+    corpus = _markdown_corpus(
+        Path(CONFIG.sandbox_data_path) / "shared" / "memory" / "archive",
+        Path(CONFIG.notebook_dir),
+    )
+    if not corpus:
+        return len(rows)
+    missing = 0
+    for row in rows:
+        text = " ".join(str(row.get("content", "")).split()).lower()[:90]
+        if text and text not in corpus:
+            missing += 1
+    return missing
+
+
+def export_to_daily_logs(rows: list, archive_dir: Path) -> int:
+    """Append each legacy row to the daily log for the date it was created.
+
+    The daily logs are append-only, so this only ever adds a section; the indexer picks
+    the file up on its next pass and the row finally acquires a `source_file`. Rows with
+    no usable date go to a single `legacy-undated.md` rather than being guessed at.
+    """
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    by_date: dict = {}
+    for row in rows:
+        date = str(row.get("created_at") or "")[:10]
+        if len(date) != 10:
+            date = "legacy-undated"
+        by_date.setdefault(date, []).append(row)
+
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    written = 0
+    for date, group in sorted(by_date.items()):
+        path = archive_dir / f"{date}.md"
+        lines = [
+            f"\n## legacy import — {stamp}\n",
+            "<!-- Rows recovered from the pre-June direct-insert index, which had no "
+            "markdown record. Content verbatim; category unknown. -->\n",
+        ]
+        for row in group:
+            content = " ".join(str(row.get("content", "")).split())
+            if content:
+                lines.append(f"- [legacy] {content}")
+                written += 1
+        if not path.exists():
+            path.write_text(f"# Daily Log - {date}\n", encoding="utf-8")
+        with open(path, "a", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+    return written
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    from suzent.config import CONFIG
+    from suzent.memory.lancedb_store import LanceDBMemoryStore
+
+    uri = args.uri or CONFIG.lancedb_uri
+    print(f"index: {uri}")
+    store = LanceDBMemoryStore(uri=uri, embedding_dim=CONFIG.embedding_dimension)
+    await store.connect()
+
+    rows = await load_rows(store.archival_table)
+    buckets = Counter()
+    legacy = []
+    for row in rows:
+        try:
+            metadata = json.loads(row.get("metadata") or "{}")
+        except Exception:
+            metadata = {}
+        kind = _classify(metadata)
+        buckets[kind] += 1
+        if kind == "legacy_direct":
+            legacy.append(row)
+
+    print(f"\n{len(rows)} archival rows")
+    for kind, n in buckets.most_common():
+        print(f"  {n:>6}  {kind}")
+
+    if not legacy:
+        print("\nNothing to retire.")
+        return 0
+
+    dates = sorted(str(r.get("created_at"))[:10] for r in legacy if r.get("created_at"))
+    if dates:
+        print(f"\nlegacy rows span {dates[0]} -> {dates[-1]}")
+
+    for row in legacy[: args.sample]:
+        print(f"  - {' '.join(str(row.get('content', '')).split())[:110]}")
+
+    unrecorded = count_unrecorded(legacy)
+    print(
+        f"\n{unrecorded} of {len(legacy)} legacy row(s) appear nowhere in markdown "
+        f"— for those, this index is the only copy."
+    )
+
+    if args.export:
+        written = export_to_daily_logs(legacy, args.export)
+        print(f"exported {written} row(s) into daily logs under {args.export}")
+        print("Reindex (or let the watcher catch up), then re-run with --apply.")
+        return 0
+
+    if not args.apply:
+        print(
+            f"\n{len(legacy)} row(s) would be deleted. Export them first "
+            f"(--export), then re-run with --apply."
+        )
+        return 0
+
+    if unrecorded and not args.force:
+        print(
+            f"\nRefusing to delete: {unrecorded} row(s) are recorded nowhere else. "
+            f"Run --export first, or pass --force to delete them anyway."
+        )
+        return 1
+
+    table_dir = Path(uri) / "archival_memories.lance"
+    if table_dir.exists():
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        backup = table_dir.with_name(f"archival_memories.backup-{stamp}.lance")
+        print(f"\nbacking up {table_dir.name} -> {backup.name} ...", flush=True)
+        shutil.copytree(table_dir, backup)
+    else:
+        print(
+            f"\nWARNING: no table directory at {table_dir}; deleting without a backup"
+        )
+
+    ids = [r["id"] for r in legacy if r.get("id")]
+    deleted = 0
+    for i in range(0, len(ids), 200):
+        chunk = ids[i : i + 200]
+        quoted = ", ".join("'" + str(x).replace("'", "''") + "'" for x in chunk)
+        await store.archival_table.delete(f"id IN ({quoted})")
+        deleted += len(chunk)
+        print(f"  deleted {deleted}/{len(ids)}", flush=True)
+
+    if hasattr(store, "optimize"):
+        await store.optimize()
+    print(f"\nretired {deleted} legacy row(s)")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--uri", default=None, help="LanceDB path (default: configured)")
+    ap.add_argument("--apply", action="store_true", help="actually delete the rows")
+    ap.add_argument("--sample", type=int, default=5, help="example rows to print")
+    ap.add_argument(
+        "--export",
+        nargs="?",
+        const=True,
+        default=None,
+        metavar="ARCHIVE_DIR",
+        help="append the rows to daily logs (default: the configured archive dir)",
+    )
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="delete even rows that are recorded nowhere else",
+    )
+    args = ap.parse_args()
+
+    if os.environ.get("SUZENT_DATA_DIR"):
+        print(f"SUZENT_DATA_DIR={os.environ['SUZENT_DATA_DIR']}")
+
+    if args.export is True:
+        from suzent.config import CONFIG
+
+        args.export = Path(CONFIG.sandbox_data_path) / "shared" / "memory" / "archive"
+    elif args.export:
+        args.export = Path(args.export)
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/notebook/okf.md
+++ b/skills/notebook/okf.md
@@ -17,3 +17,13 @@ For synthesized concept pages:
 - Use standard Markdown links with vault-relative paths for portable concept links.
 - Preserve unknown frontmatter keys. Emit `generated` or `verified` only when the actor and
   verification event are known; never infer them.
+
+For personal pages:
+
+- `stale_after` is required, derived from the fact category per `schema.md`. It is what gives
+  a revisit pass something to select on; a claim with no expiry is never re-examined.
+- The per-claim confirmation marker plays the role of OKF `sources[].usage_count`, kept inline
+  because these claims are bullets on a shared page rather than one document each. A repeated
+  fact is a ranking signal, not new knowledge.
+- A user editing a fact directly is a `human:` actor and outranks anything the extractor
+  produced. Record it as `verified` only if you actually observed that edit.

--- a/skills/notebook/schema_example.md
+++ b/skills/notebook/schema_example.md
@@ -70,6 +70,46 @@ Use standard Markdown links with full vault-relative paths, for example
 
 Standard sections: `## Overview`, `## Key Facts`, `## Related`, `## Sources`.
 
+### Personal pages (`3_Personal/`)
+
+These hold consolidated facts about the user, so their lifecycle matters more than their
+structure. Frontmatter:
+
+```yaml
+---
+type: personal
+title: Human-readable title
+updated: YYYY-MM-DD
+stale_after: YYYY-MM-DD
+---
+```
+
+`stale_after` is required here. Derive it from the fact category rather than guessing:
+
+| category | default lifetime |
+|---|---|
+| identity | none — omit `stale_after` |
+| `preference` | 1 year |
+| `technical` | 6 months |
+| `goal` | 3 months |
+| `context` | 3 weeks |
+
+A claim the same user keeps repeating is one claim confirmed many times, not many claims.
+Record that on the bullet rather than by restating it:
+
+```markdown
+- Wants to be reminded to drink water hourly from 9 AM to 9 PM. (confirmed 12x, last 2026-08-20)
+```
+
+Rules for the marker:
+
+- Omit it entirely the first time a claim is written. A claim with no marker is confirmed once.
+- On a repeat, increment the count and set the date. Never add a second bullet.
+- When the repeat is *more specific*, replace the bullet text with the sharper wording and
+  keep the accumulated count — the claim did not change, the phrasing got better.
+- When the repeat *contradicts* the bullet, it is a correction or a change over time, not a
+  confirmation. Reset the count and follow the correction rules above.
+
 `## Overview` must be a coherent synthesis paragraph — not a stub or a list.
 `## Related` links must use full vault-relative paths and explain the connection in one line.
 
@@ -101,7 +141,7 @@ Section headings used in `index.md`:
 ## Maintenance Rules
 
 1. **Contradictions** — if Source A conflicts with Source B, add `> [!warning] Conflicting claims: [description]` on the page, set `review: needs-review`, and flag it in `log.md`.
-2. **Stale pages** — honor `stale_after` first. Otherwise, a synthesis not updated in 90 days must be flagged `review: needs-review`.
+2. **Stale pages** — honor `stale_after` first. Otherwise, a synthesis not updated in 90 days must be flagged `review: needs-review`. On personal pages, a passed `stale_after` means re-confirm the claim from recent logs or mark it `status: deprecated` — not delete it.
 3. **No orphans** — every wiki page must link back to a concept page or appear in `index.md`.
 
 ---

--- a/src/suzent/config/__init__.py
+++ b/src/suzent/config/__init__.py
@@ -358,6 +358,12 @@ class ConfigModel(BaseModel):
     memory_consolidation_timeout_seconds: int = 600
     memory_consolidation_max_days: int = 14
     memory_consolidation_max_retries: int = 3
+    # Confirmations and expiring claims are queued by the write path, not by a daily
+    # log, so an install whose conversations only repeat known facts is "caught up"
+    # while the queues grow. This many pending confirmations makes a run worth doing
+    # on its own. Kept well above a single chatty afternoon so it never competes with
+    # ordinary ingest.
+    memory_consolidation_min_confirmations: int = 25
     memory_consolidation_memory_max_lines: int = 200
     memory_consolidation_model: Optional[str] = None
     memory_dream_tools: List[str] = [

--- a/src/suzent/core/dream_runner.py
+++ b/src/suzent/core/dream_runner.py
@@ -542,6 +542,66 @@ class DreamRunner(BaseBrain):
     async def _advance_watermark(self, mgr, w_new: str):
         await mgr.markdown_store.write_watermark_entry(self._today_utc(), w_new)
 
+    # Below this, a "superseded" line is too generic to safely match a log line.
+    MIN_SUPERSEDED_CHARS = 24
+
+    async def _retire_superseded(self, mgr) -> int:
+        """Tombstone the fact lines the dream folded into the vault, then reindex.
+
+        The daily logs stay append-only — nothing is rewritten. Tombstoning is what
+        removes the derived row, and it is the runner's job rather than the agent's
+        so the agent never touches the index. The explicit per-date reindex is not
+        optional: appending a tombstone does not change the log's mtime, so
+        `check_and_update` would never revisit those days on its own.
+        """
+        store_md = mgr.markdown_store
+        try:
+            lines = store_md.read_superseded()
+        except Exception as e:
+            logger.warning(f"[dream] could not read superseded facts: {e}")
+            return 0
+        if not lines:
+            return 0
+
+        kept = [ln for ln in lines if len(ln) >= self.MIN_SUPERSEDED_CHARS]
+        if len(kept) != len(lines):
+            logger.info(
+                f"[dream] ignoring {len(lines) - len(kept)} superseded line(s) too "
+                "short to match a log line unambiguously"
+            )
+        if not kept:
+            store_md.clear_superseded()
+            return 0
+
+        dates = store_md.archive_dates_containing(kept)
+        for content in kept:
+            try:
+                await store_md.append_tombstone(content)
+            except Exception as e:
+                logger.warning(f"[dream] failed to tombstone a superseded fact: {e}")
+
+        for date in dates:
+            try:
+                await mgr._core_indexer.reindex_file_now(
+                    markdown_store=store_md,
+                    lancedb_store=mgr.store,
+                    embedding_gen=mgr.embedding_gen,
+                    user_id=CONFIG.user_id,
+                    label="archive",
+                    filename=f"{date}.md",
+                )
+            except Exception as e:
+                logger.error(f"[dream] reindex of {date} after supersede failed: {e}")
+
+        # Cleared only after the tombstones are durable: a crash before this point
+        # replays the same lines next run, which is idempotent. Clearing first would
+        # lose them.
+        store_md.clear_superseded()
+        logger.info(
+            f"[dream] retired {len(kept)} superseded fact(s) across {len(dates)} log(s)"
+        )
+        return len(kept)
+
     async def _reindex(self, mgr) -> None:
         """Reconcile the vault into the search index, with a hard timeout.
 
@@ -556,6 +616,11 @@ class DreamRunner(BaseBrain):
                 "[dream] skipping search reindex: no embedding model configured"
             )
             return
+
+        try:
+            await self._retire_superseded(mgr)
+        except Exception as e:
+            logger.error(f"[dream] retiring superseded facts failed: {e}")
 
         await asyncio.wait_for(
             mgr._core_indexer.check_and_update(

--- a/src/suzent/core/dream_runner.py
+++ b/src/suzent/core/dream_runner.py
@@ -807,11 +807,20 @@ class DreamRunner(BaseBrain):
 
     @staticmethod
     def _due_revisits(mgr, limit: int = 25) -> List[dict]:
-        """Vault pages whose `stale_after` has passed, soonest-expired first.
+        """Vault pages due for a revisit, soonest-expired first.
 
         Built here rather than by the agent: it is a deterministic scan of frontmatter,
         and asking an LLM to find expired pages by reading the whole vault is both
         slower and less reliable than reading the dates ourselves.
+
+        A page with no `stale_after` at all is also due, and queues after every genuinely
+        expired one. Every page written before `07f24c4b` is in that state, and selecting
+        strictly on the field would mean they are never queued, so the dream never visits
+        them, so the field is never written — the pages that most need a first pass would
+        be the only ones permanently exempt from one. Queuing them is what lets the dream
+        backfill the field itself, which is better than a script guessing an expiry: a
+        wrong `stale_after` actively damps a good claim in ranking, and only the dream can
+        see which category the claim belongs to.
         """
         try:
             from suzent.memory.indexer import CoreMemoryFileIndexer
@@ -829,14 +838,21 @@ class DreamRunner(BaseBrain):
                 stale_after = lifecycle.get("stale_after", "")[:10]
                 if lifecycle.get("status", "").lower() == "deprecated":
                     continue
-                if len(stale_after) == 10 and stale_after < today:
-                    rows.append(
-                        {
-                            "page": store_md.notebook_rel(path),
-                            "stale_after": stale_after,
-                        }
-                    )
-            rows.sort(key=lambda r: r["stale_after"])
+                rel = store_md.notebook_rel(path)
+                dated = len(stale_after) == 10
+                if dated and stale_after >= today:
+                    continue
+                if not dated and not rel.replace("\\", "/").startswith("3_Personal/"):
+                    # `stale_after` is a personal-claim field. A wiki or project page
+                    # having none is correct, not a backlog item — only the pages the
+                    # rule actually applies to are missing anything.
+                    continue
+                rows.append(
+                    {"page": rel, "stale_after": stale_after if dated else "unset"}
+                )
+            # Expired pages first, oldest expiry first; the undated ones follow, since a
+            # known-stale claim is more urgent than one we simply have no expiry for.
+            rows.sort(key=lambda r: (r["stale_after"] == "unset", r["stale_after"]))
             return rows[:limit]
         except Exception as e:
             logger.warning(f"[dream] could not build the revisit queue: {e}")

--- a/src/suzent/core/dream_runner.py
+++ b/src/suzent/core/dream_runner.py
@@ -46,7 +46,10 @@ class DreamRunner(BaseBrain):
         self._lock = asyncio.Lock()
         # Ephemeral pacing state (NOT the watermark, which lives in log.md).
         self._last_attempt_at: float = 0.0
-        self._failures: dict = {}  # batch-end-date -> consecutive no-op count
+        # batch-end-date -> consecutive no-op count. Mirrors the durable copy in
+        # the vault's .state/dream_state.json; see _load_failures.
+        self._failures: dict = {}
+        self._failures_loaded = False
         self._last_started_at: Optional[str] = None
         self._last_finished_at: Optional[str] = None
         self._last_result: Optional[dict[str, Any]] = None
@@ -85,6 +88,28 @@ class DreamRunner(BaseBrain):
     @staticmethod
     def _today_utc() -> str:
         return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    def _load_failures(self, mgr) -> None:
+        """Hydrate retry counters from disk once per process.
+
+        Retry-then-skip only works if the count survives a restart: the runner is
+        gated to one attempt per batch per app run, so an in-memory counter never
+        reaches max_retries on a desktop app and the backlog wedges silently.
+        """
+        if self._failures_loaded:
+            return
+        try:
+            self._failures = mgr.markdown_store.read_dream_failures()
+        except Exception as e:
+            logger.warning(f"[dream] could not read pacing state: {e}")
+            self._failures = {}
+        self._failures_loaded = True
+
+    def _save_failures(self, mgr) -> None:
+        try:
+            mgr.markdown_store.write_dream_failures(self._failures)
+        except Exception as e:
+            logger.warning(f"[dream] could not persist pacing state: {e}")
 
     def _pending_dates(self, mgr, watermark: Optional[str]) -> List[str]:
         """Daily-log dates not yet consolidated and strictly before today (UTC)."""
@@ -167,6 +192,7 @@ class DreamRunner(BaseBrain):
                 "last_lint_result": last_lint_result,
             }
 
+        self._load_failures(mgr)
         watermark = mgr.markdown_store.read_watermark()
         pending = self._pending_dates(mgr, watermark)
         pending_facts = self._count_fact_lines(mgr, pending)
@@ -228,6 +254,7 @@ class DreamRunner(BaseBrain):
         mgr = get_memory_manager()
         if not mgr or not mgr.markdown_store or not mgr.llm_client:
             return
+        self._load_failures(mgr)
 
         watermark = mgr.markdown_store.read_watermark()
         pending = self._pending_dates(mgr, watermark)
@@ -339,6 +366,8 @@ class DreamRunner(BaseBrain):
             return {"ran": False, "reason": "already running"}
         async with self._lock:
             self._phase = "preparing"
+            # force_run reaches here without going through _tick.
+            self._load_failures(mgr)
             self._last_attempt_at = time.time()
             self._last_started_at = datetime.now(timezone.utc).isoformat()
             batch = pending[: CONFIG.memory_consolidation_max_days]
@@ -349,6 +378,7 @@ class DreamRunner(BaseBrain):
                 logger.warning(f"[dream] skipping un-consolidatable batch <= {w_new}")
                 await self._advance_watermark(mgr, w_new)
                 self._failures.pop(w_new, None)
+                self._save_failures(mgr)
                 result = {
                     "ran": True,
                     "phase": "ingest",
@@ -389,6 +419,7 @@ class DreamRunner(BaseBrain):
             changed = self._content_pages_state(mgr) != before
             if not (agent_ok and changed):
                 self._failures[w_new] = self._failures.get(w_new, 0) + 1
+                self._save_failures(mgr)
                 reason = (
                     "agent run failed/timed out"
                     if not agent_ok
@@ -409,6 +440,7 @@ class DreamRunner(BaseBrain):
                 return result
 
             self._failures.pop(w_new, None)
+            self._save_failures(mgr)
             result_summary = summary or f"Consolidated through {w_new}."
             await self._advance_watermark(mgr, w_new)
             # Promote MEMORY.md (bounded) so the curated summary reflects this batch.

--- a/src/suzent/core/dream_runner.py
+++ b/src/suzent/core/dream_runner.py
@@ -390,6 +390,12 @@ class DreamRunner(BaseBrain):
 
             start = watermark or "0000-00-00"
             before = self._content_pages_state(mgr)
+            # How many confirmations the agent is about to be shown. Conversations keep
+            # appending while it runs; only this many may be dropped afterwards.
+            try:
+                consumed_confirmations = len(mgr.markdown_store.read_confirmations())
+            except Exception:
+                consumed_confirmations = 0
 
             self._pause_watcher()
             agent_ok = False
@@ -400,7 +406,7 @@ class DreamRunner(BaseBrain):
                     title="Memory consolidation (dream ingest)",
                 )
                 self._phase = "running_agent"
-                summary = await self._run_agent(start, w_new)
+                summary = await self._run_agent(mgr, start, w_new)
                 agent_ok = True
             except Exception as e:
                 logger.error(f"[dream] agent run failed: {e}")
@@ -443,6 +449,10 @@ class DreamRunner(BaseBrain):
             self._save_failures(mgr)
             result_summary = summary or f"Consolidated through {w_new}."
             await self._advance_watermark(mgr, w_new)
+            # Only the confirmations the agent actually saw, and only now that the run
+            # is known good. A failed run keeps them queued for the next one.
+            if consumed_confirmations:
+                mgr.markdown_store.clear_confirmations(consumed_confirmations)
             # Promote MEMORY.md (bounded) so the curated summary reflects this batch.
             try:
                 await asyncio.wait_for(
@@ -795,15 +805,65 @@ class DreamRunner(BaseBrain):
             except Exception:
                 pass
 
-    async def _run_agent(self, start: str, end: str) -> str:
+    @staticmethod
+    def _due_revisits(mgr, limit: int = 25) -> List[dict]:
+        """Vault pages whose `stale_after` has passed, soonest-expired first.
+
+        Built here rather than by the agent: it is a deterministic scan of frontmatter,
+        and asking an LLM to find expired pages by reading the whole vault is both
+        slower and less reliable than reading the dates ourselves.
+        """
+        try:
+            from suzent.memory.indexer import CoreMemoryFileIndexer
+
+            store_md = mgr.markdown_store
+            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            rows: List[dict] = []
+            for path in store_md.list_notebook_pages():
+                try:
+                    lifecycle = CoreMemoryFileIndexer._parse_page_lifecycle(
+                        path.read_text(encoding="utf-8", errors="replace")
+                    )
+                except OSError:
+                    continue
+                stale_after = lifecycle.get("stale_after", "")[:10]
+                if lifecycle.get("status", "").lower() == "deprecated":
+                    continue
+                if len(stale_after) == 10 and stale_after < today:
+                    rows.append(
+                        {
+                            "page": store_md.notebook_rel(path),
+                            "stale_after": stale_after,
+                        }
+                    )
+            rows.sort(key=lambda r: r["stale_after"])
+            return rows[:limit]
+        except Exception as e:
+            logger.warning(f"[dream] could not build the revisit queue: {e}")
+            return []
+
+    async def _run_agent(self, mgr, start: str, end: str) -> str:
         """Ingest phase: fold daily logs in (start, end] into the vault.
 
-        Returns the agent's one-paragraph summary (shown in the dream panel).
+        Also hands the agent the two deterministic queues the runner owns: the
+        confirmations recorded by the write path, and the claims past their
+        `stale_after`. Returns the agent's one-paragraph summary (shown in the panel).
         """
+        try:
+            confirmations = mgr.markdown_store.summarize_confirmations()
+        except Exception as e:
+            logger.warning(f"[dream] could not read confirmations: {e}")
+            confirmations = []
+
         return await self._run_forked_agent(
             DREAM_CHAT_ID,
             memory_context.DREAM_SYSTEM_PROMPT,
-            memory_context.DREAM_INSTRUCTIONS.format(start=start, end=end),
+            memory_context.DREAM_INSTRUCTIONS.format(
+                start=start,
+                end=end,
+                confirmations=memory_context.format_confirmations_block(confirmations),
+                revisits=memory_context.format_revisits_block(self._due_revisits(mgr)),
+            ),
         )
 
     async def _run_lint_agent(self) -> str:

--- a/src/suzent/core/dream_runner.py
+++ b/src/suzent/core/dream_runner.py
@@ -124,6 +124,26 @@ class DreamRunner(BaseBrain):
             dates.append(d)
         return dates
 
+    def _pending_confirmations(self, mgr) -> int:
+        """How many confirmation records are waiting for a dream to fold them in.
+
+        These are the facts the write path deliberately kept out of the daily logs,
+        so they raise no pending date and cannot start a run by themselves. Without
+        counting them, an install that is caught up on logs reports nothing pending
+        while the sidecar grows without bound.
+        """
+        try:
+            return len(mgr.markdown_store.read_confirmations())
+        except Exception:
+            return 0
+
+    def _queues_due(self, mgr) -> bool:
+        """Whether the runner-owned queues justify a run with no new logs."""
+        return (
+            self._pending_confirmations(mgr)
+            >= CONFIG.memory_consolidation_min_confirmations
+        )
+
     def _count_fact_lines(self, mgr, dates: List[str]) -> int:
         n = 0
         for d in dates:
@@ -223,6 +243,10 @@ class DreamRunner(BaseBrain):
             "pending_dates": pending,
             "pending_count": len(pending),
             "pending_facts": pending_facts,
+            # Surfaced so a caught-up install does not read as "nothing pending" while
+            # the sidecar holds work: these are facts memory captured that no daily log
+            # shows, and only a dream retires them.
+            "pending_confirmations": self._pending_confirmations(mgr),
             "archive_count": total_count,
             "consolidated_count": consolidated_count,
             "progress_percent": progress_percent,
@@ -275,6 +299,15 @@ class DreamRunner(BaseBrain):
             await self._run_dream(mgr, watermark, pending)
             return
 
+        # Caught up on logs, but the queues the write path fills raise no pending date
+        # of their own. Same backoff as steady-state ingest, so this stays occasional.
+        if self._queues_due(mgr):
+            if (
+                time.time() - self._last_attempt_at
+            ) >= CONFIG.memory_consolidation_min_hours * 3600:
+                await self._run_dream(mgr, watermark, [])
+                return
+
         # Ingest is caught up. Only now consider the (slower) lint pass, so the
         # editorial audit never starves new-log consolidation.
         if self._lint_due(mgr):
@@ -287,7 +320,7 @@ class DreamRunner(BaseBrain):
             return {"ran": False, "reason": "memory system unavailable"}
         watermark = mgr.markdown_store.read_watermark()
         pending = self._pending_dates(mgr, watermark)
-        if not pending:
+        if not pending and not self._pending_confirmations(mgr):
             return {"ran": False, "reason": "nothing pending"}
         return await self._run_dream(mgr, watermark, pending)
 
@@ -306,11 +339,12 @@ class DreamRunner(BaseBrain):
 
         watermark = mgr.markdown_store.read_watermark()
         pending = self._pending_dates(mgr, watermark)
-        if not pending:
+        if not pending and not self._pending_confirmations(mgr):
             return {"ran": False, "started": False, "reason": "nothing pending"}
 
         self._phase = "queued"
-        target = pending[: CONFIG.memory_consolidation_max_days][-1]
+        batch = pending[: CONFIG.memory_consolidation_max_days]
+        target = batch[-1] if batch else (watermark or self._today_utc())
         task = asyncio.create_task(self._run_dream(mgr, watermark, pending))
         self._background_task = task
 
@@ -371,10 +405,20 @@ class DreamRunner(BaseBrain):
             self._last_attempt_at = time.time()
             self._last_started_at = datetime.now(timezone.utc).isoformat()
             batch = pending[: CONFIG.memory_consolidation_max_days]
-            w_new = batch[-1]
+            # A queue-only run has no new logs, so there is no new watermark: it stays
+            # where it is and the agent works the confirmations and revisit queues over
+            # an empty date range. `w_new` is still needed as the retry-counter key.
+            queues_only = not batch
+            w_new = batch[-1] if batch else (watermark or self._today_utc())
 
             # retry-then-skip: a batch that keeps producing nothing must not wedge the backlog.
-            if self._failures.get(w_new, 0) >= CONFIG.memory_consolidation_max_retries:
+            # A queue-only run has no backlog to wedge and shares its key with the date
+            # already consolidated, so it neither reads nor writes the retry counters.
+            if (
+                not queues_only
+                and self._failures.get(w_new, 0)
+                >= CONFIG.memory_consolidation_max_retries
+            ):
                 logger.warning(f"[dream] skipping un-consolidatable batch <= {w_new}")
                 await self._advance_watermark(mgr, w_new)
                 self._failures.pop(w_new, None)
@@ -390,12 +434,16 @@ class DreamRunner(BaseBrain):
 
             start = watermark or "0000-00-00"
             before = self._content_pages_state(mgr)
-            # How many confirmations the agent is about to be shown. Conversations keep
-            # appending while it runs; only this many may be dropped afterwards.
+            # What the agent is about to be shown, in both senses that matter when the
+            # sidecar is cleared: how long the file was (conversations keep appending
+            # while it runs, and none of that may be dropped) and which claims made it
+            # into the bounded prompt (the rest keep their evidence for the next run).
             try:
                 consumed_confirmations = len(mgr.markdown_store.read_confirmations())
+                shown_confirmations = mgr.markdown_store.summarize_confirmations()
             except Exception:
                 consumed_confirmations = 0
+                shown_confirmations = []
 
             self._pause_watcher()
             agent_ok = False
@@ -406,7 +454,7 @@ class DreamRunner(BaseBrain):
                     title="Memory consolidation (dream ingest)",
                 )
                 self._phase = "running_agent"
-                summary = await self._run_agent(mgr, start, w_new)
+                summary = await self._run_agent(mgr, start, w_new, shown_confirmations)
                 agent_ok = True
             except Exception as e:
                 logger.error(f"[dream] agent run failed: {e}")
@@ -424,8 +472,9 @@ class DreamRunner(BaseBrain):
             # eventually retry-skipped if it stays un-consolidatable).
             changed = self._content_pages_state(mgr) != before
             if not (agent_ok and changed):
-                self._failures[w_new] = self._failures.get(w_new, 0) + 1
-                self._save_failures(mgr)
+                if not queues_only:
+                    self._failures[w_new] = self._failures.get(w_new, 0) + 1
+                    self._save_failures(mgr)
                 reason = (
                     "agent run failed/timed out"
                     if not agent_ok
@@ -445,14 +494,22 @@ class DreamRunner(BaseBrain):
                 self._record_result(result)
                 return result
 
-            self._failures.pop(w_new, None)
-            self._save_failures(mgr)
-            result_summary = summary or f"Consolidated through {w_new}."
-            await self._advance_watermark(mgr, w_new)
+            if not queues_only:
+                self._failures.pop(w_new, None)
+                self._save_failures(mgr)
+                await self._advance_watermark(mgr, w_new)
+            result_summary = summary or (
+                "Worked the confirmation and revisit queues."
+                if queues_only
+                else f"Consolidated through {w_new}."
+            )
             # Only the confirmations the agent actually saw, and only now that the run
             # is known good. A failed run keeps them queued for the next one.
             if consumed_confirmations:
-                mgr.markdown_store.clear_confirmations(consumed_confirmations)
+                mgr.markdown_store.clear_confirmations(
+                    consumed_confirmations,
+                    folded=[r.get("content", "") for r in shown_confirmations],
+                )
             # Promote MEMORY.md (bounded) so the curated summary reflects this batch.
             try:
                 await asyncio.wait_for(
@@ -858,18 +915,26 @@ class DreamRunner(BaseBrain):
             logger.warning(f"[dream] could not build the revisit queue: {e}")
             return []
 
-    async def _run_agent(self, mgr, start: str, end: str) -> str:
+    async def _run_agent(
+        self, mgr, start: str, end: str, confirmations: Optional[List[dict]] = None
+    ) -> str:
         """Ingest phase: fold daily logs in (start, end] into the vault.
 
         Also hands the agent the two deterministic queues the runner owns: the
         confirmations recorded by the write path, and the claims past their
         `stale_after`. Returns the agent's one-paragraph summary (shown in the panel).
+
+        *confirmations* is passed in rather than read here so that the caller clears
+        exactly the claims that went into the prompt. Reading the sidecar twice would
+        let a conversation land between the two reads and put a claim in the cleared
+        set that the agent never saw.
         """
-        try:
-            confirmations = mgr.markdown_store.summarize_confirmations()
-        except Exception as e:
-            logger.warning(f"[dream] could not read confirmations: {e}")
-            confirmations = []
+        if confirmations is None:
+            try:
+                confirmations = mgr.markdown_store.summarize_confirmations()
+            except Exception as e:
+                logger.warning(f"[dream] could not read confirmations: {e}")
+                confirmations = []
 
         return await self._run_forked_agent(
             DREAM_CHAT_ID,

--- a/src/suzent/memory/classifier.py
+++ b/src/suzent/memory/classifier.py
@@ -1,0 +1,163 @@
+"""Classify an extracted fact against what memory already holds.
+
+Issue #34 was write-time deduplication silently dropping an *update*, so the write
+path has been strictly append-only ever since: every extracted fact goes to the daily
+log, and the dream resolves repetition later. That is safe, and it is also why the
+same claim can occupy a hundred rows — each retelling is a fresh row that competes
+with the original in retrieval.
+
+This module lets the write path recognise the one case where appending adds nothing:
+the fact is a re-statement of a claim that is *already durably recorded*, in the same
+words, with no new specifics. Those become a line in a confirmations sidecar — the
+recurrence is kept as evidence, the redundant row is not created.
+
+Everything else, including anything that merely *looks* similar, keeps the old
+behaviour. The asymmetry is deliberate: a redundant row costs a little ranking
+quality, a dropped revision costs a fact.
+"""
+
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+# Same claim, same words -> a confirmation, provided it adds no new specifics.
+CONFIRM_SIMILARITY = 0.97
+
+# Close but not identical -> a revision. Written to the log exactly as before; the
+# threshold exists so the dream can be told which claim it revises.
+REVISION_SIMILARITY = 0.90
+
+# A statement that says everything the old one said and then some is a revision even
+# when the extra words push the symmetric similarity down. "Moved to Berlin in 2024"
+# only overlaps "moved to Berlin" by 0.8 Dice, but it is plainly the same claim,
+# updated -- which is precisely the case that must never be mistaken for a repeat.
+REVISION_COVERAGE = 0.90
+
+# Words that carry no claim content, so their presence or absence should not make two
+# statements of the same fact look different.
+_STOPWORDS = frozenset(
+    """a an the and or but if then than that this these those is are was were be been
+    being am do does did doing have has had having of in on at to for with from by as
+    it its his her their our my your user users he she they we you i not no also very
+    just really quite so such about into over under again more most some any each""".split()
+)
+
+# Anything that pins a claim down: numbers, dates, versions, money, times, identifiers,
+# paths, URLs, emails, and quoted strings. A token like this appearing in the new
+# statement but not the old one means the new statement says something more, however
+# similar the surrounding prose is.
+_SPECIFIC_RE = re.compile(
+    r"""(?:
+        [\w.+-]+@[\w-]+\.[\w.]+          # email
+      | \w+://\S+                        # url
+      | [A-Za-z]:[\\/][^\s,;]+           # windows path
+      | /[^\s,;]{2,}                     # posix path
+      | \d[\w.:/-]*                      # anything starting with a digit
+      | "[^"]+"                          # quoted string
+    )""",
+    re.VERBOSE,
+)
+
+_WORD_RE = re.compile(r"[\w'-]+", re.UNICODE)
+
+
+@dataclass
+class ClaimVerdict:
+    """What the write path should do with one extracted fact."""
+
+    kind: str  # "confirmation" | "revision" | "new"
+    similarity: float = 0.0
+    matched: str = ""
+    new_specifics: List[str] = field(default_factory=list)
+
+    @property
+    def is_confirmation(self) -> bool:
+        return self.kind == "confirmation"
+
+    @property
+    def is_revision(self) -> bool:
+        return self.kind == "revision"
+
+
+def normalize_claim(text: str) -> str:
+    """Lowercase, collapse whitespace, and drop the daily log's `- [category] ` prefix."""
+    t = " ".join((text or "").split())
+    t = re.sub(r"^-\s*", "", t)
+    t = re.sub(r"^\[[^\]]+\]\s*", "", t)
+    return t.lower()
+
+
+def _content_tokens(text: str) -> List[str]:
+    return [w for w in _WORD_RE.findall(normalize_claim(text)) if w not in _STOPWORDS]
+
+
+def claim_similarity(a: str, b: str) -> float:
+    """Dice coefficient over content words, in [0.0, 1.0].
+
+    Deliberately lexical rather than semantic. An embedding comparison would cost a
+    call per fact per turn, and the only band that changes behaviour here is
+    "practically the same sentence" — which is exactly what a lexical measure is good
+    at, and exactly what a semantic one is too generous about. Two different facts on
+    the same topic are ~0.9 cosine apart and nowhere near identical in words.
+    """
+    ta, tb = set(_content_tokens(a)), set(_content_tokens(b))
+    if not ta or not tb:
+        return 0.0
+    return 2 * len(ta & tb) / (len(ta) + len(tb))
+
+
+def claim_coverage(new: str, old: str) -> float:
+    """How much of *old*'s content the *new* statement restates, in [0.0, 1.0]."""
+    tn, to = set(_content_tokens(new)), set(_content_tokens(old))
+    if not to:
+        return 0.0
+    return len(tn & to) / len(to)
+
+
+def new_specifics(new: str, old: str) -> List[str]:
+    """Specific tokens the new statement has and the old one does not.
+
+    This is the guard that keeps "moved to Berlin in 2024" from being folded into
+    "moved to Berlin" as a mere repeat.
+    """
+    old_tokens = {t.lower() for t in _SPECIFIC_RE.findall(normalize_claim(old))}
+    out = []
+    for t in _SPECIFIC_RE.findall(normalize_claim(new)):
+        if t.lower() not in old_tokens and t not in out:
+            out.append(t)
+    return out
+
+
+def classify_fact(content: str, known: Optional[List[str]]) -> ClaimVerdict:
+    """Compare one extracted fact against the nearest known facts.
+
+    *known* is the recall set already assembled for the extraction prompt, so this
+    costs no extra retrieval. Only claims the caller knows to be durably recorded
+    should be passed — see `MemoryManager._recall_known_facts`.
+    """
+    best_score, best_text = 0.0, ""
+    for candidate in known or []:
+        score = claim_similarity(content, candidate)
+        if score > best_score:
+            best_score, best_text = score, candidate
+
+    specifics = new_specifics(content, best_text) if best_text else []
+    superset = (
+        bool(specifics) and claim_coverage(content, best_text) >= REVISION_COVERAGE
+    )
+    if best_score < REVISION_SIMILARITY and not superset:
+        return ClaimVerdict(kind="new", similarity=best_score, matched=best_text)
+
+    if best_score >= CONFIRM_SIMILARITY and not specifics:
+        return ClaimVerdict(
+            kind="confirmation", similarity=best_score, matched=best_text
+        )
+
+    # Similar but not identical, or identical prose carrying a new detail. Either way
+    # it may be an update, so it is written exactly as before.
+    return ClaimVerdict(
+        kind="revision",
+        similarity=best_score,
+        matched=best_text,
+        new_specifics=specifics,
+    )

--- a/src/suzent/memory/classifier.py
+++ b/src/suzent/memory/classifier.py
@@ -38,8 +38,20 @@ REVISION_COVERAGE = 0.90
 _STOPWORDS = frozenset(
     """a an the and or but if then than that this these those is are was were be been
     being am do does did doing have has had having of in on at to for with from by as
-    it its his her their our my your user users he she they we you i not no also very
+    it its his her their our my your user users he she they we you i also very
     just really quite so such about into over under again more most some any each""".split()
+)
+
+# Negation is the one "small" word that reverses a claim rather than decorating it, so
+# it is never a stopword and never merely a token. "The project is active" and "the
+# project is not active" are a claim and its correction; on a long sentence the single
+# extra word barely moves a lexical score, so polarity is compared separately rather
+# than left to similarity. Step 4 of the dream prompt promises the agent that a
+# contradicting restatement never reaches the confirmations list -- this is what keeps
+# that true.
+_NEGATIONS = frozenset(
+    """not no never none nor neither cannot cant wont dont doesnt didnt isnt arent
+    wasnt werent hasnt havent hadnt without lacks lacking failed stopped""".split()
 )
 
 # Anything that pins a claim down: numbers, dates, versions, money, times, identifiers,
@@ -84,11 +96,27 @@ def normalize_claim(text: str) -> str:
     t = " ".join((text or "").split())
     t = re.sub(r"^-\s*", "", t)
     t = re.sub(r"^\[[^\]]+\]\s*", "", t)
-    return t.lower()
+    # Apostrophes go so that "isn't" and "isnt" are one token; the negation set would
+    # otherwise miss whichever spelling it did not list.
+    return t.lower().replace("’", "").replace("'", "")
 
 
 def _content_tokens(text: str) -> List[str]:
     return [w for w in _WORD_RE.findall(normalize_claim(text)) if w not in _STOPWORDS]
+
+
+def polarity_differs(a: str, b: str) -> bool:
+    """Whether one statement negates something the other does not.
+
+    Compared as a set of negation words rather than folded into similarity, because a
+    single "not" added to a long sentence moves a lexical score by almost nothing --
+    "the deployment pipeline runs nightly against staging" and the same sentence with
+    "does not run" are 0.97 apart on Dice, which is confirmation territory. The claim
+    they make is opposite.
+    """
+    na = {t for t in _WORD_RE.findall(normalize_claim(a)) if t in _NEGATIONS}
+    nb = {t for t in _WORD_RE.findall(normalize_claim(b)) if t in _NEGATIONS}
+    return na != nb
 
 
 def claim_similarity(a: str, b: str) -> float:
@@ -148,7 +176,8 @@ def classify_fact(content: str, known: Optional[List[str]]) -> ClaimVerdict:
     if best_score < REVISION_SIMILARITY and not superset:
         return ClaimVerdict(kind="new", similarity=best_score, matched=best_text)
 
-    if best_score >= CONFIRM_SIMILARITY and not specifics:
+    negated = bool(best_text) and polarity_differs(content, best_text)
+    if best_score >= CONFIRM_SIMILARITY and not specifics and not negated:
         return ClaimVerdict(
             kind="confirmation", similarity=best_score, matched=best_text
         )

--- a/src/suzent/memory/indexer.py
+++ b/src/suzent/memory/indexer.py
@@ -768,6 +768,10 @@ class CoreMemoryFileIndexer:
         if confirmations > 1:
             score += min(0.25, 0.08 * math.log2(confirmations))
 
+        # Only `deprecated` and `draft` change the score. Everything else — `stable`,
+        # the `active` the live vault actually wrote before the schema said `stable`,
+        # a typo, nothing at all — is neutral: a page is never demoted for predating a
+        # rule, and an unrecognised status is missing information, not bad evidence.
         status = (lifecycle.get("status") or "").lower()
         if status == "deprecated":
             # A softer tombstone: still readable and linkable, out of the running.

--- a/src/suzent/memory/indexer.py
+++ b/src/suzent/memory/indexer.py
@@ -203,6 +203,11 @@ class TranscriptIndexer:
 # Core files are small, so we set a generous limit to keep context coherent.
 CORE_FILE_MAX_CHUNK_CHARS = 1200
 
+# Importance floor for a claim a person verified themselves. Below 1.0 so a verified
+# claim that is *also* heavily confirmed can still outrank a verified one-off, and so
+# the value stays a floor rather than a ceiling everything piles up against.
+HUMAN_VERIFIED_FLOOR = 0.9
+
 
 class CoreMemoryFileIndexer:
     """Watches persona.md, user.md, MEMORY.md, and archive/*.md for changes
@@ -551,33 +556,49 @@ class CoreMemoryFileIndexer:
                 else ["core_memory", label, filename]
             )
             # Vault pages carry a lifecycle (frontmatter status/stale_after, inline
-            # confirmation counts); core files do not, and get the neutral default.
+            # confirmation counts). Core files carry none of that, with one exception:
+            # MEMORY.md's manual zone is where a person edits their own memory, and
+            # `write_memory_manual_zone` stamps it with a `human:` actor. Everything
+            # else on this path stays on the neutral default.
             lifecycle = (
                 self._parse_page_lifecycle(content) if source_type == "notebook" else {}
             )
-            rows = [
-                (
-                    chunk,
-                    {
-                        "source_type": source_type,
-                        "source_file": filename,
-                        "chunk_index": i,
-                        "label": label,
-                        "category": source_type,
-                        "tags": tags,
-                        **(
-                            {k: v for k, v in lifecycle.items()}
-                            if source_type == "notebook"
-                            else {}
-                        ),
-                    },
-                    self._claim_strength(chunk, lifecycle)
-                    if source_type == "notebook"
-                    else 0.5,
-                )
-                for i, chunk in enumerate(self._chunk_by_paragraphs(content))
-                if chunk.strip() and " ".join(chunk.lower().split()) not in tombstones
-            ]
+            if source_type == "notebook":
+                segments = [(content, lifecycle)]
+            else:
+                # Chunked per zone, not per file: `_chunk_by_paragraphs` merges short
+                # paragraphs, so chunking MEMORY.md whole produces a single row
+                # spanning the generated half and the human half — one row that is
+                # both machine output and user-verified, which is neither.
+                segments = self._provenance_segments(content)
+
+            rows = []
+            i = 0
+            for segment, claim_lifecycle in segments:
+                for chunk in self._chunk_by_paragraphs(segment):
+                    i += 1
+                    if (
+                        not chunk.strip()
+                        or " ".join(chunk.lower().split()) in tombstones
+                    ):
+                        continue
+                    rows.append(
+                        (
+                            chunk,
+                            {
+                                "source_type": source_type,
+                                "source_file": filename,
+                                "chunk_index": i,
+                                "label": label,
+                                "category": source_type,
+                                "tags": tags,
+                                **claim_lifecycle,
+                            },
+                            self._claim_strength(chunk, claim_lifecycle)
+                            if claim_lifecycle
+                            else 0.5,
+                        )
+                    )
 
         # 2. Archive logs are appended to many times a day, and every append used to
         #    re-embed the whole file: ~28x more embedding calls than facts across the
@@ -737,10 +758,49 @@ class CoreMemoryFileIndexer:
         if not m:
             return lifecycle
         for line in m.group(1).splitlines():
-            kv = re.match(r"^(status|stale_after)\s*:\s*(.+?)\s*$", line.strip())
+            kv = re.match(
+                r"^(status|stale_after|verified_by|verified_at)\s*:\s*(.+?)\s*$",
+                line.strip(),
+            )
             if kv:
                 lifecycle[kv.group(1)] = kv.group(2).strip().strip("\"'")
         return lifecycle
+
+    @staticmethod
+    def _provenance_segments(content: str) -> List[tuple]:
+        """Split a core file into `(text, lifecycle)` regions by who wrote them.
+
+        MEMORY.md is the only file with two authors: a generated zone rewritten on
+        every consolidation, and a manual zone a person edits and `write_memory_manual_zone`
+        stamps with a `human:` actor. Only the region *after* the end marker carries
+        that verification — everything above it is machine output, and scoring it as
+        human-verified would launder the generator's own text into the strongest
+        evidence class the ranker has. Every other core file comes back as one
+        unstamped segment, which is the neutral default it had before.
+        """
+        from .markdown_store import MEMORY_GENERATED_END
+
+        if MEMORY_GENERATED_END not in content:
+            return [(content, {})]
+        head, _, tail = content.partition(MEMORY_GENERATED_END)
+        verification = CoreMemoryFileIndexer._parse_verification(tail)
+        return [(head, {}), (tail, verification)]
+
+    @staticmethod
+    def _parse_verification(content: str) -> dict:
+        """Read the `<!-- verified: <actor> at <ts> -->` stamp, if the text carries one.
+
+        Written by `write_memory_manual_zone` when a person edits MEMORY.md, which is
+        the only place in the system where a claim comes from the user directly rather
+        than from extraction. Returned in the same shape as the frontmatter lifecycle
+        so both paths feed `_claim_strength` through one argument.
+        """
+        m = re.search(
+            r"<!--\s*verified:\s*(.+?)\s+at\s+(\S+?)\s*-->", content, re.IGNORECASE
+        )
+        if not m:
+            return {}
+        return {"verified_by": m.group(1).strip(), "verified_at": m.group(2).strip()}
 
     @staticmethod
     def _claim_strength(
@@ -778,6 +838,16 @@ class CoreMemoryFileIndexer:
             return 0.1
         if status == "draft":
             score -= 0.05
+
+        # A person typed this. That outranks every other signal here: confirmation
+        # counts, extraction confidence and expiry dates are all evidence *about* a
+        # claim, whereas this is the claim's subject stating it directly. It takes a
+        # floor rather than a bonus so it cannot be diluted by a low base score, and
+        # it skips the staleness decay below — an expiry says "nobody has re-confirmed
+        # this lately", which is exactly the thing a human verification answers.
+        # `deprecated` still wins, above: a person retiring a claim is also a person.
+        if (lifecycle.get("verified_by") or "").lower().startswith("human:"):
+            return max(HUMAN_VERIFIED_FLOOR, min(1.0, score))
 
         # Past its stale_after the claim is not wrong, just unverified — decay it
         # rather than dropping it, and let the revisit queue confirm or deprecate.

--- a/src/suzent/memory/indexer.py
+++ b/src/suzent/memory/indexer.py
@@ -13,7 +13,9 @@ Also provides:
 
 import asyncio
 import json
+import math
 import re
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
 
@@ -522,8 +524,9 @@ class CoreMemoryFileIndexer:
         """
         tombstones = tombstones or set()
 
-        # 1. Build the rows to index: (text, metadata, importance). Importance is a
-        #    constant — ranking is relevance + recency, not a tuned lever.
+        # 1. Build the rows to index: (text, metadata, importance). Daily-log facts
+        #    are raw capture with no lifecycle, so they stay at the neutral 0.5;
+        #    vault pages are scored from the signals the dream records on them.
         if label == "archive":
             rows = [
                 (
@@ -547,6 +550,11 @@ class CoreMemoryFileIndexer:
                 if label == "notebook"
                 else ["core_memory", label, filename]
             )
+            # Vault pages carry a lifecycle (frontmatter status/stale_after, inline
+            # confirmation counts); core files do not, and get the neutral default.
+            lifecycle = (
+                self._parse_page_lifecycle(content) if source_type == "notebook" else {}
+            )
             rows = [
                 (
                     chunk,
@@ -557,8 +565,15 @@ class CoreMemoryFileIndexer:
                         "label": label,
                         "category": source_type,
                         "tags": tags,
+                        **(
+                            {k: v for k, v in lifecycle.items()}
+                            if source_type == "notebook"
+                            else {}
+                        ),
                     },
-                    0.5,
+                    self._claim_strength(chunk, lifecycle)
+                    if source_type == "notebook"
+                    else 0.5,
                 )
                 for i, chunk in enumerate(self._chunk_by_paragraphs(content))
                 if chunk.strip() and " ".join(chunk.lower().split()) not in tombstones
@@ -708,6 +723,67 @@ class CoreMemoryFileIndexer:
             if rest:
                 facts.append({"content": rest, "category": category, "tags": tags})
         return facts
+
+    @staticmethod
+    def _parse_page_lifecycle(content: str) -> dict:
+        """Read `status` and `stale_after` out of a vault page's frontmatter.
+
+        Deliberately not a YAML parse: the frontmatter is hand-editable and a page with
+        a malformed block must still be indexed. Unreadable keys simply go missing,
+        which lands the page on the neutral defaults.
+        """
+        lifecycle: dict = {}
+        m = re.match(r"^---\s*\n(.*?)\n---\s*(\n|$)", content, re.DOTALL)
+        if not m:
+            return lifecycle
+        for line in m.group(1).splitlines():
+            kv = re.match(r"^(status|stale_after)\s*:\s*(.+?)\s*$", line.strip())
+            if kv:
+                lifecycle[kv.group(1)] = kv.group(2).strip().strip("\"'")
+        return lifecycle
+
+    @staticmethod
+    def _claim_strength(
+        chunk: str, lifecycle: dict, today: Optional[str] = None
+    ) -> float:
+        """Importance for one vault chunk, from the signals the dream writes.
+
+        `importance` is already a scoring term in hybrid search (`importance_boost`),
+        and until now every row carried a constant 0.5 — so a claim confirmed twelve
+        times ranked exactly like a one-off, and a claim months past its expiry ranked
+        exactly like one confirmed yesterday. This is the read side of the lifecycle
+        the writer has been recording since `07f24c4b`.
+
+        Bounded to [0.1, 1.0] on purpose. Nothing here can push a claim out of
+        retrieval — `deprecated` demotes, it does not delete, and deletion stays with
+        tombstones so it remains reversible and auditable.
+        """
+        score = 0.5
+
+        # A repeated fact is one claim confirmed many times, not many facts. Log-scaled
+        # so the difference between 1x and 5x matters and 40x vs 60x does not.
+        confirmations = 0
+        for m in re.finditer(r"\(confirmed\s+(\d+)x", chunk, re.IGNORECASE):
+            confirmations = max(confirmations, int(m.group(1)))
+        if confirmations > 1:
+            score += min(0.25, 0.08 * math.log2(confirmations))
+
+        status = (lifecycle.get("status") or "").lower()
+        if status == "deprecated":
+            # A softer tombstone: still readable and linkable, out of the running.
+            return 0.1
+        if status == "draft":
+            score -= 0.05
+
+        # Past its stale_after the claim is not wrong, just unverified — decay it
+        # rather than dropping it, and let the revisit queue confirm or deprecate.
+        stale_after = lifecycle.get("stale_after", "")
+        if re.match(r"^\d{4}-\d{2}-\d{2}", stale_after):
+            now = today or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            if stale_after[:10] < now:
+                score *= 0.6
+
+        return max(0.1, min(1.0, score))
 
     @staticmethod
     def _chunk_by_paragraphs(

--- a/src/suzent/memory/indexer.py
+++ b/src/suzent/memory/indexer.py
@@ -23,6 +23,24 @@ from suzent.logger import get_logger
 
 logger = get_logger(__name__)
 
+
+def _owned_by_file(row: dict) -> bool:
+    """Whether a stored row is maintained by the markdown file it came from.
+
+    `source_file` is what makes a row reindexable: `_reindex_file` is delete-then-add
+    keyed on it. A row without one is a pre-June direct insert that no file owns, and
+    treating it as the indexed form of a log line is how an exported legacy fact ends
+    up deleted with nothing put back.
+    """
+    metadata = row.get("metadata")
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata or "{}")
+        except Exception:
+            return False
+    return bool((metadata or {}).get("source_file"))
+
+
 # ---------------------------------------------------------------------------
 # Transcript Indexer (Phase 5)
 # ---------------------------------------------------------------------------
@@ -675,10 +693,20 @@ class CoreMemoryFileIndexer:
         # Duplicate content within one day collapses to a single key. That matches
         # what the search index should hold anyway, and the extra copies get dropped
         # here as stale — the log itself keeps every line.
+        #
+        # A row without `source_file` is never a match, however identical its text.
+        # It is a pre-June direct insert that no file owns: nothing will ever reindex
+        # it, and `retire_legacy_rows.py --export` writes its text into this very log
+        # precisely so an owned row can replace it. Counting it as already-indexed
+        # would skip that replacement, and the export's `--apply` would then delete
+        # the only copy. So it is retired here and the line re-added under the file.
         indexed: dict = {}
         stale_ids: List[str] = []
         for row in existing:
             key = " ".join(str(row.get("content", "")).lower().split())
+            if not _owned_by_file(row):
+                stale_ids.append(row.get("id"))
+                continue
             if not key or key in indexed:
                 stale_ids.append(row.get("id"))
                 continue

--- a/src/suzent/memory/indexer.py
+++ b/src/suzent/memory/indexer.py
@@ -564,13 +564,27 @@ class CoreMemoryFileIndexer:
                 if chunk.strip() and " ".join(chunk.lower().split()) not in tombstones
             ]
 
-        # 2. Embed ALL rows BEFORE mutating the index. embedding_gen.generate() raises
+        # 2. Archive logs are appended to many times a day, and every append used to
+        #    re-embed the whole file: ~28x more embedding calls than facts across the
+        #    real corpus, quadratic in appends per day, and hundreds of thousands of
+        #    single-row inserts fragmenting the table. Diff against what is already
+        #    indexed instead. Correctness is unchanged — the end state is the same set
+        #    of rows — and a diff that comes back empty degrades to the old full
+        #    replace, so a failed query costs work, never accuracy.
+        if label == "archive":
+            replaced = await self._sync_archive_rows(
+                filename, rows, lancedb_store, embedding_gen, user_id
+            )
+            if replaced is not None:
+                return replaced
+
+        # 3. Embed ALL rows BEFORE mutating the index. embedding_gen.generate() raises
         #    on failure (e.g. embedding backend unreachable) — letting it propagate here
         #    leaves the existing index untouched and the file gets retried next pass,
         #    instead of deleting rows and replacing them with poisoned zero vectors.
         embeddings = [await embedding_gen.generate(text) for text, _, _ in rows]
 
-        # 3. Replace: clear this file's old rows, then add the freshly-embedded ones.
+        # 4. Replace: clear this file's old rows, then add the freshly-embedded ones.
         #    Reached only after every embedding succeeded. Archive logs may also carry
         #    legacy source_date metadata, so use the broader date-based delete for them.
         if label == "archive":
@@ -593,6 +607,85 @@ class CoreMemoryFileIndexer:
             indexed += 1
 
         return indexed
+
+    async def _sync_archive_rows(
+        self,
+        filename: str,
+        rows: List[tuple],
+        lancedb_store,
+        embedding_gen,
+        user_id: str,
+    ) -> Optional[int]:
+        """Bring one daily log's rows in line by diffing, not by re-embedding it.
+
+        Returns the row count now indexed for the file, or None to fall back to the
+        full delete-then-add path. None is returned whenever the diff cannot be
+        trusted — the store has no `list_source_rows`, the query failed, or the index
+        holds nothing for this date yet (a first index, where the diff would be the
+        whole file anyway).
+        """
+        date = filename.removesuffix(".md")
+        lister = getattr(lancedb_store, "list_source_rows", None)
+        if lister is None:
+            return None
+        try:
+            existing = await lister(date, user_id)
+        except Exception as e:
+            logger.warning(f"Archive diff unavailable for {date}; full reindex: {e}")
+            return None
+        if not existing:
+            return None
+
+        # Duplicate content within one day collapses to a single key. That matches
+        # what the search index should hold anyway, and the extra copies get dropped
+        # here as stale — the log itself keeps every line.
+        indexed: dict = {}
+        stale_ids: List[str] = []
+        for row in existing:
+            key = " ".join(str(row.get("content", "")).lower().split())
+            if not key or key in indexed:
+                stale_ids.append(row.get("id"))
+                continue
+            indexed[key] = row.get("id")
+
+        wanted = {
+            " ".join(text.lower().split()): (text, meta, imp)
+            for text, meta, imp in rows
+        }
+
+        for key, row_id in indexed.items():
+            if key not in wanted and row_id:
+                stale_ids.append(row_id)
+
+        added = 0
+        for key, (text, metadata, importance) in wanted.items():
+            if key in indexed:
+                continue
+            embedding = await embedding_gen.generate(text)
+            await lancedb_store.add_memory(
+                content=text,
+                embedding=embedding,
+                user_id=user_id,
+                chat_id=None,
+                metadata=metadata,
+                importance=importance,
+            )
+            added += 1
+
+        # Removals last: a crash before this point leaves rows that a later pass will
+        # clear, whereas deleting first could drop a fact that never gets re-added.
+        for row_id in stale_ids:
+            try:
+                await lancedb_store.delete_memory(row_id)
+            except Exception as e:
+                logger.warning(f"Could not delete stale row {row_id}: {e}")
+
+        if added or stale_ids:
+            logger.debug(
+                f"Archive {date}: +{added} -{len(stale_ids)} (diffed, "
+                f"{len(wanted)} facts in file)"
+            )
+        return len(wanted)
 
     @staticmethod
     def _parse_archive_facts(content: str) -> List[dict]:

--- a/src/suzent/memory/indexer.py
+++ b/src/suzent/memory/indexer.py
@@ -217,6 +217,9 @@ class CoreMemoryFileIndexer:
     """
 
     INDEX_STATE_FILENAME = ".index_state.json"
+    # Bumped when the shape or the key scheme of the state file changes; older
+    # payloads are discarded on load rather than migrated.
+    STATE_VERSION = 2
 
     # Map from block label → filename as stored in LanceDB metadata
     CORE_FILES: dict = {
@@ -233,19 +236,49 @@ class CoreMemoryFileIndexer:
         # watcher's check_and_update, and the dream's reconcile).
         self._lock = asyncio.Lock()
 
+    @staticmethod
+    def _state_key(label: str, filename: str) -> str:
+        """Portable identity for a tracked file: ``label:filename``.
+
+        Deliberately not the absolute path. Path-keyed state travels with a synced
+        vault and survives a moved base dir, so entries from another machine sit in
+        the file forever; any tracked file whose stale recorded mtime happens to
+        match is then skipped for good and never makes it into the index. The
+        (label, filename) pair is already the file's identity everywhere else —
+        it is what LanceDB deletion is keyed on.
+        """
+        return f"{label}:{filename}"
+
     def _load_state(self, markdown_store) -> None:
         """Load persisted mtime state from disk (called once on first check).
 
         If the state file does not exist, pre-populate mtimes from all existing
         files so that the first run after this change skips re-indexing entirely.
+
+        STATE_VERSION 1 state is keyed by absolute path and cannot be trusted (see
+        _state_key), so it is discarded rather than migrated. That costs one full
+        reindex, which is the point: the files it was wrongly skipping are exactly
+        the ones missing from the index.
         """
         import json as _json
 
         self._state_path = markdown_store.base_dir / self.INDEX_STATE_FILENAME
         if self._state_path.exists():
             try:
-                self._mtimes = _json.loads(self._state_path.read_text(encoding="utf-8"))
-                logger.debug(f"Loaded index state: {len(self._mtimes)} entries")
+                payload = _json.loads(self._state_path.read_text(encoding="utf-8"))
+                if (
+                    isinstance(payload, dict)
+                    and payload.get("version") == self.STATE_VERSION
+                ):
+                    mtimes = payload.get("mtimes")
+                    self._mtimes = mtimes if isinstance(mtimes, dict) else {}
+                    logger.debug(f"Loaded index state: {len(self._mtimes)} entries")
+                else:
+                    self._mtimes = {}
+                    logger.info(
+                        "Index state is path-keyed (pre-v%s); discarding it so every "
+                        "tracked file is re-indexed once." % self.STATE_VERSION
+                    )
             except Exception as e:
                 logger.warning(f"Failed to load index state, starting fresh: {e}")
                 self._mtimes = {}
@@ -258,9 +291,13 @@ class CoreMemoryFileIndexer:
                     else markdown_store._block_path(label)
                 )
                 if path.exists():
-                    self._mtimes[str(path)] = path.stat().st_mtime
+                    self._mtimes[self._state_key(label, filename)] = (
+                        path.stat().st_mtime
+                    )
             for archive_path in markdown_store.archive_dir.glob("????-??-??.md"):
-                self._mtimes[str(archive_path)] = archive_path.stat().st_mtime
+                self._mtimes[self._state_key("archive", archive_path.name)] = (
+                    archive_path.stat().st_mtime
+                )
             self._save_state()
             logger.info(
                 f"Initialized index state with {len(self._mtimes)} existing files (no reindex)"
@@ -274,7 +311,10 @@ class CoreMemoryFileIndexer:
             import json as _json
 
             self._state_path.write_text(
-                _json.dumps(self._mtimes, indent=2), encoding="utf-8"
+                _json.dumps(
+                    {"version": self.STATE_VERSION, "mtimes": self._mtimes}, indent=2
+                ),
+                encoding="utf-8",
             )
         except Exception as e:
             logger.warning(f"Failed to save index state: {e}")
@@ -345,7 +385,7 @@ class CoreMemoryFileIndexer:
             if not path.exists():
                 continue
 
-            path_key = str(path)
+            path_key = self._state_key(label, filename)
 
             # Watermark-aware archives: a log already folded into the vault (date ≤ W)
             # must NOT remain in the search index — drop it once.
@@ -425,7 +465,7 @@ class CoreMemoryFileIndexer:
 
             content = path.read_text(encoding="utf-8", errors="replace").strip()
             if not content:
-                self._mtimes[str(path)] = path.stat().st_mtime
+                self._mtimes[self._state_key(label, filename)] = path.stat().st_mtime
                 self._save_state()
                 return 0
 
@@ -439,7 +479,7 @@ class CoreMemoryFileIndexer:
                 tombstones=markdown_store.read_tombstones(),
             )
             # Record post-write mtime so the watcher treats this file as handled.
-            self._mtimes[str(path)] = path.stat().st_mtime
+            self._mtimes[self._state_key(label, filename)] = path.stat().st_mtime
             self._save_state()
             return n
 

--- a/src/suzent/memory/lancedb_store.py
+++ b/src/suzent/memory/lancedb_store.py
@@ -808,6 +808,33 @@ class LanceDBMemoryStore:
             logger.error(f"delete_memories_by_source_date failed: {e}")
             return False
 
+    async def list_source_rows(
+        self, source_date: str, user_id: str
+    ) -> List[Dict[str, Any]]:
+        """`[{"id", "content"}]` for one archive date — no vectors.
+
+        Lets the indexer diff a daily log against what is already indexed instead of
+        re-embedding the whole file. Mirrors the matching in
+        `delete_memories_by_source_date`, including the legacy `source_date` rows, so
+        the diff sees exactly the rows that a full delete would have removed.
+        """
+        try:
+            safe_user = _escape_sql(user_id)
+            safe_date = source_date.replace("'", "")
+            safe_file = f"{safe_date}.md".replace('"', '\\"')
+            clause = (
+                f"user_id = '{safe_user}'"
+                f' AND (metadata LIKE \'%"source_date": "{safe_date}"%\''
+                f'   OR metadata LIKE \'%"source_file": "{safe_file}"%\')'
+            )
+            res = await (
+                self.archival_table.query().where(clause).select(["id", "content"])
+            ).to_arrow()
+            return res.to_pylist()
+        except Exception as e:
+            logger.error(f"list_source_rows failed for {source_date}: {e}")
+            return []
+
     async def delete_all_memory_blocks(
         self, user_id: str, chat_id: Optional[str] = None
     ) -> bool:

--- a/src/suzent/memory/lancedb_store.py
+++ b/src/suzent/memory/lancedb_store.py
@@ -816,12 +816,16 @@ class LanceDBMemoryStore:
     async def list_source_rows(
         self, source_date: str, user_id: str
     ) -> List[Dict[str, Any]]:
-        """`[{"id", "content"}]` for one archive date — no vectors.
+        """`[{"id", "content", "metadata"}]` for one archive date — no vectors.
 
         Lets the indexer diff a daily log against what is already indexed instead of
         re-embedding the whole file. Mirrors the matching in
         `delete_memories_by_source_date`, including the legacy `source_date` rows, so
         the diff sees exactly the rows that a full delete would have removed.
+
+        `metadata` comes back because a legacy row matching a log line is not the same
+        as that line being indexed: only a row carrying `source_file` is owned by the
+        file and will be maintained with it. The indexer needs to tell them apart.
         """
         try:
             safe_user = _escape_sql(user_id)
@@ -833,7 +837,9 @@ class LanceDBMemoryStore:
                 f'   OR metadata LIKE \'%"source_file": "{safe_file}"%\')'
             )
             res = await (
-                self.archival_table.query().where(clause).select(["id", "content"])
+                self.archival_table.query()
+                .where(clause)
+                .select(["id", "content", "metadata"])
             ).to_arrow()
             return res.to_pylist()
         except Exception as e:

--- a/src/suzent/memory/lancedb_store.py
+++ b/src/suzent/memory/lancedb_store.py
@@ -174,7 +174,12 @@ class LanceDBMemoryStore:
 
     async def _init_tables(self) -> None:
         """Initialize tables if they don't exist."""
-        table_names = await self.db.list_tables()
+        # list_tables() returns a paginated result object, not a list — `"x" not in
+        # <that object>` is always True, so both branches below took the create path on
+        # every startup and were saved only by exist_ok. Harmless today, but it means
+        # "the table did not exist" was never actually known.
+        listing = await self.db.list_tables()
+        table_names = list(getattr(listing, "tables", listing) or [])
 
         # Memory Blocks
         if "memory_blocks" not in table_names:

--- a/src/suzent/memory/lifecycle.py
+++ b/src/suzent/memory/lifecycle.py
@@ -14,6 +14,29 @@ from suzent.logger import get_logger
 
 logger = get_logger(__name__)
 
+
+def resolve_notebook_dir() -> str:
+    """The vault the app actually uses, which is often not `CONFIG.notebook_dir`.
+
+    A user who mounts their own vault at `/mnt/notebook` (an Obsidian folder, say) is
+    mapping the agent's side of the sandbox; `CONFIG.notebook_dir` keeps pointing at
+    the default under the data dir, which `_build_volumes` still creates and which then
+    sits there empty apart from whatever a first run bootstrapped into it. Anything
+    that reads `CONFIG.notebook_dir` directly is therefore liable to read a stale
+    skeleton and conclude the vault is nearly empty — so every caller resolves the
+    mapped volume first, through here.
+    """
+    from pathlib import Path
+
+    from suzent.tools.filesystem.path_resolver import PathResolver
+
+    for vol in CONFIG.sandbox_volumes or []:
+        parsed = PathResolver.parse_volume_string(vol)
+        if parsed and parsed[1] == "/mnt/notebook":
+            return str(Path(parsed[0]).resolve())
+    return str(Path(CONFIG.notebook_dir).resolve())
+
+
 # --- Memory System State ---
 memory_manager = None
 memory_store = None
@@ -237,22 +260,10 @@ async def _initialize_memory_system() -> bool:
         # if they provided one, else the default CONFIG.notebook_dir. The vault is
         # bootstrapped (nav files + zone folders) unconditionally so the dream
         # consolidation can always run.
-        from suzent.tools.filesystem.path_resolver import PathResolver
         from suzent.memory.wiki_manager import WikiManager
         from pathlib import Path
 
-        notebook_host_path = None
-        for vol in CONFIG.sandbox_volumes or []:
-            parsed = PathResolver.parse_volume_string(vol)
-            if parsed and parsed[1] == "/mnt/notebook":
-                notebook_host_path = parsed[0]
-                break
-
-        resolved_notebook = str(
-            Path(notebook_host_path).resolve()
-            if notebook_host_path
-            else Path(CONFIG.notebook_dir).resolve()
-        )
+        resolved_notebook = resolve_notebook_dir()
         memory_manager.notebook_dir = resolved_notebook
         memory_manager.wiki_manager = WikiManager(notebook_path=resolved_notebook)
         # Align the markdown store's vault pointer (it may default differently).

--- a/src/suzent/memory/manager.py
+++ b/src/suzent/memory/manager.py
@@ -181,11 +181,16 @@ class MemoryManager:
 
     async def refresh_core_memory_facts(self, user_id: str):
         """
-        Refresh the 'facts' core memory block by summarizing highly important archival memories.
+        Refresh the 'facts' core memory block by summarizing top archival memories.
 
-        This condenses scattered archival memories into a high-density 'facts' block
-        that is always visible to the agent.
+        Legacy path, kept only until the vault has enough consolidated personal pages
+        for `promote_memory_md` to take over — which is why it stands down as soon as
+        those pages exist rather than racing the dream for the same file.
         """
+        if await self._vault_owns_memory_file():
+            logger.debug("Vault has personal pages; leaving MEMORY.md to the dream")
+            return
+
         try:
             # 1. Fetch top important memories
             # We use list_memories instead of search to get global top facts for user
@@ -199,15 +204,19 @@ class MemoryManager:
             if not memories:
                 return
 
-            # Filter for high importance only
+            # The rows are already the top 50 by importance, and that is as much
+            # selectivity as the column can offer: the indexer stamps every row it
+            # writes with a constant 0.5, so an additional
+            # `>= IMPORTANT_MEMORY_THRESHOLD` cut here matched nothing except the
+            # pre-June legacy rows — quietly rebuilding MEMORY.md from data months
+            # out of date, and set to produce an empty file the moment those rows
+            # are retired. Rank, then take what we get.
             important_facts = [
-                f"- {m['content']}"
-                for m in memories
-                if m.get("importance", 0) >= IMPORTANT_MEMORY_THRESHOLD
+                f"- {m['content']}" for m in memories if m.get("content", "").strip()
             ]
 
             if not important_facts:
-                logger.debug("No important facts found for core memory refresh")
+                logger.debug("No facts available for core memory refresh")
                 return
 
             facts_list_text = "\n".join(important_facts)
@@ -222,10 +231,15 @@ class MemoryManager:
                     max_tokens=1000,
                 )
 
-                # 3. Write summary to MEMORY.md (file-based SSoT)
+                # 3. Write summary to MEMORY.md (file-based SSoT). The store stamps
+                #    the file itself, in UTC; this used to add a second stamp from a
+                #    naive `datetime.now()`, so every generated file carried two
+                #    timestamps an hour apart wherever local time is not UTC.
                 if summary:
                     stats = await self.get_memory_stats(user_id)
-                    final_content = f"{summary.strip()}\n\n(Last updated: {datetime.now().strftime('%Y-%m-%d %H:%M')} | Total Memories: {stats['total_memories']})"
+                    final_content = (
+                        f"{summary.strip()}\n\n_{stats['total_memories']} memories._"
+                    )
 
                     if self.markdown_store:
                         try:
@@ -239,6 +253,22 @@ class MemoryManager:
 
         except Exception as e:
             logger.error(f"Failed to refresh core memory facts: {e}")
+
+    async def _vault_owns_memory_file(self) -> bool:
+        """True once `promote_memory_md` has real material to work from.
+
+        Both writers regenerate the same file, and the newer one is strictly better
+        informed — it reads consolidated pages rather than raw extractions. Handing
+        over on the first personal page means the transition needs no flag day and no
+        config: as the dream fills the vault, the legacy path simply stops firing.
+        """
+        if not self.markdown_store:
+            return False
+        try:
+            personal_dir = self.markdown_store.notebook_dir / "3_Personal"
+            return any(personal_dir.rglob("*.md"))
+        except Exception:
+            return False
 
     async def promote_memory_md(self, user_id: str) -> None:
         """Regenerate the always-visible MEMORY.md from the vault's personal facts +

--- a/src/suzent/memory/manager.py
+++ b/src/suzent/memory/manager.py
@@ -161,8 +161,12 @@ class MemoryManager:
                         # No chat_id — skip silently (context is always session-scoped)
                         logger.debug("Skipping context write: no chat_id provided")
                 elif label == "facts":
-                    # MEMORY.md — write raw (no auto-header here; agent owns the file)
-                    await self.markdown_store.write_block("MEMORY", content)
+                    # MEMORY.md — a person editing this block is the highest-quality
+                    # signal the system gets, so it goes to the zone that generators
+                    # never touch, stamped with a `human:` actor.
+                    await self.markdown_store.write_memory_manual_zone(
+                        content, actor=f"human:{user_id or 'unknown'}"
+                    )
                 else:
                     await self.markdown_store.write_block(label, content)
             else:

--- a/src/suzent/memory/manager.py
+++ b/src/suzent/memory/manager.py
@@ -35,6 +35,13 @@ DEFAULT_IMPORTANCE = 0.5
 # Extraction settings
 LLM_EXTRACTION_TEMPERATURE = 1.0
 
+# Already-known facts shown to the extractor so a re-mention is not stored again.
+# Ten is enough to cover the stable identity/preference facts that dominate the
+# duplicate clusters without crowding out the turn itself.
+KNOWN_FACTS_LIMIT = 10
+KNOWN_FACTS_MAX_CHARS = 240
+KNOWN_FACTS_QUERY_CHARS = 2000
+
 
 class MemoryManager:
     """Central memory management service.
@@ -481,10 +488,13 @@ class MemoryManager:
             MemoryExtractionResult with the list of extracted fact contents.
 
         Append-only write path (fixes #34): facts are written to the markdown daily
-        log (the source of truth) and indexed into LanceDB. There is NO write-time
-        deduplication — duplicate/contradictory facts are resolved later by the dream
-        consolidation pass, which has full context. See
-        docs/02-concepts/memory/consolidation.md.
+        log (the source of truth) and indexed into LanceDB. There is still NO
+        write-time deduplication — an update to a fact must never be silently
+        dropped, which is what #34 was. Repetition is suppressed one step earlier
+        instead, by showing the extractor what memory already holds so a re-mention
+        is not extracted at all. What survives that is resolved by the dream
+        consolidation pass. See docs/02-concepts/memory/consolidation.md and
+        docs/02-concepts/memory/deduplication.md.
         """
         result = MemoryExtractionResult.empty()
 
@@ -495,10 +505,11 @@ class MemoryManager:
             else:
                 turn = conversation_turn
 
-            # Extract facts from the formatted turn
-            extracted_facts = await self._extract_facts_llm(
-                turn.format_for_extraction()
-            )
+            # Extract facts from the formatted turn, showing the model what memory
+            # already holds so a re-mention is not stored as a new fact.
+            turn_text = turn.format_for_extraction()
+            known_facts = await self._recall_known_facts(turn_text, user_id, chat_id)
+            extracted_facts = await self._extract_facts_llm(turn_text, known_facts)
 
             if not extracted_facts:
                 logger.debug("No facts extracted from conversation turn")
@@ -547,6 +558,41 @@ class MemoryManager:
 
         return result
 
+    async def _recall_known_facts(
+        self, turn_text: str, user_id: str, chat_id: Optional[str] = None
+    ) -> List[str]:
+        """Facts already in memory that are close to this turn, nearest-first.
+
+        Best-effort: any failure returns [] and extraction runs exactly as it did
+        before. Enriching the prompt must never be able to block a memory write.
+        """
+        query = turn_text[:KNOWN_FACTS_QUERY_CHARS]
+        if not query.strip():
+            return []
+        try:
+            results = await self.search_memories(
+                query=query,
+                limit=KNOWN_FACTS_LIMIT,
+                user_id=user_id,
+                chat_id=chat_id,
+            )
+        except Exception as e:
+            logger.warning(f"Known-fact recall failed; extracting without it: {e}")
+            return []
+
+        facts: List[str] = []
+        seen: set = set()
+        for r in results:
+            content = " ".join(str(r.get("content", "")).split())
+            if not content:
+                continue
+            key = content.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            facts.append(content[:KNOWN_FACTS_MAX_CHARS])
+        return facts
+
     async def _write_facts_to_markdown(
         self, facts: List[ExtractedFact], chat_id: str
     ) -> Optional[str]:
@@ -585,18 +631,27 @@ class MemoryManager:
             logger.warning(f"Failed to write facts to markdown daily log: {e}")
             return None
 
-    async def _extract_facts_llm(self, content: str) -> List[ExtractedFact]:
+    async def _extract_facts_llm(
+        self, content: str, known_facts: Optional[List[str]] = None
+    ) -> List[ExtractedFact]:
         """
         Extract facts using LLM with Pydantic schema-based structured output.
 
         Uses LiteLLM's structured output feature to enforce the FactExtractionResponse
         schema, ensuring validated ExtractedFact models are returned.
 
+        Args:
+            content: The formatted conversation turn.
+            known_facts: Facts already in memory, nearest-first, so the model can tell
+                a repeat from an update. Omitted when retrieval is unavailable.
+
         Returns:
             List of ExtractedFact models
         """
         system_prompt = memory_context.FACT_EXTRACTION_SYSTEM_PROMPT
-        user_prompt = memory_context.format_fact_extraction_user_prompt(content)
+        user_prompt = memory_context.format_fact_extraction_user_prompt(
+            content, known_facts
+        )
         extraction_model = self.llm_extraction_model or getattr(
             self.llm_client, "model", None
         )

--- a/src/suzent/memory/manager.py
+++ b/src/suzent/memory/manager.py
@@ -3,13 +3,14 @@ Memory Manager - orchestrates core and archival memory operations.
 """
 
 from typing import Dict, List, Any, Optional, Union, TYPE_CHECKING
-from datetime import datetime
+from datetime import datetime, timezone
 
 from suzent.logger import get_logger
 from suzent.llm import EmbeddingGenerator, LLMClient
 from .lancedb_store import LanceDBMemoryStore
 from .markdown_store import MarkdownMemoryStore
 from .indexer import CoreMemoryFileIndexer
+from .classifier import classify_fact
 from . import memory_context
 from .models import (
     ConversationTurn,
@@ -41,6 +42,11 @@ LLM_EXTRACTION_TEMPERATURE = 1.0
 KNOWN_FACTS_LIMIT = 10
 KNOWN_FACTS_MAX_CHARS = 240
 KNOWN_FACTS_QUERY_CHARS = 2000
+
+# Sources where a matched claim is already written down for good. A transcript row is
+# the user saying something, and MEMORY.md is generated from other rows -- neither is a
+# record the write path can defer to.
+DURABLE_SOURCE_TYPES = frozenset({"notebook", "archive_log"})
 
 
 class MemoryManager:
@@ -542,11 +548,25 @@ class MemoryManager:
             # Extract facts from the formatted turn, showing the model what memory
             # already holds so a re-mention is not stored as a new fact.
             turn_text = turn.format_for_extraction()
-            known_facts = await self._recall_known_facts(turn_text, user_id, chat_id)
-            extracted_facts = await self._extract_facts_llm(turn_text, known_facts)
+            known = await self._recall_known_facts(turn_text, user_id, chat_id)
+            extracted_facts = await self._extract_facts_llm(
+                turn_text, [k["content"] for k in known]
+            )
 
             if not extracted_facts:
                 logger.debug("No facts extracted from conversation turn")
+                return result
+
+            # Separate out the re-statements. What is left keeps the append-only path.
+            extracted_facts, confirmations = await self._split_confirmations(
+                extracted_facts, known, chat_id
+            )
+            result.confirmed_facts = [c[0] for c in confirmations]
+
+            if not extracted_facts:
+                logger.debug(
+                    f"Turn held only re-statements: {len(confirmations)} confirmed"
+                )
                 return result
 
             result.extracted_facts = [f.content for f in extracted_facts]
@@ -592,10 +612,73 @@ class MemoryManager:
 
         return result
 
+    async def _split_confirmations(
+        self,
+        facts: List[ExtractedFact],
+        known: List[Dict[str, Any]],
+        chat_id: str,
+    ) -> tuple:
+        """Divide extracted facts into ones to write and ones already on record.
+
+        Returns `(to_write, confirmations)`. A fact is a confirmation only when it
+        matches a *durably recorded* claim in the same words with no new specifics
+        (see `classifier.classify_fact`); it then becomes a line in the confirmations
+        sidecar instead of a redundant row in the daily log. Nothing is lost by that:
+        the identical text is already in a vault page or an earlier log, and the fact
+        that it recurred is what the sidecar records.
+
+        A revision is written exactly as before — issue #34 was a write-time dedup that
+        swallowed an update, and nothing here is allowed to do that again. It is only
+        tagged, so the dream knows to treat it as an update to a claim it already holds.
+
+        Best-effort: if the sidecar write fails, the fact falls back to the normal
+        append-only path.
+        """
+        if not self.markdown_store or not known:
+            return facts, []
+
+        date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        durable = [k["content"] for k in known if k.get("durable")]
+        to_write: List[ExtractedFact] = []
+        confirmations: List[tuple] = []
+
+        for fact in facts:
+            verdict = classify_fact(fact.content, durable)
+            if verdict.is_confirmation:
+                try:
+                    await self.markdown_store.append_confirmation(
+                        content=fact.content,
+                        matched=verdict.matched,
+                        date=date,
+                        chat_id=chat_id,
+                    )
+                    confirmations.append((fact.content, verdict.matched))
+                    continue
+                except Exception as e:
+                    logger.warning(
+                        f"Confirmation sidecar write failed; logging the fact: {e}"
+                    )
+            elif verdict.is_revision and "revision" not in (fact.tags or []):
+                fact.tags = list(fact.tags or []) + ["revision"]
+            to_write.append(fact)
+
+        if confirmations:
+            logger.info(
+                f"{len(confirmations)} fact(s) already on record; "
+                f"recorded as confirmations rather than new rows"
+            )
+        return to_write, confirmations
+
     async def _recall_known_facts(
         self, turn_text: str, user_id: str, chat_id: Optional[str] = None
-    ) -> List[str]:
+    ) -> List[Dict[str, Any]]:
         """Facts already in memory that are close to this turn, nearest-first.
+
+        Returns `[{"content", "durable"}]`. *durable* marks the rows that come from an
+        append-only store — a vault page or a daily log — as opposed to a chat
+        transcript or the generated `MEMORY.md`. Only a durable match can justify not
+        writing a repeat to the log, because only there is the claim already recorded
+        somewhere the write path is not about to record it.
 
         Best-effort: any failure returns [] and extraction runs exactly as it did
         before. Enriching the prompt must never be able to block a memory write.
@@ -614,7 +697,7 @@ class MemoryManager:
             logger.warning(f"Known-fact recall failed; extracting without it: {e}")
             return []
 
-        facts: List[str] = []
+        facts: List[Dict[str, Any]] = []
         seen: set = set()
         for r in results:
             content = " ".join(str(r.get("content", "")).split())
@@ -624,7 +707,13 @@ class MemoryManager:
             if key in seen:
                 continue
             seen.add(key)
-            facts.append(content[:KNOWN_FACTS_MAX_CHARS])
+            metadata = r.get("metadata") or {}
+            facts.append(
+                {
+                    "content": content[:KNOWN_FACTS_MAX_CHARS],
+                    "durable": metadata.get("source_type") in DURABLE_SOURCE_TYPES,
+                }
+            )
         return facts
 
     async def _write_facts_to_markdown(

--- a/src/suzent/memory/manager.py
+++ b/src/suzent/memory/manager.py
@@ -549,8 +549,14 @@ class MemoryManager:
             # already holds so a re-mention is not stored as a new fact.
             turn_text = turn.format_for_extraction()
             known = await self._recall_known_facts(turn_text, user_id, chat_id)
+            # Only the durable ones. The prompt tells the model not to re-extract what
+            # it is shown, and a fact that exists solely in a transcript or in the
+            # generated MEMORY.md is not recorded anywhere the write path is about to
+            # record it -- suppressing it there means it never reaches the append-only
+            # log at all, and `_split_confirmations` cannot recover a fact the model
+            # already declined to emit.
             extracted_facts = await self._extract_facts_llm(
-                turn_text, [k["content"] for k in known]
+                turn_text, [k["content"] for k in known if k.get("durable")]
             )
 
             if not extracted_facts:

--- a/src/suzent/memory/markdown_store.py
+++ b/src/suzent/memory/markdown_store.py
@@ -180,12 +180,6 @@ class MarkdownMemoryStore:
                     continue
         return out
 
-    def truncate_recalls(self) -> None:
-        try:
-            self.recall_log_path.write_text("", encoding="utf-8")
-        except Exception:
-            pass
-
     # --- Tombstones (user-deleted facts the indexer must skip) ---
 
     @property

--- a/src/suzent/memory/markdown_store.py
+++ b/src/suzent/memory/markdown_store.py
@@ -445,6 +445,47 @@ class MarkdownMemoryStore:
             return ""
         return existing.strip()
 
+    async def write_memory_manual_zone(self, content: str, actor: str) -> None:
+        """Replace the human-owned half of MEMORY.md, keeping the generated half.
+
+        This is the fourth writer to this file: a person editing the `facts` block in
+        the UI. It used to be a raw whole-file write, which meant a human correction
+        either got clobbered by the next consolidation or got copied down into the
+        manual zone alongside the generated original.
+
+        Their text lands in the manual zone, where nothing overwrites it, and carries
+        an OKF-style `human:` verification stamp — a person's correction is evidence
+        of a different quality than anything the extractor produced, and this is the
+        record of that. Anything they typed inside the generated zone is dropped: the
+        marker says outright that the region is rewritten, and silently preserving it
+        would duplicate every fact the next pass regenerates.
+        """
+        async with self._write_lock:
+            path = self.memory_file_path
+            existing = path.read_text(encoding="utf-8") if path.exists() else ""
+
+            if MEMORY_GENERATED_START in existing and MEMORY_GENERATED_END in existing:
+                head = existing.split(MEMORY_GENERATED_END, 1)[0] + MEMORY_GENERATED_END
+            else:
+                timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+                head = (
+                    f"# Long-term Memory\n_Consolidated {timestamp}._\n\n"
+                    f"{MEMORY_GENERATED_START}\n{MEMORY_GENERATED_END}"
+                )
+
+            submitted = content
+            if MEMORY_GENERATED_END in submitted:
+                submitted = submitted.split(MEMORY_GENERATED_END, 1)[1]
+
+            stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            body = f"{head}\n\n<!-- verified: {actor} at {stamp} -->\n"
+            if submitted.strip():
+                body += f"{submitted.strip()}\n"
+
+            path.write_text(body, encoding="utf-8")
+
+        logger.info("Updated MEMORY.md manual zone (%s)", actor)
+
     async def write_memory_file(self, content: str) -> None:
         """Rewrite the generated zone of MEMORY.md, preserving the manual zone.
 

--- a/src/suzent/memory/markdown_store.py
+++ b/src/suzent/memory/markdown_store.py
@@ -17,7 +17,7 @@ import json
 import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from suzent.logger import get_logger
 
@@ -255,6 +255,98 @@ class MarkdownMemoryStore:
                 self.superseded_path.write_text("", encoding="utf-8")
         except Exception as e:
             logger.warning(f"Failed to clear superseded file: {e}")
+
+    # --- Confirmations (write path hand-off to the dream) ---
+
+    @property
+    def confirmations_path(self) -> Path:
+        return self.notebook_state_dir / "confirmations.jsonl"
+
+    async def append_confirmation(
+        self, content: str, matched: str, date: str, chat_id: str = ""
+    ) -> None:
+        """Record that a claim already on record was stated again.
+
+        The line the user just said is not appended to the daily log — it is word-for-
+        word something durably recorded already, so the only new information is that
+        it recurred, and that is what this file holds. The dream folds these into the
+        vault's `(confirmed Nx, last YYYY-MM-DD)` markers.
+        """
+        async with self._write_lock:
+            with open(self.confirmations_path, "a", encoding="utf-8") as f:
+                f.write(
+                    json.dumps(
+                        {
+                            "content": content,
+                            "matched": matched,
+                            "date": date,
+                            "chat_id": chat_id,
+                        },
+                        ensure_ascii=False,
+                    )
+                    + "\n"
+                )
+
+    def read_confirmations(self) -> List[dict]:
+        """Pending confirmations, oldest first. Malformed lines are skipped."""
+        p = self.confirmations_path
+        if not p.exists():
+            return []
+        out: List[dict] = []
+        for line in _read_text(p).splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            if isinstance(rec, dict) and rec.get("content"):
+                out.append(rec)
+        return out
+
+    def summarize_confirmations(self, limit: int = 40) -> List[dict]:
+        """Pending confirmations collapsed to one row per claim, most-repeated first.
+
+        `[{"content", "count", "last"}]` — the shape the dream prompt needs to bump a
+        marker without reading the raw file.
+        """
+        grouped: Dict[str, dict] = {}
+        for rec in self.read_confirmations():
+            key = self._normalize(rec.get("content", ""))
+            if not key:
+                continue
+            row = grouped.setdefault(
+                key, {"content": rec["content"], "count": 0, "last": ""}
+            )
+            row["count"] += 1
+            date = str(rec.get("date") or "")
+            if date > row["last"]:
+                row["last"] = date
+        rows = sorted(grouped.values(), key=lambda r: (-r["count"], r["content"]))
+        return rows[:limit]
+
+    def clear_confirmations(self, consumed: Optional[int] = None) -> None:
+        """Drop the confirmations the dream has folded in (never raises).
+
+        *consumed* is the number of lines that were in the file when the prompt was
+        built. Conversations keep appending here while the dream runs, so truncating
+        the whole file would silently discard every confirmation recorded during the
+        run — the one thing this sidecar exists to not do. Passing None truncates.
+        """
+        try:
+            p = self.confirmations_path
+            if not p.exists():
+                return
+            if consumed is None:
+                p.write_text("", encoding="utf-8")
+                return
+            remaining = _read_text(p).splitlines()[consumed:]
+            p.write_text(
+                "\n".join(remaining) + ("\n" if remaining else ""), encoding="utf-8"
+            )
+        except Exception as e:
+            logger.warning(f"Failed to clear confirmations file: {e}")
 
     def archive_dates_containing(self, contents: List[str]) -> List[str]:
         """Dates whose daily log holds any of *contents*, oldest first.

--- a/src/suzent/memory/markdown_store.py
+++ b/src/suzent/memory/markdown_store.py
@@ -208,6 +208,43 @@ class MarkdownMemoryStore:
         ts = tombstones if tombstones is not None else self.read_tombstones()
         return self._normalize(content) in ts
 
+    # --- Dream pacing state (durable across restarts) ---
+
+    @property
+    def dream_state_path(self) -> Path:
+        return self.notebook_state_dir / "dream_state.json"
+
+    def read_dream_failures(self) -> dict:
+        """Consecutive no-op counts per batch end date, `{"YYYY-MM-DD": int}`.
+
+        Durable because retry-then-skip is what stops one un-consolidatable batch
+        from wedging the backlog forever. Held only in memory, the counter resets
+        on every process start, so the skip never fires on a desktop app that
+        restarts between attempts and the watermark stops advancing for good.
+        """
+        p = self.dream_state_path
+        if not p.exists():
+            return {}
+        try:
+            data = json.loads(_read_text(p))
+        except Exception:
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        failures = data.get("failures")
+        if not isinstance(failures, dict):
+            return {}
+        return {k: v for k, v in failures.items() if isinstance(v, int)}
+
+    def write_dream_failures(self, failures: dict) -> None:
+        """Best-effort persist of the retry counters (never raises)."""
+        try:
+            self.dream_state_path.write_text(
+                json.dumps({"failures": failures}, indent=2), encoding="utf-8"
+            )
+        except Exception as e:
+            logger.warning(f"Failed to persist dream state: {e}")
+
     # --- Daily Logs ---
 
     def _daily_log_path(self, date: str) -> Path:

--- a/src/suzent/memory/markdown_store.py
+++ b/src/suzent/memory/markdown_store.py
@@ -320,27 +320,56 @@ class MarkdownMemoryStore:
         rows = sorted(grouped.values(), key=lambda r: (-r["count"], r["content"]))
         return rows[:limit]
 
-    def clear_confirmations(self, consumed: Optional[int] = None) -> None:
+    def clear_confirmations(
+        self,
+        consumed: Optional[int] = None,
+        folded: Optional[List[str]] = None,
+    ) -> None:
         """Drop the confirmations the dream has folded in (never raises).
 
-        *consumed* is the number of lines that were in the file when the prompt was
-        built. Conversations keep appending here while the dream runs, so truncating
-        the whole file would silently discard every confirmation recorded during the
-        run — the one thing this sidecar exists to not do. Passing None truncates.
+        Two things have to be true of what is dropped, and each guards a different way
+        of losing evidence this sidecar exists to keep.
+
+        *consumed* is how many lines the file held when the prompt was built. Anything
+        after that arrived while the dream ran and the agent never saw it, so the line
+        count bounds the damage a truncation could do. Passing None truncates.
+
+        *folded* is the claims that were actually in the prompt. `summarize_confirmations`
+        is bounded, so a busy period can leave the file holding more distinct claims
+        than the agent was shown; dropping by position alone would then delete the
+        unshown ones' evidence permanently. Lines whose claim is not in *folded* are
+        kept, wherever they sit. Passing None keeps the old positional behaviour, for
+        callers that show everything.
         """
         try:
             p = self.confirmations_path
             if not p.exists():
                 return
-            if consumed is None:
+            if consumed is None and folded is None:
                 p.write_text("", encoding="utf-8")
                 return
-            remaining = _read_text(p).splitlines()[consumed:]
+            lines = _read_text(p).splitlines()
+            head, tail = lines[: consumed or 0], lines[consumed or 0 :]
+            if folded is not None:
+                keys = {self._normalize(c) for c in folded if c}
+                head = [
+                    ln for ln in head if ln.strip() and self._line_claim(ln) not in keys
+                ]
+            else:
+                head = []
+            remaining = head + tail
             p.write_text(
                 "\n".join(remaining) + ("\n" if remaining else ""), encoding="utf-8"
             )
         except Exception as e:
             logger.warning(f"Failed to clear confirmations file: {e}")
+
+    def _line_claim(self, line: str) -> str:
+        """The normalized claim a raw sidecar line records, or "" if unreadable."""
+        try:
+            return self._normalize(json.loads(line).get("content", ""))
+        except Exception:
+            return ""
 
     def archive_dates_containing(self, contents: List[str]) -> List[str]:
         """Dates whose daily log holds any of *contents*, oldest first.

--- a/src/suzent/memory/markdown_store.py
+++ b/src/suzent/memory/markdown_store.py
@@ -23,6 +23,17 @@ from suzent.logger import get_logger
 
 logger = get_logger(__name__)
 
+# MEMORY.md is written by two generators and edited directly by the agent, which the
+# core-memory prompt actively tells it to do. Only the region between these markers is
+# regenerated; everything after the end marker is preserved verbatim, so a note the
+# agent or the user adds is not destroyed by the next consolidation.
+MEMORY_GENERATED_START = "<!-- memory:generated - rewritten on consolidation -->"
+MEMORY_GENERATED_END = "<!-- /memory:generated - notes below this line are kept -->"
+
+# The footer written by every pre-marker version of write_memory_file. Its presence is
+# what identifies an unmarked file as generator-authored and therefore safe to replace.
+_LEGACY_FOOTER_RE = re.compile(r"^\*Last updated: .*UTC\*\s*$", re.MULTILINE)
+
 
 def _read_text(path: Path) -> str:
     """Read a memory file as UTF-8, tolerating stray non-UTF-8 bytes.
@@ -414,23 +425,56 @@ class MarkdownMemoryStore:
         """Path to the curated long-term memory file."""
         return self.base_dir / "MEMORY.md"
 
-    async def write_memory_file(self, content: str) -> None:
+    def manual_tail(self, existing: str) -> str:
+        """Whatever a generator must not touch, taken from the current MEMORY.md.
+
+        Three cases, in order:
+
+        - Marked file: everything after the end marker is the manual zone.
+        - Unmarked but generator-authored: nothing to keep. Recognised by the footer
+          only this method ever wrote, so the test cannot be fooled by an agent that
+          merely reused the heading.
+        - Anything else: the whole file. A file we did not write is somebody's work,
+          and a blind overwrite is exactly how it used to get lost.
         """
-        Write/update the MEMORY.md file.
+        if MEMORY_GENERATED_END in existing:
+            return existing.split(MEMORY_GENERATED_END, 1)[1].strip()
+        if not existing.strip():
+            return ""
+        if _LEGACY_FOOTER_RE.search(existing):
+            return ""
+        return existing.strip()
+
+    async def write_memory_file(self, content: str) -> None:
+        """Rewrite the generated zone of MEMORY.md, preserving the manual zone.
+
+        This file has two writers in code and a third in practice: the agent edits it
+        with its ordinary file tools because the core-memory prompt invites it to. The
+        write used to be an unconditional `write_text`, so whichever generator ran next
+        destroyed that work with no merge, no warning, and no way to notice afterwards.
 
         Args:
-            content: Full content to write (replaces existing)
+            content: the generated section. Everything after the end marker survives.
         """
         async with self._write_lock:
-            header = "# Long-term Memory\n\n"
+            path = self.memory_file_path
+            existing = path.read_text(encoding="utf-8") if path.exists() else ""
+            tail = self.manual_tail(existing)
             timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-            footer = f"\n\n---\n*Last updated: {timestamp}*\n"
 
-            self.memory_file_path.write_text(
-                header + content + footer, encoding="utf-8"
+            body = (
+                f"# Long-term Memory\n"
+                f"_Consolidated {timestamp}._\n\n"
+                f"{MEMORY_GENERATED_START}\n"
+                f"{content.strip()}\n"
+                f"{MEMORY_GENERATED_END}\n"
             )
+            if tail:
+                body += f"\n{tail}\n"
 
-        logger.info("Updated MEMORY.md")
+            path.write_text(body, encoding="utf-8")
+
+        logger.info("Updated MEMORY.md (generated zone, %d chars kept)", len(tail))
 
     async def read_memory_file(self) -> Optional[str]:
         """

--- a/src/suzent/memory/markdown_store.py
+++ b/src/suzent/memory/markdown_store.py
@@ -208,6 +208,64 @@ class MarkdownMemoryStore:
         ts = tombstones if tombstones is not None else self.read_tombstones()
         return self._normalize(content) in ts
 
+    # --- Superseded facts (dream hand-off to the runner) ---
+
+    @property
+    def superseded_path(self) -> Path:
+        return self.notebook_state_dir / "superseded.txt"
+
+    def read_superseded(self) -> List[str]:
+        """Fact lines the dream folded into the vault and wants out of the index.
+
+        The dream only ever appends here. Turning these into tombstones and
+        reindexing the affected logs is the runner's job, so that index mutation
+        stays out of the agent's hands and the daily logs stay append-only.
+        """
+        p = self.superseded_path
+        if not p.exists():
+            return []
+        out: List[str] = []
+        seen: set = set()
+        for line in _read_text(p).splitlines():
+            line = line.strip().lstrip("-").strip()
+            if not line:
+                continue
+            key = self._normalize(line)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(line)
+        return out
+
+    def clear_superseded(self) -> None:
+        """Truncate the hand-off file once its lines are tombstoned (never raises)."""
+        try:
+            if self.superseded_path.exists():
+                self.superseded_path.write_text("", encoding="utf-8")
+        except Exception as e:
+            logger.warning(f"Failed to clear superseded file: {e}")
+
+    def archive_dates_containing(self, contents: List[str]) -> List[str]:
+        """Dates whose daily log holds any of *contents*, oldest first.
+
+        Matching is normalized-substring against the whole log line rather than a
+        parse of it: the fact body sits inside the line, and a false positive only
+        costs one redundant reindex, which is delete-then-add and therefore
+        idempotent. Missing a date, by contrast, would leave the row in the index
+        with no mtime change to ever bring the watcher back to it.
+        """
+        wanted = [self._normalize(c) for c in contents if c and c.strip()]
+        if not wanted:
+            return []
+        dates: set = set()
+        for path in sorted(self.archive_dir.glob("????-??-??.md")):
+            if not path.is_file():
+                continue
+            body = self._normalize(_read_text(path))
+            if any(w in body for w in wanted):
+                dates.add(path.stem)
+        return sorted(dates)
+
     # --- Dream pacing state (durable across restarts) ---
 
     @property

--- a/src/suzent/memory/memory_context.py
+++ b/src/suzent/memory/memory_context.py
@@ -360,11 +360,15 @@ DREAM_INSTRUCTIONS = f"""Consolidate the daily memory logs dated after {{start}}
    a. Find the page it belongs to (index.md + glob_search/grep_search + memory_search).
       Personal facts about the user -> 3_Personal/ ; domain knowledge -> 2_Wiki/.
    b. Apply the matching case:
-      - Duplicate (same fact reworded)              -> keep the richest wording on the
-                                                       page, then retire the weaker log
-                                                       lines (step 3d). Never keep a
-                                                       vaguer restatement of a fact you
-                                                       already hold in more detail.
+      - Duplicate (same fact reworded)              -> confirm, do not restate. Bump the
+                                                       claim's confirmation marker
+                                                       (step 3e), replace the bullet text
+                                                       only if the new wording is MORE
+                                                       specific, then retire the log lines
+                                                       (step 3d). Never add a second
+                                                       bullet, and never let a vaguer
+                                                       restatement overwrite a detailed
+                                                       claim you already hold.
       - New, non-conflicting                        -> add under the right section.
       - Correction (new entry shows old was wrong)  -> replace the wrong statement.
       - Change over time (both true at diff. times) -> rewrite as "Currently X (since {{end}});
@@ -380,6 +384,15 @@ DREAM_INSTRUCTIONS = f"""Consolidate the daily memory logs dated after {{start}}
       on a page AND adds nothing the page does not say. The runner drops those from the
       search index; the daily logs themselves stay untouched. When in doubt, leave it
       out — a duplicate in the index is cheaper than a fact that vanishes.
+   e. Lifecycle on {DREAM_NOTEBOOK_ROOT}/3_Personal/ pages, whether or not this vault's
+      schema.md mentions it (older vaults were seeded before these rules existed):
+      - A repeated claim gets a marker on its bullet: `(confirmed 12x, last YYYY-MM-DD)`.
+        Absent marker means confirmed once. Increment it and set the date; a claim the user
+        keeps repeating is one claim confirmed many times, not many claims.
+      - A repeat that CONTRADICTS the bullet is a correction, not a confirmation — reset the
+        count and apply the correction case above.
+      - Give each page a `stale_after` derived from the fact category: identity none,
+        preference 1 year, technical 6 months, goal 3 months, context 3 weeks.
 4. Add `## Related` links using the schema's link style.
 5. Update index.md. Do NOT write the watermark to log.md — the runner records it.
 
@@ -418,6 +431,8 @@ LINT_INSTRUCTIONS = f"""Run an editorial lint pass over the notebook vault.
    related page, or delete only if truly obsolete.
 6. Reciprocal links: if A links B in `## Related`, add B→A where meaningful.
 7. Decay: apply page-level `stale_after` and the schema's fallback decay rule, using its review marker.
+   On 3_Personal/ pages a passed `stale_after` means re-confirm the claim against recent logs or mark it
+   `status: deprecated` — never delete it, and never reset a claim's confirmation marker during lint.
 8. Gaps: note recurring topics with no synthesized page and dangling internal links.
 
 Do NOT append the lint entry to log.md — the runner records it.

--- a/src/suzent/memory/memory_context.py
+++ b/src/suzent/memory/memory_context.py
@@ -250,22 +250,57 @@ For each fact:
 - State facts directly: "Prefers X" not "User mentioned they prefer X"
 - Skip greetings, ephemeral debugging, small talk
 - Fewer high-quality facts > many low-quality ones
+
+## Already-known facts
+The prompt may list facts already in memory. They are context, not material:
+
+- Do NOT re-extract one because it came up again. Stable facts (someone's name, how
+  they like to be addressed, a long-running project) surface constantly; re-stating
+  them is what fills memory with duplicates.
+- DO extract when the turn CHANGES a known fact — new specifics, a correction, a
+  reversal. Write the full updated fact, not the delta, and lead with what changed.
+- A near-repeat that adds nothing is not a change. "Wants water reminders" after
+  "Wants water reminders hourly 9am-9pm" is a step backwards; skip it.
+- When in doubt about a fact that carries NEW information, extract it. Losing an
+  update is worse than storing a duplicate.
 """
 
 
-def format_fact_extraction_user_prompt(content: str) -> str:
+def format_known_facts_block(known_facts: Optional[List[str]]) -> str:
+    """Render already-known facts for the extraction prompt, or "" if there are none.
+
+    Extraction is otherwise blind: it sees one conversation turn and no memory, so
+    every mention of a stable fact reads as new. Showing what is already stored is
+    what lets the model tell a repeat from an update.
+    """
+    if not known_facts:
+        return ""
+    lines = "\n".join(f"- {f}" for f in known_facts)
+    return f"""## Already in memory
+{lines}
+
+Do not re-extract these. Extract only what is new, or what CHANGES one of them.
+
+"""
+
+
+def format_fact_extraction_user_prompt(
+    content: str, known_facts: Optional[List[str]] = None
+) -> str:
     """
     Format user prompt for fact extraction from a conversation turn.
 
     Args:
         content: The formatted conversation turn text (user message + assistant response + actions)
+        known_facts: Facts already in memory, nearest-first. Omitted when retrieval
+            is unavailable — extraction then behaves exactly as it did before.
 
     Returns:
         Formatted extraction prompt
     """
     return f"""Extract memorable facts from this conversation turn. One concise sentence per fact.
 
----
+{format_known_facts_block(known_facts)}---
 {content}
 ---
 

--- a/src/suzent/memory/memory_context.py
+++ b/src/suzent/memory/memory_context.py
@@ -327,6 +327,13 @@ Max 2000 words. Respond with the summary only.
 DREAM_MEMORY_ROOT = "/shared/memory"  # daily logs: {DREAM_MEMORY_ROOT}/archive/*.md
 DREAM_NOTEBOOK_ROOT = "/mnt/notebook"  # the vault the agent maintains
 
+# Where the dream drops fact lines it has folded into the vault and wants dropped
+# from the search index. The agent only ever writes this file; the runner turns the
+# lines into tombstones and reindexes the affected logs, keeping index mutation out
+# of the agent's hands and the daily logs append-only.
+DREAM_SUPERSEDED_FILENAME = "superseded.txt"
+DREAM_SUPERSEDED_PATH = f"{DREAM_NOTEBOOK_ROOT}/.state/{DREAM_SUPERSEDED_FILENAME}"
+
 DREAM_SYSTEM_PROMPT = f"""You are Suzent's memory consolidation agent ("dream"). You run \
 autonomously to turn the raw, append-only daily memory logs into a clean, durable, \
 cross-referenced knowledge vault.
@@ -342,6 +349,7 @@ Rules:
 - Preserve history: when a fact changes over time, record "currently X; previously Y" — never silently overwrite.
 - Only remove a statement when it is a genuine correction or an exact duplicate.
 - Do NOT write to log.md — the runner records consolidation events there. Put conflicts on content pages.
+- {DREAM_SUPERSEDED_PATH} is append-only and write-only for you: read it if you must, never clear it.
 """
 
 DREAM_INSTRUCTIONS = f"""Consolidate the daily memory logs dated after {{start}} through {{end}} into the vault.
@@ -352,7 +360,11 @@ DREAM_INSTRUCTIONS = f"""Consolidate the daily memory logs dated after {{start}}
    a. Find the page it belongs to (index.md + glob_search/grep_search + memory_search).
       Personal facts about the user -> 3_Personal/ ; domain knowledge -> 2_Wiki/.
    b. Apply the matching case:
-      - Duplicate (same fact reworded)              -> do nothing.
+      - Duplicate (same fact reworded)              -> keep the richest wording on the
+                                                       page, then retire the weaker log
+                                                       lines (step 3d). Never keep a
+                                                       vaguer restatement of a fact you
+                                                       already hold in more detail.
       - New, non-conflicting                        -> add under the right section.
       - Correction (new entry shows old was wrong)  -> replace the wrong statement.
       - Change over time (both true at diff. times) -> rewrite as "Currently X (since {{end}});
@@ -362,6 +374,12 @@ DREAM_INSTRUCTIONS = f"""Consolidate the daily memory logs dated after {{start}}
         content page (or create a conflict-review page in the schema's appropriate location
         if no topical page exists) and apply the schema's needs-review marker.
    c. Convert relative dates ("yesterday") to absolute.
+   d. Retire what you folded in: append the exact log fact text (the part after the
+      `- [category] ` prefix, without the trailing backtick tags) to
+      {DREAM_SUPERSEDED_PATH}, one per line, for any line that is now fully represented
+      on a page AND adds nothing the page does not say. The runner drops those from the
+      search index; the daily logs themselves stay untouched. When in doubt, leave it
+      out — a duplicate in the index is cheaper than a fact that vanishes.
 4. Add `## Related` links using the schema's link style.
 5. Update index.md. Do NOT write the watermark to log.md — the runner records it.
 

--- a/src/suzent/memory/memory_context.py
+++ b/src/suzent/memory/memory_context.py
@@ -398,11 +398,50 @@ DREAM_INSTRUCTIONS = f"""Consolidate the daily memory logs dated after {{start}}
         count and apply the correction case above.
       - Give each page a `stale_after` derived from the fact category: identity none,
         preference 1 year, technical 6 months, goal 3 months, context 3 weeks.
-4. Add `## Related` links using the schema's link style.
-5. Update index.md. Do NOT write the watermark to log.md — the runner records it.
+4. Confirmations recorded by the write path since the last consolidation. These were
+   said again word-for-word and deliberately NOT written to a daily log, so this list
+   is the only record that they recurred. For each, find the claim on its page and bump
+   its marker by the count shown (step 3e); do not add a bullet, and do not treat one
+   as a correction — a contradicting restatement never reaches this list.
+{{confirmations}}
+5. Claims past their `stale_after`. Re-confirm each against the logs you just read: if
+   it is supported, refresh the date; if it is contradicted, apply the correction case;
+   if the logs say nothing either way, leave it and let lint decide. Never delete here.
+{{revisits}}
+6. Add `## Related` links using the schema's link style.
+7. Update index.md. Do NOT write the watermark to log.md — the runner records it.
 
 Return a one-paragraph summary of what you created, updated, superseded, or flagged.
 """
+
+
+def format_confirmations_block(rows: Optional[List[dict]]) -> str:
+    """Render the confirmations sidecar for the dream prompt.
+
+    `rows` is `markdown_store.summarize_confirmations()` output: one entry per claim
+    with a count and the last date it was restated.
+    """
+    if not rows:
+        return "   (none pending)"
+    lines = []
+    for row in rows:
+        content = " ".join(str(row.get("content", "")).split())
+        if not content:
+            continue
+        lines.append(
+            f"   - {content} — +{row.get('count', 1)}x, last {row.get('last')}"
+        )
+    return "\n".join(lines) or "   (none pending)"
+
+
+def format_revisits_block(rows: Optional[List[dict]]) -> str:
+    """Render the revisit queue: vault pages whose `stale_after` has passed."""
+    if not rows:
+        return "   (none due)"
+    return "\n".join(
+        f"   - {row['page']} (stale_after {row['stale_after']})" for row in rows
+    )
+
 
 # ---- Lint phase: periodic editorial audit of the vault (runs after ingest catches up) ----
 

--- a/src/suzent/memory/memory_context.py
+++ b/src/suzent/memory/memory_context.py
@@ -404,9 +404,11 @@ DREAM_INSTRUCTIONS = f"""Consolidate the daily memory logs dated after {{start}}
    its marker by the count shown (step 3e); do not add a bullet, and do not treat one
    as a correction — a contradicting restatement never reaches this list.
 {{confirmations}}
-5. Claims past their `stale_after`. Re-confirm each against the logs you just read: if
-   it is supported, refresh the date; if it is contradicted, apply the correction case;
-   if the logs say nothing either way, leave it and let lint decide. Never delete here.
+5. Claims due for a revisit. Re-confirm each against the logs you just read: if it is
+   supported, refresh the date; if it is contradicted, apply the correction case; if the
+   logs say nothing either way, leave it and let lint decide. Never delete here.
+   A page listed as `stale_after unset` predates the rule and has no expiry at all: give
+   it one from step 3's category table while you are there, whatever the logs say.
 {{revisits}}
 6. Add `## Related` links using the schema's link style.
 7. Update index.md. Do NOT write the watermark to log.md — the runner records it.

--- a/src/suzent/memory/memory_context.py
+++ b/src/suzent/memory/memory_context.py
@@ -6,6 +6,8 @@ Centralizes all prompt engineering for the memory system.
 
 from typing import Dict, List, Any, Optional
 
+from suzent.memory.markdown_store import MEMORY_GENERATED_END
+
 
 # ===== Core Memory Context Prompts =====
 
@@ -101,6 +103,9 @@ Your memory lives in plain markdown files you can read and write directly:
 **How to update your memory:**
 - To update persona, user profile, or long-term context: use `edit_file` or `write_file` on the corresponding `.md` file
 - To update session scratchpad / task state: write to `context.md` in the sessions directory
+- `MEMORY.md` is part generated: consolidation rewrites everything above the
+  `{MEMORY_GENERATED_END}` marker, so put anything you want to keep **below** it. Text
+  above that line is not yours and will not survive the next pass
 - Do **not** append duplicate or ephemeral information; keep files concise and scannable
 
 {notebook_title}

--- a/src/suzent/memory/models.py
+++ b/src/suzent/memory/models.py
@@ -271,6 +271,13 @@ class MemoryExtractionResult(BaseModel):
     extracted_facts: List[str] = Field(
         default_factory=list, description="List of extracted fact contents"
     )
+    confirmed_facts: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Facts that restated a claim already durably recorded. Not written to the "
+            "daily log; recorded in the confirmations sidecar for the dream to fold in."
+        ),
+    )
     conflicts_detected: List[Dict[str, Any]] = Field(
         default_factory=list, description="Any detected conflicts (reserved)"
     )

--- a/tests/memory/test_archive_incremental_index.py
+++ b/tests/memory/test_archive_incremental_index.py
@@ -1,0 +1,184 @@
+"""Appending to a daily log must not re-embed the whole day.
+
+reindex_file_now runs after every conversation turn, and the archive path used to
+delete the date's rows and re-embed every fact in the file. Across the real corpus
+that is ~28x more embedding calls than there are facts - quadratic in appends per
+day - plus a single-row insert for each, which is what fragments the table.
+
+The diff must not change the end state: whatever the old full replace would have
+left in the index is what the diff leaves too.
+"""
+
+import pytest
+
+from suzent.memory.indexer import CoreMemoryFileIndexer
+
+
+class _FakeEmbeddings:
+    model = "fake"
+
+    def __init__(self):
+        self.calls = []
+
+    async def generate(self, text):
+        self.calls.append(text)
+        return [0.1, 0.2, 0.3]
+
+
+class _FakeStore:
+    """Enough of the LanceDB surface for the archive path."""
+
+    def __init__(self, rows=None, lister_raises=False):
+        self.rows = list(rows or [])
+        self.deleted_dates = []
+        self.deleted_ids = []
+        self.lister_raises = lister_raises
+        self._n = 0
+
+    async def list_source_rows(self, source_date, user_id):
+        if self.lister_raises:
+            raise RuntimeError("query failed")
+        return [dict(r) for r in self.rows]
+
+    async def add_memory(
+        self, content, embedding, user_id, chat_id, metadata, importance
+    ):
+        self._n += 1
+        rid = f"id-{self._n}"
+        self.rows.append({"id": rid, "content": content})
+        return rid
+
+    async def delete_memory(self, memory_id):
+        self.deleted_ids.append(memory_id)
+        self.rows = [r for r in self.rows if r["id"] != memory_id]
+        return True
+
+    async def delete_memories_by_source_date(self, date, user_id):
+        self.deleted_dates.append(date)
+        self.rows = []
+        return True
+
+
+def _log(*facts):
+    return "\n".join(f"- [preference] {f}" for f in facts)
+
+
+async def _reindex(store, emb, content):
+    return await CoreMemoryFileIndexer()._reindex_file(
+        label="archive",
+        filename="2026-08-23.md",
+        content=content,
+        lancedb_store=store,
+        embedding_gen=emb,
+        user_id="u1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_only_the_new_fact_is_embedded():
+    store = _FakeStore([{"id": "a", "content": "Prefers dark mode"}])
+    emb = _FakeEmbeddings()
+
+    n = await _reindex(store, emb, _log("Prefers dark mode", "Uses Unreal Engine 5"))
+
+    assert emb.calls == ["Uses Unreal Engine 5"]
+    assert n == 2
+    assert store.deleted_dates == []
+
+
+@pytest.mark.asyncio
+async def test_a_settled_log_costs_nothing():
+    """The watcher re-checks files constantly; an unchanged day must be free."""
+    store = _FakeStore([{"id": "a", "content": "Prefers dark mode"}])
+    emb = _FakeEmbeddings()
+
+    await _reindex(store, emb, _log("Prefers dark mode"))
+
+    assert emb.calls == []
+    assert store.deleted_ids == []
+
+
+@pytest.mark.asyncio
+async def test_rows_whose_fact_is_gone_are_dropped():
+    """A tombstoned fact is filtered out of `rows`, so the diff must remove it."""
+    store = _FakeStore(
+        [
+            {"id": "a", "content": "Prefers dark mode"},
+            {"id": "b", "content": "Tombstoned fact"},
+        ]
+    )
+
+    await _reindex(store, _FakeEmbeddings(), _log("Prefers dark mode"))
+
+    assert store.deleted_ids == ["b"]
+    assert [r["content"] for r in store.rows] == ["Prefers dark mode"]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_rows_for_one_day_collapse():
+    store = _FakeStore(
+        [
+            {"id": "a", "content": "Prefers dark mode"},
+            {"id": "b", "content": "prefers   dark mode"},
+        ]
+    )
+
+    await _reindex(store, _FakeEmbeddings(), _log("Prefers dark mode"))
+
+    assert store.deleted_ids == ["b"]
+
+
+@pytest.mark.asyncio
+async def test_first_index_of_a_day_uses_the_full_path():
+    """Nothing indexed yet means the diff is the whole file; don't pay for the query."""
+    store = _FakeStore([])
+    emb = _FakeEmbeddings()
+
+    n = await _reindex(store, emb, _log("Prefers dark mode", "Uses Unreal Engine 5"))
+
+    assert n == 2
+    assert len(emb.calls) == 2
+    assert store.deleted_dates == ["2026-08-23"]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_diff_falls_back_to_full_replace():
+    """Degrading to more work is fine; degrading to a wrong index is not."""
+    store = _FakeStore(
+        [{"id": "a", "content": "Prefers dark mode"}], lister_raises=True
+    )
+    emb = _FakeEmbeddings()
+
+    n = await _reindex(store, emb, _log("Prefers dark mode", "Uses Unreal Engine 5"))
+
+    assert n == 2
+    assert len(emb.calls) == 2
+    assert store.deleted_dates == ["2026-08-23"]
+
+
+@pytest.mark.asyncio
+async def test_notebook_pages_still_replace_wholesale():
+    """Vault pages are rewritten in place, so a diff would buy nothing."""
+    store = _FakeStore([{"id": "a", "content": "old paragraph"}])
+    emb = _FakeEmbeddings()
+
+    async def _no(*a, **k):
+        raise AssertionError("archive-only path used for a notebook page")
+
+    store.list_source_rows = _no
+
+    async def _del_file(f, u):
+        return True
+
+    store.delete_memories_by_source_file = _del_file
+
+    n = await CoreMemoryFileIndexer()._reindex_file(
+        label="notebook",
+        filename="3_Personal/Suzy.md",
+        content="a new paragraph",
+        lancedb_store=store,
+        embedding_gen=emb,
+        user_id="u1",
+    )
+
+    assert n == 1

--- a/tests/memory/test_archive_incremental_index.py
+++ b/tests/memory/test_archive_incremental_index.py
@@ -29,7 +29,14 @@ class _FakeStore:
     """Enough of the LanceDB surface for the archive path."""
 
     def __init__(self, rows=None, lister_raises=False):
-        self.rows = list(rows or [])
+        # Rows default to archive-owned. A row without `source_file` is a pre-June
+        # direct insert that no file maintains, and the diff deliberately retires it
+        # rather than counting it as the indexed form of a log line — see
+        # test_a_legacy_row_is_replaced_not_matched.
+        self.rows = [
+            {"metadata": {"source_file": f"{r.get('date', '2026-08-23')}.md"}, **r}
+            for r in (rows or [])
+        ]
         self.deleted_dates = []
         self.deleted_ids = []
         self.lister_raises = lister_raises
@@ -45,7 +52,7 @@ class _FakeStore:
     ):
         self._n += 1
         rid = f"id-{self._n}"
-        self.rows.append({"id": rid, "content": content})
+        self.rows.append({"id": rid, "content": content, "metadata": metadata})
         return rid
 
     async def delete_memory(self, memory_id):
@@ -182,3 +189,47 @@ async def test_notebook_pages_still_replace_wholesale():
     )
 
     assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_a_legacy_row_is_replaced_not_matched():
+    """The one case where identical text must NOT count as already indexed.
+
+    `retire_legacy_rows.py --export` writes a pre-June row's text into the daily log
+    for its date, precisely so a row carrying `source_file` can take it over. If the
+    diff treated the legacy row as the indexed form of that line, no owned row would
+    be created — and the documented `--apply` step, seeing the text present in
+    markdown, would then delete the only copy. The fact would leave retrieval with
+    the file's mtime already recorded, so nothing would ever put it back.
+    """
+    store = _FakeStore()
+    store.rows = [{"id": "legacy", "content": "Prefers dark mode", "metadata": {}}]
+    emb = _FakeEmbeddings()
+
+    await _reindex(store, emb, _log("Prefers dark mode"))
+
+    assert emb.calls == ["Prefers dark mode"]
+    assert store.deleted_ids == ["legacy"]
+    assert [r["metadata"]["source_file"] for r in store.rows] == ["2026-08-23.md"]
+
+
+@pytest.mark.asyncio
+async def test_the_replacement_is_added_before_the_legacy_row_is_dropped():
+    """A crash between the two must leave a duplicate, never a hole."""
+    store = _FakeStore()
+    store.rows = [{"id": "legacy", "content": "Prefers dark mode", "metadata": {}}]
+    order = []
+    original_add, original_delete = store.add_memory, store.delete_memory
+
+    async def add(*a, **kw):
+        order.append("add")
+        return await original_add(*a, **kw)
+
+    async def delete(*a, **kw):
+        order.append("delete")
+        return await original_delete(*a, **kw)
+
+    store.add_memory, store.delete_memory = add, delete
+    await _reindex(store, _FakeEmbeddings(), _log("Prefers dark mode"))
+
+    assert order == ["add", "delete"]

--- a/tests/memory/test_claim_lifecycle_prompts.py
+++ b/tests/memory/test_claim_lifecycle_prompts.py
@@ -1,0 +1,58 @@
+"""Personal claims must carry lifecycle, not just accumulate.
+
+A fact the user repeats is one claim confirmed many times. Without somewhere to put
+that count the dream can only retire the repeat, losing the strongest ranking signal
+in the corpus; without `stale_after` nothing ever revisits a claim that went out of
+date. Both rules live in the dream prompt as well as the schema, because schema.md is
+seeded once per vault and existing vaults predate them.
+"""
+
+from suzent.memory import memory_context
+
+SCHEMA = "skills/notebook/schema_example.md"
+OKF = "skills/notebook/okf.md"
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def test_duplicates_are_confirmed_not_restated():
+    text = memory_context.DREAM_INSTRUCTIONS
+
+    assert "confirmed 12x, last YYYY-MM-DD" in text
+    assert "Never add a second" in text
+
+
+def test_a_contradicting_repeat_is_not_a_confirmation():
+    """Otherwise a reversal would be counted as evidence for the thing it reverses."""
+    assert "CONTRADICTS" in memory_context.DREAM_INSTRUCTIONS
+
+
+def test_lifecycle_rules_do_not_depend_on_the_seeded_schema():
+    assert "whether or not this vault's" in memory_context.DREAM_INSTRUCTIONS
+    assert "stale_after" in memory_context.DREAM_INSTRUCTIONS
+
+
+def test_lint_never_deletes_or_unconfirms_a_stale_personal_claim():
+    text = memory_context.LINT_INSTRUCTIONS
+
+    assert "never delete it" in text
+    assert "never reset a claim's confirmation marker" in text
+
+
+def test_schema_documents_the_personal_page_contract():
+    schema = _read(SCHEMA)
+
+    assert "type: personal" in schema
+    assert "confirmed 12x" in schema
+    for category in ("preference", "technical", "goal", "context"):
+        assert category in schema
+
+
+def test_okf_profile_maps_the_marker_to_usage_count():
+    okf = _read(OKF)
+
+    assert "usage_count" in okf
+    assert "stale_after" in okf

--- a/tests/memory/test_claim_ranking.py
+++ b/tests/memory/test_claim_ranking.py
@@ -214,3 +214,118 @@ async def test_editing_facts_before_any_generation_still_works(tmp_path):
     text = store.memory_file_path.read_text(encoding="utf-8")
 
     assert "- first note" in text and "- generated" in text
+
+
+def test_a_human_verification_outranks_every_other_signal():
+    """The last open item from step 6: a person editing their own memory is the claim's
+    subject stating it directly, not evidence *about* the claim. It takes a floor, so a
+    low base score cannot dilute it."""
+    verified = {"verified_by": "human:u1", "verified_at": "2026-08-23T10:00:00Z"}
+
+    assert strength("- I moved to Berlin", verified) > strength(
+        "- I moved to Berlin (confirmed 40x, last 2026-08-20)", {}
+    )
+
+
+def test_an_expiry_cannot_decay_a_claim_the_user_verified():
+    """`stale_after` means nobody has re-confirmed this lately — which is exactly the
+    question a human verification answers."""
+    stale = {"stale_after": "2020-01-01"}
+    verified = dict(stale, verified_by="human:u1")
+
+    assert strength("- a claim", stale) < BASE
+    assert strength("- a claim", verified) >= 0.9
+
+
+def test_a_person_deprecating_a_claim_is_also_a_person():
+    retired = {"status": "deprecated", "verified_by": "human:u1"}
+
+    assert strength("- an old claim", retired) == 0.1
+
+
+def test_only_a_human_actor_gets_the_floor():
+    """An agent stamping itself as the verifier would launder its own output into the
+    strongest evidence class there is."""
+    assert strength("- a claim", {"verified_by": "agent:dream"}) == BASE
+
+
+def test_the_stamp_is_read_off_the_file():
+    parsed = CoreMemoryFileIndexer._parse_verification(
+        "<!-- verified: human:u1 at 2026-08-23T10:00:00Z -->\n- a note"
+    )
+
+    assert parsed == {"verified_by": "human:u1", "verified_at": "2026-08-23T10:00:00Z"}
+    assert CoreMemoryFileIndexer._parse_verification("- just a note") == {}
+
+
+@pytest.mark.asyncio
+async def test_indexing_memory_md_scores_the_manual_zone_and_not_the_generated_one(
+    tmp_path,
+):
+    """Everything above the end marker is rewritten by a generator on the next pass.
+    Scoring it as verified would launder machine output into the human evidence class."""
+    store = MarkdownMemoryStore(
+        base_dir=tmp_path, notebook_dir=str(tmp_path / "notebook")
+    )
+    await store.write_memory_file("- generated claim")
+    await store.write_memory_manual_zone("- I moved to Berlin", "human:u1")
+
+    indexer = CoreMemoryFileIndexer()
+    captured = []
+
+    class _Store:
+        async def delete_memories_by_source_file(self, f, u):
+            return True
+
+        async def delete_memories_by_source_date(self, d, u):
+            return True
+
+        async def add_memory(self, **kw):
+            captured.append((kw["content"], kw["importance"], kw["metadata"]))
+
+    class _Emb:
+        async def generate(self, text):
+            return [0.1, 0.2, 0.3]
+
+    await indexer._reindex_file(
+        "facts",
+        "MEMORY.md",
+        store.memory_file_path.read_text(encoding="utf-8"),
+        _Store(),
+        _Emb(),
+        "u1",
+    )
+
+    manual = [c for c in captured if "Berlin" in c[0]]
+    generated = [c for c in captured if "generated claim" in c[0]]
+
+    assert manual and manual[0][1] >= 0.9
+    assert manual[0][2]["verified_by"] == "human:u1"
+    assert generated and generated[0][1] == BASE
+    assert "verified_by" not in generated[0][2]
+
+
+@pytest.mark.asyncio
+async def test_an_unstamped_core_file_is_unchanged(tmp_path):
+    indexer = CoreMemoryFileIndexer()
+    captured = []
+
+    class _Store:
+        async def delete_memories_by_source_file(self, f, u):
+            return True
+
+        async def delete_memories_by_source_date(self, d, u):
+            return True
+
+        async def add_memory(self, **kw):
+            captured.append((kw["content"], kw["importance"], kw["metadata"]))
+
+    class _Emb:
+        async def generate(self, text):
+            return [0.1, 0.2, 0.3]
+
+    await indexer._reindex_file(
+        "persona", "persona.md", "- a plain core file", _Store(), _Emb(), "u1"
+    )
+
+    assert captured[0][1] == BASE

--- a/tests/memory/test_claim_ranking.py
+++ b/tests/memory/test_claim_ranking.py
@@ -61,6 +61,13 @@ def test_draft_ranks_just_below_stable():
     assert strength("- A guess", {"status": "draft"}) < strength("- A guess", {})
 
 
+def test_a_status_the_schema_does_not_know_is_neutral():
+    """The live vault predates the schema and writes `status: active`; a page must not
+    be demoted for having been written before the rule existed."""
+    for status in ("active", "stable", "Active", "whatever"):
+        assert strength("- Lives in Berlin", {"status": status}) == BASE
+
+
 # --- stale_after ---
 
 

--- a/tests/memory/test_claim_ranking.py
+++ b/tests/memory/test_claim_ranking.py
@@ -1,0 +1,209 @@
+"""Retrieval reads the lifecycle the dream writes.
+
+The writer side landed in `07f24c4b`: personal claims carry `(confirmed 12x, last
+YYYY-MM-DD)` and pages carry `status` / `stale_after`. Nothing read any of it — every
+indexed row got a constant importance of 0.5, so a claim confirmed twelve times ranked
+exactly like a one-off and a claim months past its expiry ranked exactly like one
+confirmed yesterday.
+
+`importance` is already a term in hybrid search, so it is where these signals belong.
+"""
+
+import pytest
+
+from suzent.memory.indexer import CoreMemoryFileIndexer
+from suzent.memory.markdown_store import (
+    MEMORY_GENERATED_END,
+    MEMORY_GENERATED_START,
+    MarkdownMemoryStore,
+)
+
+BASE = 0.5
+strength = CoreMemoryFileIndexer._claim_strength
+lifecycle = CoreMemoryFileIndexer._parse_page_lifecycle
+
+
+# --- confirmation count ---
+
+
+def test_an_unconfirmed_claim_keeps_the_neutral_default():
+    assert strength("- Prefers dark mode", {}) == BASE
+
+
+def test_confirmations_raise_the_claim_and_saturate():
+    once = strength("- Prefers dark mode", {})
+    few = strength("- Prefers dark mode (confirmed 4x, last 2026-08-20)", {})
+    many = strength("- Prefers dark mode (confirmed 64x, last 2026-08-20)", {})
+
+    assert once < few < many
+    assert many <= BASE + 0.25, "log-scaled: 40x and 60x must not diverge much"
+
+
+def test_the_strongest_marker_on_a_chunk_wins():
+    """Chunks are paragraphs, so one may hold several claims."""
+    chunk = "- a (confirmed 2x, last 2026-01-01)\n- b (confirmed 30x, last 2026-08-01)"
+
+    assert strength(chunk, {}) == strength("- b (confirmed 30x, last 2026-08-01)", {})
+
+
+# --- status ---
+
+
+def test_deprecated_demotes_but_never_removes():
+    """A softer tombstone: still retrievable, out of the running. Deletion stays with
+    tombstones so it remains reversible."""
+    score = strength("- An old address (confirmed 30x)", {"status": "deprecated"})
+
+    assert 0 < score < BASE
+
+
+def test_draft_ranks_just_below_stable():
+    assert strength("- A guess", {"status": "draft"}) < strength("- A guess", {})
+
+
+# --- stale_after ---
+
+
+def test_an_expired_claim_decays_rather_than_disappearing():
+    fresh = strength(
+        "- Works at Acme", {"stale_after": "2027-01-01"}, today="2026-08-23"
+    )
+    expired = strength(
+        "- Works at Acme", {"stale_after": "2026-01-01"}, today="2026-08-23"
+    )
+
+    assert expired < fresh
+    assert expired > 0, "unverified is not wrong — the revisit queue decides"
+
+
+def test_confirmations_still_outrank_an_expiry():
+    """Something confirmed sixty times and nominally stale beats an unconfirmed
+    one-off; the decay is a discount, not a veto."""
+    stale_but_certain = strength(
+        "- Lives in Berlin (confirmed 60x, last 2026-08-01)",
+        {"stale_after": "2026-01-01"},
+        today="2026-08-23",
+    )
+
+    assert stale_but_certain > 0.4
+
+
+def test_a_malformed_date_is_ignored():
+    assert strength("- x", {"stale_after": "soonish"}, today="2026-08-23") == BASE
+
+
+# --- frontmatter parsing ---
+
+
+def test_lifecycle_is_read_from_frontmatter():
+    page = (
+        "---\n"
+        "type: personal\n"
+        'status: "stable"\n'
+        "stale_after: 2027-02-01\n"
+        "---\n\n# Preferences\n"
+    )
+
+    assert lifecycle(page) == {"status": "stable", "stale_after": "2027-02-01"}
+
+
+def test_a_page_without_frontmatter_is_still_indexable():
+    assert lifecycle("# Preferences\n\n- dark mode") == {}
+    assert lifecycle("---\nbroken frontmatter\n\n# Page") == {}
+
+
+# --- the row build ---
+
+
+@pytest.mark.asyncio
+async def test_vault_pages_are_scored_and_logs_are_not(tmp_path):
+    """Daily logs are raw capture with no lifecycle; only the vault carries claims."""
+    indexer = CoreMemoryFileIndexer()
+    captured = []
+
+    class _Store:
+        async def delete_memories_by_source_file(self, f, u):
+            return True
+
+        async def delete_memories_by_source_date(self, d, u):
+            return True
+
+        async def add_memory(self, **kw):
+            captured.append((kw["content"], kw["importance"], kw["metadata"]))
+
+    class _Emb:
+        async def generate(self, text):
+            return [0.1, 0.2, 0.3]
+
+    page = (
+        "---\nstatus: stable\nstale_after: 2027-01-01\n---\n\n"
+        "- Prefers dark mode (confirmed 20x, last 2026-08-20)"
+    )
+    await indexer._reindex_file(
+        "notebook", "3_Personal/prefs.md", page, _Store(), _Emb(), "u1"
+    )
+    scored = [c for c in captured if "dark mode" in c[0]]
+
+    assert scored and scored[0][1] > BASE
+    assert scored[0][2]["status"] == "stable"
+
+    captured.clear()
+    await indexer._reindex_file(
+        "archive", "2026-08-20.md", "- [preference] dark mode", _Store(), _Emb(), "u1"
+    )
+
+    assert captured[0][1] == BASE
+
+
+# --- a human edit is a different kind of evidence ---
+
+
+@pytest.mark.asyncio
+async def test_a_human_edit_lands_in_the_zone_generators_cannot_touch(tmp_path):
+    store = MarkdownMemoryStore(
+        base_dir=tmp_path, notebook_dir=str(tmp_path / "notebook")
+    )
+    await store.write_memory_file("- generated claim")
+
+    await store.write_memory_manual_zone("- Actually I moved to Berlin", "human:u1")
+    await store.write_memory_file("- regenerated claim")
+
+    text = store.memory_file_path.read_text(encoding="utf-8")
+
+    assert "- Actually I moved to Berlin" in text
+    assert "- regenerated claim" in text
+    assert "- generated claim" not in text
+    assert "<!-- verified: human:u1 at " in text
+
+
+@pytest.mark.asyncio
+async def test_a_human_edit_does_not_copy_the_generated_half_down(tmp_path):
+    """The UI submits the whole file. Keeping the generated half as 'manual' would
+    duplicate every fact the next pass regenerates."""
+    store = MarkdownMemoryStore(
+        base_dir=tmp_path, notebook_dir=str(tmp_path / "notebook")
+    )
+    await store.write_memory_file("- generated claim")
+    submitted = store.memory_file_path.read_text(encoding="utf-8") + "\n- my note\n"
+
+    await store.write_memory_manual_zone(submitted, "human:u1")
+    text = store.memory_file_path.read_text(encoding="utf-8")
+
+    assert text.count("- generated claim") == 1
+    assert text.count(MEMORY_GENERATED_START) == 1
+    assert text.count(MEMORY_GENERATED_END) == 1
+    assert "- my note" in text
+
+
+@pytest.mark.asyncio
+async def test_editing_facts_before_any_generation_still_works(tmp_path):
+    store = MarkdownMemoryStore(
+        base_dir=tmp_path, notebook_dir=str(tmp_path / "notebook")
+    )
+
+    await store.write_memory_manual_zone("- first note", "human:u1")
+    await store.write_memory_file("- generated")
+
+    text = store.memory_file_path.read_text(encoding="utf-8")
+
+    assert "- first note" in text and "- generated" in text

--- a/tests/memory/test_dream_failures_persist.py
+++ b/tests/memory/test_dream_failures_persist.py
@@ -1,0 +1,79 @@
+"""The dream's retry counter must survive a process restart.
+
+Retry-then-skip exists so one un-consolidatable batch cannot wedge the backlog
+forever. The runner attempts a given batch at most once per app run, so a counter
+held only in memory never reaches ``max_retries`` on a desktop app that restarts
+between attempts — the skip never fires and the watermark stops advancing for good.
+"""
+
+import json
+
+import pytest
+
+from suzent.core.dream_runner import DreamRunner
+from suzent.memory.markdown_store import MarkdownMemoryStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return MarkdownMemoryStore(
+        base_dir=tmp_path / "memory", notebook_dir=tmp_path / "notebook"
+    )
+
+
+class _FakeManager:
+    def __init__(self, markdown_store):
+        self.markdown_store = markdown_store
+
+
+def test_failures_roundtrip_through_disk(store):
+    assert store.read_dream_failures() == {}
+
+    store.write_dream_failures({"2026-03-25": 2})
+
+    assert store.read_dream_failures() == {"2026-03-25": 2}
+    assert json.loads(store.dream_state_path.read_text(encoding="utf-8")) == {
+        "failures": {"2026-03-25": 2}
+    }
+
+
+def test_counter_survives_a_new_runner_instance(store):
+    """A fresh process must see the count a previous one recorded."""
+    mgr = _FakeManager(store)
+
+    first = DreamRunner()
+    first._load_failures(mgr)
+    first._failures["2026-03-25"] = first._failures.get("2026-03-25", 0) + 1
+    first._save_failures(mgr)
+
+    second = DreamRunner()  # stands in for the next app launch
+    second._load_failures(mgr)
+
+    assert second._failures == {"2026-03-25": 1}
+
+
+def test_hydration_happens_once_per_process(store):
+    """Later disk writes must not clobber counters the live runner is mutating."""
+    mgr = _FakeManager(store)
+    runner = DreamRunner()
+    runner._load_failures(mgr)
+    runner._failures["2026-03-25"] = 3
+
+    store.write_dream_failures({"2026-03-25": 0})
+    runner._load_failures(mgr)
+
+    assert runner._failures == {"2026-03-25": 3}
+
+
+def test_unreadable_state_degrades_to_empty(store):
+    store.dream_state_path.write_text("{not json", encoding="utf-8")
+
+    assert store.read_dream_failures() == {}
+
+
+def test_malformed_state_shapes_are_ignored(store):
+    store.dream_state_path.write_text(
+        json.dumps({"failures": {"2026-03-25": "three"}}), encoding="utf-8"
+    )
+
+    assert store.read_dream_failures() == {}

--- a/tests/memory/test_dream_queues.py
+++ b/tests/memory/test_dream_queues.py
@@ -125,3 +125,83 @@ def test_empty_queues_render_as_explicit_nothing():
     assert memory_context.format_confirmations_block([]) == "   (none pending)"
     assert memory_context.format_confirmations_block(None) == "   (none pending)"
     assert memory_context.format_revisits_block([]) == "   (none due)"
+
+
+# --- a caught-up install still has work ---
+
+
+@pytest.mark.asyncio
+async def test_pending_confirmations_alone_can_start_a_run(store, monkeypatch):
+    """The queues raise no pending date, so nothing else would ever start them.
+
+    A confirmation deliberately does not create a daily-log entry. On an install that
+    is caught up on logs, `_pending_dates` is empty forever and both the automatic
+    tick and the manual trigger report "nothing pending" while the sidecar grows
+    without bound — the recurrence evidence never reaching a page.
+    """
+    from suzent.config import CONFIG
+
+    for i in range(CONFIG.memory_consolidation_min_confirmations):
+        await store.append_confirmation(f"claim {i}", "x", "2026-08-01")
+
+    runner = DreamRunner()
+    ran = []
+
+    async def _fake_run_dream(mgr, watermark, pending):
+        ran.append((watermark, list(pending)))
+        return {"ran": True}
+
+    runner._run_dream = _fake_run_dream
+    runner._failures_loaded = True
+    monkeypatch.setattr(
+        "suzent.core.dream_runner.get_memory_manager", lambda: _Mgr(store)
+    )
+    mgr = _Mgr(store)
+    mgr.llm_client = object()
+    monkeypatch.setattr("suzent.core.dream_runner.get_memory_manager", lambda: mgr)
+
+    await runner._tick()
+
+    assert ran and ran[0][1] == []
+
+
+@pytest.mark.asyncio
+async def test_a_quiet_sidecar_does_not_start_a_run(store, monkeypatch):
+    """The threshold is what keeps this occasional rather than a second scheduler."""
+    await store.append_confirmation("one lonely claim", "x", "2026-08-01")
+
+    runner = DreamRunner()
+    ran = []
+    runner._run_dream = lambda *a, **kw: ran.append(a)
+    runner._failures_loaded = True
+    mgr = _Mgr(store)
+    mgr.llm_client = object()
+    monkeypatch.setattr("suzent.core.dream_runner.get_memory_manager", lambda: mgr)
+    runner._lint_due = lambda _mgr: False
+
+    await runner._tick()
+
+    assert ran == []
+
+
+@pytest.mark.asyncio
+async def test_the_manual_trigger_runs_for_a_single_confirmation(store, monkeypatch):
+    """A person pressing RUN NOW has said what they want; the volume gate is for the
+    scheduler, not for them."""
+    await store.append_confirmation("one lonely claim", "x", "2026-08-01")
+
+    runner = DreamRunner()
+    ran = []
+
+    async def _fake_run_dream(mgr, watermark, pending):
+        ran.append(list(pending))
+        return {"ran": True}
+
+    runner._run_dream = _fake_run_dream
+    mgr = _Mgr(store)
+    mgr.llm_client = object()
+    monkeypatch.setattr("suzent.core.dream_runner.get_memory_manager", lambda: mgr)
+
+    result = await runner.force_run()
+
+    assert ran == [[]] and result == {"ran": True}

--- a/tests/memory/test_dream_queues.py
+++ b/tests/memory/test_dream_queues.py
@@ -1,0 +1,102 @@
+"""The two queues the runner hands the dream: confirmations, and claims to revisit.
+
+Both are deterministic scans the runner owns. Asking the agent to find expired pages
+by reading the whole vault, or to discover confirmations by re-reading logs that were
+deliberately not written, would be slower and less reliable than reading the files.
+"""
+
+import pytest
+
+from suzent.core.dream_runner import DreamRunner
+from suzent.memory import memory_context
+from suzent.memory.markdown_store import MarkdownMemoryStore
+
+
+class _Mgr:
+    def __init__(self, store):
+        self.markdown_store = store
+
+
+def _page(store, rel: str, body: str):
+    path = store.notebook_dir / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def store(tmp_path):
+    return MarkdownMemoryStore(
+        base_dir=tmp_path, notebook_dir=str(tmp_path / "notebook")
+    )
+
+
+# --- revisit queue ---
+
+
+def test_only_expired_pages_are_queued_soonest_first(store):
+    _page(store, "3_Personal/a.md", "---\nstale_after: 2020-01-01\n---\n- old")
+    _page(store, "3_Personal/b.md", "---\nstale_after: 2019-01-01\n---\n- older")
+    _page(store, "3_Personal/c.md", "---\nstale_after: 2099-01-01\n---\n- fresh")
+    _page(store, "3_Personal/d.md", "- no frontmatter at all")
+
+    rows = DreamRunner._due_revisits(_Mgr(store))
+
+    assert [r["page"] for r in rows] == ["3_Personal/b.md", "3_Personal/a.md"]
+
+
+def test_a_deprecated_page_is_not_worth_revisiting(store):
+    _page(
+        store,
+        "3_Personal/a.md",
+        "---\nstatus: deprecated\nstale_after: 2020-01-01\n---\n- old",
+    )
+
+    assert DreamRunner._due_revisits(_Mgr(store)) == []
+
+
+def test_the_queue_is_bounded(store):
+    for i in range(30):
+        _page(
+            store, f"3_Personal/p{i:02d}.md", "---\nstale_after: 2020-01-01\n---\n- x"
+        )
+
+    assert len(DreamRunner._due_revisits(_Mgr(store), limit=5)) == 5
+
+
+def test_an_unreadable_vault_yields_an_empty_queue():
+    class _Broken:
+        @property
+        def markdown_store(self):
+            raise RuntimeError("no vault")
+
+    assert DreamRunner._due_revisits(_Broken()) == []
+
+
+# --- prompt rendering ---
+
+
+def test_the_instructions_carry_both_queues_and_never_delete():
+    text = memory_context.DREAM_INSTRUCTIONS.format(
+        start="2026-01-01",
+        end="2026-01-02",
+        confirmations=memory_context.format_confirmations_block(
+            [{"content": "likes tea", "count": 3, "last": "2026-01-02"}]
+        ),
+        revisits=memory_context.format_revisits_block(
+            [{"page": "3_Personal/a.md", "stale_after": "2020-01-01"}]
+        ),
+    )
+
+    assert "likes tea — +3x, last 2026-01-02" in text
+    assert "3_Personal/a.md (stale_after 2020-01-01)" in text
+    assert "Never delete here." in text
+    # A restatement that contradicts the page is a correction and never reaches the
+    # confirmations list; the prompt has to say so or the agent may bump the marker.
+    assert "a contradicting restatement never reaches this list" in text
+
+
+def test_empty_queues_render_as_explicit_nothing():
+    assert memory_context.format_confirmations_block([]) == "   (none pending)"
+    assert memory_context.format_confirmations_block(None) == "   (none pending)"
+    assert memory_context.format_revisits_block([]) == "   (none due)"

--- a/tests/memory/test_dream_queues.py
+++ b/tests/memory/test_dream_queues.py
@@ -34,15 +34,38 @@ def store(tmp_path):
 # --- revisit queue ---
 
 
-def test_only_expired_pages_are_queued_soonest_first(store):
+def test_expired_pages_are_queued_soonest_first_and_fresh_ones_are_not(store):
     _page(store, "3_Personal/a.md", "---\nstale_after: 2020-01-01\n---\n- old")
     _page(store, "3_Personal/b.md", "---\nstale_after: 2019-01-01\n---\n- older")
     _page(store, "3_Personal/c.md", "---\nstale_after: 2099-01-01\n---\n- fresh")
-    _page(store, "3_Personal/d.md", "- no frontmatter at all")
 
     rows = DreamRunner._due_revisits(_Mgr(store))
 
     assert [r["page"] for r in rows] == ["3_Personal/b.md", "3_Personal/a.md"]
+
+
+def test_a_page_with_no_expiry_is_due_but_queues_last(store):
+    """Every page written before the rule existed has no `stale_after`. Selecting
+    strictly on the field would exempt exactly those pages from ever being visited,
+    which is how the field would stay unwritten forever."""
+    _page(store, "3_Personal/never_set.md", "---\nstatus: active\n---\n- a claim")
+    _page(store, "3_Personal/expired.md", "---\nstale_after: 2020-01-01\n---\n- old")
+    _page(store, "3_Personal/plain.md", "- no frontmatter at all")
+
+    rows = DreamRunner._due_revisits(_Mgr(store))
+
+    assert rows[0]["page"] == "3_Personal/expired.md"
+    assert {r["page"] for r in rows[1:]} == {
+        "3_Personal/never_set.md",
+        "3_Personal/plain.md",
+    }
+    assert all(r["stale_after"] == "unset" for r in rows[1:])
+
+
+def test_an_undated_page_is_still_skipped_when_deprecated(store):
+    _page(store, "3_Personal/a.md", "---\nstatus: deprecated\n---\n- retired")
+
+    assert DreamRunner._due_revisits(_Mgr(store)) == []
 
 
 def test_a_deprecated_page_is_not_worth_revisiting(store):
@@ -90,6 +113,8 @@ def test_the_instructions_carry_both_queues_and_never_delete():
 
     assert "likes tea — +3x, last 2026-01-02" in text
     assert "3_Personal/a.md (stale_after 2020-01-01)" in text
+    # An unset expiry has to be actionable in the prompt, not merely listed.
+    assert "stale_after unset" in text
     assert "Never delete here." in text
     # A restatement that contradicts the page is a correction and never reaches the
     # confirmations list; the prompt has to say so or the agent may bump the marker.

--- a/tests/memory/test_dream_runner_watermark.py
+++ b/tests/memory/test_dream_runner_watermark.py
@@ -168,7 +168,7 @@ async def test_watermark_not_advanced_when_agent_fails_after_partial_write(monke
     """Agent times out *after* changing one page → watermark must stay put."""
     runner = DreamRunner()
 
-    async def boom(start, end):
+    async def boom(*a, **kw):
         raise asyncio.TimeoutError("dream agent timed out mid-write")
 
     # before != after: a page WAS changed (the partial write), but the agent failed.
@@ -226,3 +226,52 @@ async def test_watermark_advances_on_clean_run_with_changes(monkeypatch):
     assert result["advanced"] is True
     assert result["changed"] is True
     assert "2026-06-03" not in runner._failures
+
+
+@pytest.mark.asyncio
+async def test_a_queue_only_run_leaves_the_watermark_alone(monkeypatch):
+    """With no new logs there is nothing to mark consolidated.
+
+    A run triggered by the confirmation queue works claims that are already on pages;
+    advancing the watermark would declare a date consolidated on the strength of work
+    that never touched its log.
+    """
+    runner = DreamRunner()
+    advanced = _wire(
+        runner,
+        monkeypatch,
+        _FakeManager(),
+        page_states=[{"p": 1.0}, {"p": 2.0}],
+        agent=_anoop,
+    )
+    monkeypatch.setattr(runner, "_pending_dates", lambda m, wm: [])
+
+    result = await runner._run_dream(_FakeManager(), "2026-06-01", [])
+
+    assert advanced == []
+    assert result["watermark"] == "2026-06-01"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_queue_only_run_does_not_charge_the_ingest_retry_counter(
+    monkeypatch,
+):
+    """Its key is a date that ingest already consolidated. Counting a queue failure
+    against it would spend the retry budget of a batch that never ran, and three of
+    them would make retry-then-skip advance the watermark past unread logs."""
+    runner = DreamRunner()
+
+    async def boom(*a, **kw):
+        raise asyncio.TimeoutError("agent timed out")
+
+    _wire(
+        runner,
+        monkeypatch,
+        _FakeManager(),
+        page_states=[{"p": 1.0}, {"p": 1.0}],
+        agent=boom,
+    )
+
+    await runner._run_dream(_FakeManager(), "2026-06-01", [])
+
+    assert runner._failures == {}

--- a/tests/memory/test_dream_supersede.py
+++ b/tests/memory/test_dream_supersede.py
@@ -1,0 +1,135 @@
+"""The dream retires duplicate log facts by tombstone, not by rewriting logs.
+
+Step 3b used to resolve a duplicate by doing nothing, which is why a fact written
+64 times stayed in the index 64 times. The dream now hands the runner the lines it
+folded into the vault; the runner tombstones them and reindexes the days they came
+from. That last part is load-bearing: appending a tombstone does not change the
+log's mtime, so the mtime watcher never revisits those days on its own.
+"""
+
+import pytest
+
+from suzent.core.dream_runner import DreamRunner
+from suzent.memory import memory_context
+from suzent.memory.markdown_store import MarkdownMemoryStore
+
+FACT = "The user wants to be reminded to drink water hourly from 9 AM to 9 PM."
+
+
+@pytest.fixture
+def store(tmp_path):
+    return MarkdownMemoryStore(
+        base_dir=str(tmp_path / "memory"), notebook_dir=str(tmp_path / "notebook")
+    )
+
+
+class _FakeIndexer:
+    def __init__(self):
+        self.reindexed = []
+
+    async def reindex_file_now(self, **kwargs):
+        self.reindexed.append((kwargs["label"], kwargs["filename"]))
+        return 1
+
+
+class _FakeManager:
+    def __init__(self, markdown_store):
+        self.markdown_store = markdown_store
+        self._core_indexer = _FakeIndexer()
+        self.store = None
+        self.embedding_gen = None
+
+
+def _log(store, date, *lines):
+    (store.archive_dir / f"{date}.md").write_text(
+        "".join(f"- [preference] {ln}\n" for ln in lines), encoding="utf-8"
+    )
+
+
+# --- prompt ---
+
+
+def test_duplicate_rule_no_longer_says_do_nothing():
+    assert "-> do nothing" not in memory_context.DREAM_INSTRUCTIONS
+    assert memory_context.DREAM_SUPERSEDED_PATH in memory_context.DREAM_INSTRUCTIONS
+
+
+# --- store ---
+
+
+def test_superseded_reads_back_deduped_and_unbulleted(store):
+    store.superseded_path.write_text(
+        f"- {FACT}\n{FACT}\n\n  \nSomething else entirely, at length.\n",
+        encoding="utf-8",
+    )
+
+    assert store.read_superseded() == [FACT, "Something else entirely, at length."]
+
+
+def test_archive_dates_containing_finds_every_day(store):
+    _log(store, "2026-03-10", FACT)
+    _log(store, "2026-03-11", "Unrelated fact about the build system.")
+    _log(store, "2026-03-12", f"  {FACT.upper()}")
+
+    assert store.archive_dates_containing([FACT]) == ["2026-03-10", "2026-03-12"]
+    assert store.archive_dates_containing([]) == []
+
+
+# --- runner ---
+
+
+@pytest.mark.asyncio
+async def test_retire_tombstones_and_reindexes_each_day(store):
+    _log(store, "2026-03-10", FACT)
+    _log(store, "2026-03-12", FACT)
+    store.superseded_path.write_text(FACT + "\n", encoding="utf-8")
+    mgr = _FakeManager(store)
+
+    n = await DreamRunner()._retire_superseded(mgr)
+
+    assert n == 1
+    assert store.is_tombstoned(FACT)
+    assert mgr._core_indexer.reindexed == [
+        ("archive", "2026-03-10.md"),
+        ("archive", "2026-03-12.md"),
+    ]
+    assert store.read_superseded() == []
+
+
+@pytest.mark.asyncio
+async def test_short_lines_are_refused(store):
+    """A generic fragment would substring-match unrelated logs; drop it instead."""
+    _log(store, "2026-03-10", "dark mode")
+    store.superseded_path.write_text("dark mode\n", encoding="utf-8")
+    mgr = _FakeManager(store)
+
+    assert await DreamRunner()._retire_superseded(mgr) == 0
+    assert not store.is_tombstoned("dark mode")
+    assert mgr._core_indexer.reindexed == []
+
+
+@pytest.mark.asyncio
+async def test_empty_handoff_is_a_no_op(store):
+    mgr = _FakeManager(store)
+
+    assert await DreamRunner()._retire_superseded(mgr) == 0
+    assert mgr._core_indexer.reindexed == []
+
+
+@pytest.mark.asyncio
+async def test_handoff_is_cleared_only_after_tombstoning(store):
+    """A crash mid-run must replay, not silently drop the lines."""
+    _log(store, "2026-03-10", FACT)
+    store.superseded_path.write_text(FACT + "\n", encoding="utf-8")
+    mgr = _FakeManager(store)
+
+    async def boom(**kwargs):
+        raise RuntimeError("lancedb down")
+
+    mgr._core_indexer.reindex_file_now = boom
+
+    await DreamRunner()._retire_superseded(mgr)
+
+    # The tombstone is durable, so the row is filtered on any future rebuild even
+    # though this run's explicit reindex failed.
+    assert store.is_tombstoned(FACT)

--- a/tests/memory/test_extraction_known_facts.py
+++ b/tests/memory/test_extraction_known_facts.py
@@ -68,6 +68,25 @@ def test_system_prompt_permits_updates():
 
 
 @pytest.mark.asyncio
+async def test_recall_marks_which_matches_are_durably_recorded():
+    """Only a vault page or a daily log is a record the write path can defer to; a
+    transcript row is the user having said something, not memory holding it."""
+    mgr = _StubManager(
+        [
+            {"content": "on a page", "metadata": {"source_type": "notebook"}},
+            {"content": "in a log", "metadata": {"source_type": "archive_log"}},
+            {"content": "said once", "metadata": {"source_type": "transcript"}},
+            {"content": "generated", "metadata": {"source_type": "core_file"}},
+            {"content": "no metadata"},
+        ]
+    )
+
+    facts = await mgr._recall_known_facts("some turn", "user-1")
+
+    assert [f["durable"] for f in facts] == [True, True, False, False, False]
+
+
+@pytest.mark.asyncio
 async def test_recall_returns_contents_nearest_first():
     mgr = _StubManager(
         [{"content": "Prefers dark mode"}, {"content": "Uses Unreal Engine 5"}]
@@ -75,7 +94,10 @@ async def test_recall_returns_contents_nearest_first():
 
     facts = await mgr._recall_known_facts("some turn", "user-1", "chat-1")
 
-    assert facts == ["Prefers dark mode", "Uses Unreal Engine 5"]
+    assert [f["content"] for f in facts] == [
+        "Prefers dark mode",
+        "Uses Unreal Engine 5",
+    ]
     assert mgr.calls[0]["limit"] == KNOWN_FACTS_LIMIT
     assert mgr.calls[0]["user_id"] == "user-1"
 
@@ -92,7 +114,7 @@ async def test_recall_dedupes_and_normalises_whitespace():
 
     facts = await mgr._recall_known_facts("some turn", "user-1")
 
-    assert facts == ["Prefers dark mode"]
+    assert [f["content"] for f in facts] == ["Prefers dark mode"]
 
 
 @pytest.mark.asyncio

--- a/tests/memory/test_extraction_known_facts.py
+++ b/tests/memory/test_extraction_known_facts.py
@@ -1,0 +1,111 @@
+"""Extraction must see what memory already holds.
+
+Blind per-turn extraction is the source of most archival duplication: a stable fact
+(a name, a long-running project, how someone likes to be addressed) is re-extracted
+every time it comes up. Showing the model the nearest known facts is what lets it
+tell a re-mention from an update — without dropping updates, which is what the
+removed write-time similarity threshold got wrong (#34).
+"""
+
+import pytest
+
+from suzent.memory import memory_context
+from suzent.memory.manager import KNOWN_FACTS_LIMIT, MemoryManager
+
+
+class _StubManager:
+    """Exercises _recall_known_facts without standing up the whole manager."""
+
+    _recall_known_facts = MemoryManager._recall_known_facts
+
+    def __init__(self, results=None, error=None):
+        self._results = results or []
+        self._error = error
+        self.calls = []
+
+    async def search_memories(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._error:
+            raise self._error
+        return self._results
+
+
+# --- prompt shape ---
+
+
+def test_known_facts_absent_leaves_the_prompt_unchanged():
+    """No retrieval, no behaviour change — the old prompt exactly."""
+    assert memory_context.format_known_facts_block([]) == ""
+    assert memory_context.format_known_facts_block(None) == ""
+
+    bare = memory_context.format_fact_extraction_user_prompt("a turn")
+
+    assert "Already in memory" not in bare
+    assert "a turn" in bare
+
+
+def test_known_facts_are_rendered_and_labelled():
+    prompt = memory_context.format_fact_extraction_user_prompt(
+        "a turn", ["Prefers dark mode", "Building a VR horror game"]
+    )
+
+    assert "## Already in memory" in prompt
+    assert "- Prefers dark mode" in prompt
+    assert "- Building a VR horror game" in prompt
+    assert "a turn" in prompt
+
+
+def test_system_prompt_permits_updates():
+    """The rule must not read as a blanket 'skip anything similar'."""
+    rules = memory_context.FACT_EXTRACTION_SYSTEM_PROMPT
+
+    assert "Already-known facts" in rules
+    assert "CHANGES" in rules
+    assert "worse than storing a duplicate" in rules
+
+
+# --- recall ---
+
+
+@pytest.mark.asyncio
+async def test_recall_returns_contents_nearest_first():
+    mgr = _StubManager(
+        [{"content": "Prefers dark mode"}, {"content": "Uses Unreal Engine 5"}]
+    )
+
+    facts = await mgr._recall_known_facts("some turn", "user-1", "chat-1")
+
+    assert facts == ["Prefers dark mode", "Uses Unreal Engine 5"]
+    assert mgr.calls[0]["limit"] == KNOWN_FACTS_LIMIT
+    assert mgr.calls[0]["user_id"] == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_recall_dedupes_and_normalises_whitespace():
+    mgr = _StubManager(
+        [
+            {"content": "Prefers   dark\nmode"},
+            {"content": "prefers dark mode"},
+            {"content": ""},
+        ]
+    )
+
+    facts = await mgr._recall_known_facts("some turn", "user-1")
+
+    assert facts == ["Prefers dark mode"]
+
+
+@pytest.mark.asyncio
+async def test_recall_failure_never_blocks_extraction():
+    """Enriching the prompt is best-effort; a search outage must not lose facts."""
+    mgr = _StubManager(error=RuntimeError("lancedb down"))
+
+    assert await mgr._recall_known_facts("some turn", "user-1") == []
+
+
+@pytest.mark.asyncio
+async def test_blank_turn_skips_the_search_entirely():
+    mgr = _StubManager([{"content": "Prefers dark mode"}])
+
+    assert await mgr._recall_known_facts("   \n  ", "user-1") == []
+    assert mgr.calls == []

--- a/tests/memory/test_extraction_known_facts.py
+++ b/tests/memory/test_extraction_known_facts.py
@@ -131,3 +131,45 @@ async def test_blank_turn_skips_the_search_entirely():
 
     assert await mgr._recall_known_facts("   \n  ", "user-1") == []
     assert mgr.calls == []
+
+
+@pytest.mark.asyncio
+async def test_only_durable_recalls_are_shown_to_the_extractor(monkeypatch):
+    """The suppression is one-way, so it must be spent only on durable rows.
+
+    The prompt tells the model not to re-extract what it is shown. A fact that lives
+    only in a transcript or in the generated MEMORY.md is not recorded anywhere the
+    write path is about to record it, and `_split_confirmations` runs *after*
+    extraction — it can divert a fact the model emitted, but it cannot recover one the
+    model was talked out of emitting. Showing a non-durable row would therefore drop
+    the fact entirely rather than deduplicate it.
+    """
+    from suzent.memory.models import ConversationTurn, Message
+
+    mgr = MemoryManager.__new__(MemoryManager)
+    mgr.markdown_store = None
+    shown = []
+
+    async def _recall(turn_text, user_id, chat_id=None):
+        return [
+            {"content": "on a page", "durable": True},
+            {"content": "said once in chat", "durable": False},
+        ]
+
+    async def _extract(content, known_facts=None):
+        shown.append(list(known_facts or []))
+        return []
+
+    mgr._recall_known_facts = _recall
+    mgr._extract_facts_llm = _extract
+
+    await mgr.process_conversation_turn_for_memories(
+        ConversationTurn(
+            user_message=Message(role="user", content="I use Unreal Engine 5"),
+            assistant_message=Message(role="assistant", content="Noted."),
+        ),
+        chat_id="c1",
+        user_id="user-1",
+    )
+
+    assert shown == [["on a page"]]

--- a/tests/memory/test_indexer_state_keys.py
+++ b/tests/memory/test_indexer_state_keys.py
@@ -1,0 +1,90 @@
+"""Indexer state must be keyed portably, not by absolute path.
+
+The vault's `.state` travels between machines and survives a moved base dir. When
+state was keyed by absolute path, entries from other machines accumulated in the
+file, and any tracked file whose stale recorded mtime happened to match was skipped
+forever — which is how daily logs went missing from the search index.
+"""
+
+import json
+
+import pytest
+
+from suzent.memory.indexer import CoreMemoryFileIndexer
+from suzent.memory.markdown_store import MarkdownMemoryStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return MarkdownMemoryStore(
+        base_dir=tmp_path / "memory", notebook_dir=tmp_path / "notebook"
+    )
+
+
+def _state_file(store):
+    return store.base_dir / CoreMemoryFileIndexer.INDEX_STATE_FILENAME
+
+
+def test_keys_are_label_and_filename_not_paths(store):
+    (store.archive_dir / "2026-03-12.md").write_text("- [goal] x\n", encoding="utf-8")
+    indexer = CoreMemoryFileIndexer()
+
+    indexer._load_state(store)
+
+    assert "archive:2026-03-12.md" in indexer._mtimes
+    assert not any("/" in k or "\\" in k for k in indexer._mtimes)
+
+
+def test_saved_state_is_versioned(store):
+    indexer = CoreMemoryFileIndexer()
+    indexer._load_state(store)
+    indexer._save_state()
+
+    payload = json.loads(_state_file(store).read_text(encoding="utf-8"))
+
+    assert payload["version"] == CoreMemoryFileIndexer.STATE_VERSION
+    assert isinstance(payload["mtimes"], dict)
+
+
+def test_path_keyed_state_is_discarded(store):
+    """A pre-v2 file must not be trusted; discarding it forces one full reindex."""
+    _state_file(store).write_text(
+        json.dumps(
+            {
+                "/Users/someone/.suzent/sandbox/shared/memory/archive/2026-05-03.md": 1.0,
+                "D:\\elsewhere\\memory\\archive\\2026-05-04.md": 2.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    indexer = CoreMemoryFileIndexer()
+
+    indexer._load_state(store)
+
+    assert indexer._mtimes == {}
+
+
+def test_versioned_state_round_trips(store):
+    _state_file(store).write_text(
+        json.dumps(
+            {
+                "version": CoreMemoryFileIndexer.STATE_VERSION,
+                "mtimes": {"archive:2026-05-03.md": 123.0},
+            }
+        ),
+        encoding="utf-8",
+    )
+    indexer = CoreMemoryFileIndexer()
+
+    indexer._load_state(store)
+
+    assert indexer._mtimes == {"archive:2026-05-03.md": 123.0}
+
+
+def test_corrupt_state_degrades_to_empty(store):
+    _state_file(store).write_text("{not json", encoding="utf-8")
+    indexer = CoreMemoryFileIndexer()
+
+    indexer._load_state(store)
+
+    assert indexer._mtimes == {}

--- a/tests/memory/test_memory_file_zones.py
+++ b/tests/memory/test_memory_file_zones.py
@@ -1,0 +1,201 @@
+"""MEMORY.md has three writers and used to have no merge.
+
+Two generators (`refresh_core_memory_facts`, `promote_memory_md`) rewrite it, and the
+agent edits it directly because the core-memory prompt tells it to. `write_memory_file`
+was an unconditional `write_text`, so a note the agent added was destroyed by whichever
+generator fired next — typically within minutes, silently.
+
+The fix is a marked generated zone: generators own the region between the markers,
+everything after the end marker is copied through untouched.
+"""
+
+import pytest
+
+from suzent.memory import memory_context
+from suzent.memory.markdown_store import (
+    MEMORY_GENERATED_END,
+    MEMORY_GENERATED_START,
+    MarkdownMemoryStore,
+)
+
+
+@pytest.fixture
+def store(tmp_path):
+    return MarkdownMemoryStore(
+        base_dir=tmp_path, notebook_dir=str(tmp_path / "notebook")
+    )
+
+
+# --- the generated zone ---
+
+
+@pytest.mark.asyncio
+async def test_first_write_creates_a_marked_file(store):
+    await store.write_memory_file("- Prefers dark mode")
+
+    text = store.memory_file_path.read_text(encoding="utf-8")
+
+    assert text.startswith("# Long-term Memory")
+    assert MEMORY_GENERATED_START in text
+    assert MEMORY_GENERATED_END in text
+    assert "- Prefers dark mode" in text
+
+
+@pytest.mark.asyncio
+async def test_regeneration_replaces_only_the_generated_zone(store):
+    await store.write_memory_file("- Old summary")
+    marked = store.memory_file_path.read_text(encoding="utf-8")
+    store.memory_file_path.write_text(
+        marked + "\n## Pinned\n- Never call me Bob\n", encoding="utf-8"
+    )
+
+    await store.write_memory_file("- New summary")
+    text = store.memory_file_path.read_text(encoding="utf-8")
+
+    assert "- New summary" in text
+    assert "- Old summary" not in text
+    assert "- Never call me Bob" in text
+
+
+@pytest.mark.asyncio
+async def test_manual_zone_survives_many_regenerations(store):
+    await store.write_memory_file("- Gen 0")
+    store.memory_file_path.write_text(
+        store.memory_file_path.read_text(encoding="utf-8") + "\n- pinned note\n",
+        encoding="utf-8",
+    )
+
+    for i in range(1, 5):
+        await store.write_memory_file(f"- Gen {i}")
+
+    text = store.memory_file_path.read_text(encoding="utf-8")
+
+    assert text.count("- pinned note") == 1, "the manual zone must not accumulate"
+    assert "- Gen 4" in text and "- Gen 3" not in text
+
+
+# --- files that predate the markers ---
+
+
+@pytest.mark.asyncio
+async def test_a_file_we_wrote_before_markers_is_replaced_wholesale(store):
+    """The old footer is the signature: that content is ours, not the user's."""
+    store.memory_file_path.write_text(
+        "# Long-term Memory\n\n- stale generated line\n\n---\n"
+        "*Last updated: 2026-01-01 09:00 UTC*\n",
+        encoding="utf-8",
+    )
+
+    await store.write_memory_file("- fresh")
+    text = store.memory_file_path.read_text(encoding="utf-8")
+
+    assert "- stale generated line" not in text
+    assert "- fresh" in text
+
+
+@pytest.mark.asyncio
+async def test_an_unrecognised_file_is_treated_as_entirely_manual(store):
+    """Degrade safe: if we cannot prove we wrote it, we do not throw it away."""
+    store.memory_file_path.write_text(
+        "# My notes\n\n- the user typed this by hand\n", encoding="utf-8"
+    )
+
+    await store.write_memory_file("- generated")
+    text = store.memory_file_path.read_text(encoding="utf-8")
+
+    assert "- the user typed this by hand" in text
+    assert "- generated" in text
+    assert text.index("- generated") < text.index("- the user typed this by hand")
+
+
+def test_manual_tail_is_pure(store):
+    assert store.manual_tail("") == ""
+    assert store.manual_tail("   \n ") == ""
+    assert store.manual_tail(f"a\n{MEMORY_GENERATED_END}\n\nb\n") == "b"
+
+
+# --- one timestamp, not two ---
+
+
+@pytest.mark.asyncio
+async def test_exactly_one_timestamp_and_it_is_utc(store):
+    """`refresh_core_memory_facts` stamped a naive local time into the content while
+    the store stamped UTC, so every generated file carried two timestamps an hour
+    apart in BST."""
+    await store.write_memory_file("- a fact")
+    text = store.memory_file_path.read_text(encoding="utf-8")
+
+    assert text.count("Consolidated") == 1
+    assert "UTC" in text
+    assert "Last updated" not in text
+
+
+# --- the agent has to be told ---
+
+
+def test_prompt_points_the_agent_below_the_marker():
+    prompt = memory_context.format_core_memory_section({}, sandbox_enabled=True)
+
+    assert MEMORY_GENERATED_END in prompt
+    assert "below" in prompt
+
+
+# --- which generator owns the file ---
+
+
+class _StubStore:
+    async def list_memories(self, **kwargs):
+        return [{"content": "an indexed fact", "importance": 0.5}]
+
+
+class _StubLLM:
+    def __init__(self):
+        self.calls = 0
+
+    async def complete(self, **kwargs):
+        self.calls += 1
+        return "- summarised"
+
+
+def _manager(tmp_path):
+    from suzent.memory.manager import MemoryManager
+
+    mgr = MemoryManager.__new__(MemoryManager)
+    mgr.store = _StubStore()
+    mgr.llm_client = _StubLLM()
+    mgr.markdown_store = MarkdownMemoryStore(
+        base_dir=tmp_path, notebook_dir=str(tmp_path / "notebook")
+    )
+    return mgr
+
+
+@pytest.mark.asyncio
+async def test_legacy_refresh_no_longer_filters_on_a_dead_column(tmp_path):
+    """The indexer stamps every row 0.5, so a >=0.7 gate matched only pre-June legacy
+    rows: MEMORY.md was being rebuilt from months-old data and would have gone empty
+    the moment those rows were retired."""
+    mgr = _manager(tmp_path)
+
+    async def _stats(user_id):
+        return {"total_memories": 1}
+
+    mgr.get_memory_stats = _stats
+
+    await mgr.refresh_core_memory_facts("user-1")
+
+    assert mgr.llm_client.calls == 1
+    assert "- summarised" in mgr.markdown_store.memory_file_path.read_text("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_legacy_refresh_stands_down_once_the_vault_has_pages(tmp_path):
+    """Two writers, one file: the better-informed one wins as soon as it can run."""
+    mgr = _manager(tmp_path)
+    personal = mgr.markdown_store.notebook_dir / "3_Personal"
+    personal.mkdir(parents=True, exist_ok=True)
+    (personal / "identity.md").write_text("- consolidated", encoding="utf-8")
+
+    await mgr.refresh_core_memory_facts("user-1")
+
+    assert mgr.llm_client.calls == 0
+    assert not mgr.markdown_store.memory_file_path.exists()

--- a/tests/memory/test_vault_resolution.py
+++ b/tests/memory/test_vault_resolution.py
@@ -1,0 +1,48 @@
+"""The vault the app uses is often not the one `CONFIG.notebook_dir` names.
+
+Mounting your own folder at `/mnt/notebook` maps the agent's side of the sandbox;
+`CONFIG.notebook_dir` keeps pointing at the default under the data dir, which still
+gets created and bootstrapped. Reading it directly means reading a stale skeleton and
+concluding the vault is nearly empty — which is exactly the mistake this resolver
+exists to prevent.
+"""
+
+from pathlib import Path
+
+from suzent.memory.lifecycle import resolve_notebook_dir
+
+
+def test_a_mounted_vault_wins_over_the_configured_default(monkeypatch, tmp_path):
+    mounted = tmp_path / "obsidian" / "vault"
+    mounted.mkdir(parents=True)
+    monkeypatch.setattr(
+        "suzent.memory.lifecycle.CONFIG.sandbox_volumes",
+        [f"{mounted}:/mnt/notebook"],
+        raising=False,
+    )
+
+    assert Path(resolve_notebook_dir()) == mounted.resolve()
+
+
+def test_other_mounts_are_ignored(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "suzent.memory.lifecycle.CONFIG.sandbox_volumes",
+        [f"{tmp_path}:/mnt/skills", f"{tmp_path}:/mnt/data"],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "suzent.memory.lifecycle.CONFIG.notebook_dir", str(tmp_path / "default")
+    )
+
+    assert Path(resolve_notebook_dir()) == (tmp_path / "default").resolve()
+
+
+def test_no_mounts_falls_back_to_the_configured_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "suzent.memory.lifecycle.CONFIG.sandbox_volumes", [], raising=False
+    )
+    monkeypatch.setattr(
+        "suzent.memory.lifecycle.CONFIG.notebook_dir", str(tmp_path / "default")
+    )
+
+    assert Path(resolve_notebook_dir()) == (tmp_path / "default").resolve()

--- a/tests/memory/test_write_path_classifier.py
+++ b/tests/memory/test_write_path_classifier.py
@@ -1,0 +1,225 @@
+"""The write path may recognise a re-statement, and nothing more.
+
+Issue #34 was write-time deduplication swallowing an update. The classifier is allowed
+to divert one specific case — the same claim, in the same words, already durably
+recorded, adding no new specifics — into the confirmations sidecar. Every test here
+exists to hold that line: anything that could be an update is written exactly as it
+was before this landed.
+"""
+
+import pytest
+
+from suzent.memory.classifier import (
+    ClaimVerdict,
+    claim_similarity,
+    classify_fact,
+    new_specifics,
+)
+from suzent.memory.markdown_store import MarkdownMemoryStore
+from suzent.memory.models import ExtractedFact
+
+KNOWN = ["User prefers dark mode in the editor"]
+
+
+def _fact(content: str, **kw) -> ExtractedFact:
+    return ExtractedFact(content=content, category="preference", importance=0.5, **kw)
+
+
+# --- similarity ---
+
+
+def test_the_same_claim_reworded_scores_high_and_a_different_one_does_not():
+    same = claim_similarity(
+        "User prefers dark mode in the editor",
+        "the user prefers dark mode in an editor",
+    )
+    different = claim_similarity(
+        "User prefers dark mode in the editor", "User works at a hardware startup"
+    )
+
+    assert same > 0.97
+    assert different < 0.3
+
+
+def test_similarity_ignores_the_daily_log_prefix():
+    assert claim_similarity("- [preference] likes tea", "likes tea") == 1.0
+
+
+# --- the guard against folding in an update ---
+
+
+def test_a_new_specific_is_what_separates_an_update_from_a_repeat():
+    assert new_specifics("moved to Berlin in 2024", "moved to Berlin") == ["2024"]
+    assert new_specifics("moved to Berlin", "moved to Berlin in 2024") == []
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "User prefers dark mode in the editor since 2025-01-01",
+        'User prefers dark mode in the editor, theme "Nord"',
+        "User prefers dark mode in the editor at 90% brightness",
+    ],
+)
+def test_added_detail_is_a_revision_even_when_the_prose_is_identical(content):
+    verdict = classify_fact(content, KNOWN)
+
+    assert verdict.is_revision
+    assert not verdict.is_confirmation
+    assert verdict.new_specifics
+
+
+def test_a_contradiction_is_never_a_confirmation():
+    verdict = classify_fact("User prefers light mode in the editor", KNOWN)
+
+    assert not verdict.is_confirmation
+
+
+def test_an_unrelated_fact_is_new():
+    assert classify_fact("User is learning Portuguese", KNOWN).kind == "new"
+
+
+def test_a_re_statement_is_a_confirmation():
+    verdict = classify_fact("The user prefers dark mode in the editor", KNOWN)
+
+    assert verdict.is_confirmation
+    assert verdict.matched == KNOWN[0]
+
+
+def test_nothing_known_means_nothing_is_diverted():
+    assert classify_fact("User prefers dark mode", []).kind == "new"
+    assert classify_fact("User prefers dark mode", None).kind == "new"
+
+
+# --- the sidecar ---
+
+
+@pytest.mark.asyncio
+async def test_confirmations_group_by_claim_and_keep_the_last_date(tmp_path):
+    store = MarkdownMemoryStore(
+        base_dir=tmp_path, notebook_dir=str(tmp_path / "notebook")
+    )
+
+    await store.append_confirmation("likes tea", "likes tea", "2026-08-01")
+    await store.append_confirmation("Likes  tea", "likes tea", "2026-08-09")
+    await store.append_confirmation("uses vim", "uses vim", "2026-08-05")
+
+    rows = store.summarize_confirmations()
+
+    assert rows[0]["count"] == 2 and rows[0]["last"] == "2026-08-09"
+    assert [r["count"] for r in rows] == [2, 1]
+
+
+@pytest.mark.asyncio
+async def test_clearing_keeps_what_arrived_during_the_run(tmp_path):
+    """The dream takes minutes and conversations keep confirming things while it runs.
+    Truncating the file wholesale would drop exactly the records it exists to keep."""
+    store = MarkdownMemoryStore(
+        base_dir=tmp_path, notebook_dir=str(tmp_path / "notebook")
+    )
+    await store.append_confirmation("seen by the dream", "x", "2026-08-01")
+    consumed = len(store.read_confirmations())
+    await store.append_confirmation("arrived mid-run", "y", "2026-08-01")
+
+    store.clear_confirmations(consumed)
+    remaining = store.read_confirmations()
+
+    assert [r["content"] for r in remaining] == ["arrived mid-run"]
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_line_does_not_break_the_sidecar(tmp_path):
+    store = MarkdownMemoryStore(
+        base_dir=tmp_path, notebook_dir=str(tmp_path / "notebook")
+    )
+    store.confirmations_path.write_text("{not json\n", encoding="utf-8")
+    await store.append_confirmation("likes tea", "likes tea", "2026-08-01")
+
+    assert [r["content"] for r in store.read_confirmations()] == ["likes tea"]
+
+
+# --- the split, as the write path performs it ---
+
+
+class _Store(MarkdownMemoryStore):
+    pass
+
+
+@pytest.fixture
+def manager(tmp_path):
+    from suzent.memory.manager import MemoryManager
+
+    mgr = MemoryManager.__new__(MemoryManager)
+    mgr.markdown_store = _Store(
+        base_dir=tmp_path, notebook_dir=str(tmp_path / "notebook")
+    )
+    return mgr
+
+
+@pytest.mark.asyncio
+async def test_only_durable_matches_may_divert_a_write(manager):
+    """A transcript row is the user having said something, not memory holding it. If a
+    repeat matched only there and we skipped the log write, the claim would exist
+    nowhere durable at all."""
+    facts = [_fact("The user prefers dark mode in the editor")]
+    transcript_only = [{"content": KNOWN[0], "durable": False}]
+
+    to_write, confirmed = await manager._split_confirmations(
+        facts, transcript_only, "c1"
+    )
+
+    assert len(to_write) == 1 and not confirmed
+
+
+@pytest.mark.asyncio
+async def test_a_confirmation_leaves_the_log_and_lands_in_the_sidecar(manager):
+    facts = [
+        _fact("The user prefers dark mode in the editor"),
+        _fact("User is learning Portuguese"),
+    ]
+    known = [{"content": KNOWN[0], "durable": True}]
+
+    to_write, confirmed = await manager._split_confirmations(facts, known, "c1")
+
+    assert [f.content for f in to_write] == ["User is learning Portuguese"]
+    assert confirmed == [("The user prefers dark mode in the editor", KNOWN[0])]
+    assert manager.markdown_store.read_confirmations()[0]["matched"] == KNOWN[0]
+
+
+@pytest.mark.asyncio
+async def test_a_revision_is_still_written_and_is_tagged(manager):
+    facts = [_fact("User prefers dark mode in the editor since 2025-01-01")]
+    known = [{"content": KNOWN[0], "durable": True}]
+
+    to_write, confirmed = await manager._split_confirmations(facts, known, "c1")
+
+    assert len(to_write) == 1 and not confirmed
+    assert "revision" in to_write[0].tags
+
+
+@pytest.mark.asyncio
+async def test_a_failed_sidecar_write_falls_back_to_the_log(manager, monkeypatch):
+    async def _boom(**kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(manager.markdown_store, "append_confirmation", _boom)
+    facts = [_fact("The user prefers dark mode in the editor")]
+    known = [{"content": KNOWN[0], "durable": True}]
+
+    to_write, confirmed = await manager._split_confirmations(facts, known, "c1")
+
+    assert len(to_write) == 1 and not confirmed
+
+
+@pytest.mark.asyncio
+async def test_with_nothing_recalled_the_path_is_untouched(manager):
+    facts = [_fact("anything at all")]
+
+    to_write, confirmed = await manager._split_confirmations(facts, [], "c1")
+
+    assert to_write == facts and not confirmed
+
+
+def test_verdict_kinds_are_mutually_exclusive():
+    assert not ClaimVerdict(kind="new").is_confirmation
+    assert not ClaimVerdict(kind="new").is_revision

--- a/tests/memory/test_write_path_classifier.py
+++ b/tests/memory/test_write_path_classifier.py
@@ -10,10 +10,12 @@ was before this landed.
 import pytest
 
 from suzent.memory.classifier import (
+    CONFIRM_SIMILARITY,
     ClaimVerdict,
     claim_similarity,
     classify_fact,
     new_specifics,
+    polarity_differs,
 )
 from suzent.memory.markdown_store import MarkdownMemoryStore
 from suzent.memory.models import ExtractedFact
@@ -223,3 +225,98 @@ async def test_with_nothing_recalled_the_path_is_untouched(manager):
 def test_verdict_kinds_are_mutually_exclusive():
     assert not ClaimVerdict(kind="new").is_confirmation
     assert not ClaimVerdict(kind="new").is_revision
+
+
+# --- negation ---
+
+
+@pytest.mark.parametrize(
+    "correction",
+    [
+        "The user does not prefer dark mode in the editor",
+        "The user no longer prefers dark mode in the editor",
+        "The user doesn't prefer dark mode in the editor",
+    ],
+)
+def test_a_negated_restatement_is_never_a_confirmation(correction):
+    """Negation is the one word that reverses a claim instead of decorating it.
+
+    Step 4 of the dream prompt tells the agent a contradicting restatement never
+    reaches the confirmations list, and bumps the marker without re-reading the page.
+    If a correction were folded in as a confirmation, the write path would swallow an
+    update and the dream would count it as evidence *for* the claim it contradicts —
+    issue #34 all over again, with a false confirmation on top.
+    """
+    verdict = classify_fact(correction, KNOWN)
+
+    assert not verdict.is_confirmation
+
+
+def test_negation_survives_a_sentence_long_enough_to_dilute_it():
+    """The failure mode a lexical score alone cannot catch: on a long claim a single
+    "not" moves Dice by ~0.03, which lands inside the confirmation band."""
+    claim = (
+        "The nightly deployment pipeline is available on the staging cluster, "
+        "publishes a coverage report to the shared engineering channel each morning, "
+        "and mirrors its artifacts to the backup registry in Frankfurt"
+    )
+    negated = claim.replace("is available", "is not available")
+
+    assert claim_similarity(claim, negated) >= CONFIRM_SIMILARITY
+    assert polarity_differs(claim, negated)
+    assert not classify_fact(negated, [claim]).is_confirmation
+
+
+def test_matching_negations_still_confirm():
+    """Only a *difference* in polarity is claim-bearing. Two statements that are both
+    negative say the same thing, and must stay eligible for the sidecar."""
+    known = ["The user does not want email notifications"]
+
+    assert classify_fact(
+        "The user does not want email notifications", known
+    ).is_confirmation
+
+
+def test_spelling_a_contraction_out_is_not_a_difference():
+    assert not polarity_differs(
+        "the build isn't reproducible", "the build isnt reproducible"
+    )
+
+
+@pytest.mark.asyncio
+async def test_clearing_keeps_claims_the_prompt_could_not_fit(tmp_path):
+    """`summarize_confirmations` is bounded; the file is not.
+
+    A busy stretch can leave more distinct claims pending than the prompt shows. The
+    agent bumps markers only for what it saw, so dropping by position alone would
+    destroy the evidence for the rest — and the sidecar is the *only* record that
+    those facts recurred, because the write path deliberately kept them out of the
+    daily log.
+    """
+    store = MarkdownMemoryStore(
+        base_dir=tmp_path, notebook_dir=str(tmp_path / "notebook")
+    )
+    await store.append_confirmation("shown to the agent", "x", "2026-08-01")
+    await store.append_confirmation("did not fit in the prompt", "y", "2026-08-01")
+    consumed = len(store.read_confirmations())
+
+    store.clear_confirmations(consumed, folded=["shown to the agent"])
+
+    assert [r["content"] for r in store.read_confirmations()] == [
+        "did not fit in the prompt"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_folded_claim_is_cleared_however_its_repeats_are_interleaved(tmp_path):
+    store = MarkdownMemoryStore(
+        base_dir=tmp_path, notebook_dir=str(tmp_path / "notebook")
+    )
+    await store.append_confirmation("Prefers dark mode", "x", "2026-08-01")
+    await store.append_confirmation("unshown", "y", "2026-08-01")
+    await store.append_confirmation("prefers   DARK mode", "x", "2026-08-02")
+    consumed = len(store.read_confirmations())
+
+    store.clear_confirmations(consumed, folded=["Prefers dark mode"])
+
+    assert [r["content"] for r in store.read_confirmations()] == ["unshown"]


### PR DESCRIPTION
Archival memory has accumulated a large number of repeated items. This PR lands the diagnosis, the documented target workflow, and the fixes.

Full write-up: `docs/02-concepts/memory/deduplication.md`.

## What's wrong

Near-duplicate rate in the archival index, cosine over the stored embeddings:

| write path | rows | ≥0.995 | ≥0.95 | ≥0.92 |
| --- | ---: | ---: | ---: | ---: |
| `legacy_direct` (pre-June, had write-time dedup) | 2833 | 0.0% | 0.0% | 0.0% |
| `archive_log` (current path) | 615 | 0.3% | 10.1% | 25.4% |
| `notebook` (dream output) | 1342 | 14.7% | 15.6% | 17.6% |

On disk: 13,102 fact lines across 129 daily logs, 340 exact repeats, 581 near-duplicates in 279 clusters. The largest cluster is one identity fact written 64 times across 26 distinct days.

Three compounding causes, all three now addressed:

1. **Extraction was context-free** — the prompt saw only the current turn, so stable identity and preference facts were re-extracted every time they came up.
2. **Nothing deduplicates the archival index** — write-time dedup was removed in `98a39a3b` (fixes #34) in favour of the dream pass, but the dream consolidates into the notebook vault, treats daily logs as read-only, and resolves a duplicate by doing nothing.
3. **The dream barely ran** — two ingest runs since March, watermark stuck at `2026-03-11`.

## Commits

**`fix(memory): persist the dream's retry counter across restarts`** — cause 3, first because the rest assumes consolidation happens. `DreamRunner._failures` backs retry-then-skip, which exists so one un-consolidatable batch cannot wedge the backlog. It lived only in memory, and the runner attempts a batch at most once per app run, so on a desktop app that restarts between attempts the count never reached `max_retries` and the watermark never advanced. Counters now live in `.state/dream_state.json`.

**`fix(memory): key indexer state portably instead of by absolute path`** — `.index_state.json` sits in the vault's `.state` dir, which syncs between machines. Keyed by absolute path it had accumulated 436 entries spanning two machines and two base dirs; any file whose stale recorded mtime happened to match was skipped forever, which is how only 18 of 129 daily logs were indexed. Now keyed on `label:filename` and versioned. Pre-v2 state is discarded rather than migrated — that costs one full reindex, and the files it was wrongly skipping are exactly the ones missing, so the discard doubles as the backfill.

**`feat(memory): show the extractor what memory already holds`** — cause 1. The write path recalls the nearest 10 facts and renders them into the extraction prompt. The rule deliberately permits updates: a fact that CHANGES a known one must still be extracted, and the prompt says outright that losing an update is worse than storing a duplicate. That is the distinction the removed 0.85 threshold could not make, and why this suppresses repetition a step earlier rather than reinstating write-time dedup. Recall is best-effort — a search failure means extraction runs exactly as before.

**`feat(memory): retire duplicate log facts instead of ignoring them`** — cause 2. Step 3b's duplicate rule was literally "do nothing". It now ends in a retirement: the dream appends folded-in fact text to `notebook/.state/superseded.txt`, and the runner — not the agent — tombstones each line, reindexes every day whose log contains it, then truncates the file. The explicit per-date reindex is load-bearing (a tombstone does not change the log's mtime); truncating last means a crash replays idempotently rather than losing lines. Index mutation stays with the runner so the agent is left with file writes, and the logs stay append-only, so nothing races the live write path on today's file.

**`feat(memory): give personal claims a confirmation count and an expiry`** — retiring a repeat throws away the strongest ranking signal there is: a fact extracted 64 times is one claim confirmed 64 times. Confirmation now lives on the bullet — `(confirmed 12x, last 2026-08-20)` — which is OKF's `sources[].usage_count` in the only place it fits, since OKF frontmatter is per-document and these claims are bullets sharing a page. An absent marker means confirmed once, so nothing needs migrating. A repeat that *contradicts* the bullet is explicitly not a confirmation, or a reversal would accumulate as evidence for the thing it reverses. `3_Personal/` pages also get `stale_after` derived from the fact category (identity never / preference 1y / technical 6mo / goal 3mo / context 3w), which is what a revisit pass selects on. Stated in `DREAM_INSTRUCTIONS` as well as `schema_example.md`, because `schema.md` is seeded into a vault once and every existing vault predates these rules.

**`docs(memory): add an architecture overview with diagrams`** — `docs/02-concepts/memory/architecture.md`: the three tiers and who writes each, the per-turn write path, the dream cycle, the invariants that are easy to break by accident, and the roadmap.

**`perf(memory): diff daily logs into the index instead of re-embedding them`** — a daily log is appended to many times a day and every append re-embedded the whole file. Measured over the 130 real logs: 13,124 facts produced ~374,247 embedding calls, 28.5x amplification, quadratic in appends per day — worst day 609 facts over 106 appends, ~33,236 embeddings — plus ~374k single-row inserts, which is the fragmentation `optimize()` exists to clean up. Archive reindex now diffs the parsed file against what is already indexed, adds only what is missing, and deletes stale rows *after* the additions so a crash leaves a duplicate rather than a hole. An empty or failed diff query degrades to the old full replace, so the failure mode costs work, never accuracy.

**`fix(memory): stop MEMORY.md from clobbering its own writers`** — MEMORY.md has three writers and had no merge: two generators plus the agent, which edits the file directly because the core-memory prompt tells it to. `write_memory_file` was an unconditional `write_text`, so an agent's proactive note was destroyed by the next refresh, silently and usually within minutes. Generators now own only the region between two markers; everything after the end marker is copied through verbatim, and an unmarked file we cannot prove we wrote is treated as entirely manual instead of replaced. Two smaller defects in the same path: `refresh_core_memory_facts` filtered rows on `importance >= 0.7` while the indexer stamps every row with a constant `0.5` — so the only rows that ever passed were the pre-June legacy ones, meaning MEMORY.md was rebuilt exclusively from months-old data and would have gone empty the moment those rows were retired; and it stamped the content with a naive `datetime.now()` while the store stamped UTC, putting two timestamps an hour apart in every generated file. The legacy generator now stands down as soon as the vault has a personal page, handing the file to `promote_memory_md` with no flag day.

**`feat(memory): rank claims on the lifecycle the dream records`** — step 6. The writer side landed in `07f24c4b`; nothing read it. Retrieval now scores a vault chunk on the lifecycle it carries: confirmation count and recency lift a claim, `stale_after` in the past damps it, `deprecated` is a soft tombstone (still readable and linkable, out of the running), `draft` a small penalty. Anything else — `stable`, the `active` the live vault actually wrote before the schema said `stable`, a typo, nothing at all — is neutral, because a page is never demoted for predating a rule and an unrecognised status is missing information, not bad evidence.

**`feat(memory): dry-run harness for the dream, and read the status the vault writes`** — step 7 was the first change to mutate five months of live memory, so it got a harness first: `scripts/dream_dry_run.py` clones `~/.suzent`, redirects the `/mnt/notebook` sandbox volume at a copy of the vault, drives the real `DreamRunner`, and writes a unified diff to review before anything touches the original. The catch-up dream then ran and completed itself; the watermark is current.

**`feat(memory): recognise a restatement on the write path, and queue stale claims`** — step 8, the narrowest possible re-crossing of the #34 line. A fact is diverted from the daily log *only* when it restates, near word for word, a claim already recorded in an append-only store and adds no new specifics; it goes to `.state/confirmations.jsonl` and reaches the dream as a confirmation queue. Two guards carry the invariant: a match found only in a chat transcript or in the generated `MEMORY.md` can never divert a write, since neither is a record the write path can defer to; and any new number, date, quote, path, or version makes it a *revision*, which is written and tagged, however similar the prose reads. The comparison is lexical, not semantic, on purpose — the only band that changes behaviour is "practically the same sentence", which is what a lexical measure is good at and an embedding is too generous about, and it costs neither a model call nor a round trip on a path that runs every turn. The same commit adds the `stale_after` revisit queue: expired vault pages, soonest first, handed to the dream to re-confirm and never to delete. Both queues are runner-owned, and the confirmations sidecar is truncated only by the line count the agent was actually shown, since conversations keep appending while the dream runs.

**`feat(memory): rank a claim the user verified above every other signal`** — step 6's last open item. A person editing the `facts` block already landed in MEMORY.md's manual zone with a `human:` actor stamp; nothing read it, so their own correction ranked exactly like generated text. Retrieval now reads it, as a *floor* rather than a bonus so a low base score cannot dilute it, and it skips the `stale_after` decay — an expiry means nobody has re-confirmed this lately, which is precisely the question a human verification answers. `deprecated` still wins (a person retiring a claim is also a person), and only a `human:` actor qualifies, or an agent stamping itself would launder its own output into the strongest evidence class there is. MEMORY.md is chunked per zone rather than per file to make that possible: paragraph merging had been collapsing the file into one row spanning the generated half and the human half, a row that is both machine output and user-verified and therefore neither.

**`fix(memory): queue personal pages that never got an expiry`** — the revisit queue selected on `stale_after`, so a page without one was never due. Every `3_Personal/` page written before `07f24c4b` is in that state — 6 of the live vault's — which made the pages most in need of a first pass the only ones permanently exempt from one: never queued, so never visited, so the field never written. Undated personal pages are now due, ordered after the genuinely expired ones, and the prompt tells the dream to assign an expiry from the category table while it is there. That beats a backfill script guessing, since a wrong `stale_after` actively damps a good claim in step 6's ranking and only the dream can see the claim's category. Scoped to `3_Personal/` — a wiki page having no expiry is correct, not a backlog item.

**`feat(memory): legacy-row retirement script, export before delete`** — step 9, and the plan was wrong about it. See below.

## Also worth recording

The indexer is **not** append-only — only the markdown history is. `_reindex_file` is delete-then-add per file, keyed on mtime. Tombstones remain the right tool over log rewriting (cross-day duplication, the live today-file race), with the caveat that appending a tombstone does not change a log's mtime, so every tombstone write must be paired with an explicit reindex.

## Steps 6-8: landed

Items 6, 7 and 8 from the original plan are done and described above, including the last open piece of item 6 — a user's core-memory edit is now wired end to end to a `human:` verified actor.

## Step 9: the plan's premise was wrong

The plan said the 2,833 legacy pre-June rows were safe to delete once `MEMORY.md` stopped depending on them. Measuring instead of assuming says otherwise. `scripts/retire_legacy_rows.py` checked every legacy row's first 90 characters against every daily log and every vault page:

```
4797 archival rows
    2833  legacy_direct
    1372  notebook
     587  archive_log
       5  core_file

legacy rows span 2026-01-31 -> 2026-06-10
2832 of 2833 legacy row(s) appear nowhere in markdown - for those, this index is the only copy.
```

A separate 120-row random sample found zero of them recorded in markdown — not reworded, not summarised, not at all. They predate the markdown tier, so the index is the only place that content exists; deleting them is data loss, not index cleanup.

So the script exports first and deletes second. `--export` appends each row to the daily log for its `created_at` date, which puts it in the append-only tier and gives it a `source_file` the indexer owns, so the dream can finally consolidate it; only then is `--apply` removing a duplicate. `--apply` copies the table directory to a timestamped backup first and refuses outright while any row is recorded nowhere else.

**Neither has been run against the live index.** The export was exercised against a scratch directory (2,833 rows into 39 daily logs, correct dates, live memory untouched). Running it for real writes 2,833 lines into the user's memory directory and the delete is irreversible beyond the backup, so both are the user's call, not this PR's.

Also fixed here, surfaced by that script: `list_tables()` returns a paginated result object rather than a list, so the membership check was always true and both table branches took the create path on every startup — harmless only because of `exist_ok`, but it meant "the table did not exist" was never actually known.

## Testing

64 new tests across `test_dream_failures_persist.py`, `test_indexer_state_keys.py`, `test_extraction_known_facts.py`, `test_dream_supersede.py`, `test_claim_lifecycle_prompts.py`, `test_archive_incremental_index.py`, `test_memory_file_zones.py`, `test_claim_ranking.py`, `test_write_path_classifier.py`, and `test_dream_queues.py`. Full suite passes (1305).





