### PR TITLE
fix(ci): stop a version-file clash breaking the release refresh

### DIFF
--- a/.github/workflows/refresh-release.yml
+++ b/.github/workflows/refresh-release.yml
@@ -114,7 +114,38 @@ jobs:
               echo "updated=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            git merge --no-edit origin/main
+            # The only edit this branch makes to a version file is the version
+            # number itself, and the reconcile below re-derives that from the
+            # tags regardless. So a version file that conflicts is a textual
+            # clash - main edited a line next to `version = ` - rather than two
+            # branches disagreeing about anything. Take main's copy and write
+            # the pending version back into it. A conflict anywhere else is a
+            # real divergence, and a human has to settle it.
+            pending="$(python scripts/bump_version.py --print-version)"
+            if ! git merge --no-edit origin/main; then
+              conflicted=()
+              while IFS= read -r path; do
+                conflicted+=("$path")
+              done < <(git diff --name-only --diff-filter=U)
+              if [[ "${#conflicted[@]}" == "0" ]]; then
+                echo "::error::Merging main into $branch failed without conflicts"
+                exit 1
+              fi
+              version_files="$(python scripts/bump_version.py --list-version-files)"
+              unresolvable=()
+              for path in "${conflicted[@]}"; do
+                grep -qxF -- "$path" <<< "$version_files" || unresolvable+=("$path")
+              done
+              if [[ "${#unresolvable[@]}" != "0" ]]; then
+                echo "::error::$branch needs a hand-resolved merge with main in: ${unresolvable[*]}"
+                exit 1
+              fi
+              echo "::notice::Resolved a version-file clash with main in ${conflicted[*]}"
+              git checkout origin/main -- "${conflicted[@]}"
+              python scripts/bump_version.py "$pending" --no-changelog
+              git add -A
+              git commit --no-edit
+            fi
           else
             git switch -c "$branch" origin/main
           fi

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -565,6 +565,11 @@ def main() -> int:
         help="Print only the canonical version",
     )
     parser.add_argument(
+        "--list-version-files",
+        action="store_true",
+        help="Print the files this script owns the version line of, one per line",
+    )
+    parser.add_argument(
         "--audit-commits",
         metavar="RANGE",
         help="Warn about commits in RANGE whose prefix the bump cannot read",
@@ -581,6 +586,10 @@ def main() -> int:
 
     if args.print_version:
         print(current_version)
+        return 0
+    if args.list_version_files:
+        for target in VERSION_FILES:
+            print(target.path)
         return 0
     if args.audit_commits:
         log = _run_git(root, "log", args.audit_commits, "--format=%s", "--no-merges")

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -490,3 +490,22 @@ def test_an_unclosed_highlights_block_is_not_preserved() -> None:
     assert refreshed is not None
     assert "Someone forgot" not in refreshed
     assert "- Current draft" in refreshed
+
+
+def test_list_version_files_names_every_file_that_exists() -> None:
+    """`refresh-release` resolves a conflict in these files by taking main's
+    copy and rewriting the version. A path that has gone stale would drop out
+    of that set and turn a routine clash back into a failed workflow."""
+    root = Path(__file__).resolve().parent.parent
+
+    result = subprocess.run(
+        [sys.executable, str(root / "scripts/bump_version.py"), "--list-version-files"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    listed = result.stdout.splitlines()
+    assert listed == [target.path for target in VERSION_FILES]
+    assert [path for path in listed if not (root / path).exists()] == []


### PR DESCRIPTION
`refresh-release` re-merges main into the open release PR on every push. That merge conflicted the moment #125 rewrote `description` in pyproject.toml: the release branch had bumped `version` on the line directly above it, and git cannot auto-merge touching lines. The step had no conflict handling, so it died there and the branch stopped tracking main - three pushes in a row failed the same way.

The clash is textual, not a disagreement. The only edit the release branch makes to a version file is the number, and `--reconcile-version` re-derives that from the tags immediately afterwards regardless. So take main's copy of any version file that conflicts and write the pending version back into it. A conflict anywhere else is real divergence and still fails, now naming the files a human has to settle.

`--list-version-files` keeps that set single-sourced from VERSION_FILES rather than restating it in the workflow.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
