### PR TITLE
fix(cli): read the real AG-UI field names for tool call events

### DIFF
--- a/src/suzent/cli/agent.py
+++ b/src/suzent/cli/agent.py
@@ -8,6 +8,7 @@ Usage:
 
 import typer
 import asyncio
+import itertools
 from suzent.client import get_client
 from suzent.client.base import ClientError
 from suzent.core.stream_parser import (
@@ -181,13 +182,17 @@ def agent_chat(
             chunks = [chunk async for chunk in client.chat.stream_message(payload)]
 
             pending_approvals = []
-            for event in parser.parse(iter(chunks)):
+            # flush() closes out any tool call the stream ended mid-way through.
+            for event in itertools.chain(parser.parse(iter(chunks)), parser.flush()):
                 if isinstance(event, TextChunk):
                     color = typer.colors.GREEN if event.is_code else None
                     typer.secho(event.content, nl=False, fg=color)
 
                 elif isinstance(event, ToolCall):
                     typer.echo(f"\n[Tool Call: {event.tool_name}]", err=True)
+                    args_preview = event.format_arguments()
+                    if args_preview:
+                        typer.echo(f"  {args_preview}", err=True)
 
                 elif isinstance(event, ToolOutput):
                     typer.secho(

--- a/src/suzent/core/stream_parser.py
+++ b/src/suzent/core/stream_parser.py
@@ -37,6 +37,23 @@ class ToolCall(StreamEvent):
 
     tool_name: str
     arguments: dict
+    tool_call_id: str = ""
+    # Raw argument text as it came off the wire, kept so unparseable or
+    # truncated JSON is still displayable.
+    raw_arguments: str = ""
+
+    def format_arguments(self, max_length: int = 200) -> str:
+        """Compact one-line rendering of the arguments for terminal display."""
+        if self.arguments:
+            try:
+                text = json.dumps(self.arguments, ensure_ascii=False)
+            except (TypeError, ValueError):
+                text = str(self.arguments)
+        else:
+            text = " ".join((self.raw_arguments or "").split())
+        if len(text) > max_length:
+            return text[: max_length - 1] + "\u2026"
+        return text
 
 
 @dataclass
@@ -45,6 +62,18 @@ class ToolOutput(StreamEvent):
 
     tool_name: str
     output: str
+    tool_call_id: str = ""
+
+
+@dataclass
+class _PendingToolCall:
+    """A tool call being assembled from TOOL_CALL_START/ARGS/END events."""
+
+    tool_name: str
+    args_text: str = ""
+    # Legacy emitters send the whole argument dict on the start event.
+    inline_args: dict | None = None
+    emitted: bool = False
 
 
 @dataclass
@@ -108,6 +137,44 @@ class ApprovalRequest(StreamEvent):
         return text.strip()
 
 
+_TOOL_CALL_ID_KEYS = ("toolCallId", "tool_call_id", "id")
+_TOOL_NAME_KEYS = ("toolCallName", "toolName", "tool_name", "name")
+
+
+def _first_str(payload: dict, keys: tuple[str, ...]) -> str:
+    """Return the first non-empty string value found under ``keys``."""
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _stringify(raw: Any) -> str:
+    """Render tool output content (string, list of parts, or dict) as text."""
+    if raw is None:
+        return ""
+    if isinstance(raw, str):
+        return raw
+    try:
+        return json.dumps(raw, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(raw)
+
+
+def _parse_arguments(raw: str) -> dict:
+    """Parse accumulated TOOL_CALL_ARGS text into a dict (empty if unusable)."""
+    text = (raw or "").strip()
+    if not text:
+        return {}
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        logger.debug(f"Unparseable tool call arguments: {text[:200]}")
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
 class StreamParser:
     """
     Stateful parser for Suzent agent streams.
@@ -117,10 +184,16 @@ class StreamParser:
     - Modern Suzent events (TEXT_MESSAGE_CONTENT, TOOL_CALL, TOOL_RETURN, etc.)
     - Custom events like tool_approval_request
     - Legacy fallbacks for older agents
+
+    Tool calls arrive as TOOL_CALL_START (id + name), a run of TOOL_CALL_ARGS
+    deltas, then TOOL_CALL_END. A single ToolCall is emitted once the call
+    closes, so its arguments are complete when consumers see it.
     """
 
     def __init__(self):
         self.buffer = ""
+        self._pending_tools: dict[str, _PendingToolCall] = {}
+        self._last_tool_call_id = ""
 
     def parse(self, chunks: Iterator[Union[str, bytes]]) -> Iterator[StreamEvent]:
         """
@@ -161,15 +234,13 @@ class StreamParser:
         if evt_type == StreamEventType.TEXT_MESSAGE_CONTENT:
             yield TextChunk(payload.get("delta", ""), False)
         elif evt_type == StreamEventType.TOOL_CALL_START:
-            yield ToolCall(
-                payload.get("tool_name", "unknown"),
-                payload.get("args", {}),
-            )
+            self._start_tool_call(payload)
+        elif evt_type == StreamEventType.TOOL_CALL_ARGS:
+            self._record_tool_call_args(payload)
+        elif evt_type == StreamEventType.TOOL_CALL_END:
+            yield from self._emit_tool_call(self._resolve_tool_call_id(payload))
         elif evt_type == StreamEventType.TOOL_CALL_RESULT:
-            yield ToolOutput(
-                payload.get("tool_name", "unknown"),
-                str(payload.get("output", "")),
-            )
+            yield from self._handle_tool_call_result(payload)
         elif evt_type in (StreamEventType.CUSTOM_EVENT, StreamEventType.CUSTOM):
             # The AG-UI protocol uses type: CUSTOM with top-level name/value
             # but some internal emitters might use type: CUSTOM_EVENT with nested custom object.
@@ -191,10 +262,11 @@ class StreamParser:
                     decision=val.get("decision"),
                 )
         elif evt_type == StreamEventType.RUN_ERROR:
+            # A failed run may leave tool calls that never closed.
+            yield from self.flush()
             yield ErrorEvent(payload.get("message", "Unknown error"))
         elif evt_type == StreamEventType.AGENT_FINISHED:
-            # Just a terminator
-            pass
+            yield from self.flush()
 
         # --- Legacy Fallbacks ---
         elif evt_type == StreamEventType.STREAM_DELTA:
@@ -202,10 +274,13 @@ class StreamParser:
             yield from self._handle_delta(data)
         elif evt_type == StreamEventType.TOOL_OUTPUT:
             data = payload.get("data", {})
-            tool_name = data.get("tool_name") or data.get("tool_call", {}).get(
-                "name", "unknown"
+            tool_call = data.get("tool_call", {}) or {}
+            tool_name = data.get("tool_name") or tool_call.get("name", "unknown")
+            yield ToolOutput(
+                tool_name,
+                _stringify(data.get("output", "")),
+                tool_call_id=str(data.get("tool_call_id") or tool_call.get("id") or ""),
             )
-            yield ToolOutput(tool_name, str(data.get("output", "")))
         elif evt_type == StreamEventType.ERROR:
             data = payload.get("data", {})
             yield ErrorEvent(str(data))
@@ -213,14 +288,113 @@ class StreamParser:
             data = payload.get("data", {})
             yield FinalAnswer(str(data))
 
+    # --- Tool call assembly -------------------------------------------------
+
+    def flush(self) -> Iterator[StreamEvent]:
+        """
+        Emit any tool call that never saw a TOOL_CALL_END or a result.
+
+        Consumers can call this once a stream is exhausted so a truncated run
+        still reports the tools it started.
+        """
+        for call_id in list(self._pending_tools):
+            yield from self._emit_tool_call(call_id)
+            self._pending_tools.pop(call_id, None)
+
+    def _resolve_tool_call_id(self, payload: dict) -> str:
+        """Tool call id from the payload, falling back to the call in flight."""
+        return _first_str(payload, _TOOL_CALL_ID_KEYS) or self._last_tool_call_id
+
+    def _start_tool_call(self, payload: dict) -> None:
+        """Register a tool call; its arguments stream in as TOOL_CALL_ARGS."""
+        call_id = self._resolve_tool_call_id(payload)
+        pending = _PendingToolCall(
+            tool_name=_first_str(payload, _TOOL_NAME_KEYS) or "unknown"
+        )
+
+        raw_args = payload.get("args")
+        if isinstance(raw_args, dict):
+            pending.inline_args = raw_args
+        elif isinstance(raw_args, str):
+            pending.args_text = raw_args
+
+        # A replayed start (resume after approval) restarts argument streaming.
+        self._pending_tools[call_id] = pending
+        self._last_tool_call_id = call_id
+
+    def _record_tool_call_args(self, payload: dict) -> None:
+        """Accumulate one TOOL_CALL_ARGS delta."""
+        delta = payload.get("delta")
+        if not isinstance(delta, str) or not delta:
+            return
+
+        call_id = self._resolve_tool_call_id(payload)
+        pending = self._pending_tools.get(call_id)
+        if pending is None:
+            # Args without a start: still keep them so the call has arguments.
+            pending = _PendingToolCall(tool_name="unknown")
+            self._pending_tools[call_id] = pending
+            self._last_tool_call_id = call_id
+        pending.args_text += delta
+
+    def _emit_tool_call(self, call_id: str) -> Iterator[StreamEvent]:
+        """Emit the pending call for ``call_id`` exactly once."""
+        pending = self._pending_tools.get(call_id)
+        if pending is None or pending.emitted:
+            return
+        pending.emitted = True
+
+        if pending.inline_args is not None:
+            arguments = pending.inline_args
+        else:
+            arguments = _parse_arguments(pending.args_text)
+
+        yield ToolCall(
+            pending.tool_name,
+            arguments,
+            tool_call_id=call_id,
+            raw_arguments=pending.args_text,
+        )
+
+    def _handle_tool_call_result(self, payload: dict) -> Iterator[StreamEvent]:
+        """Emit the tool's output, closing the call first if it is still open."""
+        call_id = self._resolve_tool_call_id(payload)
+        # A result implies the call closed, even if TOOL_CALL_END never arrived.
+        yield from self._emit_tool_call(call_id)
+        pending = self._pending_tools.pop(call_id, None)
+
+        content = payload.get("content")
+        if content is None:
+            content = payload.get("output")
+        if content is None:
+            content = payload.get("result")
+
+        tool_name = (
+            _first_str(payload, _TOOL_NAME_KEYS)
+            or (pending.tool_name if pending else "")
+            or "unknown"
+        )
+        yield ToolOutput(tool_name, _stringify(content), tool_call_id=call_id)
+
     def _handle_delta(self, data: dict) -> Iterator[StreamEvent]:
         """Handle legacy stream_delta content."""
         content = data.get("content", "")
         if data.get("tool_calls"):
             for tc in data["tool_calls"]:
-                name = tc.get("function", {}).get("name", "unknown")
-                args = tc.get("function", {}).get("arguments", {})
-                yield ToolCall(name, args)
+                fn = tc.get("function", {}) or {}
+                raw_args = fn.get("arguments", {})
+                if isinstance(raw_args, str):
+                    args, raw_text = _parse_arguments(raw_args), raw_args
+                elif isinstance(raw_args, dict):
+                    args, raw_text = raw_args, ""
+                else:
+                    args, raw_text = {}, ""
+                yield ToolCall(
+                    fn.get("name", "unknown"),
+                    args,
+                    tool_call_id=str(tc.get("id") or ""),
+                    raw_arguments=raw_text,
+                )
             return
 
         if not content:

--- a/src/suzent/core/stream_parser.py
+++ b/src/suzent/core/stream_parser.py
@@ -169,8 +169,12 @@ def _parse_arguments(raw: str) -> dict:
         return {}
     try:
         parsed = json.loads(text)
-    except json.JSONDecodeError:
-        logger.debug(f"Unparseable tool call arguments: {text[:200]}")
+    except json.JSONDecodeError as exc:
+        # Never log the argument text itself: tool args carry secrets and PII.
+        logger.debug(
+            f"Unparseable tool call arguments ({len(text)} chars): {exc.msg} "
+            f"at position {exc.pos}"
+        )
         return {}
     return parsed if isinstance(parsed, dict) else {}
 
@@ -211,7 +215,9 @@ class StreamParser:
             # SSE events are separated by double newlines
             while "\n\n" in self.buffer:
                 event_block, self.buffer = self.buffer.split("\n\n", 1)
-                logger.debug(f"Parsing SSE block: {event_block[:100]}...")
+                # Log the shape, not the payload: blocks carry tool arguments
+                # and tool output, which can hold secrets and PII.
+                logger.debug(f"Parsing SSE block ({len(event_block)} chars)")
 
                 # An event block can have multiple lines (data:, event:, id:, retry:)
                 # We only care about the "data:" lines for now.

--- a/tests/core/test_stream_events.py
+++ b/tests/core/test_stream_events.py
@@ -6,6 +6,8 @@ from suzent.core.stream_parser import (
     ApprovalRequest,
     TextChunk,
     ErrorEvent,
+    ToolCall,
+    ToolOutput,
 )
 
 
@@ -139,3 +141,342 @@ async def test_chat_processor_on_event_callback():
         assert isinstance(events_received[1], ApprovalRequest)
         assert events_received[1].request_id == "req456"
         assert isinstance(events_received[2], TextChunk)
+
+
+def _sse(payload: str) -> str:
+    return f"data: {payload}\n\n"
+
+
+def test_stream_parser_assembles_tool_call_from_agui_events():
+    """TOOL_CALL_START/ARGS/END is the real wire shape: name + streamed args."""
+    parser = StreamParser()
+
+    events = list(
+        parser.parse(
+            [
+                _sse(
+                    '{"type": "TOOL_CALL_START", "toolCallId": "call_1", '
+                    '"toolCallName": "read_file"}'
+                ),
+                _sse(
+                    '{"type": "TOOL_CALL_ARGS", "toolCallId": "call_1", '
+                    '"delta": "{\\"path\\": "}'
+                ),
+                _sse(
+                    '{"type": "TOOL_CALL_ARGS", "toolCallId": "call_1", '
+                    '"delta": "\\"/tmp/a.txt\\"}"}'
+                ),
+                _sse('{"type": "TOOL_CALL_END", "toolCallId": "call_1"}'),
+            ]
+        )
+    )
+
+    assert len(events) == 1
+    call = events[0]
+    assert isinstance(call, ToolCall)
+    assert call.tool_name == "read_file"
+    assert call.arguments == {"path": "/tmp/a.txt"}
+    assert call.tool_call_id == "call_1"
+    assert call.raw_arguments == '{"path": "/tmp/a.txt"}'
+
+
+def test_stream_parser_tool_result_uses_content_and_call_id():
+    """TOOL_CALL_RESULT carries `content` and correlates by toolCallId."""
+    parser = StreamParser()
+
+    events = list(
+        parser.parse(
+            [
+                _sse(
+                    '{"type": "TOOL_CALL_START", "toolCallId": "call_1", '
+                    '"toolCallName": "read_file"}'
+                ),
+                _sse('{"type": "TOOL_CALL_END", "toolCallId": "call_1"}'),
+                _sse(
+                    '{"type": "TOOL_CALL_RESULT", "messageId": "m1", '
+                    '"toolCallId": "call_1", "content": "file contents"}'
+                ),
+            ]
+        )
+    )
+
+    assert [type(e) for e in events] == [ToolCall, ToolOutput]
+    output = events[1]
+    assert output.tool_name == "read_file"
+    assert output.output == "file contents"
+    assert output.tool_call_id == "call_1"
+
+
+def test_stream_parser_result_closes_call_without_end():
+    """A result implies the call closed even if TOOL_CALL_END never arrived."""
+    parser = StreamParser()
+
+    events = list(
+        parser.parse(
+            [
+                _sse(
+                    '{"type": "TOOL_CALL_START", "toolCallId": "call_9", '
+                    '"toolCallName": "bash_execute"}'
+                ),
+                _sse(
+                    '{"type": "TOOL_CALL_ARGS", "toolCallId": "call_9", '
+                    '"delta": "{\\"content\\": \\"ls\\"}"}'
+                ),
+                _sse(
+                    '{"type": "TOOL_CALL_RESULT", "toolCallId": "call_9", '
+                    '"content": "a.txt"}'
+                ),
+            ]
+        )
+    )
+
+    assert [type(e) for e in events] == [ToolCall, ToolOutput]
+    assert events[0].arguments == {"content": "ls"}
+    assert events[1].output == "a.txt"
+
+
+def test_stream_parser_interleaves_parallel_tool_calls():
+    """Args deltas are routed by toolCallId, not by arrival order."""
+    parser = StreamParser()
+
+    events = list(
+        parser.parse(
+            [
+                _sse(
+                    '{"type": "TOOL_CALL_START", "toolCallId": "a", '
+                    '"toolCallName": "first"}'
+                ),
+                _sse(
+                    '{"type": "TOOL_CALL_START", "toolCallId": "b", '
+                    '"toolCallName": "second"}'
+                ),
+                _sse(
+                    '{"type": "TOOL_CALL_ARGS", "toolCallId": "a", '
+                    '"delta": "{\\"x\\": 1}"}'
+                ),
+                _sse(
+                    '{"type": "TOOL_CALL_ARGS", "toolCallId": "b", '
+                    '"delta": "{\\"y\\": 2}"}'
+                ),
+                _sse('{"type": "TOOL_CALL_END", "toolCallId": "b"}'),
+                _sse('{"type": "TOOL_CALL_END", "toolCallId": "a"}'),
+            ]
+        )
+    )
+
+    assert [(e.tool_name, e.arguments, e.tool_call_id) for e in events] == [
+        ("second", {"y": 2}, "b"),
+        ("first", {"x": 1}, "a"),
+    ]
+
+
+def test_stream_parser_emits_tool_call_once_per_call():
+    """END then RESULT must not produce two ToolCall events."""
+    parser = StreamParser()
+
+    events = list(
+        parser.parse(
+            [
+                _sse(
+                    '{"type": "TOOL_CALL_START", "toolCallId": "c", '
+                    '"toolCallName": "t"}'
+                ),
+                _sse('{"type": "TOOL_CALL_END", "toolCallId": "c"}'),
+                _sse('{"type": "TOOL_CALL_RESULT", "toolCallId": "c", "content": ""}'),
+                _sse('{"type": "AGENT_FINISHED"}'),
+            ]
+        )
+    )
+
+    assert sum(isinstance(e, ToolCall) for e in events) == 1
+
+
+def test_stream_parser_flush_emits_unclosed_tool_call():
+    """A stream that ends mid-call still reports the tool it started."""
+    parser = StreamParser()
+
+    streamed = list(
+        parser.parse(
+            [
+                _sse(
+                    '{"type": "TOOL_CALL_START", "toolCallId": "c", '
+                    '"toolCallName": "web_search"}'
+                ),
+                _sse(
+                    '{"type": "TOOL_CALL_ARGS", "toolCallId": "c", '
+                    '"delta": "{\\"q\\": \\"suzent\\"}"}'
+                ),
+            ]
+        )
+    )
+    assert streamed == []
+
+    flushed = list(parser.flush())
+    assert len(flushed) == 1
+    assert flushed[0].tool_name == "web_search"
+    assert flushed[0].arguments == {"q": "suzent"}
+    # Already emitted, so a second flush is a no-op.
+    assert list(parser.flush()) == []
+
+
+def test_stream_parser_run_error_flushes_open_tool_call():
+    parser = StreamParser()
+
+    events = list(
+        parser.parse(
+            [
+                _sse(
+                    '{"type": "TOOL_CALL_START", "toolCallId": "c", '
+                    '"toolCallName": "t"}'
+                ),
+                _sse('{"type": "RUN_ERROR", "message": "boom"}'),
+            ]
+        )
+    )
+
+    assert [type(e) for e in events] == [ToolCall, ErrorEvent]
+    assert events[1].message == "boom"
+
+
+def test_stream_parser_tool_call_partial_args_keep_raw_text():
+    """Truncated JSON yields empty arguments but preserves the raw text."""
+    parser = StreamParser()
+
+    list(
+        parser.parse(
+            [
+                _sse(
+                    '{"type": "TOOL_CALL_START", "toolCallId": "c", '
+                    '"toolCallName": "t"}'
+                ),
+                _sse(
+                    '{"type": "TOOL_CALL_ARGS", "toolCallId": "c", '
+                    '"delta": "{\\"path\\": "}'
+                ),
+            ]
+        )
+    )
+    call = list(parser.flush())[0]
+
+    assert call.arguments == {}
+    assert call.raw_arguments == '{"path": '
+    assert call.format_arguments() == '{"path":'
+
+
+def test_stream_parser_replayed_start_restarts_args():
+    """Resume after approval replays START; args must not be concatenated."""
+    parser = StreamParser()
+
+    events = list(
+        parser.parse(
+            [
+                _sse(
+                    '{"type": "TOOL_CALL_START", "toolCallId": "c", '
+                    '"toolCallName": "t"}'
+                ),
+                _sse(
+                    '{"type": "TOOL_CALL_ARGS", "toolCallId": "c", '
+                    '"delta": "{\\"x\\": 1}"}'
+                ),
+                _sse(
+                    '{"type": "TOOL_CALL_START", "toolCallId": "c", '
+                    '"toolCallName": "t"}'
+                ),
+                _sse(
+                    '{"type": "TOOL_CALL_ARGS", "toolCallId": "c", '
+                    '"delta": "{\\"x\\": 2}"}'
+                ),
+                _sse('{"type": "TOOL_CALL_END", "toolCallId": "c"}'),
+            ]
+        )
+    )
+
+    assert len(events) == 1
+    assert events[0].arguments == {"x": 2}
+
+
+def test_stream_parser_legacy_tool_field_names_still_work():
+    """Older emitters send tool_name/args on START and `output` on RESULT."""
+    parser = StreamParser()
+
+    events = list(
+        parser.parse(
+            [
+                _sse(
+                    '{"type": "TOOL_CALL_START", "tool_name": "legacy_tool", '
+                    '"args": {"a": 1}}'
+                ),
+                _sse('{"type": "TOOL_CALL_RESULT", "output": "done"}'),
+            ]
+        )
+    )
+
+    assert [type(e) for e in events] == [ToolCall, ToolOutput]
+    assert events[0].tool_name == "legacy_tool"
+    assert events[0].arguments == {"a": 1}
+    assert events[1].tool_name == "legacy_tool"
+    assert events[1].output == "done"
+
+
+def test_stream_parser_tool_result_stringifies_structured_content():
+    parser = StreamParser()
+
+    events = list(
+        parser.parse(
+            [
+                _sse(
+                    '{"type": "TOOL_CALL_START", "toolCallId": "c", '
+                    '"toolCallName": "t"}'
+                ),
+                _sse(
+                    '{"type": "TOOL_CALL_RESULT", "toolCallId": "c", '
+                    '"content": [{"type": "text", "text": "hi"}]}'
+                ),
+            ]
+        )
+    )
+
+    output = events[-1]
+    assert isinstance(output, ToolOutput)
+    assert output.output == '[{"type": "text", "text": "hi"}]'
+
+
+def test_stream_parser_legacy_stream_delta_tool_calls():
+    """Legacy stream_delta keeps working and now parses string arguments."""
+    parser = StreamParser()
+
+    events = list(
+        parser.parse(
+            [
+                _sse(
+                    '{"type": "stream_delta", "data": {"tool_calls": [{"id": "t1", '
+                    '"function": {"name": "calc", "arguments": "{\\"x\\": 1}"}}]}}'
+                )
+            ]
+        )
+    )
+
+    assert len(events) == 1
+    assert events[0].tool_name == "calc"
+    assert events[0].arguments == {"x": 1}
+    assert events[0].tool_call_id == "t1"
+
+
+def test_stream_parser_legacy_tool_output_event():
+    parser = StreamParser()
+
+    events = list(
+        parser.parse(
+            [
+                _sse(
+                    '{"type": "tool_output", "data": {"tool_call_id": "t1", '
+                    '"tool_call": {"name": "calc"}, "output": "42"}}'
+                )
+            ]
+        )
+    )
+
+    assert len(events) == 1
+    assert events[0].tool_name == "calc"
+    assert events[0].output == "42"
+    assert events[0].tool_call_id == "t1"

--- a/tests/core/test_stream_events.py
+++ b/tests/core/test_stream_events.py
@@ -480,3 +480,36 @@ def test_stream_parser_legacy_tool_output_event():
     assert events[0].tool_name == "calc"
     assert events[0].output == "42"
     assert events[0].tool_call_id == "t1"
+
+
+def test_stream_parser_does_not_log_raw_tool_arguments():
+    """Malformed args must not reach the logs: they can carry secrets/PII."""
+    from suzent.logger import logger
+
+    records: list[str] = []
+    sink_id = logger.add(records.append, level="DEBUG")
+    try:
+        parser = StreamParser()
+        list(
+            parser.parse(
+                [
+                    _sse(
+                        '{"type": "TOOL_CALL_START", "toolCallId": "c", '
+                        '"toolCallName": "bash_execute"}'
+                    ),
+                    _sse(
+                        '{"type": "TOOL_CALL_ARGS", "toolCallId": "c", '
+                        '"delta": "{\\"sk-secret-token\\": "}'
+                    ),
+                ]
+            )
+        )
+        call = list(parser.flush())[0]
+    finally:
+        logger.remove(sink_id)
+
+    assert call.arguments == {}
+    assert call.raw_arguments  # still available to the caller, just not logged
+    logged = "".join(records)
+    assert "sk-secret-token" not in logged
+    assert "Unparseable tool call arguments" in logged


### PR DESCRIPTION
## Problem

`suzent agent chat` rendered every tool call as `[Tool Call: unknown]` with no arguments.

`StreamParser._handle_event` read stale field names:

| Event | Parser read | Backend emits |
| --- | --- | --- |
| `TOOL_CALL_START` | `tool_name`, `args` | `toolCallId`, `toolCallName` |
| `TOOL_CALL_ARGS` | *(ignored)* | `toolCallId`, `delta` |
| `TOOL_CALL_RESULT` | `output` | `toolCallId`, `content` |

Arguments never appear on the start event at all — they stream in as `TOOL_CALL_ARGS` deltas, which the parser dropped on the floor.

## Changes

- **Assemble tool calls across events.** `TOOL_CALL_START` registers a pending call; `TOOL_CALL_ARGS` deltas accumulate per `toolCallId` (so parallel/interleaved calls don't cross-contaminate); `TOOL_CALL_END` emits a single `ToolCall` with complete, parsed arguments.
- **`TOOL_CALL_RESULT`** reads `content` (falling back to `output`/`result`), stringifies structured content, and closes a call that never saw an `END`.
- **`tool_call_id` on `ToolCall` and `ToolOutput`** so output correlates with its call. `ToolCall` also carries `raw_arguments` — the un-parsed text, kept so truncated or invalid JSON is still displayable — plus a `format_arguments()` helper for terminal display.
- **New `flush()`** emits calls that never closed; also run on `RUN_ERROR` and `AGENT_FINISHED`, so a failed or truncated run still reports the tools it started.
- **Legacy fallbacks preserved**: `tool_name`/`toolName`/`args` on start, `output` on result, and the `stream_delta` / `tool_output` events — the latter now also parse OpenAI-style string arguments and carry the call id.
- **CLI consumer** ([`src/suzent/cli/agent.py`](src/suzent/cli/agent.py)) chains `flush()` after the stream and prints a compact args preview under each `[Tool Call: …]` line.

`src/suzent/acp/*` is untouched — the ACP surface has its own translator and does not route through `StreamParser`.

## Tests

14 new tests in `tests/core/test_stream_events.py`, matching the existing style: full START/ARGS/END assembly, result-by-`content`, result without `END`, interleaved parallel calls, single-emission guarantee, `flush()` and `RUN_ERROR` flush, truncated-JSON raw text, replayed `START` after approval, and each legacy field-name path.

```
uv run --extra dev pytest tests/ -q -m "not sandbox and not integration and not slow"   # 1381 passed
uv run --extra dev pre-commit run --files <changed>                                     # ruff check + format pass
```

Also round-tripped real `ag_ui.encoder` output through the parser as a sanity check: `ToolCall(tool_name='bash_execute', arguments={'content': 'ls -la'}, tool_call_id='c1', …)` followed by the matching `ToolOutput`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)