### PR TITLE
fix: self-host Monaco so file diffs stop hanging at "Loading viewer"

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "dompurify": "^3.4.13",
         "marked": "^16.4.0",
         "mermaid": "^11.16.0",
+        "monaco-editor": "^0.56.0",
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -961,6 +962,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1310,6 +1312,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001733",
         "electron-to-chromium": "^1.5.199",
@@ -1644,6 +1647,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -2053,6 +2057,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4344,7 +4349,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -4675,6 +4679,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
@@ -4864,6 +4869,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4876,6 +4882,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5485,6 +5492,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -5608,6 +5616,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5897,6 +5906,7 @@
       "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "dompurify": "^3.4.13",
     "marked": "^16.4.0",
     "mermaid": "^11.16.0",
+    "monaco-editor": "^0.56.0",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/frontend/src/components/chat/FileDiffViewer.tsx
+++ b/frontend/src/components/chat/FileDiffViewer.tsx
@@ -1,6 +1,12 @@
-import React, { useMemo } from 'react';
-import { Editor, DiffEditor, type BeforeMount } from '@monaco-editor/react';
+import React, { Suspense, lazy, useMemo } from 'react';
+import type { BeforeMount } from '@monaco-editor/react';
 import { SCHEME_COLORS, type Scheme, useTheme } from '../../hooks/useTheme';
