### PR TITLE
fix(chat): repair how a streaming turn renders

### DIFF
--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -1305,7 +1305,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   const showTransientAssistant = streamingForCurrentChat || hasPendingTransientApprovals;
 
   // Safe values
-  const safeMessages = useMemo(
+  const reconciledMessages = useMemo(
     () =>
       reconcileToolCallMessages(
         hideStreamingDrafts(messages || [], showTransientAssistant),
@@ -1313,6 +1313,24 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       ),
     [messages, showTransientAssistant, streamingParts]
   );
+  // `reconcileToolCallMessages` rebuilds the array on every streaming chunk,
+  // and a token delta never touches a settled message. Handing a fresh identity
+  // downstream anyway re-renders the whole history -- render plan, minimap
+  // markers, every tool block -- per token, which is what makes scrolling crawl
+  // while the agent works. Keep the previous array whenever it is element-wise
+  // unchanged so the memoised consumers can bail out.
+  const stableMessagesRef = useRef<Message[]>(reconciledMessages);
+  const safeMessages = useMemo(() => {
+    const previous = stableMessagesRef.current;
+    if (
+      previous.length === reconciledMessages.length &&
+      previous.every((message, index) => message === reconciledMessages[index])
+    ) {
+      return previous;
+    }
+    stableMessagesRef.current = reconciledMessages;
+    return reconciledMessages;
+  }, [reconciledMessages]);
   const visibleMessageStartIndex = Math.max(0, safeMessages.length - visibleMessageCount);
   const visibleMessages = useMemo(
     () => safeMessages.slice(visibleMessageStartIndex),
@@ -1372,6 +1390,26 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       _base.agent || (_isPlatformChat ? _prefs?.agent || backendConfig?.agents?.[0] || '' : ''),
     tools: _base.tools?.length ? _base.tools : _isPlatformChat ? (_prefs?.tools ?? []) : [],
   });
