### PR TITLE
feat: keep hand-written release highlights across changelog refreshes

### DIFF
--- a/docs/03-developing/releasing.md
+++ b/docs/03-developing/releasing.md
@@ -1,88 +1,89 @@
 # Release Guide
 
-Suzent uses a Release PR workflow. Preparing a release is a single manual
-action; version synchronization, tagging, cross-platform builds, and GitHub
-Release publication are automated.
+Suzent keeps a Release PR permanently open against `main`. There is no "start a
+release" step: every push to `main` re-merges into that PR, re-derives the
+version from the commit range, and rewrites the notes. Releasing is a merge.
+
+Version synchronization, tagging, cross-platform builds, and GitHub Release
+publication are automated from there.
 
 ## Before you start
 
-1. Make sure all changes intended for the release have been merged into
-   `main`, and that its required CI checks pass.
-2. Decide the next [semantic version](https://semver.org/):
-   - `patch` for backward-compatible fixes;
-   - `minor` for backward-compatible features;
-   - `major` for breaking changes;
-   - an exact `X.Y.Z` version only when the automatically calculated version
-     is not appropriate.
-3. Decide how desktop assets should be handled:
-   - use `build` for every normal release and for any frontend, desktop,
-     installer, or `API_VERSION` change;
-   - use `reuse` only for a backend-only hotfix that remains compatible with
-     the previous desktop application.
+1. Make sure everything intended for the release is merged into `main` and its
+   CI checks pass.
+2. Check that the derived version on the open Release PR is the one you want.
+   You do not choose it — it comes from the commit prefixes in the range since
+   the last tag:
+
+   | Prefix in the range | Bump |
+   | --- | --- |
+   | `feat:` | minor |
+   | `fix:`, `perf:` | patch |
+   | `feat!:`, or a `BREAKING CHANGE:` footer | major, but **minor while below 1.0** |
+   | only `chore:`, `ci:`, `docs:`, `test:`, `style:`, `build:`, `refactor:` | patch, as maintenance |
+
+   The highest-ranking prefix in the range wins, so one `feat:` among twenty
+   fixes makes the release a minor. Reaching 1.0.0 stays a deliberate human act:
+   a breaking change below 1.0 bumps the minor rather than declaring stability.
+3. Check `.release-assets-mode` on the release branch:
+   - `build` for every normal release and for any frontend, desktop, installer,
+     or `API_VERSION` change;
+   - `reuse` only for a backend-only hotfix that remains compatible with the
+     previously published desktop application.
+
+   It carries over from `main`, so it is `build` unless someone changed it.
 
 ## Normal release
 
-1. In GitHub, open **Actions → Prepare Release → Run workflow** and select the
-   `main` branch.
-2. Set **version** to `patch`, `minor`, `major`, or an exact version such as
-   `0.8.0`. Set **desktop_assets** to `build` unless the release meets all of
-   the `reuse` conditions above, then run the workflow.
-3. Wait for the workflow to open a `release/vX.Y.Z` pull request. Do not create
-   the release branch, tag, or GitHub Release manually.
-4. Review the pull request:
-   - confirm the version is correct in every changed manifest and lock file;
-   - edit the generated `CHANGELOG.md` section so it is accurate and useful to
-     users;
-   - confirm `.release-assets-mode` contains the intended `build` or `reuse`
-     value;
-   - wait for all required checks to pass.
-5. Merge the Release PR into `main`. The merge automatically creates the
-   `vX.Y.Z` tag and starts **Build and Publish Desktop Release**.
-6. Wait for that workflow to complete. The GitHub Release stays in draft state
-   until every required asset has been uploaded and checksums are generated.
-7. Open the [Releases page](https://github.com/cyzus/suzent/releases) and verify:
-   - the release is published rather than draft and is marked as the latest
-     release;
-   - its title, tag, and release notes match the merged changelog;
+1. Open the Release PR — it is the open pull request from `release/next`,
+   titled `chore: release vX.Y.Z`. If none is open, nothing user-visible has
+   landed since the last tag; see [Nothing is open](#nothing-is-open).
+2. Review it:
+   - confirm the derived version is what you intend, in the title and in every
+     changed manifest and lock file;
+   - read the generated `CHANGELOG.md` section, and add a
+     [highlights block](#writing-release-highlights) so the release page opens
+     with something better than a list of commit subjects;
+   - confirm `.release-assets-mode` holds the intended `build` or `reuse`;
+   - wait for all checks to pass.
+3. Merge it into `main` with **Create a merge commit**. The branch is `main`
+   plus a version bump, so squashing writes a redundant duplicate-content
+   commit. The merge automatically creates the `vX.Y.Z` tag and starts
+   **Build and Publish Desktop Release**.
+4. Wait for that workflow to complete. The GitHub Release stays a draft until
+   every asset is uploaded and checksums are generated.
+5. Open the [Releases page](https://github.com/cyzus/suzent/releases) and verify:
+   - the release is published rather than draft, and is marked as latest;
+   - its title, tag, and notes match the merged changelog;
    - all eight `suzent-*` application and installer assets are present (two
      each for Windows, Linux, macOS Intel, and macOS Apple Silicon);
    - `SHA256SUMS` is attached.
 
-The release is complete only after the publication and asset checks in step 7
-pass. If the workflow fails, follow [Recovery](#recovery) rather than manually
-publishing the draft.
+The release is complete only after the checks in step 5 pass. If the workflow
+fails, follow [Recovery](#recovery) rather than publishing the draft by hand.
 
-The release remains a draft while Windows, macOS Intel, macOS Apple Silicon,
-and Linux builds run. It is published only after every build succeeds. A failed
-build therefore cannot expose a partially populated release.
+The release remains a draft while the Windows, macOS Intel, macOS Apple
+Silicon, and Linux builds run, and is published only after every build
+succeeds — so a failed build cannot expose a partially populated release.
 
 Backend-only hotfixes still receive a normal version and Git tag for auditing,
 rollback, and dependency locking, but they do not rebuild four desktop targets.
-When `desktop_assets=reuse`, the workflow copies the previous published UI and
-installer assets into the new release. The frontend accepts a different backend
-build commit as long as `API_VERSION` matches. Incompatible route or payload
-changes must bump `API_VERSION` and use `desktop_assets=build`.
+With `.release-assets-mode` set to `reuse`, the workflow copies the previously
+published UI and installer assets into the new release. The frontend accepts a
+different backend build commit as long as `API_VERSION` matches. Incompatible
+route or payload changes must bump `API_VERSION` and use `build`.
 
-### If main changes before merge
+Do not create the release branch, tag, or GitHub Release by hand.
 
-Do not merge a stale Release PR. Every push to `main` automatically runs
-**Refresh Release PR**. It finds the single open same-repository `release/v*`
-PR, refreshes it, and starts CI. No PR number or manual action is required.
+### Nothing is open
 
-The refresh workflow merges the latest `main` into the release branch,
-regenerates the current version's changelog section, validates every version
-source, pushes the result, and explicitly starts CI. Review the regenerated
-notes again before merging because refresh replaces any manual edits in that
-version's section — with the single exception of the highlights block described
-below.
+A range containing only `chore`, `ci`, `docs`, `test`, `style`, `build`, or
+`refactor` commits does not open a Release PR on its own. Nothing in it earns a
+bump, so there is nothing a user would notice; it waits and rides along with the
+next real change.
 
-For recovery, **Actions → Refresh Release PR → Run workflow** performs the same
-lookup without inputs. If there is no open Release PR it exits successfully. If
-there is more than one, it stops and lists the candidates instead of guessing.
-
-The post-merge workflow independently verifies that the Release PR head
-contained the latest pre-merge `main` commit. If it did not, tag creation and
-publication stop instead of releasing code that is missing from the notes.
+To release anyway — to ship a dependency bump, say — use
+[Prepare Release](#manual-override-prepare-release).
 
 ### Writing release highlights
 
@@ -115,6 +116,37 @@ everything else and the release is published with its summary already in place.
 Drafting it from `git log <last-tag>..HEAD` is a reasonable job to hand to an
 agent; deciding which of those commits a user actually cares about is not.
 
+### Releasing a version other than the derived one
+
+Edit the version files on `release/next` before merging. The tag follows the
+files at merge time, not the branch name — which is why the branch is called
+`release/next` and never names a version.
+
+Be aware that the next push to `main` re-derives the version and will overwrite
+a hand-edited one. Only the highlights block survives a refresh.
+
+### If main changes before merge
+
+Do not merge a stale Release PR — though you rarely have to think about it,
+because every push to `main` runs **Refresh Release PR** automatically. It finds
+the single open same-repository PR whose head branch starts with `release/`,
+merges `main` into it, re-derives the version, rewrites the notes, validates
+every version source, pushes, and starts CI. No PR number or manual action is
+required.
+
+The refresh replaces any manual edits in the pending version's changelog
+section, with the single exception of the highlights block above. If the branch
+is already up to date with `main`, or the reconcile produces no file changes, it
+makes no commit at all.
+
+For recovery, **Actions → Refresh Release PR → Run workflow** performs the same
+lookup without inputs. If there is no open Release PR it exits successfully. If
+there is more than one, it stops and lists the candidates instead of guessing.
+
+The post-merge workflow independently verifies that the Release PR head
+contained the latest pre-merge `main` commit. If it did not, tag creation and
+publication stop instead of releasing code that is missing from the notes.
+
 ## What is automated
 
 `scripts/bump_version.py` synchronizes the version in:
@@ -124,18 +156,38 @@ agent; deciding which of those commits a user actually cares about is not.
 - the main Tauri configuration, Cargo manifest, and Cargo lock;
 - the standalone installer's Tauri, npm, and Cargo files.
 
-It also generates a changelog draft from commits since the last tag. Scoped
+It also generates the changelog section from commits since the last tag. Scoped
 conventional commits such as `feat(ui): ...` are categorized, while unprefixed
-commit subjects are retained under **Changed** so release notes are not silently
-lost.
+subjects are retained under **Changed** so release notes are not silently lost.
+The baseline for re-deriving the version is always the last *tagged* release,
+never the version already written into the release branch — otherwise each push
+would bump on top of the previous bump.
 
-CI runs `python scripts/bump_version.py --check` on every pull request. A tag
-whose version does not match the manifests or changelog is rejected before any
-desktop build starts.
+CI runs `python scripts/bump_version.py --check` on every pull request, and
+advisory-audits commit prefixes it cannot read. A prefix nobody recognizes earns
+no bump, so an unreadable one silently changes the version that ships; the audit
+warns without blocking a merge. A tag whose version does not match the manifests
+or changelog is rejected before any desktop build starts.
 
-Release PR workflows explicitly dispatch CI after bot-created or bot-refreshed
-branches. This avoids GitHub's suppression of ordinary workflow events created
-with the built-in token.
+Release workflows explicitly dispatch CI and the desktop build rather than
+relying on the push events they create. GitHub suppresses ordinary workflow
+events triggered by its built-in token, and this is what works around it.
+
+## Manual override: Prepare Release
+
+**Actions → Prepare Release → Run workflow** opens a release branch with a
+version you choose. Use it only when the automatic flow will not do:
+
+- to ship a range the automatic flow considers unreleasable;
+- to force an exact version, a major, or a bump the prefixes do not imply;
+- to set `.release-assets-mode` to `reuse` as the branch is created.
+
+Set **version** to `auto`, `patch`, `minor`, `major`, or an exact version such
+as `0.8.0`, and **desktop_assets** to `build` or `reuse`.
+
+It refuses to run while `release/next` already exists, rather than overwriting
+review edits on an open PR. Close that PR and delete the branch first, or just
+edit the version files on the branch that is already open.
 
 ## Local fallback
 
@@ -144,6 +196,9 @@ The same preparation can be run locally:
 ```bash
 # Preview release notes without changing files
 uv run python scripts/bump_version.py patch --changelog
+
+# Show the bump the commit history implies, without changing files
+uv run python scripts/bump_version.py --suggest-bump
 
 # Synchronize files and add the changelog entry
 uv run python scripts/bump_version.py patch
@@ -162,19 +217,18 @@ It refuses to overwrite an already published release.
 
 ## Repository setup
 
-The workflows use the built-in `GITHUB_TOKEN` for tagging and publication.
-No release credential is required.
+Tagging and publication use the built-in `GITHUB_TOKEN`.
 
-GitHub suppresses ordinary workflow events caused by its built-in token. The
-release pipeline accounts for this by explicitly dispatching the desktop build
-after creating the tag.
+Opening and refreshing the Release PR uses `RELEASE_BOT_TOKEN`, a fine-grained
+personal access token scoped to this repository, falling back to `GITHUB_TOKEN`
+when the secret is absent. Without it the Release PR is still created and
+refreshed, but GitHub will not run `pull_request` workflows on a branch the
+built-in token pushed, so the PR's checks never start.
 
-For repositories that require pull-request checks to be triggered by the
-release bot, add a fine-grained `RELEASE_BOT_TOKEN` secret with access to
-contents and pull requests. Without it, Release PR creation still works, but
-GitHub may not trigger other workflows from the bot-created branch and pull
-request. The **Prepare Release** workflow always performs its own version
-validation.
+The token needs **Contents: Read and write**, **Pull requests: Read and write**,
+and **Workflows: Read and write**. The last one is not optional: the refresh
+merges `main` into the release branch, and that merge carries any change under
+`.github/workflows/`, which GitHub refuses from a token without it.
 
 Optionally protect the `main` branch and require review of Release PRs. That
 keeps changelog approval manual while leaving all mechanical release work
@@ -184,17 +238,27 @@ automated.
 
 ### A platform build fails
 
-Fix the cause on `main`, prepare a new patch release, and merge it. The failed
-version remains a draft and is not advertised as the latest release.
+Fix the cause on `main`, let the refreshed Release PR pick up the fix, and merge
+it. The failed version remains a draft and is not advertised as the latest
+release.
 
 If the failure was transient and the tagged source is correct, rerun
 **Build and Publish Desktop Release** with the existing tag.
 
 ### A Release PR needs changes
 
-Edit the changelog directly on its `release/vX.Y.Z` branch. Do not rerun
+Edit the changelog or the version files directly on `release/next`. Do not rerun
 **Prepare Release** for the same version while that branch exists; the workflow
 stops instead of overwriting review edits.
+
+Remember that the next push to `main` regenerates the changelog section. Put
+anything you want to keep inside the highlights markers.
+
+### More than one Release PR is open
+
+**Refresh Release PR** stops and lists the candidates rather than guessing which
+one to update. Close the ones that are not wanted, delete their branches, and
+re-run the workflow.
 
 ### A wrong tag was created
 

--- a/docs/03-developing/releasing.md
+++ b/docs/03-developing/releasing.md
@@ -73,7 +73,8 @@ The refresh workflow merges the latest `main` into the release branch,
 regenerates the current version's changelog section, validates every version
 source, pushes the result, and explicitly starts CI. Review the regenerated
 notes again before merging because refresh replaces any manual edits in that
-version's section.
+version's section — with the single exception of the highlights block described
+below.
 
 For recovery, **Actions → Refresh Release PR → Run workflow** performs the same
 lookup without inputs. If there is no open Release PR it exits successfully. If
@@ -82,6 +83,37 @@ there is more than one, it stops and lists the candidates instead of guessing.
 The post-merge workflow independently verifies that the Release PR head
 contained the latest pre-merge `main` commit. If it did not, tag creation and
 publication stop instead of releasing code that is missing from the notes.
+
+### Writing release highlights
+
+A generated changelog section is a flat list of commit subjects. For a large
+release that is thirty or more bullets with no indication of what the release is
+actually about, and the GitHub release body is this section copied verbatim.
+
+Anything wrapped in highlights markers, placed directly under the version
+heading, survives every refresh:
+
+```markdown
+## [v0.10.0] - 2026-08-25
+
+<!-- highlights -->
+Memory is the story of this release: claims now carry a confirmation count and
+an expiry, duplicate facts retire instead of accumulating, and the memory tab
+is finally readable.
+<!-- /highlights -->
+
+### 🚀 Added
+- ...
+```
+
+Both markers are required and each must sit alone on its own line. An unclosed
+block is discarded on the next refresh rather than swallowing the rest of the
+entry. The markers are HTML comments so they stay invisible on the release page.
+
+Write this on the Release PR, before merging, so it goes through review with
+everything else and the release is published with its summary already in place.
+Drafting it from `git log <last-tag>..HEAD` is a reasonable job to hand to an
+agent; deciding which of those commits a user actually cares about is not.
 
 ## What is automated
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -422,6 +422,34 @@ def generate_changelog_draft(
     return "\n".join(lines).rstrip() + "\n"
 
 
+HIGHLIGHTS_START = "<!-- highlights -->"
+HIGHLIGHTS_END = "<!-- /highlights -->"
+
+_HIGHLIGHTS = re.compile(
+    rf"(?ms)^{re.escape(HIGHLIGHTS_START)}$\n.*?\n^{re.escape(HIGHLIGHTS_END)}$"
+)
+
+
+def _extract_highlights(entry: str) -> str | None:
+    """Pull a hand-written highlights block out of one changelog entry.
+
+    The pending entry is rebuilt from commit subjects on every push to main, so
+    prose written on the release PR would not otherwise survive to the merge.
+    Anything between the delimiters is lifted out and put back verbatim.
+
+    HTML comments are the delimiters because the GitHub release body is this
+    entry, copied out of the file - the markers have to be invisible there.
+    """
+    match = _HIGHLIGHTS.search(entry)
+    return match.group(0) if match else None
+
+
+def _inject_highlights(draft: str, highlights: str) -> str:
+    """Put a preserved highlights block back, directly under the heading."""
+    heading, _, rest = draft.partition("\n")
+    return f"{heading}\n\n{highlights}\n{rest}"
+
+
 def _replace_changelog_entry(
     existing: str,
     version: str,
@@ -431,6 +459,9 @@ def _replace_changelog_entry(
     match = entry.search(existing)
     if not match:
         return None
+    highlights = _extract_highlights(match.group(0))
+    if highlights:
+        draft = _inject_highlights(draft, highlights)
     return existing[: match.start()] + draft.rstrip() + "\n\n" + existing[match.end() :]
 
 

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -29,6 +29,7 @@ read_version = bump_version.read_version
 write_version = bump_version.write_version
 git_subjects_since_last_release = bump_version._git_subjects_since_last_release
 replace_changelog_entry = bump_version._replace_changelog_entry
+retitle_changelog_entry = bump_version._retitle_changelog_entry
 update_changelog = bump_version.update_changelog
 infer_bump = bump_version.infer_bump
 
@@ -383,3 +384,109 @@ def test_last_release_tag_ignores_an_untagged_pending_version(
     git, _ = _release_repo(tmp_path, monkeypatch)
 
     assert bump_version.last_release_tag(tmp_path) == "v0.9.1"
+
+
+PENDING_WITH_HIGHLIGHTS = (
+    "# Changelog\n\n"
+    "## [v1.1.0] - 2026-07-02\n\n"
+    "<!-- highlights -->\n"
+    "Memory is the story of this release: claims now expire, and the\n"
+    "vault stops losing facts on restart.\n"
+    "<!-- /highlights -->\n\n"
+    "### ⚡ Changed\n"
+    "- Stale draft\n\n"
+    "## [v1.0.0] - 2026-07-01\n\n"
+    "### 🚀 Added\n"
+    "- Previous release\n"
+)
+
+
+def test_refresh_preserves_hand_written_highlights() -> None:
+    draft = "## [v1.1.0] - 2026-07-03\n\n### 🐛 Fixed\n- Current draft\n"
+
+    refreshed = replace_changelog_entry(PENDING_WITH_HIGHLIGHTS, "1.1.0", draft)
+
+    assert refreshed is not None
+    # The generated body is rebuilt from scratch...
+    assert "Stale draft" not in refreshed
+    assert "- Current draft" in refreshed
+    # ...but the prose written on the release PR survives it.
+    assert "Memory is the story of this release" in refreshed
+    assert "vault stops losing facts on restart." in refreshed
+    assert "- Previous release" in refreshed
+
+
+def test_highlights_sit_directly_under_the_heading() -> None:
+    draft = "## [v1.1.0] - 2026-07-03\n\n### 🐛 Fixed\n- Current draft\n"
+
+    refreshed = replace_changelog_entry(PENDING_WITH_HIGHLIGHTS, "1.1.0", draft)
+
+    assert refreshed is not None
+    lines = refreshed.split("\n")
+    heading = lines.index("## [v1.1.0] - 2026-07-03")
+    assert lines[heading + 1] == ""
+    assert lines[heading + 2] == "<!-- highlights -->"
+    # The generated sections come after the preserved block, not before it.
+    assert lines.index("### 🐛 Fixed") > lines.index("<!-- /highlights -->")
+
+
+def test_refreshing_twice_leaves_the_highlights_alone() -> None:
+    draft = "## [v1.1.0] - 2026-07-03\n\n### 🐛 Fixed\n- Current draft\n"
+
+    once = replace_changelog_entry(PENDING_WITH_HIGHLIGHTS, "1.1.0", draft)
+    assert once is not None
+    twice = replace_changelog_entry(once, "1.1.0", draft)
+
+    # Without this, every push to main would nest another copy of the block.
+    assert twice == once
+    assert once.count("<!-- highlights -->") == 1
+
+
+def test_highlights_survive_a_retitle_when_the_bump_grows(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(PENDING_WITH_HIGHLIGHTS, encoding="utf-8")
+
+    # A `feat` merging into a patch release PR promotes 1.0.1 -> 1.1.0; here the
+    # pending entry is renamed the same way the reconcile renames it.
+    retitle_changelog_entry(tmp_path, "1.1.0", "2.0.0")
+    renamed = changelog.read_text(encoding="utf-8")
+    assert "## [v2.0.0]" in renamed
+
+    draft = "## [v2.0.0] - 2026-07-03\n\n### 🚀 Added\n- Breaking change\n"
+    refreshed = replace_changelog_entry(renamed, "2.0.0", draft)
+
+    assert refreshed is not None
+    assert "Memory is the story of this release" in refreshed
+
+
+def test_entry_without_highlights_is_replaced_wholesale() -> None:
+    existing = (
+        "# Changelog\n\n## [v1.1.0] - 2026-07-02\n\n### ⚡ Changed\n- Stale draft\n"
+    )
+    draft = "## [v1.1.0] - 2026-07-03\n\n### 🐛 Fixed\n- Current draft\n"
+
+    refreshed = replace_changelog_entry(existing, "1.1.0", draft)
+
+    assert refreshed is not None
+    assert "highlights" not in refreshed
+    assert "Stale draft" not in refreshed
+
+
+def test_an_unclosed_highlights_block_is_not_preserved() -> None:
+    # Better to lose an unterminated block than to swallow the whole entry into
+    # it and stop regenerating the release notes.
+    existing = (
+        "# Changelog\n\n"
+        "## [v1.1.0] - 2026-07-02\n\n"
+        "<!-- highlights -->\n"
+        "Someone forgot the closing marker.\n\n"
+        "### ⚡ Changed\n"
+        "- Stale draft\n"
+    )
+    draft = "## [v1.1.0] - 2026-07-03\n\n### 🐛 Fixed\n- Current draft\n"
+
+    refreshed = replace_changelog_entry(existing, "1.1.0", draft)
+
+    assert refreshed is not None
+    assert "Someone forgot" not in refreshed
+    assert "- Current draft" in refreshed


### PR DESCRIPTION
The pending release's changelog entry is regenerated from commit subjects on
every push to `main`, so any prose written on the Release PR was overwritten
before the merge. Since the GitHub release body is that entry copied verbatim,
every release shipped as a flat list of commit subjects. v0.10.0 is 33 bullets,
21 of them memory work, and nothing on the page says so.

## What changed

Anything between `<!-- highlights -->` markers, placed directly under the
version heading, is now lifted out of the old entry and re-emitted at the top of
the regenerated one. HTML comments are the delimiters because the markers have
to stay invisible on the release page.

Wired into `_replace_changelog_entry`, so both `--reconcile-version` and
`--refresh-changelog` inherit it.

An unclosed block is **discarded**, not preserved. Matching to end-of-entry
would swallow the generated sections into an open HTML comment and silently stop
the notes rendering; losing a paragraph is the better failure.

## Tests

Six new cases (file now 26): preservation, position under the heading,
idempotency across two refreshes, survival through a version retitle (the
1.0.1 -> 2.0.0 promotion path), the no-highlights case still replacing
wholesale, and the unclosed block.

Also smoke-tested against the real `release/next` changelog rather than only
fixtures.

## Docs

`docs/03-developing/releasing.md` still described the flow from before the
Release PR became permanent. Rewritten around what actually happens now, fixing
four things it stated as fact:

- "No release credential is required" — `RELEASE_BOT_TOKEN` is required for the
  Release PR's checks to run at all, and needs **Workflows: Read and write**,
  because the refresh merges `main` and that merge carries `.github/workflows/`.
- The refresh matches a `release/` prefix, not `release/v*`.
- `desktop_assets` is no longer chosen at release time; it is
  `.release-assets-mode` on the branch.
- Merging the Release PR must be a merge commit, not a squash.