### PR TITLE
seo: build the sovereignty content cluster

### DIFF
--- a/docs/01-getting-started/intro.md
+++ b/docs/01-getting-started/intro.md
@@ -9,12 +9,25 @@ Suzent is a **sovereign AI agent** whose identity, memory, skills, workspace,
 and runtime remain under your control. Models are replaceable, platforms are
 temporary, and the continuity of your agent belongs to you.
 
+## What is a sovereign AI agent?
+
+A sovereign AI agent is an AI agent whose identity, memory, skills, workspace,
+and runtime are owned and governed by its user rather than by a model provider
+or platform. Its durable state lives in files you can read, edit, version, and
+move; its actions run inside permission boundaries you define; and replacing the
+underlying model does not reset the agent that knows your work.
+
+The phrase "sovereign AI" is also used at the scale of nations, for
+state-controlled models, data, and compute. A sovereign agent applies the same
+idea at the scale of a person.
+
 ## Core ideas
 
-**Sovereign** means more than running locally. You own the agent's mind,
-authority, vessel, and continuity: its durable state lives in files you can
-inspect and move, its actions follow boundaries you define, and changing a
-model or provider does not reset the agent that knows your work.
+**Sovereign** means more than running locally. Agent sovereignty has four
+conditions — a sovereign mind, sovereign authority, a sovereign vessel, and
+sovereign continuity. The full definition, and a five-question test for deciding
+whether any agent meets it, is on
+[what makes an agent sovereign](https://suzent.com/sovereign).
 
 **Local agent** means it is built for more than one-off answers. It can keep long-term memory, schedule recurring work, and run the operations you explicitly allow.
 

--- a/docs/02-concepts/automation/automation.md
+++ b/docs/02-concepts/automation/automation.md
@@ -2,8 +2,12 @@
 
 **Sovereign authority.** Proactive action is the sharpest edge of agent
 autonomy: work that happens when you are not watching. Both systems below run
-on schedules and instructions you write, inside the same permission boundaries
-as interactive work. See [what makes an agent sovereign](https://suzent.com/sovereign).
+on schedules and instructions you write. Neither inherits the permission mode of
+the chat you scheduled it from: background turns always run in Auto mode under a
+headless profile, where an action that cannot be classified as safe is denied
+rather than queued for an approval nobody is present to give. See
+[Headless Runs](https://suzent.com/docs/concepts/tools/human-in-the-loop#headless-runs)
+for what that permits, and [what makes an agent sovereign](https://suzent.com/sovereign).
 
 This guide covers the automation systems in Suzent — scheduled cron jobs and periodic heartbeat check-ins.
 

--- a/docs/02-concepts/automation/automation.md
+++ b/docs/02-concepts/automation/automation.md
@@ -1,5 +1,10 @@
 # Suzent Automation Guide
 
+**Sovereign authority.** Proactive action is the sharpest edge of agent
+autonomy: work that happens when you are not watching. Both systems below run
+on schedules and instructions you write, inside the same permission boundaries
+as interactive work. See [what makes an agent sovereign](https://suzent.com/sovereign).
+
 This guide covers the automation systems in Suzent — scheduled cron jobs and periodic heartbeat check-ins.
 
 ## Overview

--- a/docs/02-concepts/filesystem.md
+++ b/docs/02-concepts/filesystem.md
@@ -1,5 +1,10 @@
 # Filesystem & Execution
 
+**Sovereign vessel.** A sovereign agent runs in a domain you control. The
+modes below decide exactly which folders it can reach and where its code
+executes — granted deliberately by you, not inherited from a platform. See
+[what makes an agent sovereign](https://suzent.com/sovereign).
+
 Suzent provides secure file access and code execution through two modes: **Sandbox Mode** (isolated Docker container) and **Host Mode** (direct execution with restrictions).
 
 ## Execution Modes

--- a/docs/02-concepts/github-sync/README.md
+++ b/docs/02-concepts/github-sync/README.md
@@ -1,5 +1,10 @@
 # GitHub Sync
 
+**Sovereign continuity.** Portability is what lets an agent outlive the
+machine it started on. Sync moves the parts that make up the agent while
+credentials stay device-local, so moving to a new machine never means shipping
+your keys. See [what makes an agent sovereign](https://suzent.com/sovereign).
+
 GitHub Sync keeps a portable copy of Suzent configuration, user skills, and
 Markdown memory in a private Git repository. Credentials remain on each device.
 

--- a/docs/02-concepts/memory/README.md
+++ b/docs/02-concepts/memory/README.md
@@ -1,5 +1,12 @@
 # Memory System
 
+**Sovereign continuity.** Memory is where a sovereign AI agent keeps its self.
+Because Suzent's memory is Markdown on your own disk rather than rows in a
+vendor's database, you can read it, edit it, track it in Git, and carry it to
+another machine. That is the first question in the
+[sovereignty test](https://suzent.com/sovereign) — and the reason a model swap does not reset the agent
+that knows your work.
+
 Suzent remembers things across conversations — facts you've shared, your preferences, and
 context from past sessions. Everything it remembers is stored as plain Markdown files you
 can open, edit, or delete yourself.

--- a/docs/02-concepts/nodes/nodes.md
+++ b/docs/02-concepts/nodes/nodes.md
@@ -1,5 +1,10 @@
 # Suzent Nodes Guide
 
+**Sovereign vessel.** Extending an agent across devices is where most
+systems quietly hand control to a cloud relay. Nodes instead reach only the
+machines you pair, over links you approve, with capabilities each device
+declares. See [what makes an agent sovereign](https://suzent.com/sovereign).
+
 This guide covers the node system in Suzent — how to connect companion devices and control them remotely.
 
 ## Overview

--- a/docs/02-concepts/providers/README.md
+++ b/docs/02-concepts/providers/README.md
@@ -5,6 +5,11 @@ title: Providers
 
 # Providers
 
+**Sovereign mind.** The model is an engine, not the self. Being able to
+configure many providers and switch between them per session is what keeps
+identity in your memory, skills, and workspace rather than in any one vendor's
+account. See [what makes an agent sovereign](https://suzent.com/sovereign).
+
 Suzent is model-agnostic. Configure any number of providers in **Settings → Providers** and switch between them per session.
 
 API keys are stored in the local database — never in plain text config files.

--- a/docs/02-concepts/skills/skills.md
+++ b/docs/02-concepts/skills/skills.md
@@ -1,5 +1,10 @@
 # Suzent Skills Guide
 
+**Sovereign mind.** Skills are knowledge you author and own. They are
+Markdown in your own directory, not a capability a platform grants you and can
+revoke — which is why they survive a change of model or provider intact. See
+[what makes an agent sovereign](https://suzent.com/sovereign).
+
 This guide covers the skills system in Suzent and how to use and create skills to extend agent capabilities.
 
 ## Overview

--- a/docs/02-concepts/tools/human-in-the-loop.md
+++ b/docs/02-concepts/tools/human-in-the-loop.md
@@ -1,5 +1,10 @@
 # Tool Permissions and Human Approval
 
+**Sovereign authority.** This is the boundary where an agent's reasoning
+becomes action in the world. A sovereign agent does not cross it on its own
+terms: every gated call below is a point at which Suzent stops and asks, under
+rules you set. See [what makes an agent sovereign](https://suzent.com/sovereign).
+
 Suzent evaluates every deferred tool call through one backend permission engine. The engine decides whether to allow, deny, or ask, and it supplies the exact actions shown by the frontend. The client never constructs permission rules itself.
 
 ## Deferred Tools

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,11 @@
 # Documentation
 
+Suzent is a sovereign AI agent: an open-source, local-first agent whose identity,
+memory, skills, workspace, and runtime stay under your control, independent of
+any model or platform. For the definition of agent sovereignty and the
+five-question ownership test, see
+[what makes an agent sovereign](https://suzent.com/sovereign).
+
 ## Getting Started
 - [What is Suzent?](01-getting-started/intro.md): Core concepts and architecture overview
 - [Quickstart](01-getting-started/quickstart.md): Set up Suzent from scratch in under 5 minutes

--- a/website/blog/2026-08-25-own-your-ai-agent-memory.md
+++ b/website/blog/2026-08-25-own-your-ai-agent-memory.md
@@ -1,0 +1,102 @@
+---
+slug: own-your-ai-agent-memory
+title: "How to Own Your AI Agent's Memory"
+description: "Agent memory you cannot read, edit, or move is not yours. What ownable memory looks like in practice, and how Suzent keeps it as Markdown on your own disk."
+authors: [suzent]
+tags: [sovereignty, memory, continuity]
+date: 2026-08-25T11:00:00
+---
+
+Memory is the part of an AI agent that is genuinely yours, in the sense that it
+could not have come from anywhere else. The model is a commodity — impressive,
+interchangeable, and someone else's. What your agent knows about your projects,
+your preferences, and the decisions you already made is not.
+
+Which makes it worth asking where that lives, and on whose terms.
+
+{/* truncate */}
+
+## Three questions that decide ownership
+
+Whatever agent you use, memory is ownable to the degree that you can answer yes
+to these:
+
+**Can you read all of it?** Not a summary, not a settings screen showing the
+last twenty items. The whole thing, in a format you can open.
+
+**Can you change it?** Agents form wrong impressions. If the only correction
+mechanism is telling the agent it was wrong and hoping the correction sticks,
+you do not have edit access — you have a suggestion box.
+
+**Can you take it with you?** To another machine, another tool, another decade.
+If the answer requires the vendor to still exist and still offer an export
+endpoint, that is a conditional yes, which is a no.
+
+Most hosted agent memory fails at least two of these, usually the second and
+third. Not maliciously — opaque memory is just the path of least resistance when
+you are building a product and memory is an implementation detail.
+
+## What ownable memory looks like
+
+The design that satisfies all three is unglamorous: **plain text files on a
+filesystem you control.**
+
+Suzent's memory is Markdown. After an exchange, it picks out what is worth
+keeping — a preference, a project detail, a fact — and appends it to that day's
+log. Overnight, a consolidation pass folds those logs into topic pages, merging
+duplicates and resolving contradictions.
+
+The consequences of that being files rather than rows are practical:
+
+- **You can read it.** Open the directory. It is a folder of Markdown.
+- **You can edit it.** Fix a wrong fact in your editor. Delete the page about
+  the project you abandoned. The agent's next read sees your version.
+- **You can version it.** Put the memory directory under Git and you have full
+  history, diffs of what your agent learned this week, and the ability to revert
+  a bad consolidation pass.
+- **You can move it.** Copy the folder. That is the migration.
+- **You can grep it.** Every tool you already own works on it.
+
+There is a semantic index for retrieval, because search over a year of Markdown
+needs one. The important architectural commitment is the direction of authority:
+**the index serves the files, and can be rebuilt from them.** Delete the index
+and nothing is lost. Delete the files and the index is meaningless. That
+ordering is what keeps the memory yours rather than the database's.
+
+The [memory documentation](https://suzent.com/docs/concepts/memory) covers the
+capture and consolidation mechanics in detail.
+
+## The parts that should not be portable
+
+One caveat worth stating, because "own your memory" invites an obvious mistake:
+not everything the agent holds should travel with it.
+
+API keys, provider credentials, device identity, and the local secret store are
+deliberately excluded from portable state. When Suzent
+[syncs to a private Git repository](https://suzent.com/docs/concepts/github-sync),
+the payload builder rejects those paths before push. Memory and skills move;
+secrets stay on the device.
+
+This matters because the failure mode of naive portability is a memory folder
+that quietly accumulates credentials and then gets pushed somewhere. Ownership
+means being able to move the agent *without* moving your keys.
+
+## Why this is the first sovereignty question
+
+Of the five questions in the [sovereignty test](https://suzent.com/sovereign),
+memory is first, because it is the one that decides whether the others can even
+be asked.
+
+If memory is portable and readable, swapping models is a configuration change —
+identity lives in the files, not the weights. If memory is portable and
+readable, a provider shutting down costs you an API key. If it is not, then
+every other form of independence is theoretical: you can leave any time you
+like, as long as you are willing to start over.
+
+Start with the memory. The rest follows from it.
+
+---
+
+[Memory docs](https://suzent.com/docs/concepts/memory) ·
+[Quickstart](https://suzent.com/docs/getting-started/quickstart) ·
+[Source](https://github.com/cyzus/suzent)

--- a/website/blog/2026-08-25-sovereign-agent-vs-cloud-assistant.md
+++ b/website/blog/2026-08-25-sovereign-agent-vs-cloud-assistant.md
@@ -1,0 +1,105 @@
+---
+slug: sovereign-ai-agent-vs-cloud-assistant
+title: "Sovereign AI Agent vs Cloud AI Assistant"
+description: "An honest comparison of a sovereign AI agent and a hosted cloud AI assistant: what each one owns, what each one costs you, and when the rented option is the right call."
+authors: [suzent]
+tags: [sovereignty, comparison, sovereign-ai]
+date: 2026-08-25T10:00:00
+---
+
+A cloud AI assistant is a product you log into. A **sovereign AI agent** is a
+system you own: its identity, memory, skills, workspace, and runtime are
+governed by you rather than by a model provider or platform.
+
+The difference is not local versus remote, and it is not open source versus
+closed. It is about which side of the boundary the durable parts live on. Here
+is the comparison without the marketing.
+
+{/* truncate */}
+
+## Where each one keeps the things that matter
+
+| | Cloud AI assistant | Sovereign AI agent |
+|---|---|---|
+| **Memory** | Vendor database; readable through a UI, exportable in part | Files on your disk; readable, editable, versionable in Git |
+| **Identity** | Coupled to the vendor's model and product decisions | Held in memory, skills, and workspace, independent of the model |
+| **Model choice** | Whatever the vendor ships, when they ship it | Any provider, or a local model; swappable per session |
+| **Permissions** | Vendor-defined; you accept or decline the whole product | Rules you write, per tool and per scope, with approval gates |
+| **Execution** | Vendor's sandbox, vendor's integrations | Your machine, your folders, your approved devices |
+| **Continuity** | Ends when the account, product, or terms end | Survives providers, models, and machines |
+| **Setup cost** | Sign up | Install, configure keys, choose your boundaries |
+| **Maintenance** | None, by design | Yours |
+| **Default quality** | Tuned end to end by a large team | Depends on the model and configuration you choose |
+
+## The honest case for the rented option
+
+The last three rows are not throwaways, and a comparison that pretends otherwise
+is not worth reading.
+
+Hosted assistants are genuinely easier. Someone else handles model upgrades,
+infrastructure, safety tuning, and the thousand small integration details that
+make a product feel finished. For a great many uses — drafting, summarizing,
+answering questions, the occasional bit of research — that convenience is worth
+far more than ownership of the transcript, and paying for it is a perfectly
+sensible decision.
+
+Sovereignty has real costs. You choose the model, which means you can choose
+badly. You set the permission boundaries, which means you can set them wrong.
+Nothing upgrades itself unless you decide it should. If the agent is a
+convenience rather than infrastructure, that overhead may simply not be worth
+carrying.
+
+## When ownership starts to matter
+
+The calculus changes as the agent accumulates two things: **context about you**
+and **authority to act**.
+
+Context compounds. An agent that has watched you work for a year knows your
+projects, your conventions, the things you have already decided and do not want
+re-litigated. That is expensive to rebuild and impossible to rebuild exactly.
+When it lives somewhere you cannot read or move, you are one policy change away
+from starting over.
+
+Authority is sharper. An assistant that suggests text is a different proposition
+from an agent that runs commands, edits files, sends messages, and acts on a
+schedule while you sleep. Once an agent can do things, the question of who
+defines the limits stops being philosophical. Suzent's answer is
+[explicit permission rules with human approval gates](https://suzent.com/docs/concepts/tools/human-in-the-loop);
+a hosted product's answer is its terms of service.
+
+If your agent has both — deep context and real authority — then "the vendor
+could change this" is a live operational risk rather than an abstract one.
+
+## The test that separates them
+
+The useful question is not which category a product claims. It is what happens
+under pressure:
+
+1. Can you inspect, edit, version, and delete its memory?
+2. Can you replace the model without resetting its identity?
+3. Can you define, approve, and audit what it is allowed to do?
+4. Can you move its state without exporting your credentials?
+5. Can the agent survive the disappearance of its provider?
+
+A cloud assistant answers "partly" to the first and "no" to the rest. That is
+not a defect; it is what being a hosted product means. But it tells you exactly
+what you are choosing.
+
+The full version of the test, and what each answer implies, is on
+[what makes an agent sovereign](https://suzent.com/sovereign).
+
+## Not actually either/or
+
+Worth saying: these are not mutually exclusive. A sovereign agent that calls
+GPT, Claude, or Gemini through an API gets frontier model quality while keeping
+memory, skills, and permissions on your side of the boundary. You are renting
+the engine, deliberately, while owning the vehicle.
+
+That combination — [any provider you like](https://suzent.com/docs/concepts/providers),
+[memory in your own files](https://suzent.com/docs/concepts/memory) — is the
+configuration most people actually want, and it is what Suzent is built to be.
+
+---
+
+[Quickstart](https://suzent.com/docs/getting-started/quickstart) ·
+[Source](https://github.com/cyzus/suzent) (Apache-2.0)

--- a/website/blog/2026-08-25-sovereign-ai-for-individuals.md
+++ b/website/blog/2026-08-25-sovereign-ai-for-individuals.md
@@ -1,0 +1,106 @@
+---
+slug: sovereign-ai-for-individuals
+title: "Sovereign AI for Individuals, Not Nations"
+description: "The phrase sovereign AI usually means state-controlled models and compute. The same idea applies at the scale of one person, and that is what a sovereign AI agent is."
+authors: [suzent]
+tags: [sovereignty, sovereign-ai, definitions]
+date: 2026-08-25T09:00:00
+---
+
+Search for "sovereign AI" and you will find nations. Countries building
+domestic model training capacity, governments procuring GPU clusters they
+control outright, regulators drawing borders around where citizen data may be
+processed. The word means something specific there: a state that does not need
+another state's permission to compute.
+
+That is a real and important use of the term. It is also not the only scale at
+which the idea makes sense.
+
+{/* truncate */}
+
+## The same argument, one person wide
+
+Strip the national framing away and the argument underneath is simple. A
+capability you depend on, which someone else can revoke, price, or redefine
+without asking you, is not really yours. Nations noticed this about model
+infrastructure. The same thing is true of the AI agent that reads your notes,
+remembers your projects, and increasingly acts on your behalf.
+
+A **sovereign AI agent** is an AI agent whose identity, memory, skills,
+workspace, and runtime are owned and governed by its user rather than by a model
+provider or platform. Its durable state lives in files you can read, edit,
+version, and move. Its actions run inside permission boundaries you define. And
+replacing the underlying model does not reset the agent that knows your work.
+
+Nations want sovereign AI so a foreign vendor cannot switch off their compute.
+You want a sovereign agent so a vendor cannot switch off your memory. It is the
+same objection at a different scale.
+
+## What you actually rent today
+
+Most people's "AI assistant" is an account. Consider what that means
+concretely:
+
+- The memory of your past conversations lives in a database you cannot read,
+  export in full, or correct.
+- The assistant's personality and instructions are configured through a form
+  whose behaviour changes when the vendor updates the model beneath it.
+- Its ability to act on anything — files, email, calendars — exists only through
+  integrations the vendor chose to build and can retire.
+- If you stop paying, or the vendor changes terms, or the product is
+  discontinued, the accumulated context is gone. Not degraded. Gone.
+
+None of that is scandalous. It is the normal shape of a hosted product, and
+hosted products are often the right trade. But it is worth naming plainly,
+because the thing being accumulated in that account — a model of how you work —
+is unusually expensive to rebuild.
+
+## Sovereignty is not the same as self-hosting
+
+The most common misreading is that sovereignty means running something on your
+own hardware. Local execution is part of it, but it is neither sufficient nor
+the whole point.
+
+You can run a model locally and still have a non-sovereign agent: if its memory
+is an opaque binary blob, if its identity is welded to the specific model
+weights you happen to be running, if there is no way to inspect or constrain
+what it does with your filesystem, then "local" bought you privacy but not
+ownership.
+
+Conversely, an agent can call a hosted frontier model over an API and remain
+sovereign, provided the parts that constitute the agent — memory, skills,
+configuration, permissions, workspace — stay on your side of the line. The model
+is an engine. Engines are replaceable. That is the point.
+
+Agent sovereignty has four conditions:
+
+1. **Sovereign mind** — the model is an engine, not the self.
+2. **Sovereign authority** — autonomy operates under rules you write.
+3. **Sovereign vessel** — the runtime is a domain you control.
+4. **Sovereign continuity** — the agent outlives any platform it ran on.
+
+Each is spelled out, with a five-question test for checking whether any given
+agent actually meets them, on
+[what makes an agent sovereign](https://suzent.com/sovereign).
+
+## Why the distinction matters now
+
+Agents are crossing from answering to acting. An assistant that drafts a
+paragraph and an agent that files the expense report, pushes the commit, or
+sends the message are different kinds of thing to hand your life to. The second
+kind accumulates a great deal of context about you, and exercises a great deal
+of authority on your behalf.
+
+The moment to decide who holds that context and that authority is before it is
+substantial enough to be painful to lose.
+
+Nations arrived at this conclusion about compute. The version for individuals is
+smaller, cheaper, and considerably easier to act on: keep the agent's memory in
+files you can open, keep its permissions in rules you wrote, and make sure you
+could move both tomorrow.
+
+---
+
+Suzent is an open-source, local-first implementation of that idea. The
+[quickstart](https://suzent.com/docs/getting-started/quickstart) takes about
+five minutes, and the [source](https://github.com/cyzus/suzent) is Apache-2.0.

--- a/website/blog/2026-08-25-swap-models-keep-the-agent.md
+++ b/website/blog/2026-08-25-swap-models-keep-the-agent.md
@@ -1,0 +1,103 @@
+---
+slug: swap-models-keep-the-agent
+title: "Swap the Model, Keep the Agent"
+description: "Why a sovereign AI agent's identity lives in its memory, skills, and workspace rather than in the model — and what has to be true architecturally for a model swap to be a config change."
+authors: [suzent]
+tags: [sovereignty, models, architecture]
+date: 2026-08-25T13:00:00
+---
+
+A useful way to tell whether you own an AI agent: change the model underneath it
+and see what happens.
+
+If the agent forgets who you are, loses its instructions, or has to be
+reconstructed from scratch, then its identity was never in the parts you
+controlled. It was in the vendor's product, and you were borrowing it.
+
+If the agent keeps working — same memory, same skills, same boundaries, same
+accumulated understanding of your projects — then the model was doing what a
+model should do: thinking, not *being*.
+
+{/* truncate */}
+
+## The model is an engine, not the self
+
+This is the first condition of agent sovereignty, and it is the one people find
+least intuitive, because the model is the impressive part. It writes the words.
+It does the reasoning. Surely that is the agent?
+
+But consider what actually distinguishes *your* agent from an identical
+installation belonging to someone else. Same code, same model, same version. The
+difference is entirely in:
+
+- what it remembers about you and your work,
+- the skills you gave it,
+- the workspace and files it can reach,
+- the permissions and rules you set,
+- the conventions it has learned not to violate.
+
+None of that is in the model. All of it is in state that can live on your side
+of the line. The model supplies capability; the state supplies identity. Swap
+the first and the second is untouched — provided the architecture kept them
+separate in the first place.
+
+That is why Suzent supports [many providers](https://suzent.com/docs/concepts/providers)
+— OpenAI, Anthropic, Gemini, DeepSeek, Ollama and local models, and others — and
+lets you switch per session rather than per installation.
+
+## What has to be true for the swap to be cheap
+
+"Model-agnostic" is a claim a lot of tools make. Three things determine whether
+it survives contact with a real migration.
+
+**Memory has to be model-independent.** If what the agent knows is stored as
+embeddings from one provider's model, switching means re-embedding everything,
+and any drift in retrieval quality is invisible until it bites. Suzent's source
+of truth is [Markdown](https://suzent.com/docs/concepts/memory); the semantic
+index is derived from those files and can be rebuilt. Changing the embedding
+model is a reindex, not a data loss.
+
+**Skills have to be prose, not prompts tuned to one model.** Suzent
+[skills](https://suzent.com/docs/concepts/skills) are Markdown knowledge modules
+describing how to work in a domain. Documentation transfers between models.
+Brittle prompt scaffolding tuned to one model's quirks does not.
+
+**Capability differences have to be handled, not ignored.** This is the honest
+caveat. Models genuinely differ — context windows, tool-calling reliability,
+vision support, instruction-following under long autonomous runs. A swap is a
+config change, but it is not a *no-op*. A smaller local model will not carry a
+long agentic task the way a frontier model does. Sovereignty gives you the
+freedom to choose; it does not make the choices equivalent, and any project
+telling you otherwise is selling something.
+
+## What this buys you day to day
+
+Model independence sounds like insurance against a rare disaster. In practice it
+pays out constantly, in ordinary ways:
+
+- Run a cheap fast model for routine work and a frontier model for hard
+  problems, in the same agent, with the same memory.
+- Move sensitive work to a local model without moving to a different tool or
+  losing context.
+- Adopt a new release the week it ships instead of waiting for a vendor to
+  integrate it.
+- Stop caring, structurally, about which lab is currently ahead.
+
+That last one is the real dividend. When identity is independent of the model,
+the frontier race becomes something you benefit from rather than something you
+are exposed to.
+
+## The check
+
+Question two of the [sovereignty test](https://suzent.com/sovereign): *can I
+replace the model without resetting its identity?*
+
+It is worth actually trying, rather than trusting the marketing copy. Point your
+agent at a different provider and ask it something only your agent would know.
+The answer tells you where its identity was living all along.
+
+---
+
+[Providers](https://suzent.com/docs/concepts/providers) ·
+[What makes an agent sovereign](https://suzent.com/sovereign) ·
+[Source](https://github.com/cyzus/suzent)

--- a/website/blog/2026-08-25-when-your-ai-provider-disappears.md
+++ b/website/blog/2026-08-25-when-your-ai-provider-disappears.md
@@ -1,0 +1,103 @@
+---
+slug: when-your-ai-provider-disappears
+title: "What Happens to Your AI Agent When the Provider Shuts Down"
+description: "Model deprecations, price changes, and product sunsets are routine. What you actually lose depends entirely on which side of the boundary your agent's memory and configuration live."
+authors: [suzent]
+tags: [sovereignty, continuity, sovereign-ai]
+date: 2026-08-25T12:00:00
+---
+
+Shutdowns make the argument vividly, but they are the rare case. The common case
+is quieter and happens constantly: a model you depended on is deprecated, a
+price tier changes, a product is folded into another product, a rate limit
+arrives, terms are revised, a feature you built a workflow around is retired.
+
+The interesting question is not whether that happens. It is what it costs you
+when it does — and that is decided long before, by where your agent's durable
+parts live.
+
+{/* truncate */}
+
+## Two versions of the same bad Tuesday
+
+Suppose the provider behind your agent announces a sunset in ninety days.
+
+**If your agent is an account**, the ninety days are a migration project. The
+accumulated context — everything it learned about your work — is in a database
+you can query only through whatever export the vendor offers, in whatever shape
+they offer it. Custom instructions have to be rewritten for a different product
+with different conventions. Integrations have to be rebuilt against different
+APIs. And the new agent starts at zero: it does not know your projects, your
+preferences, or the eleven things you already told the old one not to do.
+
+The cost is not the subscription. It is the re-accumulation.
+
+**If your agent is a system you own**, the ninety days are a config edit. The
+memory is Markdown in a directory you control, unchanged. The skills are your
+own Markdown modules, unchanged. The permission rules are yours, unchanged. You
+point at a different provider, and the agent that knows your work continues
+knowing it.
+
+What you lost was an API key.
+
+## The boundary that decides which Tuesday you get
+
+The distinction is not paranoia about vendors and it is not a bet on which
+company survives. It is a structural question you can answer in advance:
+
+> Which parts of this agent could the provider take away, and which parts are
+> already mine?
+
+For a sovereign AI agent, the answer is drawn deliberately:
+
+- **Memory** — [Markdown files on your disk](https://suzent.com/docs/concepts/memory),
+  readable and versionable.
+- **Skills** — knowledge modules you author, in your own directory.
+- **Configuration and permissions** — rules you wrote, stored locally.
+- **Workspace** — [folders and sandboxes you granted](https://suzent.com/docs/concepts/filesystem).
+- **The model** — rented, deliberately, and replaceable.
+
+Everything above the last line is yours regardless of what happens to the
+company below it. That is what the fifth question of the
+[sovereignty test](https://suzent.com/sovereign) is checking: *can the agent
+survive the disappearance of its provider?*
+
+## Continuity is a design decision, not a promise
+
+It is worth being precise about what makes this work, because "we will never
+shut down" is not a plan and no vendor can honestly offer one.
+
+Continuity comes from two properties, both of which are architectural:
+
+**Identity is not in the model.** If what makes the agent *yours* is its
+memory, skills, and workspace rather than a specific set of weights or a
+specific vendor's fine-tune, then models become interchangeable engines. Suzent
+supports [many providers](https://suzent.com/docs/concepts/providers) and lets
+you switch per session precisely so that no single one becomes load-bearing.
+
+**State is portable without secrets.** Moving an agent should not mean moving
+your credentials. Suzent's
+[sync design](https://suzent.com/docs/concepts/github-sync) carries
+configuration, skills, and Markdown memory to a private repository while keeping
+API keys, device identity, and the local secret store off the wire entirely.
+
+Neither of these is exotic. Both have to be decided early, because retrofitting
+portability onto an agent whose memory is a proprietary blob is not a small
+change — it is a rewrite.
+
+## The unglamorous version of the advice
+
+You do not need to predict which provider will falter. You need your agent's
+answer to one question to be yes:
+
+If this provider vanished tonight, would I still have the agent tomorrow?
+
+Keep the memory in files you can open. Keep the permissions in rules you wrote.
+Keep the credentials separable from both. Then a sunset notice is an
+inconvenience rather than an eviction.
+
+---
+
+[Read the sovereignty protocol](https://suzent.com/sovereign) ·
+[Quickstart](https://suzent.com/docs/getting-started/quickstart) ·
+[Source](https://github.com/cyzus/suzent)


### PR DESCRIPTION
Second half of the "sovereign AI agent" work, and the part I held back from
[#125](https://github.com/cyzus/suzent/pull/125) because it is voice-sensitive.
#125 fixed titles, schema, and package metadata; this makes the corpus itself
say the words.

Independent of #125 — branched from `main`, no overlapping files, merges in
either order.

## Docs copy pass

Every concept page is a retrieval chunk. A chunk about memory architecture that
never mentions sovereignty will not surface for a sovereignty question,
regardless of what the manifesto page says. So each major concept doc now opens
with one short paragraph tying it to the pillar it implements:

| Doc | Pillar |
|---|---|
| `memory/`, `github-sync/` | Sovereign continuity |
| `tools/human-in-the-loop`, `automation/` | Sovereign authority |
| `filesystem`, `nodes/` | Sovereign vessel |
| `providers/`, `skills/` | Sovereign mind |

Plus `docs/README.md` (had zero mentions — now opens with the entity sentence)
and `intro.md`, which gains a standalone **"What is a sovereign AI agent?"**
section with the definition and the national-vs-personal disambiguation.

Two notes on execution:

- The paragraphs are written in each doc's own plain register, not the homepage
  voice. They read as orientation, not as slogans bolted to the top.
- Docusaurus derives page meta descriptions from the first paragraph, so these
  now become the search-result snippets for those pages. Verified in the build
  and they read well, but worth a look since it is a visible side effect.

## Blog cluster

Five posts, covering the definitional and comparison queries that previously had
no landing page:

1. **[Sovereign AI for Individuals, Not Nations](https://suzent.com/blog/sovereign-ai-for-individuals)**
   — takes the national/personal ambiguity head on. Realistically the only way
   to get anything out of the contested head term is to meet it and redirect.
2. **[Sovereign AI Agent vs Cloud AI Assistant](https://suzent.com/blog/sovereign-ai-agent-vs-cloud-assistant)**
   — comparison table, plus a section on when the rented option is genuinely the
   better call. A comparison that only lists our advantages does not get cited.
3. **[How to Own Your AI Agent's Memory](https://suzent.com/blog/own-your-ai-agent-memory)**
   — three ownership questions, and why "the index serves the files" is the
   load-bearing architectural decision.
4. **[What Happens to Your AI Agent When the Provider Shuts Down](https://suzent.com/blog/when-your-ai-provider-disappears)**
   — framed around deprecations and price changes as the common case, since
   actual shutdowns are rare and leading with them reads as FUD.
5. **[Swap the Model, Keep the Agent](https://suzent.com/blog/swap-models-keep-the-agent)**
   — includes the caveat that a model swap is a config change but not a no-op;
   a small local model will not carry a long agentic task like a frontier one.

Each opens with a definition-shaped paragraph — that is the unit an answer
engine lifts — and cross-links into the docs and `/sovereign`.

## Two things worth your call before merge

**Post dates.** All five are dated today with staggered times, so they publish
immediately. Five posts landing at once is fine for ranking but reads as a dump
in the feed. If you would rather drip them over a few weeks, edit the `date:`
frontmatter — future-dated posts stay unpublished until their date.

**Voice.** These are more plainspoken than
[the Mesh post](https://suzent.com/blog/suzent-mesh-nodes), deliberately: the
"silicon cage" register is good brand writing but bad quotable-definition
writing, and these posts exist to be quoted. They sit closer to the `/sovereign`
page's tone. Happy to push them toward the Mesh voice if you would rather the
blog read consistently.

## Verification

`npm run build` — both locales succeed. Confirmed in the build output: all five
blog routes generated, truncation markers working, per-post `description` meta
tags emitted, all posts present in `sitemap.xml` (en and zh-Hans), and the doc
framing paragraphs rendering on the concept pages.

## Follow-up

`llms.txt` and `llms-full.txt` (added in #125) do not yet include the blog. Once
both land, worth adding a "Writing" section to `llms.txt` and the posts to the
`generate-llms-full.js` section list. Left out here to avoid a conflict between
the two branches.