+
+// Monaco is bundled, not fetched from a CDN — see ./monacoEditors. Loading it
+// lazily keeps it out of the initial bundle: the chunk is pulled the first time
+// a file preview renders.
+const Editor = lazy(() => import('./monacoEditors').then((m) => ({ default: m.Editor })));
+const DiffEditor = lazy(() => import('./monacoEditors').then((m) => ({ default: m.DiffEditor })));
 
 const EDITOR_OPTIONS = {
   readOnly: true,
@@ -275,30 +281,32 @@ export const FileContentDiffViewer: React.FC<FileContentDiffViewerProps> = ({
         <span className="opacity-60 uppercase shrink-0">{language}</span>
       </div>
       <div style={{ height: `${height}px` }} className="w-full">
-        {isDiff ? (
-          <DiffEditor
-            original={original}
-            modified={modified}
-            language={language}
-            theme={editorTheme}
-            options={EDITOR_OPTIONS}
-            beforeMount={beforeMount}
-            loading={LOADING_FALLBACK}
-            // Chat blocks mount and unmount quickly. Keeping models alive avoids
-            // a Monaco teardown race that can abort the surrounding React render.
-            keepCurrentOriginalModel
-            keepCurrentModifiedModel
-          />
-        ) : (
-          <Editor
-            value={modified}
-            language={language}
-            theme={editorTheme}
-            options={EDITOR_OPTIONS}
-            beforeMount={beforeMount}
-            loading={LOADING_FALLBACK}
-          />
-        )}
+        <Suspense fallback={LOADING_FALLBACK}>
+          {isDiff ? (
+            <DiffEditor
+              original={original}
+              modified={modified}
+              language={language}
+              theme={editorTheme}
+              options={EDITOR_OPTIONS}
+              beforeMount={beforeMount}
+              loading={LOADING_FALLBACK}
+              // Chat blocks mount and unmount quickly. Keeping models alive avoids
+              // a Monaco teardown race that can abort the surrounding React render.
+              keepCurrentOriginalModel
+              keepCurrentModifiedModel
+            />
+          ) : (
+            <Editor
+              value={modified}
+              language={language}
+              theme={editorTheme}
+              options={EDITOR_OPTIONS}
+              beforeMount={beforeMount}
+              loading={LOADING_FALLBACK}
+            />
+          )}
+        </Suspense>
       </div>
     </div>
   );

--- a/frontend/src/components/chat/monacoEditors.ts
+++ b/frontend/src/components/chat/monacoEditors.ts
@@ -1,0 +1,54 @@
+/**
+ * Self-hosted Monaco.
+ *
+ * `@monaco-editor/react` otherwise fetches Monaco from a jsdelivr URL at runtime.
+ * That script is blocked outright in the packaged app — the Tauri CSP declares no
+ * `script-src`, so it falls back to `default-src 'self'` — and in dev it depends on
+ * the CDN being reachable. The wrapper only `console.error`s when the fetch fails
+ * and never leaves its loading state, and the loader is a one-shot module
+ * singleton, so a single failed fetch wedges every diff for the rest of the
+ * session with no retry.
+ *
+ * Pointing the loader at a bundled instance makes `init()` resolve from local
+ * state without touching the network, so dev and production behave identically
+ * and both work offline.
+ *
+ * FileDiffViewer imports this module lazily to keep Monaco out of the initial
+ * bundle. `loader.config` runs at module evaluation, which always precedes the
+ * mount of any editor re-exported from here.
+ */
+import { loader } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor';
+import EditorWorker from 'monaco-editor/editor/editor.worker?worker';
+import CssWorker from 'monaco-editor/languages/features/css/css.worker?worker';
+import HtmlWorker from 'monaco-editor/languages/features/html/html.worker?worker';
+import JsonWorker from 'monaco-editor/languages/features/json/json.worker?worker';
+import TsWorker from 'monaco-editor/languages/features/typescript/ts.worker?worker';
+
+// Monaco resolves its workers through this global rather than through imports.
+self.MonacoEnvironment = {
+  getWorker(_workerId: string, label: string) {
+    switch (label) {
+      case 'json':
+        return new JsonWorker();
+      case 'css':
+      case 'scss':
+      case 'less':
+        return new CssWorker();
+      case 'html':
+      case 'handlebars':
+      case 'razor':
+        return new HtmlWorker();
+      case 'typescript':
+      case 'javascript':
+        return new TsWorker();
+      default:
+        // Also the worker the diff editor uses to compute diffs.
+        return new EditorWorker();
+    }
+  },
+};
+
+loader.config({ monaco });
+
+export { DiffEditor, Editor } from '@monaco-editor/react';


### PR DESCRIPTION
## Problem

File diff previews in chat sometimes never render — the tool card shows its header (`AUTHENTICATION.MD` / `MARKDOWN`) but the editor area stays stuck on the `Loading viewer...` fallback forever.

`@monaco-editor/react` fetches Monaco from `cdn.jsdelivr.net` at runtime; nothing in the app configured a local loader. Two ways that fails:

- **Packaged app — always.** The Tauri CSP declares no `script-src`, so it falls back to `default-src 'self'` and the injected CDN script is blocked outright. `connect-src` also excludes jsdelivr.
- **Dev — intermittently.** Tauri only injects CSP for assets served through the `tauri://` protocol (`get_asset` in `manager/mod.rs`). With `devUrl` the HTML comes from Vite untouched, so there's no CSP and the only gate is whether the CDN is actually reachable.

Either failure is permanent for the session, which is what makes it look flaky rather than broken:

- The wrapper only `console.error`s when `init()` rejects — it never updates state, so `isEditorReady` stays `false` and the loading fallback renders forever with no error UI.
- The loader is a one-shot module singleton (`isInitialized` + a single `wrapperPromise`). Whichever diff renders first triggers the one and only fetch and decides the outcome for every diff after it. There is no retry; only a page reload resets it.

## Fix

Point the loader at a bundled Monaco instance so `init()` resolves from local state without touching the network. Dev and production now behave identically and both work offline.

The editors are imported through `React.lazy` to keep Monaco out of the initial bundle — it still loads on the first file preview, as before. That also guarantees `loader.config` runs at chunk evaluation, before any editor from that module can mount.

One gotcha worth knowing: monaco-editor 0.56 routes deep imports through its `exports` map, so the customary `monaco-editor/esm/vs/...` worker paths resolve to a doubled `esm/vs/esm/vs/...` path. `monaco-editor/editor/editor.worker` is the correct form.

## Verification

Rendered both code paths in a real browser against the dev server:

- Diff editor and plain editor both mount and paint — markdown diff with `+2 −1` and word-level highlighting, Python syntax colors.
- `performance.getEntriesByType('resource')`: **0** requests matching `jsdelivr|unpkg|cdn.` out of 212. Everything local.
- `window.monaco` is `undefined`, confirming the bundled instance rather than the AMD global path.
- No console errors; no `Loading viewer` text left in the DOM.

Checked the production build against the app CSP specifically, since that case was broken 100% of the time:

- Workers emit as `new Worker('/assets/editor.worker-*.js')` — same-origin, permitted by `default-src 'self'`.
- Monaco's blob-worker fallback is never reached: `createWorkerClient` short-circuits on `t instanceof Worker`, which is what `getWorker` returns.
- Codicon font emits as `/assets/codicon-*.ttf`, not a `data:` URI (which `font-src` → `'self'` would have blocked).

`tsc -b` clean, 168 tests pass, `npm run build` succeeds with Monaco still splitting into its own lazy chunk.

## Follow-up, not in this PR

Importing full Monaco pulls the TypeScript/JSON/CSS/HTML language services and their workers — `ts.worker` alone is 6.9 MB, ~9 MB across the four. The viewer is `readOnly` with hover, codeLens, and suggestions disabled, so those services only spawn workers for diagnostics that are never shown. Trimming to tokenizers plus the base editor worker (the diff editor does need that one) would recover most of it, at the cost of hand-picking the editor contributions that `index.js` currently imports for us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)