### PR TITLE
fix(ci): stop refresh-release failing on the push that merges a release

### DIFF
--- a/.github/workflows/refresh-release.yml
+++ b/.github/workflows/refresh-release.yml
@@ -136,10 +136,24 @@ jobs:
           fi
           if [[ "$PR_FOUND" == "true" ]]; then
             git push origin "HEAD:$branch"
+            echo "openable=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$(git rev-list --count origin/main..HEAD)" == "0" ]]; then
+            # Nothing is pending: the reconcile changed nothing, so this branch
+            # is main. Pushing it would leave a branch with no PR behind - which
+            # `prepare-release` then refuses to run against - and opening a PR
+            # for it fails outright with "No commits between main and ...".
+            #
+            # This is the state right after a release merges. The tag is created
+            # by `release-on-merge`, which is still running when this workflow
+            # fires on the same push, so the range since the last tag still
+            # looks releasable here even though it has just shipped.
+            echo "::notice::Nothing pending; the release branch would be identical to main"
+            echo "openable=false" >> "$GITHUB_OUTPUT"
           else
             # No PR is open, so anything still sitting on the branch is a
             # leftover from a closed one and would only reject the push.
             git push --force origin "HEAD:$branch"
+            echo "openable=true" >> "$GITHUB_OUTPUT"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
         env:
@@ -149,7 +163,8 @@ jobs:
       - name: Open the Release PR
         if: >-
           steps.pr.outputs.found != 'true' &&
-          steps.releasable.outputs.ok == 'true'
+          steps.releasable.outputs.ok == 'true' &&
+          steps.refresh.outputs.openable == 'true'
         shell: bash
         run: |
           # printf rather than a heredoc: a `run: |` block cannot carry a line at


### PR DESCRIPTION
Found by releasing v0.10.0. Run
[32884438782](https://github.com/cyzus/suzent/actions/runs/32884438782) failed
with:

```
pull request create failed: GraphQL: No commits between main and release/next (createPullRequest)
```

## Why

Merging a Release PR pushes to `main`, which fires `refresh-release` at the same
moment `release-on-merge` starts. The tag is not created yet, so from this
workflow's point of view the range since the last tag still contains everything
that just shipped — it looks releasable. PR #119 is closed by then, so `found`
is false, and the job cuts a fresh branch from `main`, reconciles it to no
change, force-pushes it, and tries to open a PR against an identical `main`.

## Fix

The reconcile producing no commit is itself the signal that nothing is pending —
a branch identical to `main` is not a release. That is now detected before the
push, and neither the push nor the PR creation happens.

Not pushing matters as much as not opening: a `release/next` with no PR attached
is exactly what `prepare-release` refuses to run against, so the failed run left
the manual override blocked until the branch was deleted by hand.

## Impact of the original bug

Cosmetic but misleading — a red workflow on every release, plus a stale branch.
No release state was corrupted: v0.10.0 tagged and built normally.