### PR TITLE
feat(acp): serve Suzent as an ACP agent

### DIFF
--- a/docs/02-concepts/nodes/acp.md
+++ b/docs/02-concepts/nodes/acp.md
@@ -1,0 +1,129 @@
+# ACP — Suzent in Someone Else's Editor
+
+Suzent speaks [ACP (Agent Client Protocol)](https://agentclientprotocol.com/)
+in **both directions**:
+
+| Direction | Role | Entry point | What it means |
+|---|---|---|---|
+| Outbound | Suzent is the **client** | `suzent.acp.client` | Suzent drives Claude Code, Codex, … as subagents |
+| Inbound | Suzent is the **agent** | `suzent acp` | Zed, enoxian, any ACP client drives *your* geist |
+
+This page covers the inbound half. See [a2a.md](./a2a.md) for A2A, which reaches
+agents over the network; ACP is local and process-scoped — the client spawns the
+agent and speaks JSON-RPC on its stdin/stdout.
+
+## 1. What the client gets
+
+```sh
+suzent acp
+```
+
+That command is not meant to be typed. An ACP client spawns it, keeps the pipe,
+and passes its workspace as the session `cwd`:
+
+```
+client -> agent:  initialize
+client -> agent:  session/new       (cwd = the client's workspace)
+client -> agent:  session/prompt
+agent  -> client: session/update    (message chunks, thoughts, tool calls)
+agent  -> client: session/request_permission
+client -> agent:  session/cancel
+```
+
+Implemented methods: `initialize`, `authenticate`, `session/new`,
+`session/load`, `session/prompt`, `session/cancel`. Advertised capabilities:
+`loadSession: true`, text prompts with embedded context. Images and audio are
+declined at the handshake rather than silently dropped.
+
+## 2. It is a translator, not a second agent
+
+`suzent acp` runs no model. Every turn is posted to the **already-running
+backend** over the loopback API and its AG-UI event stream is translated back
+into ACP:
+
+| Suzent stream event | ACP session update |
+|---|---|
+| `TEXT_MESSAGE_CONTENT` | `agent_message_chunk` |
+| `THINKING_TEXT_MESSAGE_CONTENT` | `agent_thought_chunk` |
+| `TOOL_CALL_START` / `_ARGS` / `_END` | `tool_call`, then `tool_call_update` with `rawInput` |
+| `TOOL_CALL_RESULT` | `tool_call_update` (`completed`) |
+| `tool_approval_request` | `session/request_permission` |
+| `RUN_ERROR` | JSON-RPC error on the prompt turn |
+
+That indirection is the point. One process owns the database, so an ACP session
+is a **real chat**: it appears in the desktop UI, uses the same memory, skills,
+model config, and permission rules, and survives a restart. `suzent serve` (or
+`suzent start`) must be running; without it the first session fails with a
+connect error rather than quietly starting a second agent stack.
+
+An ACP session id **is** a chat id. `session/load` therefore resumes a real
+conversation — and refuses any chat this surface did not create, so a client
+cannot address one of your local conversations by guessing an id.
+
+## 3. Where the files are
+
+`session/new` binds the client's `cwd` to the session as a custom volume mounted
+at `/mnt/workspace`, and pins the agent's working directory to the path the
+active execution mode can actually use:
+
+| Mode | Mount | Agent cwd |
+|---|---|---|
+| Sandbox | `<client cwd>:/mnt/workspace` | `/mnt/workspace` |
+| Host | same mapping, resolved on the host | the real client cwd |
+
+The binding rides along with every prompt, the same way the desktop UI sends a
+chat's config on every turn, so a `session/load` that arrives with a different
+`cwd` rebinds immediately. The mount is also announced in the system prompt
+(host path, mount point, and whether it is a Git repo), so the model knows where
+it is working.
+
+Because edits land on the real files through a bind mount, a client that tracks
+workspace changes — enoxian's proposal engine, an editor's diff view — sees them
+as ordinary file writes.
+
+## 4. Approvals stay yours
+
+By default an ACP session runs in `default` permission mode, so a tool call that
+needs approval becomes a `session/request_permission` request and the turn
+blocks on the client's answer. The options offered are built from the backend's
+own decision contract, so a client sees exactly the authority Suzent is willing
+to grant:
+
+| Suzent action | ACP option kind |
+|---|---|
+| `allow_once` | `allow_once` |
+| `allow_session` / `allow_global` | `allow_always` |
+| `reject` | `reject_once` |
+
+Choosing an `allow_always` option persists the rule the label promised (a
+command prefix such as `git log …`, or a whole tool), because the selected
+option id is handed back to the backend as the action to resolve. A cancelled
+outcome stops the turn.
+
+To skip prompting entirely — for an unattended client — start the agent with
+`--permission-mode auto` or `--permission-mode full_access`.
+
+## 5. Flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--server-url` | the running local backend | Bridge to a specific backend URL |
+| `--permission-mode` | `default` | `default`, `auto`, or `full_access` |
+| `--log-level` | `WARNING` | Diagnostics level on **stderr** |
+
+`stdout` carries protocol traffic only. Logging is forced to stderr before
+anything can write, `-v` included.
+
+## 6. Registering with a client
+
+**enoxian** — register the agent, then mention `@suzent` in the circle chat
+(mentions only launch anything when this device's reaction policy is `push`):
+
+```sh
+enox agent add suzent --driver acp -- suzent acp
+```
+
+**Any other client** — register `suzent acp` wherever it configures external
+agent servers (command `suzent`, args `["acp"]`), and it will be spawned with
+the workspace as the process cwd and the session `cwd`. Check the client's own
+docs for where that configuration lives.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@
 - [GitHub Sync](02-concepts/github-sync/README.md): Sync portable brain data to a private GitHub repo
 - [Social Messaging](02-concepts/social-messaging/README.md): Telegram, Discord, Slack, and Feishu integration
 - [Nodes](02-concepts/nodes/nodes.md): Connect and control companion devices remotely
+- [ACP](02-concepts/nodes/acp.md): Serve Suzent as an ACP agent for editors and other clients
 
 ### Runtime
 - [Retry](02-concepts/runtime/retry.md): Roll back the last agent turn and rerun

--- a/src/suzent/acp/__init__.py
+++ b/src/suzent/acp/__init__.py
@@ -1,6 +1,20 @@
-"""Local Agent Client Protocol (ACP) integration."""
+"""Local Agent Client Protocol (ACP) integration.
+
+Both directions live here: :mod:`suzent.acp.client` drives external ACP agents
+as subagents, and :mod:`suzent.acp.server` serves this Suzent *as* an ACP agent
+to an external client.
+"""
 
 from .manager import ACPManager, get_acp_manager
 from .registry import ACPAgent, ACPAgentRegistry
+from .server import ACPAgentServer, SuzentBackend, serve_stdio
 
-__all__ = ["ACPAgent", "ACPAgentRegistry", "ACPManager", "get_acp_manager"]
+__all__ = [
+    "ACPAgent",
+    "ACPAgentRegistry",
+    "ACPAgentServer",
+    "ACPManager",
+    "SuzentBackend",
+    "get_acp_manager",
+    "serve_stdio",
+]

--- a/src/suzent/acp/server.py
+++ b/src/suzent/acp/server.py
@@ -1,0 +1,909 @@
+"""Serve Suzent itself as an Agent Client Protocol (ACP) agent over stdio.
+
+Suzent already speaks ACP as a *client*: ``suzent.acp.client`` drives Claude
+Code, Codex, and friends as subagents. This module is the other direction. It
+turns Suzent into an ACP **agent**, so any ACP client — Zed, enoxian, an editor
+that implements the protocol — can drive the local geist inside its own
+workspace::
+
+    client -> agent:  initialize
+    client -> agent:  session/new       (cwd = the client's workspace)
+    client -> agent:  session/prompt
+    agent  -> client: session/update    (message chunks, thoughts, tool calls)
+    agent  -> client: session/request_permission
+    client -> agent:  session/cancel
+
+The process is a translator, not a second agent. Every turn runs on the
+already-running Suzent backend over the loopback API, so an ACP session is a
+real chat: it shows up in the desktop UI, shares the same memory, skills, model
+config, and permission rules, and one process stays the owner of the database.
+
+The client's ``cwd`` is bound to the session as a sandbox volume mounted at
+``/mnt/workspace``, so file tools act on the client's real workspace instead of
+a private project directory — which is also what makes an ACP client's own
+change tracking see the edits.
+
+See <https://agentclientprotocol.com/protocol/schema>.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from suzent.logger import get_logger
+
+logger = get_logger(__name__)
+
+# The ACP major version this agent implements.
+PROTOCOL_VERSION = 1
+
+# Where the client's workspace is mounted for the agent's file tools. Sandbox
+# mode needs a container path; host mode uses the real cwd (see _session_config).
+WORKSPACE_MOUNT = "/mnt/workspace"
+
+# Chat config key marking a chat as owned by this surface. session/load refuses
+# anything else, so a client cannot address an arbitrary local conversation by
+# guessing an id.
+SESSION_MARKER = "_acp_server"
+
+# JSON-RPC 2.0 error codes.
+INVALID_REQUEST = -32600
+METHOD_NOT_FOUND = -32601
+INVALID_PARAMS = -32602
+INTERNAL_ERROR = -32603
+
+# Suzent tool name -> ACP tool-call kind. Anything unlisted is "other", which is
+# what a client renders for a tool it has no special affordance for.
+_TOOL_KINDS: dict[str, str] = {
+    "read_file": "read",
+    "glob_search": "search",
+    "grep_search": "search",
+    "session_search": "search",
+    "memory_search": "search",
+    "write_file": "edit",
+    "edit_file": "edit",
+    "run_command": "execute",
+    "start_command": "execute",
+    "check_command": "execute",
+    "stop_command": "execute",
+    "skill_execute": "execute",
+    "web_search": "fetch",
+    "webpage_fetch": "fetch",
+    "browser_action": "fetch",
+}
+
+
+def tool_kind(tool_name: str) -> str:
+    """Return the ACP tool-call kind for a Suzent tool name."""
+    return _TOOL_KINDS.get(tool_name, "other")
+
+
+class ACPServerError(Exception):
+    """A failure to report to the client as a JSON-RPC error."""
+
+    def __init__(self, message: str, code: int = INTERNAL_ERROR):
+        super().__init__(message)
+        self.code = code
+
+
+# ── Backend ───────────────────────────────────────────────────────────────────
+
+
+class SuzentBackend:
+    """The loopback backend surface one ACP session needs.
+
+    Thin on purpose: the ACP layer should own protocol translation and nothing
+    else, and every call here is a request to the running daemon.
+    """
+
+    def __init__(self, base_url: str | None = None):
+        from suzent.client.api import SuzentAsyncClient
+
+        self._client = SuzentAsyncClient(base_url)
+
+    @property
+    def base_url(self) -> str:
+        return self._client.base_url
+
+    async def sandbox_enabled(self) -> bool:
+        """Whether turns execute in the Docker sandbox rather than on the host."""
+        data = await self._client.config.get()
+        preference = (data.get("userPreferences") or {}).get("sandbox_enabled")
+        if isinstance(preference, bool):
+            return preference
+        return bool(data.get("sandboxEnabled"))
+
+    async def create_chat(self, title: str, config: dict[str, Any]) -> str:
+        chat = await self._client.chat.create_chat(
+            {"title": title, "config": config, "messages": []}
+        )
+        chat_id = str(chat.get("id") or "")
+        if not chat_id:
+            raise ACPServerError("the backend returned a chat without an id")
+        return chat_id
+
+    async def get_chat(self, chat_id: str) -> dict[str, Any] | None:
+        from suzent.client.base import ClientError
+
+        try:
+            return await self._client.chat.get_chat(chat_id)
+        except ClientError as exc:
+            logger.debug(f"[acp-server] chat {chat_id} unavailable: {exc}")
+            return None
+
+    def stream_turn(self, payload: dict[str, Any]) -> AsyncIterator[bytes]:
+        # No read timeout: a turn is as long as the model needs, and the client
+        # cancels through session/cancel rather than by us giving up.
+        return self._client.chat.stream_message(payload, timeout=None)
+
+    async def stop_turn(self, chat_id: str) -> None:
+        from suzent.client.base import ClientError
+
+        try:
+            await self._client.chat.stop(chat_id, "cancelled by the ACP client")
+        except ClientError as exc:
+            # A finished stream has nothing to stop; that is not an error here.
+            logger.debug(f"[acp-server] stop for {chat_id} was a no-op: {exc}")
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+
+# ── Turn translation ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class Update:
+    """A ``session/update`` payload to forward to the client."""
+
+    payload: dict[str, Any]
+
+
+@dataclass
+class Approval:
+    """The backend suspended the turn awaiting a tool-call decision."""
+
+    info: dict[str, Any]
+
+
+@dataclass
+class TurnError:
+    """The backend reported the turn as failed."""
+
+    message: str
+
+
+TurnItem = Update | Approval | TurnError
+
+
+def _text_block(text: str) -> dict[str, Any]:
+    return {"type": "text", "text": text}
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, default=str)
+
+
+class TurnTranslator:
+    """Translate one Suzent AG-UI SSE turn into ACP session updates.
+
+    Stateful across chunks: SSE frames arrive split at arbitrary byte
+    boundaries, and tool-call arguments stream in as deltas that only become a
+    ``rawInput`` once the call is closed.
+    """
+
+    def __init__(self) -> None:
+        self._buffer = ""
+        self._tool_names: dict[str, str] = {}
+        self._tool_args: dict[str, str] = {}
+        self._announced: set[str] = set()
+
+    def feed(self, chunk: bytes | str) -> Iterator[TurnItem]:
+        text = chunk if isinstance(chunk, str) else chunk.decode("utf-8", "replace")
+        self._buffer += text
+        while "\n\n" in self._buffer:
+            block, self._buffer = self._buffer.split("\n\n", 1)
+            for line in block.splitlines():
+                if not line.startswith("data: "):
+                    continue
+                raw = line[6:].strip()
+                if not raw or raw == "[DONE]":
+                    continue
+                try:
+                    event = json.loads(raw)
+                except ValueError:
+                    logger.debug(f"[acp-server] unparseable SSE payload: {raw[:120]}")
+                    continue
+                if isinstance(event, dict):
+                    yield from self._translate(event)
+
+    def _translate(self, event: dict[str, Any]) -> Iterator[TurnItem]:
+        kind = str(event.get("type") or "")
+
+        if kind == "TEXT_MESSAGE_CONTENT":
+            if delta := str(event.get("delta") or ""):
+                yield Update(
+                    {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": _text_block(delta),
+                    }
+                )
+
+        elif kind == "THINKING_TEXT_MESSAGE_CONTENT":
+            if delta := str(event.get("delta") or ""):
+                yield Update(
+                    {
+                        "sessionUpdate": "agent_thought_chunk",
+                        "content": _text_block(delta),
+                    }
+                )
+
+        elif kind == "TOOL_CALL_START":
+            tool_call_id = str(event.get("toolCallId") or "")
+            if not tool_call_id:
+                return
+            name = str(event.get("toolCallName") or "tool")
+            self._tool_names[tool_call_id] = name
+            self._tool_args[tool_call_id] = ""
+            if tool_call_id in self._announced:
+                # Resuming after an approval replays the start for a call the
+                # client already knows about — that is an update, not a new call.
+                yield Update(
+                    {
+                        "sessionUpdate": "tool_call_update",
+                        "toolCallId": tool_call_id,
+                        "status": "in_progress",
+                    }
+                )
+            else:
+                self._announced.add(tool_call_id)
+                yield Update(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": tool_call_id,
+                        "title": name,
+                        "kind": tool_kind(name),
+                        "status": "in_progress",
+                    }
+                )
+
+        elif kind == "TOOL_CALL_ARGS":
+            tool_call_id = str(event.get("toolCallId") or "")
+            if tool_call_id:
+                self._tool_args[tool_call_id] = self._tool_args.get(
+                    tool_call_id, ""
+                ) + str(event.get("delta") or "")
+
+        elif kind == "TOOL_CALL_END":
+            tool_call_id = str(event.get("toolCallId") or "")
+            arguments = self._decode_args(tool_call_id)
+            if tool_call_id and arguments is not None:
+                yield Update(
+                    {
+                        "sessionUpdate": "tool_call_update",
+                        "toolCallId": tool_call_id,
+                        "rawInput": arguments,
+                    }
+                )
+
+        elif kind == "TOOL_CALL_RESULT":
+            tool_call_id = str(event.get("toolCallId") or "")
+            if not tool_call_id:
+                return
+            output = _stringify(
+                event.get("content")
+                if event.get("content") is not None
+                else event.get("output")
+            )
+            update: dict[str, Any] = {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": tool_call_id,
+                "status": "completed",
+            }
+            if output:
+                update["content"] = [
+                    {"type": "content", "content": _text_block(output)}
+                ]
+            yield Update(update)
+
+        elif kind in ("CUSTOM", "CUSTOM_EVENT"):
+            yield from self._translate_custom(event)
+
+        elif kind == "RUN_ERROR":
+            yield TurnError(str(event.get("message") or "the turn failed"))
+
+    def _translate_custom(self, event: dict[str, Any]) -> Iterator[TurnItem]:
+        name = event.get("name")
+        value = event.get("value")
+        if not name and isinstance(event.get("custom"), dict):
+            custom = event["custom"]
+            name = custom.get("name")
+            value = custom.get("value")
+        if name == "tool_approval_request" and isinstance(value, dict):
+            yield Approval(value)
+
+    def _decode_args(self, tool_call_id: str) -> dict[str, Any] | None:
+        raw = self._tool_args.get(tool_call_id, "").strip()
+        if not raw:
+            return None
+        try:
+            parsed = json.loads(raw)
+        except ValueError:
+            return None
+        return parsed if isinstance(parsed, dict) else None
+
+    def tool_name(self, tool_call_id: str) -> str:
+        return self._tool_names.get(tool_call_id, "tool")
+
+
+# ── Sessions ──────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Session:
+    """One ACP session, backed by a Suzent chat."""
+
+    chat_id: str
+    cwd: str
+    config: dict[str, Any]
+    running: bool = False
+    cancelled: bool = False
+    seen_tool_calls: set[str] = field(default_factory=set)
+
+
+def _permission_options(decision: dict[str, Any]) -> list[dict[str, Any]]:
+    """Turn the backend's offered approval actions into ACP options.
+
+    The backend decides what may be remembered and how widely (a shell command
+    prefix, a whole tool, session or global), so the options a client sees are
+    exactly the authority Suzent is willing to grant — never a scope the client
+    invented.
+    """
+    options: list[dict[str, Any]] = []
+    for action in decision.get("actions") or []:
+        if not isinstance(action, dict):
+            continue
+        action_id = str(action.get("id") or "")
+        if not action_id:
+            continue
+        if action.get("behavior") == "deny":
+            kind = "reject_once"
+        elif action.get("scope") in ("session", "global"):
+            kind = "allow_always"
+        else:
+            kind = "allow_once"
+        options.append(
+            {
+                "optionId": action_id,
+                "name": str(action.get("label") or action_id),
+                "kind": kind,
+            }
+        )
+    return options
+
+
+_LEGACY_OPTIONS = [
+    {"optionId": "allow_once", "name": "Allow", "kind": "allow_once"},
+    {"optionId": "reject", "name": "Reject", "kind": "reject_once"},
+]
+
+
+class ACPAgentServer:
+    """Dispatch ACP JSON-RPC messages against a Suzent backend.
+
+    Transport-free by design: ``dispatch`` takes decoded messages and ``send``
+    delivers them, so the stdio loop in :func:`serve_stdio` is a thin shell and
+    the protocol is testable without a subprocess.
+    """
+
+    def __init__(
+        self,
+        backend: SuzentBackend,
+        send: Any,
+        *,
+        permission_mode: str = "default",
+    ):
+        self._backend = backend
+        self._send = send
+        self._permission_mode = permission_mode
+        self._sessions: dict[str, Session] = {}
+        self._pending: dict[int, asyncio.Future] = {}
+        self._tasks: set[asyncio.Task] = set()
+        self._next_id = 1
+        self._client_capabilities: dict[str, Any] = {}
+        self._sandbox: bool | None = None
+
+    # ── inbound ──────────────────────────────────────────────────────────────
+
+    async def dispatch(self, message: dict[str, Any]) -> None:
+        """Handle one decoded JSON-RPC message from the client."""
+        method = message.get("method")
+        if method is None:
+            self._resolve_response(message)
+            return
+
+        params = message.get("params")
+        params = params if isinstance(params, dict) else {}
+        message_id = message.get("id")
+
+        if message_id is None:
+            await self._notification(str(method), params)
+            return
+
+        # A prompt turn runs for minutes and must not block the read loop —
+        # session/cancel arrives on the same connection while it is in flight.
+        if method == "session/prompt":
+            self._spawn(self._prompt(message_id, params))
+            return
+
+        try:
+            result = await self._request(str(method), params)
+        except ACPServerError as exc:
+            await self._error(message_id, exc.code, str(exc))
+        except Exception as exc:  # noqa: BLE001 — protocol must not die on one call
+            logger.error(f"[acp-server] {method} failed: {exc}")
+            await self._error(
+                message_id, INTERNAL_ERROR, f"{type(exc).__name__}: {exc}"
+            )
+        else:
+            await self._reply(message_id, result)
+
+    async def _request(self, method: str, params: dict[str, Any]) -> Any:
+        match method:
+            case "initialize":
+                return await self._initialize(params)
+            case "authenticate":
+                # The loopback backend is the trust boundary; nothing to do.
+                return {}
+            case "session/new":
+                return await self._new_session(params)
+            case "session/load":
+                return await self._load_session(params)
+            case _:
+                raise ACPServerError(f"unknown method '{method}'", METHOD_NOT_FOUND)
+
+    async def _notification(self, method: str, params: dict[str, Any]) -> None:
+        if method == "session/cancel":
+            session = self._sessions.get(str(params.get("sessionId") or ""))
+            if session and session.running:
+                session.cancelled = True
+                await self._backend.stop_turn(session.chat_id)
+            return
+        logger.debug(f"[acp-server] ignoring notification '{method}'")
+
+    async def _initialize(self, params: dict[str, Any]) -> dict[str, Any]:
+        capabilities = params.get("clientCapabilities")
+        self._client_capabilities = (
+            capabilities if isinstance(capabilities, dict) else {}
+        )
+        return {
+            "protocolVersion": PROTOCOL_VERSION,
+            "agentCapabilities": {
+                # A session id is a chat id, so resuming is just addressing the
+                # same conversation again.
+                "loadSession": True,
+                "promptCapabilities": {
+                    "image": False,
+                    "audio": False,
+                    "embeddedContext": True,
+                },
+            },
+            "authMethods": [],
+            "agentInfo": {"name": "suzent", "version": _version()},
+        }
+
+    async def _new_session(self, params: dict[str, Any]) -> dict[str, Any]:
+        cwd = self._require_cwd(params)
+        config = await self._session_config(cwd)
+        title = f"⇄ ACP {Path(cwd).name or cwd}"
+        chat_id = await self._backend.create_chat(title, config)
+        self._sessions[chat_id] = Session(chat_id=chat_id, cwd=cwd, config=config)
+        logger.info(f"[acp-server] session {chat_id} created (cwd={cwd})")
+        return {"sessionId": chat_id}
+
+    async def _load_session(self, params: dict[str, Any]) -> None:
+        session_id = str(params.get("sessionId") or "")
+        if not session_id:
+            raise ACPServerError("session/load requires a sessionId", INVALID_PARAMS)
+        chat = await self._backend.get_chat(session_id)
+        if chat is None:
+            raise ACPServerError(f"no such session '{session_id}'", INVALID_PARAMS)
+        if not (chat.get("config") or {}).get(SESSION_MARKER):
+            # Only conversations this surface created are ACP sessions. Local
+            # chats belong to the user, not to whoever spawned this process.
+            raise ACPServerError(
+                f"'{session_id}' is not an ACP session", INVALID_PARAMS
+            )
+
+        cwd = self._require_cwd(params) if params.get("cwd") else ""
+        stored = (chat.get("config") or {}).get(SESSION_MARKER) or {}
+        cwd = cwd or str(stored.get("cwd") or "")
+        config = await self._session_config(cwd) if cwd else dict(chat["config"])
+        self._sessions[session_id] = Session(chat_id=session_id, cwd=cwd, config=config)
+
+        for update in _history_updates(chat.get("messages") or []):
+            await self._update(session_id, update)
+        logger.info(f"[acp-server] session {session_id} loaded (cwd={cwd})")
+        return None
+
+    # ── the turn ─────────────────────────────────────────────────────────────
+
+    async def _prompt(self, message_id: Any, params: dict[str, Any]) -> None:
+        session_id = str(params.get("sessionId") or "")
+        session = self._sessions.get(session_id)
+        if session is None:
+            await self._error(
+                message_id, INVALID_PARAMS, f"no such session '{session_id}'"
+            )
+            return
+        if session.running:
+            await self._error(
+                message_id, INVALID_REQUEST, "a turn is already running in this session"
+            )
+            return
+
+        text = _prompt_text(params.get("prompt"))
+        if not text:
+            await self._error(message_id, INVALID_PARAMS, "the prompt carries no text")
+            return
+
+        session.running = True
+        session.cancelled = False
+        try:
+            stop_reason = await self._run_turn(session, text)
+        except ACPServerError as exc:
+            await self._error(message_id, exc.code, str(exc))
+        except Exception as exc:  # noqa: BLE001
+            logger.error(f"[acp-server] turn failed in {session_id}: {exc}")
+            await self._error(
+                message_id, INTERNAL_ERROR, f"{type(exc).__name__}: {exc}"
+            )
+        else:
+            await self._reply(message_id, {"stopReason": stop_reason})
+        finally:
+            session.running = False
+
+    async def _run_turn(self, session: Session, text: str) -> str:
+        """Stream turns until the backend stops asking for approvals.
+
+        A suspended tool call ends the SSE stream; the turn continues by posting
+        the client's decisions back as ``resume_approvals``. That loop is what
+        makes an ACP permission request a real gate rather than a notification.
+        """
+        message = text
+        resume_approvals: list[dict[str, Any]] = []
+        failure: str | None = None
+
+        while True:
+            payload: dict[str, Any] = {
+                "message": message,
+                "chat_id": session.chat_id,
+                "stream": True,
+                "config": session.config,
+            }
+            if resume_approvals:
+                payload["resume_approvals"] = resume_approvals
+
+            translator = TurnTranslator()
+            pending: list[dict[str, Any]] = []
+            async for chunk in self._backend.stream_turn(payload):
+                if session.cancelled:
+                    break
+                for item in translator.feed(chunk):
+                    match item:
+                        case Update(payload=update):
+                            await self._update(session.chat_id, update)
+                        case Approval(info=info):
+                            pending.append(info)
+                        case TurnError(message=error):
+                            failure = error
+
+            if session.cancelled:
+                return "cancelled"
+            if failure:
+                raise ACPServerError(failure)
+            if not pending:
+                return "end_turn"
+
+            resume_approvals = []
+            for request in pending:
+                decision = await self._ask_permission(session, request, translator)
+                if decision is None:
+                    return "cancelled"
+                resume_approvals.append(decision)
+            # Resuming carries decisions, not a new user message.
+            message = ""
+
+    async def _ask_permission(
+        self,
+        session: Session,
+        request: dict[str, Any],
+        translator: TurnTranslator,
+    ) -> dict[str, Any] | None:
+        """Ask the client to decide one tool call. ``None`` means cancelled."""
+        approval_id = str(request.get("approvalId") or "")
+        tool_call_id = str(request.get("toolCallId") or approval_id)
+        tool_name = str(request.get("toolName") or translator.tool_name(tool_call_id))
+        decision = request.get("decision")
+        decision = decision if isinstance(decision, dict) else {}
+        options = _permission_options(decision) or list(_LEGACY_OPTIONS)
+
+        tool_call: dict[str, Any] = {
+            "toolCallId": tool_call_id,
+            "title": tool_name,
+            "kind": tool_kind(tool_name),
+            "status": "pending",
+        }
+        if isinstance(request.get("args"), dict):
+            tool_call["rawInput"] = request["args"]
+
+        result = await self._call(
+            "session/request_permission",
+            {
+                "sessionId": session.chat_id,
+                "toolCall": tool_call,
+                "options": options,
+            },
+        )
+        outcome = (result or {}).get("outcome") or {}
+        if outcome.get("outcome") != "selected":
+            await self._backend.stop_turn(session.chat_id)
+            return None
+
+        option_id = str(outcome.get("optionId") or "")
+        chosen = next((o for o in options if o["optionId"] == option_id), None)
+        if chosen is None:
+            raise ACPServerError(f"the client selected unknown option '{option_id}'")
+
+        resolution: dict[str, Any] = {
+            "request_id": approval_id or tool_call_id,
+            "tool_call_id": tool_call_id,
+            "approved": chosen["kind"] != "reject_once",
+        }
+        if decision.get("actions"):
+            # Let the backend resolve the offered action, so "always allow"
+            # persists the rule it promised in the option label.
+            resolution["action_id"] = option_id
+        return resolution
+
+    # ── config ───────────────────────────────────────────────────────────────
+
+    def _require_cwd(self, params: dict[str, Any]) -> str:
+        raw = str(params.get("cwd") or "")
+        if not raw:
+            raise ACPServerError("an absolute cwd is required", INVALID_PARAMS)
+        path = Path(raw)
+        if not path.is_absolute():
+            raise ACPServerError(f"cwd '{raw}' is not absolute", INVALID_PARAMS)
+        if not path.is_dir():
+            raise ACPServerError(f"cwd '{raw}' is not a directory", INVALID_PARAMS)
+        return str(path.resolve())
+
+    async def _session_config(self, cwd: str) -> dict[str, Any]:
+        """Build the per-turn config that binds a session to the client's cwd.
+
+        Sent with every prompt, exactly as the desktop UI sends a chat's config
+        on every turn, so a rebind on ``session/load`` takes effect immediately.
+        """
+        if self._sandbox is None:
+            self._sandbox = await self._backend.sandbox_enabled()
+        return {
+            "sandbox_volumes": [f"{cwd}:{WORKSPACE_MOUNT}"],
+            # Name the path the active execution mode can actually chdir into.
+            "cwd": WORKSPACE_MOUNT if self._sandbox else cwd,
+            "permission_mode": self._permission_mode,
+            SESSION_MARKER: {"cwd": cwd, "mount": WORKSPACE_MOUNT},
+        }
+
+    # ── outbound ─────────────────────────────────────────────────────────────
+
+    async def _update(self, session_id: str, update: dict[str, Any]) -> None:
+        await self._send(
+            {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {"sessionId": session_id, "update": update},
+            }
+        )
+
+    async def _call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Send a request to the client and await its response."""
+        request_id = self._next_id
+        self._next_id += 1
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[request_id] = future
+        await self._send(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": params,
+            }
+        )
+        try:
+            return await future
+        finally:
+            self._pending.pop(request_id, None)
+
+    def _resolve_response(self, message: dict[str, Any]) -> None:
+        raw_id = message.get("id")
+        future = self._pending.get(raw_id if isinstance(raw_id, int) else -1)
+        if future is None or future.done():
+            logger.debug(f"[acp-server] unmatched response id {raw_id!r}")
+            return
+        if error := message.get("error"):
+            future.set_exception(
+                ACPServerError(f"the client refused the request: {_stringify(error)}")
+            )
+        else:
+            result = message.get("result")
+            future.set_result(result if isinstance(result, dict) else {})
+
+    async def _reply(self, message_id: Any, result: Any) -> None:
+        await self._send({"jsonrpc": "2.0", "id": message_id, "result": result})
+
+    async def _error(self, message_id: Any, code: int, message: str) -> None:
+        await self._send(
+            {
+                "jsonrpc": "2.0",
+                "id": message_id,
+                "error": {"code": code, "message": message},
+            }
+        )
+
+    def _spawn(self, coro: Any) -> None:
+        task = asyncio.create_task(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def drain(self) -> None:
+        """Await in-flight turns so a closing client does not truncate one."""
+        for future in list(self._pending.values()):
+            if not future.done():
+                future.set_exception(ACPServerError("the client disconnected"))
+        if self._tasks:
+            await asyncio.gather(*list(self._tasks), return_exceptions=True)
+
+
+# ── prompt and history helpers ────────────────────────────────────────────────
+
+
+def _prompt_text(blocks: Any) -> str:
+    """Flatten ACP prompt content blocks into the text of one user message."""
+    if isinstance(blocks, str):
+        return blocks.strip()
+    if not isinstance(blocks, list):
+        return ""
+
+    parts: list[str] = []
+    for block in blocks:
+        if isinstance(block, str):
+            parts.append(block)
+            continue
+        if not isinstance(block, dict):
+            continue
+        match block.get("type"):
+            case "text":
+                parts.append(str(block.get("text") or ""))
+            case "resource_link":
+                if uri := str(block.get("uri") or block.get("name") or ""):
+                    parts.append(f"@{uri}")
+            case "resource":
+                resource = block.get("resource")
+                if isinstance(resource, dict):
+                    uri = str(resource.get("uri") or "")
+                    text = str(resource.get("text") or "")
+                    if text:
+                        parts.append(f"{uri}\n{text}" if uri else text)
+                    elif uri:
+                        parts.append(f"@{uri}")
+            case _:
+                # image/audio are not advertised in promptCapabilities, so a
+                # client should not send them; note it rather than drop it.
+                parts.append(f"[unsupported {block.get('type')} content]")
+    return "\n\n".join(part for part in parts if part).strip()
+
+
+def _history_updates(messages: list[Any]) -> Iterator[dict[str, Any]]:
+    """Replay a chat transcript as ACP message-chunk updates."""
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = str(message.get("content") or "").strip()
+        if not content:
+            continue
+        role = str(message.get("role") or "")
+        if role == "user":
+            yield {
+                "sessionUpdate": "user_message_chunk",
+                "content": _text_block(content),
+            }
+        elif role == "assistant":
+            yield {
+                "sessionUpdate": "agent_message_chunk",
+                "content": _text_block(content),
+            }
+
+
+def _version() -> str:
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return version("suzent")
+    except PackageNotFoundError:
+        return "0"
+
+
+# ── stdio transport ───────────────────────────────────────────────────────────
+
+
+def redirect_logs_to_stderr(level: str = "WARNING") -> None:
+    """Keep stdout for protocol traffic only.
+
+    Suzent's default loguru sink is stdout; one log line there would corrupt the
+    JSON-RPC stream, so this must run before anything else can log.
+    """
+    from loguru import logger as loguru_logger
+
+    import suzent.logger as suzent_logger
+
+    loguru_logger.remove()
+    loguru_logger.add(
+        sys.stderr,
+        level=level.upper(),
+        format="{time:HH:mm:ss} | {level:8} | {name}:{function} | {message}",
+    )
+    suzent_logger._logging_configured = True
+
+
+async def serve_stdio(
+    *,
+    base_url: str | None = None,
+    permission_mode: str = "default",
+) -> int:
+    """Run the ACP agent over stdin/stdout until the client closes the pipe."""
+    backend = SuzentBackend(base_url)
+    write_lock = asyncio.Lock()
+
+    async def send(message: dict[str, Any]) -> None:
+        line = json.dumps(message, ensure_ascii=False, separators=(",", ":"))
+        async with write_lock:
+            sys.stdout.write(line + "\n")
+            sys.stdout.flush()
+
+    server = ACPAgentServer(backend, send, permission_mode=permission_mode)
+    logger.info(f"[acp-server] serving ACP over stdio against {backend.base_url}")
+
+    try:
+        while True:
+            # A thread read keeps this portable: connect_read_pipe on stdin is
+            # unavailable on Windows' proactor loop.
+            line = await asyncio.to_thread(sys.stdin.readline)
+            if line == "":
+                break
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except ValueError:
+                logger.warning(
+                    f"[acp-server] unparseable line from client: {line[:120]}"
+                )
+                continue
+            if isinstance(message, dict):
+                await server.dispatch(message)
+    finally:
+        await server.drain()
+        await backend.aclose()
+    return 0

--- a/src/suzent/cli/__init__.py
+++ b/src/suzent/cli/__init__.py
@@ -10,6 +10,7 @@ This package splits CLI commands into focused modules:
 
 import typer
 
+from suzent.cli.acp import register_acp_command
 from suzent.cli.agent import agent_app
 from suzent.cli.config import config_app
 from suzent.cli.main import (
@@ -31,6 +32,7 @@ app = typer.Typer(help="Suzent CLI - Your Digital Co-worker Manager")
 
 @app.callback()
 def main(
+    ctx: typer.Context,
     verbose: bool = typer.Option(
         False, "--verbose", "-v", help="Enable verbose logging (DEBUG level)"
     ),
@@ -39,12 +41,20 @@ def main(
     Suzent CLI - Your Digital Co-worker Manager.
     """
     _configure_console_encoding()
-    configure_logging(verbose)
+    if ctx.invoked_subcommand == "acp":
+        # `suzent acp` speaks JSON-RPC on stdout, so no log line may land there
+        # -- not even the DEBUG output -v would otherwise enable.
+        from suzent.acp.server import redirect_logs_to_stderr
+
+        redirect_logs_to_stderr("DEBUG" if verbose else "WARNING")
+    else:
+        configure_logging(verbose)
     load_environment()
 
 
 # Register top-level commands (start, doctor, update, upgrade, setup-build_tools)
 register_commands(app)
+register_acp_command(app)
 
 # Attach subcommand groups
 app.add_typer(node_app, name="nodes")

--- a/src/suzent/cli/acp.py
+++ b/src/suzent/cli/acp.py
@@ -1,0 +1,60 @@
+"""CLI entry point that serves Suzent as an ACP agent over stdio.
+
+``suzent acp`` is meant to be *spawned by an ACP client* (Zed, enoxian, any
+editor implementing the protocol) rather than run by hand: the client owns the
+process, speaks JSON-RPC on its stdin/stdout, and passes the workspace as the
+session ``cwd``. See ``docs/02-concepts/nodes/acp.md``.
+"""
+
+import asyncio
+
+import typer
+
+
+def register_acp_command(app: typer.Typer) -> None:
+    """Attach the ``acp`` command to the top-level CLI app."""
+
+    @app.command("acp")
+    def acp(
+        server_url: str = typer.Option(
+            None,
+            "--server-url",
+            help="Backend URL to bridge to (default: the running local backend)",
+        ),
+        permission_mode: str = typer.Option(
+            "default",
+            "--permission-mode",
+            help=(
+                "Permission mode for ACP sessions: 'default' asks the client to "
+                "approve tool calls, 'auto' and 'full_access' never ask"
+            ),
+        ),
+        log_level: str = typer.Option(
+            "WARNING",
+            "--log-level",
+            help="Log level for diagnostics on stderr (stdout carries the protocol)",
+        ),
+    ):
+        """Serve this Suzent as an ACP agent on stdin/stdout."""
+        modes = {"default", "auto", "full_access"}
+        if permission_mode not in modes:
+            # stderr: stdout belongs to the protocol even when we refuse to start.
+            typer.secho(
+                f"Unknown permission mode '{permission_mode}'. "
+                f"Expected one of: {', '.join(sorted(modes))}.",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            raise typer.Exit(code=2)
+
+        from suzent.acp.server import redirect_logs_to_stderr, serve_stdio
+
+        redirect_logs_to_stderr(log_level)
+        raise typer.Exit(
+            code=asyncio.run(
+                serve_stdio(
+                    base_url=server_url,
+                    permission_mode=permission_mode,
+                )
+            )
+        )

--- a/src/suzent/client/api.py
+++ b/src/suzent/client/api.py
@@ -276,9 +276,18 @@ class ChatAPI:
     async def create_chat(self, payload: dict) -> dict:
         return await self.client.post("/chats", json=payload)
 
-    async def stream_message(self, payload: dict):
-        async for chunk in self.client.stream_post("/chat", json=payload):
+    async def stream_message(self, payload: dict, timeout: float | None = 60.0):
+        """Stream one turn. ``timeout=None`` waits as long as the model runs."""
+        async for chunk in self.client.stream_post(
+            "/chat", json=payload, timeout=timeout
+        ):
             yield chunk
+
+    async def stop(self, chat_id: str, reason: str = "") -> dict:
+        body: dict = {"chat_id": chat_id}
+        if reason:
+            body["reason"] = reason
+        return await self.client.post("/chat/stop", json=body)
 
 
 class SuzentAsyncClient(AsyncBaseClient):

--- a/src/suzent/client/base.py
+++ b/src/suzent/client/base.py
@@ -129,6 +129,10 @@ class AsyncBaseClient:
                 detail = str(e)
             raise ClientError(f"Server error ({e.response.status_code}): {detail}")
 
+    async def aclose(self) -> None:
+        """Release the underlying connection pool."""
+        await self._client.aclose()
+
     async def stream_post(self, path: str, json: dict | None = None, **kwargs):
         """Yields chunks of the stream response."""
         timeout = kwargs.pop("timeout", 60.0)

--- a/tests/test_acp_server.py
+++ b/tests/test_acp_server.py
@@ -1,0 +1,576 @@
+"""Tests for serving Suzent as an ACP agent (``suzent acp``).
+
+The backend is faked so these exercise the protocol translation itself: the
+handshake, cwd binding, SSE-to-session/update mapping, the approval round trip
+that gates a tool call, and cancellation.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from suzent.acp.server import (
+    ACPAgentServer,
+    PROTOCOL_VERSION,
+    SESSION_MARKER,
+    WORKSPACE_MOUNT,
+    TurnTranslator,
+    _permission_options,
+    _prompt_text,
+    tool_kind,
+)
+
+
+def sse(event: dict[str, Any]) -> bytes:
+    return f"data: {json.dumps(event)}\n\n".encode()
+
+
+class FakeBackend:
+    """Records what the ACP layer asked the backend to do."""
+
+    def __init__(self, turns: list[list[bytes]], *, sandbox: bool = True):
+        self.turns = turns
+        self._sandbox = sandbox
+        self.created: list[tuple[str, dict[str, Any]]] = []
+        self.payloads: list[dict[str, Any]] = []
+        self.stopped: list[str] = []
+        self.chats: dict[str, dict[str, Any]] = {}
+
+    async def sandbox_enabled(self) -> bool:
+        return self._sandbox
+
+    async def create_chat(self, title: str, config: dict[str, Any]) -> str:
+        chat_id = f"chat-{len(self.created) + 1}"
+        self.created.append((title, config))
+        self.chats[chat_id] = {"id": chat_id, "config": config, "messages": []}
+        return chat_id
+
+    async def get_chat(self, chat_id: str) -> dict[str, Any] | None:
+        return self.chats.get(chat_id)
+
+    async def stream_turn(self, payload: dict[str, Any]):
+        self.payloads.append(payload)
+        for chunk in self.turns.pop(0) if self.turns else []:
+            yield chunk
+
+    async def stop_turn(self, chat_id: str) -> None:
+        self.stopped.append(chat_id)
+
+    async def aclose(self) -> None:
+        return None
+
+
+class Wire:
+    """Collects everything the server sends to the client."""
+
+    def __init__(self):
+        self.sent: list[dict[str, Any]] = []
+        self.responder = None
+
+    async def __call__(self, message: dict[str, Any]) -> None:
+        self.sent.append(message)
+        if self.responder and message.get("method") and message.get("id") is not None:
+            await self.responder(message)
+
+    def updates(self) -> list[dict[str, Any]]:
+        return [
+            m["params"]["update"]
+            for m in self.sent
+            if m.get("method") == "session/update"
+        ]
+
+    def result(self, message_id: int) -> Any:
+        for message in self.sent:
+            if message.get("id") == message_id and "result" in message:
+                return message["result"]
+        return None
+
+    def error(self, message_id: int) -> dict[str, Any] | None:
+        for message in self.sent:
+            if message.get("id") == message_id and "error" in message:
+                return message["error"]
+        return None
+
+
+def request(message_id: int, method: str, params: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": message_id, "method": method, "params": params}
+
+
+# ── handshake and session binding ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_initialize_advertises_v1_and_resume(tmp_path):
+    wire = Wire()
+    server = ACPAgentServer(FakeBackend([]), wire)
+
+    await server.dispatch(request(1, "initialize", {"clientCapabilities": {}}))
+
+    result = wire.result(1)
+    assert result["protocolVersion"] == PROTOCOL_VERSION
+    assert result["agentCapabilities"]["loadSession"] is True
+    assert result["agentInfo"]["name"] == "suzent"
+
+
+@pytest.mark.asyncio
+async def test_session_new_binds_the_client_cwd_as_a_mount(tmp_path):
+    backend = FakeBackend([], sandbox=True)
+    wire = Wire()
+    server = ACPAgentServer(backend, wire)
+
+    await server.dispatch(request(1, "initialize", {}))
+    await server.dispatch(request(2, "session/new", {"cwd": str(tmp_path)}))
+
+    assert wire.result(2) == {"sessionId": "chat-1"}
+    _title, config = backend.created[0]
+    assert config["sandbox_volumes"] == [f"{tmp_path.resolve()}:{WORKSPACE_MOUNT}"]
+    # Sandbox turns run in the container, so the agent's cwd is the mount point.
+    assert config["cwd"] == WORKSPACE_MOUNT
+    assert config[SESSION_MARKER]["cwd"] == str(tmp_path.resolve())
+
+
+@pytest.mark.asyncio
+async def test_host_mode_session_uses_the_real_directory_as_cwd(tmp_path):
+    backend = FakeBackend([], sandbox=False)
+    server = ACPAgentServer(backend, Wire())
+
+    await server.dispatch(request(1, "initialize", {}))
+    await server.dispatch(request(2, "session/new", {"cwd": str(tmp_path)}))
+
+    _title, config = backend.created[0]
+    assert config["cwd"] == str(tmp_path.resolve())
+
+
+@pytest.mark.asyncio
+async def test_session_new_rejects_a_relative_cwd():
+    wire = Wire()
+    server = ACPAgentServer(FakeBackend([]), wire)
+
+    await server.dispatch(request(1, "session/new", {"cwd": "relative/dir"}))
+
+    assert "not absolute" in wire.error(1)["message"]
+
+
+@pytest.mark.asyncio
+async def test_session_load_refuses_a_chat_this_surface_did_not_create(tmp_path):
+    backend = FakeBackend([])
+    backend.chats["local-chat"] = {"id": "local-chat", "config": {}, "messages": []}
+    wire = Wire()
+    server = ACPAgentServer(backend, wire)
+
+    await server.dispatch(request(1, "session/load", {"sessionId": "local-chat"}))
+
+    assert "not an ACP session" in wire.error(1)["message"]
+
+
+@pytest.mark.asyncio
+async def test_session_load_replays_history(tmp_path):
+    backend = FakeBackend([])
+    wire = Wire()
+    server = ACPAgentServer(backend, wire)
+    await server.dispatch(request(1, "initialize", {}))
+    await server.dispatch(request(2, "session/new", {"cwd": str(tmp_path)}))
+    backend.chats["chat-1"]["messages"] = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+
+    await server.dispatch(
+        request(3, "session/load", {"sessionId": "chat-1", "cwd": str(tmp_path)})
+    )
+
+    kinds = [u["sessionUpdate"] for u in wire.updates()]
+    assert kinds == ["user_message_chunk", "agent_message_chunk"]
+    assert wire.error(3) is None
+
+
+# ── one turn ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_prompt_streams_text_and_tool_calls(tmp_path):
+    backend = FakeBackend(
+        [
+            [
+                sse({"type": "TEXT_MESSAGE_CONTENT", "delta": "Look"}),
+                sse({"type": "THINKING_TEXT_MESSAGE_CONTENT", "delta": "hmm"}),
+                sse(
+                    {
+                        "type": "TOOL_CALL_START",
+                        "toolCallId": "t1",
+                        "toolCallName": "read_file",
+                    }
+                ),
+                sse(
+                    {
+                        "type": "TOOL_CALL_ARGS",
+                        "toolCallId": "t1",
+                        "delta": '{"path": "a.py"}',
+                    }
+                ),
+                sse({"type": "TOOL_CALL_END", "toolCallId": "t1"}),
+                sse(
+                    {
+                        "type": "TOOL_CALL_RESULT",
+                        "toolCallId": "t1",
+                        "content": "print(1)",
+                    }
+                ),
+                sse({"type": "TEXT_MESSAGE_CONTENT", "delta": "ing"}),
+                sse({"type": "AGENT_FINISHED"}),
+            ]
+        ]
+    )
+    wire = Wire()
+    server = ACPAgentServer(backend, wire)
+    await server.dispatch(request(1, "initialize", {}))
+    await server.dispatch(request(2, "session/new", {"cwd": str(tmp_path)}))
+
+    await server.dispatch(
+        request(
+            3,
+            "session/prompt",
+            {"sessionId": "chat-1", "prompt": [{"type": "text", "text": "read a.py"}]},
+        )
+    )
+    await server.drain()
+
+    assert wire.result(3) == {"stopReason": "end_turn"}
+    updates = wire.updates()
+    assert updates[0] == {
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "Look"},
+    }
+    assert updates[1]["sessionUpdate"] == "agent_thought_chunk"
+    assert updates[2] == {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "t1",
+        "title": "read_file",
+        "kind": "read",
+        "status": "in_progress",
+    }
+    assert updates[3]["rawInput"] == {"path": "a.py"}
+    assert updates[4]["status"] == "completed"
+    assert updates[4]["content"][0]["content"]["text"] == "print(1)"
+    # The turn text is what the backend streamed, and only the client's config
+    # binding rides along with it.
+    assert backend.payloads[0]["message"] == "read a.py"
+    assert backend.payloads[0]["chat_id"] == "chat-1"
+
+
+@pytest.mark.asyncio
+async def test_prompt_reports_a_backend_run_error(tmp_path):
+    backend = FakeBackend([[sse({"type": "RUN_ERROR", "message": "model exploded"})]])
+    wire = Wire()
+    server = ACPAgentServer(backend, wire)
+    await server.dispatch(request(1, "initialize", {}))
+    await server.dispatch(request(2, "session/new", {"cwd": str(tmp_path)}))
+
+    await server.dispatch(
+        request(
+            3,
+            "session/prompt",
+            {"sessionId": "chat-1", "prompt": [{"type": "text", "text": "go"}]},
+        )
+    )
+    await server.drain()
+
+    assert wire.error(3)["message"] == "model exploded"
+
+
+@pytest.mark.asyncio
+async def test_prompt_on_an_unknown_session_is_an_error():
+    wire = Wire()
+    server = ACPAgentServer(FakeBackend([]), wire)
+
+    await server.dispatch(
+        request(
+            1,
+            "session/prompt",
+            {"sessionId": "nope", "prompt": [{"type": "text", "text": "go"}]},
+        )
+    )
+    await server.drain()
+
+    assert "no such session" in wire.error(1)["message"]
+
+
+# ── approvals ─────────────────────────────────────────────────────────────────
+
+
+APPROVAL_EVENT = {
+    "type": "CUSTOM",
+    "name": "tool_approval_request",
+    "value": {
+        "approvalId": "a1",
+        "toolCallId": "t1",
+        "toolName": "run_command",
+        "args": {"content": "git status"},
+        "decision": {
+            "actions": [
+                {
+                    "id": "allow_once",
+                    "label": "Allow",
+                    "behavior": "allow",
+                    "scope": "once",
+                },
+                {
+                    "id": "allow_global",
+                    "label": "Always allow all git …",
+                    "behavior": "allow",
+                    "scope": "global",
+                },
+                {
+                    "id": "reject",
+                    "label": "Reject",
+                    "behavior": "deny",
+                    "scope": "once",
+                },
+            ]
+        },
+    },
+}
+
+
+def suspended_then_finished() -> list[list[bytes]]:
+    return [
+        [
+            sse(
+                {
+                    "type": "TOOL_CALL_START",
+                    "toolCallId": "t1",
+                    "toolCallName": "run_command",
+                }
+            ),
+            sse(APPROVAL_EVENT),
+        ],
+        [
+            sse({"type": "TEXT_MESSAGE_CONTENT", "delta": "done"}),
+        ],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_approval_becomes_a_client_permission_request(tmp_path):
+    backend = FakeBackend(suspended_then_finished())
+    wire = Wire()
+
+    async def answer(message: dict[str, Any]) -> None:
+        assert message["method"] == "session/request_permission"
+        assert message["params"]["toolCall"]["rawInput"] == {"content": "git status"}
+        await server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "outcome": {"outcome": "selected", "optionId": "allow_global"}
+                },
+            }
+        )
+
+    wire.responder = answer
+    server = ACPAgentServer(backend, wire)
+    await server.dispatch(request(1, "initialize", {}))
+    await server.dispatch(request(2, "session/new", {"cwd": str(tmp_path)}))
+
+    await server.dispatch(
+        request(
+            3,
+            "session/prompt",
+            {"sessionId": "chat-1", "prompt": [{"type": "text", "text": "status"}]},
+        )
+    )
+    await server.drain()
+
+    assert wire.result(3) == {"stopReason": "end_turn"}
+    # The decision resumes the same turn, carrying the backend's own action id
+    # so "always allow" persists the rule the option promised.
+    resume = backend.payloads[1]["resume_approvals"]
+    assert resume == [
+        {
+            "request_id": "a1",
+            "tool_call_id": "t1",
+            "approved": True,
+            "action_id": "allow_global",
+        }
+    ]
+    assert backend.payloads[1]["message"] == ""
+
+
+@pytest.mark.asyncio
+async def test_rejected_permission_resumes_as_a_denial(tmp_path):
+    backend = FakeBackend(suspended_then_finished())
+    wire = Wire()
+
+    async def answer(message: dict[str, Any]) -> None:
+        await server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {"outcome": {"outcome": "selected", "optionId": "reject"}},
+            }
+        )
+
+    wire.responder = answer
+    server = ACPAgentServer(backend, wire)
+    await server.dispatch(request(1, "initialize", {}))
+    await server.dispatch(request(2, "session/new", {"cwd": str(tmp_path)}))
+
+    await server.dispatch(
+        request(
+            3,
+            "session/prompt",
+            {"sessionId": "chat-1", "prompt": [{"type": "text", "text": "status"}]},
+        )
+    )
+    await server.drain()
+
+    assert backend.payloads[1]["resume_approvals"][0]["approved"] is False
+
+
+@pytest.mark.asyncio
+async def test_cancelled_permission_stops_the_turn(tmp_path):
+    backend = FakeBackend(suspended_then_finished())
+    wire = Wire()
+
+    async def answer(message: dict[str, Any]) -> None:
+        await server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {"outcome": {"outcome": "cancelled"}},
+            }
+        )
+
+    wire.responder = answer
+    server = ACPAgentServer(backend, wire)
+    await server.dispatch(request(1, "initialize", {}))
+    await server.dispatch(request(2, "session/new", {"cwd": str(tmp_path)}))
+
+    await server.dispatch(
+        request(
+            3,
+            "session/prompt",
+            {"sessionId": "chat-1", "prompt": [{"type": "text", "text": "status"}]},
+        )
+    )
+    await server.drain()
+
+    assert wire.result(3) == {"stopReason": "cancelled"}
+    assert backend.stopped == ["chat-1"]
+
+
+# ── cancellation ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_session_cancel_ends_the_turn_as_cancelled(tmp_path):
+    wire = Wire()
+
+    class SlowBackend(FakeBackend):
+        async def stream_turn(self, payload):
+            self.payloads.append(payload)
+            yield sse({"type": "TEXT_MESSAGE_CONTENT", "delta": "start"})
+            # The client cancels between frames, which is the realistic case:
+            # a stop lands while the model is still producing.
+            await server.dispatch(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "session/cancel",
+                    "params": {"sessionId": "chat-1"},
+                }
+            )
+            yield sse({"type": "TEXT_MESSAGE_CONTENT", "delta": " more"})
+
+    backend = SlowBackend([])
+    server = ACPAgentServer(backend, wire)
+    await server.dispatch(request(1, "initialize", {}))
+    await server.dispatch(request(2, "session/new", {"cwd": str(tmp_path)}))
+
+    await server.dispatch(
+        request(
+            3,
+            "session/prompt",
+            {"sessionId": "chat-1", "prompt": [{"type": "text", "text": "go"}]},
+        )
+    )
+    await server.drain()
+
+    assert wire.result(3) == {"stopReason": "cancelled"}
+    assert backend.stopped == ["chat-1"]
+    texts = [u["content"]["text"] for u in wire.updates()]
+    assert texts == ["start"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_method_is_method_not_found():
+    wire = Wire()
+    server = ACPAgentServer(FakeBackend([]), wire)
+
+    await server.dispatch(request(1, "session/teleport", {}))
+
+    assert wire.error(1)["code"] == -32601
+
+
+# ── translation units ─────────────────────────────────────────────────────────
+
+
+def test_translator_handles_frames_split_across_chunks():
+    translator = TurnTranslator()
+    frame = sse({"type": "TEXT_MESSAGE_CONTENT", "delta": "hello"})
+    assert list(translator.feed(frame[:12])) == []
+    items = list(translator.feed(frame[12:]))
+    assert items[0].payload["content"]["text"] == "hello"
+
+
+def test_replayed_tool_call_start_updates_instead_of_duplicating():
+    translator = TurnTranslator()
+    start = sse(
+        {"type": "TOOL_CALL_START", "toolCallId": "t1", "toolCallName": "edit_file"}
+    )
+    first = list(translator.feed(start))
+    second = list(translator.feed(start))
+    assert first[0].payload["sessionUpdate"] == "tool_call"
+    assert second[0].payload == {
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "t1",
+        "status": "in_progress",
+    }
+
+
+def test_prompt_text_flattens_content_blocks():
+    text = _prompt_text(
+        [
+            {"type": "text", "text": "fix"},
+            {"type": "resource_link", "uri": "file:///a.py"},
+            {
+                "type": "resource",
+                "resource": {"uri": "file:///b.py", "text": "x = 1"},
+            },
+        ]
+    )
+    assert text == "fix\n\n@file:///a.py\n\nfile:///b.py\nx = 1"
+
+
+def test_permission_options_derive_kinds_from_backend_scope():
+    options = _permission_options(APPROVAL_EVENT["value"]["decision"])
+    assert options == [
+        {"optionId": "allow_once", "name": "Allow", "kind": "allow_once"},
+        {
+            "optionId": "allow_global",
+            "name": "Always allow all git …",
+            "kind": "allow_always",
+        },
+        {"optionId": "reject", "name": "Reject", "kind": "reject_once"},
+    ]
+
+
+def test_tool_kinds_cover_the_common_tools():
+    assert tool_kind("read_file") == "read"
+    assert tool_kind("edit_file") == "edit"
+    assert tool_kind("run_command") == "execute"
+    assert tool_kind("web_search") == "fetch"
+    assert tool_kind("summon_daemon") == "other"


### PR DESCRIPTION
Suzent already spoke ACP as a **client** — `suzent.acp.client` drives Claude Code and Codex as subagents. This adds the other direction: `suzent acp` serves the local geist *as* an ACP agent, so Zed, enoxian, or any editor implementing the protocol can drive it inside that client's own workspace.

```
client -> agent:  initialize
client -> agent:  session/new       (cwd = the client's workspace)
client -> agent:  session/prompt
agent  -> client: session/update    (message chunks, thoughts, tool calls)
agent  -> client: session/request_permission
client -> agent:  session/cancel
```

## A translator, not a second agent

`suzent acp` runs no model. Each turn is posted to the already-running backend over the loopback API and its AG-UI stream is translated back into ACP. One process stays the owner of the database, so an ACP session is a **real chat**: it appears in the desktop UI, shares the same memory, skills, model config, and permission rules, and survives a restart.

A session id **is** a chat id, so `session/load` is a real resume. It refuses any chat this surface did not create — a client cannot address one of your local conversations by guessing an id.

## Where the files are

`session/new` binds the client's `cwd` as a custom volume at `/mnt/workspace` and pins the agent's cwd to the path the active execution mode can actually use (container path under sandbox, real path on host). The binding rides along with every prompt, the way the UI sends a chat's config per turn, so a `session/load` with a different `cwd` rebinds immediately.

Edits therefore land on the client's real files through the bind mount, which is what makes a client's own change tracking — enoxian's proposal engine, an editor's diff view — see them as ordinary writes.

## Approvals stay a real gate

A suspended tool call becomes `session/request_permission` and the turn blocks on the client's answer. The options are built from the backend's own decision contract:

| Suzent action | ACP option kind |
|---|---|
| `allow_once` | `allow_once` |
| `allow_session` / `allow_global` | `allow_always` |
| `reject` | `reject_once` |

The selected option id is handed back as the action to resolve, so an "always allow" choice persists exactly the rule its label promised (a command prefix such as `git log …`, or a whole tool) rather than a scope the client invented.

`--permission-mode auto|full_access` skips prompting for an unattended client.

## stdout hygiene

`stdout` carries protocol traffic only. Logging is redirected to stderr at the CLI callback — before `-v` could install a stdout sink and corrupt the stream.

## Verification

- 19 new tests in `tests/test_acp_server.py` covering the handshake, cwd binding in both execution modes, SSE→`session/update` mapping, frames split across chunk boundaries, the approval round trip, rejection, cancellation, and `session/load` authorization. Full suite: 1387 passed.
- A live turn against a real backend: `initialize` → `session/new` → `end_turn` with the expected text, then resumed in a fresh process with history replayed.
- End to end through enoxian: `enox agent run suzent "..."` → `[acp] initialized (loadSession=true)` → `session created (cwd=<circle workspace>)` → `✓ stop_reason=end_turn`.

## Notes

- ACP session modes are not mapped onto permission modes; the mode is a CLI flag instead.
- `ChatAPI.stream_message` gained a `timeout` parameter (a turn must not die at the 60s default) and `ChatAPI.stop` / `AsyncBaseClient.aclose` were added — the ACP layer needs both.