+
+  // `safeConfig` is rebuilt on every render, so passing its policy object
+  // straight into the memoised message list would defeat the memo and re-render
+  // the whole history on each streaming chunk. Hold the previous object while
+  // its contents are unchanged.
+  const toolApprovalPolicy = safeConfig.tool_approval_policy;
+  const stableToolApprovalPolicyRef = useRef(toolApprovalPolicy);
+  const stableToolApprovalPolicy = useMemo(() => {
+    const previous = stableToolApprovalPolicyRef.current;
+    const previousKeys = Object.keys(previous ?? {});
+    const nextKeys = Object.keys(toolApprovalPolicy ?? {});
+    if (
+      previousKeys.length === nextKeys.length &&
+      nextKeys.every((key) => previous?.[key] === toolApprovalPolicy?.[key])
+    ) {
+      return previous;
+    }
+    stableToolApprovalPolicyRef.current = toolApprovalPolicy;
+    return toolApprovalPolicy;
+  }, [toolApprovalPolicy]);
 
   useEffect(() => {
     if (!_isCronChat || !Number.isFinite(cronJobId)) {
@@ -1504,6 +1542,13 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   const fallbackModelSignature = safeConfig.acp_agent_id
     ? `acp/${safeConfig.acp_agent_id}`
     : safeConfig.model;
+
+  const handleOpenForkOrigin = useCallback(
+    (chatId: string) => {
+      void loadChat(chatId, { force: true });
+    },
+    [loadChat]
+  );
 
   const handleStopSubAgent = useCallback(async (taskId: string) => {
     try {
@@ -2496,7 +2541,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
                     onImageClick={setViewingImage}
                     onFileClick={handleFileClick}
                     onToolApproval={handleToolApproval}
-                    toolApprovalPolicy={safeConfig.tool_approval_policy}
+                    toolApprovalPolicy={stableToolApprovalPolicy}
                     onRemoveApprovalPolicy={handleRemoveApprovalPolicy}
                     onInlineAction={handleInlineAction}
                     subAgentTasks={subAgentTasks}
@@ -2506,7 +2551,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
                     onRetry={!isStreaming ? handleRetry : undefined}
                     onFork={!isStreaming ? requestFork : undefined}
                     forkOrigin={forkOrigin}
-                    onOpenForkOrigin={(chatId) => void loadChat(chatId, { force: true })}
+                    onOpenForkOrigin={handleOpenForkOrigin}
                     onEditUserMessage={!isStreaming ? handleEditUserMessage : undefined}
                     fallbackModel={fallbackModelSignature}
                   />

--- a/frontend/src/components/chat/ActivityRail.header.test.tsx
+++ b/frontend/src/components/chat/ActivityRail.header.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { ActivityRail } from './ActivityRail';
+
+function renderRail(props: Partial<React.ComponentProps<typeof ActivityRail>>): string {
+  return renderToStaticMarkup(
+    <ActivityRail itemCount={5} {...props}>
+      <div />
+    </ActivityRail>
+  );
+}
+
+// A turn that interleaves prose with tool calls renders one rail per activity
+// group. Every rail used to claim the turn's worked-for time and to animate as
+// if it were live, so a long turn showed several identical running headers.
+describe('ActivityRail header', () => {
+  it('reports the worked time on the first rail of a turn only', () => {
+    expect(renderRail({ showDuration: true, isActive: true, isCurrent: false })).toContain(
+      'Worked for'
+    );
+  });
+
+  it('describes its own work instead of repeating the duration', () => {
+    const markup = renderRail({
+      showDuration: false,
+      isActive: true,
+      isCurrent: false,
+      currentLabel: 'Read main.py',
+    });
+
+    expect(markup).toContain('Read main.py');
+    expect(markup).not.toContain('Worked for');
+  });
+
+  it('animates only the rail the agent is working in', () => {
+    const settled = renderRail({
+      showDuration: false,
+      isActive: true,
+      isCurrent: false,
+      currentLabel: 'Ran 4 commands',
+    });
+    const live = renderRail({
+      showDuration: false,
+      isActive: true,
+      isCurrent: true,
+      currentLabel: 'Running npm test',
+    });
+
+    expect(settled).not.toContain('activity-rail-header-active');
+    expect(live).toContain('activity-rail-header-active');
+  });
+
+  it('falls back to a neutral label when the group exposes nothing to describe', () => {
+    expect(renderRail({ showDuration: false, isActive: true, isCurrent: false })).toContain(
+      'Activity'
+    );
+  });
+});

--- a/frontend/src/components/chat/ActivityRail.labels.test.ts
+++ b/frontend/src/components/chat/ActivityRail.labels.test.ts
@@ -85,6 +85,34 @@ describe('getAguiActivityLabel', () => {
     expect(getAguiActivityLabel(chunks, true)).toBe('Running npm test');
   });
 
+  it('still describes a group whose work is already finished', () => {
+    // A turn that interleaves prose with tool calls renders one rail per group.
+    // Without a label the settled rails fall back to the header's worked-for
+    // text, so every rail in the turn repeats the same duration.
+    const chunks = [
+      {
+        chunk: {
+          type: 'tool',
+          items: [
+            toolPart({ toolName: 'read_file', args: JSON.stringify({ file_path: 'src/main.py' }) }),
+          ],
+        },
+      },
+    ];
+
+    expect(getAguiActivityLabel(chunks, false)).toBe('Read main.py');
+  });
+
+  it('counts a finished streak in the past tense', () => {
+    const chunks = [
+      {
+        chunk: { type: 'tool', items: Array.from({ length: 4 }, () => toolPart()) },
+      },
+    ];
+
+    expect(getAguiActivityLabel(chunks, false)).toBe('Ran 4 commands');
+  });
+
   it('describes a lone call instead of counting it', () => {
     const items = [
       toolPart({ toolName: 'read_file' }),

--- a/frontend/src/components/chat/ActivityRail.tsx
+++ b/frontend/src/components/chat/ActivityRail.tsx
@@ -4,6 +4,7 @@ import type { ContentBlock } from '../../lib/chatUtils';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { getRepeatedToolLabel, getToolSummary, normalizeToolName } from './toolSummary';
 import type { ToolTense } from './toolSummary';
+import { useTypewriter } from '../../hooks/useTypewriter';
 import { tForLocale } from '../../i18n';
 
 export type ActivityRenderGroup<T> =
@@ -186,10 +187,13 @@ export function getAguiActivityLabel(
       const items = chunks
         .slice(0, i + 1)
         .flatMap((entry) => (entry.chunk.type === 'tool' ? (entry.chunk.items ?? []) : []));
-      const toolIndex = findLastIndex(
+      // Prefer the call still in flight; once the group has finished, describe
+      // what it ended on so a settled rail still says what it did.
+      const unfinishedIndex = findLastIndex(
         items,
         (part) => !part.output || part.state === 'approval-requested'
       );
+      const toolIndex = unfinishedIndex >= 0 ? unfinishedIndex : items.length - 1;
       if (toolIndex >= 0) {
         const tool = items[toolIndex];
         return formatActiveToolLabel(
@@ -234,10 +238,11 @@ export function getLegacyActivityLabel(
       const blocks = chunks
         .slice(0, i + 1)
         .flatMap((entry) => (entry.chunk.type === 'toolCall' ? (entry.chunk.blocks ?? []) : []));
-      const toolIndex = findLastIndex(
+      const unfinishedIndex = findLastIndex(
         blocks,
         (block) => !block.content || block.approvalState === 'pending'
       );
+      const toolIndex = unfinishedIndex >= 0 ? unfinishedIndex : blocks.length - 1;
       if (toolIndex >= 0) {
         const tool = blocks[toolIndex];
         return formatActiveToolLabel(
@@ -285,7 +290,14 @@ export const ActivityRail: React.FC<{
   startedAtMs?: number;
   showDuration?: boolean;
   defaultExpanded?: boolean;
+  /** The turn is still streaming — keeps the worked-for clock running. */
   isActive?: boolean;
+  /**
+   * This rail is the one the agent is working in right now. A turn that
+   * interleaves prose with tool calls renders several rails, and only the last
+   * of them is live: the earlier ones are finished work and must not animate.
+   */
+  isCurrent?: boolean;
   hasPending?: boolean;
   currentLabel?: string;
 }> = ({
@@ -296,10 +308,14 @@ export const ActivityRail: React.FC<{
   showDuration = true,
   defaultExpanded = false,
   isActive = false,
+  isCurrent = isActive,
   hasPending = false,
   currentLabel,
 }) => {
   const [expanded, setExpanded] = useState(defaultExpanded);
+  // Once the user has opened or closed a rail themselves, stop steering it —
+  // auto-collapsing a rail they deliberately opened is worse than leaving it.
+  const userToggledRef = React.useRef(false);
   // Use the caller-provided start time when available so the timer resumes from
   // the original start across remounts (e.g. reconnecting to a stream after a
   // chat switch); otherwise fall back to mount time.
@@ -314,10 +330,11 @@ export const ActivityRail: React.FC<{
     }
   }, [startedAtMs]);
 
+  // Follow the caller in both directions so a rail the agent has moved past
+  // folds itself away instead of leaving the whole turn expanded at once.
   useEffect(() => {
-    if (defaultExpanded) {
-      setExpanded(true);
-    }
+    if (userToggledRef.current) return;
+    setExpanded(defaultExpanded);
   }, [defaultExpanded]);
 
   useEffect(() => {
@@ -335,19 +352,20 @@ export const ActivityRail: React.FC<{
   // Only the turn's first rail reports the worked time. When assistant text
   // splits a turn into several rails they all belong to one stretch of work, so
   // the later ones show what is happening instead of starting a second clock.
-  const headerLabel = showDuration
-    ? durationLabel
-    : (currentLabel ?? (isActive ? durationLabel : 'Activity'));
+  const headerLabel = showDuration ? durationLabel : (currentLabel ?? 'Activity');
 
   return (
     <div className="activity-rail-shell min-w-0 w-full">
       <button
         type="button"
-        onClick={() => setExpanded((value) => !value)}
+        onClick={() => {
+          userToggledRef.current = true;
+          setExpanded((value) => !value);
+        }}
         className={`activity-rail-header ${
           hasPending && !expanded
             ? 'activity-rail-header-pending'
-            : isActive && !expanded
+            : isCurrent && !expanded
               ? 'activity-rail-header-active'
               : ''
         }`}
@@ -425,6 +443,9 @@ export const ReasoningRailItem: React.FC<{
   onFileClick?: (filePath: string, fileName: string, shiftKey?: boolean) => void;
 }> = ({ text, isStreaming, onFileClick }) => {
   const [expanded, setExpanded] = useState(false);
+  // Reasoning arrives in the same uneven bursts as the answer; reveal it at a
+  // steady rate so an expanded thought reads as flowing text.
+  const revealedText = useTypewriter(text, Boolean(isStreaming) && expanded);
   return (
     <ActivityRailItem state={isStreaming ? 'active' : 'done'}>
       <div className="min-w-0">
@@ -453,7 +474,7 @@ export const ReasoningRailItem: React.FC<{
             <div className="mt-2 pt-1">
               <div className="text-[13px] md:text-sm text-brutal-black/85 dark:text-neutral-300 leading-relaxed break-words opacity-90">
                 <MarkdownRenderer
-                  content={text}
+                  content={revealedText}
                   onFileClick={onFileClick}
                   streamingLite={isStreaming}
                 />

--- a/frontend/src/components/chat/AssistantContent.tsx
+++ b/frontend/src/components/chat/AssistantContent.tsx
@@ -253,20 +253,16 @@ const StreamingMarkdownBlock: React.FC<{
   showCursor: boolean;
   onFileClick?: (filePath: string, fileName: string, shiftKey?: boolean) => void;
 }> = ({ content, isLastBlock, showCursor, onFileClick }) => {
-  const typedContent = useTypewriter(content, 10, isLastBlock);
+  const typedContent = useTypewriter(content, isLastBlock);
   const renderedContent = isLastBlock ? typedContent : content;
 
   return (
-    <>
-      <MarkdownRenderer
-        content={renderedContent}
-        onFileClick={onFileClick}
-        streamingLite={isLastBlock}
-      />
-      {isLastBlock && showCursor && (
-        <span className="animate-brutal-blink inline-block w-2.5 h-4 bg-brutal-black align-middle ml-1" />
-      )}
-    </>
+    <MarkdownRenderer
+      content={renderedContent}
+      onFileClick={onFileClick}
+      streamingLite={isLastBlock}
+      caret={isLastBlock && showCursor}
+    />
   );
 };
 

--- a/frontend/src/components/chat/AssistantMessage.tsx
+++ b/frontend/src/components/chat/AssistantMessage.tsx
@@ -48,6 +48,7 @@ import {
   hasAguiPendingApproval,
   hasLegacyPendingApproval,
 } from './ActivityRail';
+import { useTypewriter } from '../../hooks/useTypewriter';
 import { useI18n } from '../../i18n';
 import {
   getProviderInitials,
@@ -56,6 +57,42 @@ import {
 } from '../../lib/providerVisuals';
 
 const LARGE_MARKDOWN_RENDER_THRESHOLD = 12000;
+
+/**
+ * One prose block of an assistant turn.
+ *
+ * While the block is the live one its text is revealed at a steady rate rather
+ * than in the uneven bursts the stream delivers, and it renders through the
+ * lightweight markdown path so the reveal stays cheap frame to frame.
+ */
+const AssistantTextChunk: React.FC<{
+  text: string;
+  isStreaming: boolean;
+  onFileClick?: (filePath: string, fileName: string, shiftKey?: boolean) => void;
+}> = ({ text, isStreaming, onFileClick }) => {
+  const revealedText = useTypewriter(text, isStreaming);
+
+  return (
+    <div className="relative px-1 py-1 text-brutal-black dark:text-neutral-100">
+      <div className="space-y-4">
+        <MarkdownRenderer
+          content={revealedText}
+          onFileClick={onFileClick}
+          streamingLite={isStreaming}
+          caret={isStreaming}
+        />
+      </div>
+    </div>
+  );
+};
+
+/** Index of the turn's last activity group — the only one that can be live. */
+function findLastActivityGroupIndex(groups: Array<{ type: string }>): number {
+  for (let i = groups.length - 1; i >= 0; i -= 1) {
+    if (groups[i].type === 'activity') return i;
+  }
+  return -1;
+}
 
 interface AssistantMessageProps {
   message: Message;
@@ -246,12 +283,16 @@ const AGUIPartsContent: React.FC<{
     chunks,
     (chunk) => chunk.type === 'tool' || chunk.type === 'reasoning'
   );
+  // Only the turn's final rail is live. Earlier ones are finished work: they
+  // must not animate, and must not each start their own worked-for clock.
+  const currentActivityGroupIndex = findLastActivityGroupIndex(renderGroups);
 
   return (
     <>
       {renderGroups.map((group, gi) => {
         if (group.type === 'activity') {
           const activityGroupOrdinal = getActivityGroupOrdinal(renderGroups, gi);
+          const isCurrentGroup = Boolean(isStreaming) && gi === currentActivityGroupIndex;
           return (
             <ActivityRail
               key={`activity-${gi}`}
@@ -259,10 +300,11 @@ const AGUIPartsContent: React.FC<{
               durationSeconds={workedDurationSeconds}
               startedAtMs={streamStartedAtMs}
               showDuration={activityGroupOrdinal === 0}
-              defaultExpanded={Boolean(isStreaming)}
+              defaultExpanded={isCurrentGroup}
               isActive={Boolean(isStreaming)}
+              isCurrent={isCurrentGroup}
               hasPending={hasAguiPendingApproval(group.chunks)}
-              currentLabel={getAguiActivityLabel(group.chunks, Boolean(isStreaming))}
+              currentLabel={getAguiActivityLabel(group.chunks, isCurrentGroup)}
             >
               {group.chunks.map(({ chunk, index: ci }) => {
                 if (chunk.type === 'reasoning') {
@@ -598,18 +640,12 @@ const AGUIPartsContent: React.FC<{
         // bordered box with a blinking cursor under the assembly animation.
         if (!fullText.trim()) return null;
         return (
-          <div key={ci} className="relative px-1 py-1 text-brutal-black dark:text-neutral-100">
-            <div className="space-y-4">
-              <MarkdownRenderer
-                content={fullText}
-                onFileClick={onFileClick}
-                streamingLite={Boolean(isStreaming && isLastChunk)}
-              />
-              {isStreaming && isLastChunk && (
-                <span className="animate-brutal-blink inline-block w-2.5 h-4 bg-brutal-black align-middle ml-1" />
-              )}
-            </div>
-          </div>
+          <AssistantTextChunk
+            key={ci}
+            text={fullText}
+            isStreaming={Boolean(isStreaming && isLastChunk)}
+            onFileClick={onFileClick}
+          />
         );
       })}
     </>
@@ -1092,6 +1128,7 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
     validChunks,
     (chunk) => chunk.type === 'reasoning' || chunk.type === 'toolCall'
   );
+  const currentLegacyActivityGroupIndex = findLastActivityGroupIndex(legacyRenderGroups);
 
   return (
     <CitationProvider sources={citationSourcesMap}>
@@ -1109,6 +1146,8 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
                   legacyRenderGroups,
                   groupIndex
                 );
+                const isCurrentGroup =
+                  isStreamingThis && groupIndex === currentLegacyActivityGroupIndex;
                 return (
                   <ActivityRail
                     key={`legacy-activity-${groupIndex}`}
@@ -1116,10 +1155,11 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
                     durationSeconds={workedDurationSeconds}
                     startedAtMs={streamStartedAtMs}
                     showDuration={activityGroupOrdinal === 0}
-                    defaultExpanded={isStreamingThis}
+                    defaultExpanded={isCurrentGroup}
                     isActive={isStreamingThis}
+                    isCurrent={isCurrentGroup}
                     hasPending={hasLegacyPendingApproval(group.chunks)}
-                    currentLabel={getLegacyActivityLabel(group.chunks, isStreamingThis)}
+                    currentLabel={getLegacyActivityLabel(group.chunks, isCurrentGroup)}
                   >
                     {group.chunks.map(({ chunk, index: idx }) => {
                       if (chunk.type === 'reasoning') {

--- a/frontend/src/components/chat/ChatMinimap.tsx
+++ b/frontend/src/components/chat/ChatMinimap.tsx
@@ -182,7 +182,7 @@ function buildMarkers(messages: Message[], labels: MinimapLabels): ChatMinimapMa
   return markers;
 }
 
-export const ChatMinimap: React.FC<ChatMinimapProps> = ({
+const ChatMinimapComponent: React.FC<ChatMinimapProps> = ({
   messages,
   scrollContainerRef,
   onJumpToMessage,
@@ -259,13 +259,26 @@ export const ChatMinimap: React.FC<ChatMinimapProps> = ({
     const el = scrollContainerRef.current;
     if (!el) return;
 
-    el.addEventListener('scroll', updateMetrics, { passive: true });
-    const resizeObserver = new ResizeObserver(updateMetrics);
+    // Scroll fires far faster than the screen refreshes, and each event here
+    // would otherwise re-render the whole rail. Coalesce to one update per
+    // frame so dragging the scrollbar stays smooth while a turn streams.
+    let frame: number | null = null;
+    const scheduleUpdate = () => {
+      if (frame !== null) return;
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        updateMetrics();
+      });
+    };
+
+    el.addEventListener('scroll', scheduleUpdate, { passive: true });
+    const resizeObserver = new ResizeObserver(scheduleUpdate);
     resizeObserver.observe(el);
     if (el.firstElementChild) resizeObserver.observe(el.firstElementChild);
 
     return () => {
-      el.removeEventListener('scroll', updateMetrics);
+      if (frame !== null) cancelAnimationFrame(frame);
+      el.removeEventListener('scroll', scheduleUpdate);
       resizeObserver.disconnect();
     };
   }, [markers.length, scrollContainerRef, updateMetrics]);
@@ -390,3 +403,8 @@ export const ChatMinimap: React.FC<ChatMinimapProps> = ({
     </div>
   );
 };
+
+// The rail re-renders on every scroll frame from its own state; without this it
+// would also re-render on each of the parent's streaming-chunk renders and
+// rebuild every marker preview from scratch.
+export const ChatMinimap = React.memo(ChatMinimapComponent);

--- a/frontend/src/components/chat/MarkdownRenderer.tsx
+++ b/frontend/src/components/chat/MarkdownRenderer.tsx
@@ -77,6 +77,12 @@ interface MarkdownRendererProps {
   content: string;
   onFileClick?: (filePath: string, fileName: string, shiftKey?: boolean) => void;
   streamingLite?: boolean;
+  /**
+   * Draw a blinking caret after the last character. Only honoured on the
+   * lightweight streaming path, which is the only one that renders a partial
+   * message.
+   */
+  caret?: boolean;
 }
 
 function encodePathSegments(path: string): string {
@@ -237,7 +243,7 @@ const LiteCodeBlock: React.FC<{ lang?: string; content: string }> = ({ lang, con
   const lineCount = content ? content.split('\n').length : 1;
 
   return (
-    <div className="my-3 font-mono text-sm border-2 border-brutal-black dark:border-zinc-500 bg-white dark:bg-zinc-900 overflow-hidden">
+    <div className="lite-code my-3 font-mono text-sm border-2 border-brutal-black dark:border-zinc-500 bg-white dark:bg-zinc-900 overflow-hidden">
       <div className="flex items-center gap-2 px-3 py-1.5 bg-brutal-black dark:bg-zinc-800 border-b-2 border-brutal-black dark:border-zinc-500">
         <span className="text-white dark:text-brutal-yellow font-black uppercase text-[10px] truncate">
           {safeLang}
@@ -271,7 +277,7 @@ const LiteTable: React.FC<{ lines: string[]; sourcesMap?: CitationSourcesMap | n
   const rows = lines.slice(2).map(splitLiteTableRow);
 
   return (
-    <div className="overflow-x-auto">
+    <div className="lite-table overflow-x-auto">
       <table className="text-xs border-2 border-brutal-black dark:border-zinc-500 bg-white dark:bg-zinc-900">
         <thead>
           <tr>
@@ -304,7 +310,10 @@ const LiteTable: React.FC<{ lines: string[]; sourcesMap?: CitationSourcesMap | n
   );
 };
 
-const LiteMarkdownRenderer: React.FC<{ content: string }> = ({ content }) => {
+const LiteMarkdownRenderer: React.FC<{ content: string; caret?: boolean }> = ({
+  content,
+  caret,
+}) => {
   const sourcesMap = useCitationSources();
   const parts: React.ReactNode[] = [];
   const fencePattern = /```([a-zA-Z0-9_-]*)[ \t]*\n?([\s\S]*?)(?:```|$)/g;
@@ -399,7 +408,7 @@ const LiteMarkdownRenderer: React.FC<{ content: string }> = ({ content }) => {
         parts.push(
           <div
             key={`${keyPrefix}-li-${parts.length}-${lineIndex}`}
-            className="flex gap-2 leading-relaxed"
+            className="lite-list-row flex gap-2 leading-relaxed"
           >
             <span className="shrink-0 text-neutral-500">{ordered ? `${ordered[1]}.` : '•'}</span>
             <span className="min-w-0 break-words">{renderLiteInline(body, sourcesMap)}</span>
@@ -433,7 +442,9 @@ const LiteMarkdownRenderer: React.FC<{ content: string }> = ({ content }) => {
   }
 
   return (
-    <div className="prose dark:prose-invert tight-lists prose-sm max-w-none break-words select-text space-y-3">
+    <div
+      className={`prose dark:prose-invert tight-lists prose-sm max-w-none break-words select-text space-y-3${caret ? ' streaming-caret' : ''}`}
+    >
       {parts}
     </div>
   );
@@ -477,7 +488,7 @@ function safeUrlTransform(url: string): string {
 }
 
 export const MarkdownRenderer = React.memo<MarkdownRendererProps>(
-  ({ content, onFileClick, streamingLite = false }) => {
+  ({ content, onFileClick, streamingLite = false, caret = false }) => {
     const RM: any = ReactMarkdown;
     const sourcesMap = useCitationSources();
     const openingLinksRef = React.useRef(new Map<string, number>());
@@ -827,7 +838,7 @@ export const MarkdownRenderer = React.memo<MarkdownRendererProps>(
     );
 
     if (streamingLite) {
-      return <LiteMarkdownRenderer content={sanitized} />;
+      return <LiteMarkdownRenderer content={sanitized} caret={caret} />;
     }
 
     return (

--- a/frontend/src/components/chat/StreamingCaret.test.tsx
+++ b/frontend/src/components/chat/StreamingCaret.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { MarkdownRenderer } from './MarkdownRenderer';
+
+function renderStreaming(content: string, caret = true): string {
+  return renderToStaticMarkup(<MarkdownRenderer content={content} streamingLite caret={caret} />);
+}
+
+/** The element the caret's ::after rule will attach to, given the markup. */
+function lastBlockClasses(markup: string): string {
+  const blocks = markup.match(/<(?:p|div|table)[^>]*class="[^"]*"/g) ?? [];
+  return blocks[blocks.length - 1] ?? '';
+}
+
+// The caret used to be a sibling element rendered after the whole markdown
+// block, which put it on its own line under the text. It is drawn as an
+// ::after inside the final block instead, so what matters is that the block
+// carries the marker class its caret rule expects.
+describe('streaming caret', () => {
+  it('marks the container only while streaming', () => {
+    expect(renderStreaming('hello')).toContain('streaming-caret');
+    expect(renderStreaming('hello', false)).not.toContain('streaming-caret');
+  });
+
+  it('ends on a plain paragraph, which takes the caret inline', () => {
+    const markup = renderStreaming('Some prose still being written');
+    // No marker class means the default rule applies: the caret joins the
+    // paragraph's own inline flow, right after the last word.
+    expect(lastBlockClasses(markup)).not.toMatch(/lite-(list-row|code|table)/);
+  });
+
+  it('tags a trailing list row so the caret goes in the text cell', () => {
+    expect(lastBlockClasses(renderStreaming('- first\n- second'))).toContain('lite-list-row');
+  });
+
+  it('tags a trailing code block so the caret goes after the last character', () => {
+    expect(renderStreaming('```js\nconst a = 1;')).toContain('lite-code');
+  });
+
+  it('tags a trailing table', () => {
+    expect(renderStreaming('| a | b |\n| --- | --- |\n| 1 | 2 |')).toContain('lite-table');
+  });
+});

--- a/frontend/src/components/chat/ToolCallBlock.tsx
+++ b/frontend/src/components/chat/ToolCallBlock.tsx
@@ -154,7 +154,7 @@ interface ToolCallBlockProps {
   inActivityRail?: boolean;
 }
 
-export const ToolCallBlock: React.FC<ToolCallBlockProps> = ({
+const ToolCallBlockComponent: React.FC<ToolCallBlockProps> = ({
   toolName,
   toolArgs,
   output,
@@ -898,3 +898,11 @@ export const ToolCallBlock: React.FC<ToolCallBlockProps> = ({
     </div>
   );
 };
+
+/**
+ * A streaming turn re-renders on every token, and its activity rail can hold
+ * dozens of settled tool blocks whose props never change again. Each one runs a
+ * JSON parse and an LCS diff on render, so skipping them is what keeps the page
+ * responsive while the agent works.
+ */
+export const ToolCallBlock = React.memo(ToolCallBlockComponent);

--- a/frontend/src/hooks/useAGUI.ts
+++ b/frontend/src/hooks/useAGUI.ts
@@ -4,7 +4,7 @@
  * Replaces Vercel AI SDK's useChat with a lightweight SSE client
  * that parses AG-UI events and builds up parts-based state.
  */
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import type { A2UISurface } from '../types/a2ui';
 import type { AGUIPart, AcpPermissionRequest, ApprovalRememberScope } from '../types/agui';
 import type { CitationSource } from '../lib/streamEvents';
@@ -539,7 +539,46 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
   const suppressFinishRef = useRef(false);
   // Keep a ref to latest parts so onFinish gets the final value
   const partsRef = useRef<AGUIPart[]>([]);
-  partsRef.current = parts;
+  // Publishing a token delta straight to React state re-renders the whole chat
+  // view; at streaming rates that starves the main thread and scrolling crawls.
+  // `publishParts` keeps `partsRef` exact and synchronous but coalesces the
+  // render into one update per frame. While a flush is queued the ref is ahead
+  // of `parts`, so it must not be rewound to the state value here.
+  const flushFrameRef = useRef<number | null>(null);
+  if (flushFrameRef.current === null) {
+    partsRef.current = parts;
+  }
+
+  const cancelPartsFlush = useCallback(() => {
+    if (flushFrameRef.current !== null) {
+      cancelAnimationFrame(flushFrameRef.current);
+      flushFrameRef.current = null;
+    }
+  }, []);
+
+  /**
+   * Record the newest parts. Renders are batched to the next animation frame
+   * unless `immediate`, which every terminal path (error, finish, abort) uses so
+   * the last state of a turn is never left sitting in a cancelled frame.
+   */
+  const publishParts = useCallback(
+    (next: AGUIPart[], immediate = false) => {
+      partsRef.current = next;
+      if (immediate) {
+        cancelPartsFlush();
+        setParts(next);
+        return;
+      }
+      if (flushFrameRef.current !== null) return;
+      flushFrameRef.current = requestAnimationFrame(() => {
+        flushFrameRef.current = null;
+        setParts(partsRef.current);
+      });
+    },
+    [cancelPartsFlush]
+  );
+
+  useEffect(() => cancelPartsFlush, [cancelPartsFlush]);
 
   // Pending approval tracking
   const [pendingApprovalCount, setPendingApprovalCount] = useState(0);
@@ -562,9 +601,8 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
   optionsRef.current = options;
 
   const clearParts = useCallback(() => {
-    setParts([]);
-    partsRef.current = [];
-  }, []);
+    publishParts([], true);
+  }, [publishParts]);
 
   const setPendingApprovalCountSync = useCallback((count: number) => {
     pendingApprovalCountRef.current = count;
@@ -576,15 +614,17 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
     approvalDecisionsRef.current = [];
   }, [setPendingApprovalCountSync]);
 
-  const removeInlineSurface = useCallback((surfaceId: string) => {
-    setParts((prev) => {
-      const next = prev.filter(
-        (p) => !(p.type === 'a2ui' && (p.surface as A2UISurface)?.id === surfaceId)
+  const removeInlineSurface = useCallback(
+    (surfaceId: string) => {
+      publishParts(
+        partsRef.current.filter(
+          (p) => !(p.type === 'a2ui' && (p.surface as A2UISurface)?.id === surfaceId)
+        ),
+        true
       );
-      partsRef.current = next;
-      return next;
-    });
-  }, []);
+    },
+    [publishParts]
+  );
 
   const stop = useCallback(() => {
     abortRef.current?.abort();
@@ -603,35 +643,35 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
 
   const restorePartsFromSeed = useCallback(
     (seed: AGUIPart[]) => {
-      setParts(seed);
-      partsRef.current = seed;
+      publishParts(seed, true);
       setStatus('idle');
       const approvalCount = seed.filter(
         (p) => p.type === 'tool' && p.state === 'approval-requested'
       ).length;
       setPendingApprovalCountSync(approvalCount);
     },
-    [setPendingApprovalCountSync]
+    [publishParts, setPendingApprovalCountSync]
   );
 
   // Optimistically update a tool part's state when user approves/denies
   // so buttons disappear instantly (no waiting for backend round-trip)
-  const resolveApproval = useCallback((approvalId: string, approved: boolean) => {
-    setParts((prev) => {
-      const next = prev.map((p) => {
-        if (p.type === 'tool' && p.approvalId === approvalId) {
-          return {
-            ...p,
-            state: approved ? ('running' as const) : ('error' as const),
-            approvalId: undefined,
-          };
-        }
-        return p;
-      });
-      partsRef.current = next;
-      return next;
-    });
-  }, []);
+  const resolveApproval = useCallback(
+    (approvalId: string, approved: boolean) => {
+      publishParts(
+        partsRef.current.map((p) =>
+          p.type === 'tool' && p.approvalId === approvalId
+            ? {
+                ...p,
+                state: approved ? ('running' as const) : ('error' as const),
+                approvalId: undefined,
+              }
+            : p
+        ),
+        true
+      );
+    },
+    [publishParts]
+  );
 
   // Track pending approval count from parts
   const addApprovalDecision = useCallback(
@@ -740,20 +780,21 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
           if (result.error) {
             setError(result.error);
             setStatus('error');
-            setParts(currentParts);
-            partsRef.current = currentParts;
+            publishParts(currentParts, true);
             onError?.(new Error(result.error), currentParts);
             return;
           }
         }
 
         if (events.length > 0) {
-          setParts(currentParts);
-          partsRef.current = currentParts;
+          publishParts(currentParts);
           setPendingApprovalCountSync(pendingApprovalIds.size);
         }
       }
 
+      // `currentParts` is still empty when the stream closed before any event
+      // arrived, so flush the ref -- it always holds the newest parts.
+      publishParts(partsRef.current, true);
       setStatus('idle');
       onFinish?.(currentParts);
     } catch (err) {
@@ -761,6 +802,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
         // If the abort was triggered by steerStream, do nothing here —
         // steerStream owns the status and will call onFinish when done.
         if (!isSteeringRef.current) {
+          publishParts(partsRef.current, true);
           setStatus('idle');
           onFinish?.(partsRef.current);
         }
@@ -795,8 +837,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
           ? { ...p, state: 'error' as const, approvalId: undefined }
           : p
       );
-      partsRef.current = resolved;
-      setParts(resolved);
+      publishParts(resolved, true);
     }
 
     // 1. Abort the current fetch — set flag so the AbortError handler is a no-op
@@ -830,8 +871,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
       }
 
       // Steer stream is confirmed active; start with a fresh transient message.
-      setParts([]);
-      partsRef.current = [];
+      publishParts([], true);
       setStatus('streaming');
 
       const reader = response.body.getReader();
@@ -866,33 +906,32 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
             isSteeringRef.current = false;
             setError(result.error);
             setStatus('error');
-            setParts(currentParts);
-            partsRef.current = currentParts;
+            publishParts(currentParts, true);
             onError?.(new Error(result.error), currentParts);
             return;
           }
         }
 
         if (events.length > 0) {
-          setParts(currentParts);
-          partsRef.current = currentParts;
+          publishParts(currentParts);
           setPendingApprovalCountSync(pendingApprovalIds.size);
         }
       }
 
       isSteeringRef.current = false;
+      publishParts(partsRef.current, true);
       setStatus('idle');
       onFinish?.(currentParts);
     } catch (err) {
       isSteeringRef.current = false;
       if ((err as Error).name === 'AbortError') {
+        publishParts(partsRef.current, true);
         setStatus('idle');
         onFinish?.(partsRef.current);
       } else {
         // Restore previous parts if steer failed before the replacement stream started.
         if (partsRef.current.length === 0 && previousParts.length > 0) {
-          partsRef.current = previousParts;
-          setParts(previousParts);
+          publishParts(previousParts, true);
         }
         const errorMsg = (err as Error).message;
         setError(errorMsg);
@@ -921,8 +960,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
 
       if (!isProbe) {
         // Normal send: reset immediately so the UI shows "submitted" while waiting.
-        setParts([]);
-        partsRef.current = [];
+        publishParts([], true);
         setError(undefined);
         setStatus('submitted');
         resetApprovalTracking();
@@ -967,8 +1005,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
           // consume-once, so it only replays chunks from the reconnect point —
           // the seed supplies everything before it.
           const seed = opts?.seedParts ?? [];
-          setParts(seed);
-          partsRef.current = seed;
+          publishParts(seed, true);
           setError(undefined);
           setStatus('submitted');
           resetApprovalTracking();
@@ -1013,20 +1050,22 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
             if (result.error) {
               setError(result.error);
               setStatus('error');
-              setParts(currentParts);
-              partsRef.current = currentParts;
+              publishParts(currentParts, true);
               onError?.(new Error(result.error), currentParts);
               return true;
             }
           }
 
           if (events.length > 0) {
-            setParts(currentParts);
-            partsRef.current = currentParts;
+            publishParts(currentParts);
             setPendingApprovalCountSync(pendingApprovalIds.size);
           }
         }
 
+        // Land the turn's last tokens in the same commit as the status flip
+        // instead of a frame behind it. The ref, not `currentParts`: the latter is
+        // still empty when the stream closed before delivering an event.
+        publishParts(partsRef.current, true);
         setStatus('idle');
         onFinish?.(currentParts);
         return true;
@@ -1039,6 +1078,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
           } else if (!isSteeringRef.current) {
             // If the abort was triggered by steerStream, do nothing here —
             // steerStream owns the status and will call onFinish when done.
+            publishParts(partsRef.current, true);
             setStatus('idle');
             onFinish?.(partsRef.current);
           }
@@ -1051,7 +1091,7 @@ export function useAGUI(options: UseAGUIOptions): UseAGUIReturn {
         return false;
       }
     },
-    [resetApprovalTracking, setPendingApprovalCountSync]
+    [publishParts, resetApprovalTracking, setPendingApprovalCountSync]
   );
 
   return {

--- a/frontend/src/hooks/useTypewriter.test.ts
+++ b/frontend/src/hooks/useTypewriter.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { getRevealStep } from './useTypewriter';
+
+/** Frames needed to reveal a backlog of `size` with no further text arriving. */
+function framesToDrain(size: number): number {
+  let remaining = size;
+  let frames = 0;
+  while (remaining > 0) {
+    remaining -= getRevealStep(remaining);
+    frames += 1;
+  }
+  return frames;
+}
+
+/**
+ * Backlog the reveal settles at when text keeps arriving at a steady
+ * `charsPerFrame`, i.e. how far behind the agent the reader ends up.
+ */
+function steadyStateBacklog(charsPerFrame: number): number {
+  let remaining = 0;
+  for (let frame = 0; frame < 600; frame += 1) {
+    remaining += charsPerFrame;
+    remaining = Math.max(0, remaining - getRevealStep(remaining));
+  }
+  return remaining;
+}
+
+describe('getRevealStep', () => {
+  it('drains a burst in a handful of frames however large it is', () => {
+    // The animation exists to hide uneven delivery, so a paragraph landing at
+    // once must not turn into seconds of typing.
+    expect(framesToDrain(40)).toBeLessThanOrEqual(20);
+    expect(framesToDrain(400)).toBeLessThanOrEqual(30);
+    expect(framesToDrain(2000)).toBeLessThanOrEqual(40);
+  });
+
+  it('keeps the reader close behind however fast the agent emits', () => {
+    // ~60 fps, so 5 chars/frame is a brisk 300 chars/sec and 20 is far beyond
+    // what any model sustains. Both must settle well under a second of lag.
+    expect(steadyStateBacklog(2)).toBeLessThanOrEqual(20);
+    expect(steadyStateBacklog(5)).toBeLessThanOrEqual(40);
+    expect(steadyStateBacklog(20)).toBeLessThanOrEqual(140);
+  });
+
+  it('always advances, so a trickle never stalls', () => {
+    expect(getRevealStep(1)).toBe(1);
+    expect(getRevealStep(3)).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/frontend/src/hooks/useTypewriter.ts
+++ b/frontend/src/hooks/useTypewriter.ts
@@ -1,71 +1,86 @@
 import { useState, useEffect, useRef } from 'react';
 
-export const useTypewriter = (text: string, speed: number = 20, isEnabled: boolean = true) => {
-  const [displayedText, setDisplayedText] = useState('');
-  const indexRef = useRef(0);
+/**
+ * Backlog past which the reveal gives up and jumps forward.
+ *
+ * The point of the animation is to hide the unevenness of delivery, not to
+ * pace the agent. Once the buffer is this far ahead, catching up a few
+ * characters at a time stops reading as typing and starts reading as lag.
+ */
+const MAX_ANIMATED_BACKLOG = 3000;
+
+/**
+ * Frames the reveal aims to take to drain whatever is queued.
+ *
+ * Draining a fixed share per frame rather than a fixed number of characters is
+ * what keeps the lag bounded: the rate rises with the backlog, so the display
+ * settles a constant few frames behind however fast the agent emits, and a
+ * burst still eases out instead of snapping.
+ */
+const CATCH_UP_FRAMES = 6;
+
+/** Characters to reveal this frame given how far the buffer has run ahead. */
+export const getRevealStep = (remaining: number): number =>
+  Math.max(1, Math.ceil(remaining / CATCH_UP_FRAMES));
+
+/**
+ * Reveal appended text at a steady rate instead of in the bursts it arrives in.
+ *
+ * SSE hands over whatever accumulated since the last read — a few characters,
+ * sometimes a whole paragraph — and the model emits unevenly on top of that, so
+ * raw streaming lands in visible jerks. Keeping the rendered text a little
+ * behind the buffer and closing the gap every frame reads as flowing text.
+ *
+ * Only growth after mount is animated. A component that mounts onto a turn
+ * already in progress — switching back to a streaming chat, remounting after a
+ * reconnect — shows what is already there rather than replaying it.
+ */
+export const useTypewriter = (text: string, isEnabled: boolean = true) => {
+  const [displayedText, setDisplayedText] = useState(text);
+  const indexRef = useRef(text.length);
   const prevTextRef = useRef(text);
 
-  // Reset when content is replaced (new message), but keep progress when content only appends.
+  // Content replaced rather than appended to (a different message reusing this
+  // node): adopt it whole. Rewinding to replay text the user has already read
+  // is worse than showing it.
   useEffect(() => {
-    if (!text.startsWith(prevTextRef.current) && prevTextRef.current !== '') {
-      indexRef.current = 0;
-      setDisplayedText('');
+    if (prevTextRef.current !== '' && !text.startsWith(prevTextRef.current)) {
+      indexRef.current = text.length;
+      setDisplayedText(text);
     }
     prevTextRef.current = text;
   }, [text]);
 
   useEffect(() => {
-    if (!isEnabled) {
-      setDisplayedText(text);
+    // Not animating, or the agent has run so far ahead that the reveal would
+    // read as lag. Measured against the backlog, not the total length, so a
+    // long answer keeps its smoothing all the way down.
+    if (!isEnabled || text.length - indexRef.current > MAX_ANIMATED_BACKLOG) {
       indexRef.current = text.length;
+      setDisplayedText(text);
       return;
     }
 
-    // For very large responses, avoid animation overhead entirely.
-    if (text.length > 5000) {
-      setDisplayedText(text);
-      indexRef.current = text.length;
-      return;
-    }
+    if (indexRef.current >= text.length) return;
 
     let frameId = 0;
-    let cancelled = false;
-    let lastTick = 0;
 
-    const getStep = (remaining: number): number => {
-      if (remaining > 800) return 10;
-      if (remaining > 300) return 6;
-      if (remaining > 120) return 4;
-      if (remaining > 40) return 2;
-      return 1;
-    };
-
-    const tick = (now: number) => {
-      if (cancelled) return;
-
-      // Use a soft cadence to avoid over-rendering while keeping movement smooth.
-      const cadence = Math.max(speed, 16);
-      if (now - lastTick >= cadence) {
-        if (indexRef.current < text.length) {
-          const remaining = text.length - indexRef.current;
-          const step = getStep(remaining);
-          indexRef.current = Math.min(text.length, indexRef.current + step);
-          setDisplayedText(text.slice(0, indexRef.current));
-        }
-        lastTick = now;
+    const tick = () => {
+      const remaining = text.length - indexRef.current;
+      if (remaining <= 0) {
+        frameId = 0;
+        return;
       }
-
-      if (indexRef.current < text.length) {
-        frameId = window.requestAnimationFrame(tick);
-      }
+      indexRef.current += getRevealStep(remaining);
+      setDisplayedText(text.slice(0, indexRef.current));
+      frameId = window.requestAnimationFrame(tick);
     };
 
     frameId = window.requestAnimationFrame(tick);
     return () => {
-      cancelled = true;
-      window.cancelAnimationFrame(frameId);
+      if (frameId) window.cancelAnimationFrame(frameId);
     };
-  }, [text, speed, isEnabled]);
+  }, [text, isEnabled]);
 
   return displayedText;
 };

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1269,3 +1269,41 @@ code {
 .dark .mention-editor.is-empty::before {
   color: rgb(115 115 115); /* neutral-500 */
 }
+
+/*
+ * Streaming caret.
+ *
+ * The caret belongs immediately after the last character the agent has
+ * emitted, and that character lives inside whatever block the markdown
+ * renderer produced. Rendering the caret as a sibling element left it
+ * stranded on its own line below the text, so it is drawn as an ::after
+ * inside the final block instead, where it joins the text's own inline flow.
+ *
+ * One rule per block shape the lite renderer can end on: a list row is a flex
+ * row, so the caret goes in the text cell rather than becoming a new column,
+ * and a code block ends in <pre><code>, so it goes after the last character
+ * rather than below the frame.
+ */
+.streaming-caret > :last-child:not(.lite-list-row):not(.lite-code):not(.lite-table)::after,
+.streaming-caret > .lite-list-row:last-child > span:last-child::after,
+.streaming-caret > .lite-code:last-child pre code::after,
+.streaming-caret > .lite-table:last-child::after {
+  content: '';
+  display: inline-block;
+  width: 0.5em;
+  height: 1em;
+  margin-left: 0.15em;
+  vertical-align: text-bottom;
+  background: currentColor;
+  animation: streamCaretBlink 1s step-end infinite;
+}
+
+@keyframes streamCaretBlink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
Three problems, all visible in one long turn that interleaves prose with tool calls.

### Every rail claimed the turn's worked time and animated as live

Only the first rail was meant to report the time, but the header fell back to the duration whenever it had no label of its own — and the label builder returned nothing once a group's tools had all finished, which is every group but the last. So a turn with three rails showed "Worked for 4m 46s" three times, all pulsing.

Settled groups now describe what they did ("Ran 4 commands"), and a new `isCurrent` separates the one rail the agent is working in from `isActive`, which now only keeps the turn's single clock running.

### The whole history re-rendered on every token

`reconcileToolCallMessages` builds a fresh array per streaming chunk, so the memoised message list, the minimap and the citation map never bailed out. The minimap additionally re-rendered on every scroll event and rebuilt each marker preview from the message text — that combination is what made scrolling crawl mid-turn.

- the message array keeps its identity while it is element-wise unchanged
- two props that defeated the same memo (`safeConfig.tool_approval_policy`, an inline `onOpenForkOrigin`) are stabilised
- `ChatMinimap` is memoised and its scroll metrics coalesced to one update per frame
- `ToolCallBlock` — which runs a JSON parse and an LCS diff per render — is memoised
- part updates are batched to one commit per frame rather than one per SSE read, with every terminal path flushing immediately so a turn never ends on a cancelled frame

### The reveal was as uneven as delivery, and the caret sat below it

`useTypewriter` already existed but was wired only into the legacy path, started from an empty string (so remounting onto a live turn replayed the whole message), and gave up above 5000 characters — switching smoothing off partway through exactly the answers worth watching. It now reveals a share of the backlog per frame instead of a fixed step, which settles ~75ms behind the agent at any emit speed, animates only growth after mount, and caps on the backlog rather than the total length.

The caret was a sibling element rendered after the whole markdown block, so it could only ever land on its own line below the text. It is an `::after` inside the final block now, with one rule per block shape the lite renderer can end on — a list row is a flex row, and a code block ends in `<pre><code>`.

## Verification

`tsc`, 191 tests (14 new), `format:check` and the build all pass. ESLint findings on the touched files were diffed against an upstream baseline worktree and match exactly at 68 — no new findings.

The caret is the one part unit tests can't prove, since jsdom does no layout: the assertions only check that the marker classes land on the right blocks. I served a probe page through the dev server and measured the real geometry — `::after` resolves at `display: inline-block` in all three shapes, each block stays one line tall, and the block runs ~9px wider than its text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)