### PR TITLE
feat(cli): add `suzent --version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ suzent start
 ### **THE `suzent` CLI**
 
 ```bash
-suzent --version       # Print the installed backend (and UI) version
+suzent --version       # Print the backend version, commit, and UI version
 suzent start           # Start the backend and the desktop app
 suzent serve           # Start the backend only (headless / standalone)
 suzent ui              # Start the desktop app against a running backend

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ suzent start
 ### **THE `suzent` CLI**
 
 ```bash
+suzent --version       # Print the installed backend (and UI) version
 suzent start           # Start the backend and the desktop app
 suzent serve           # Start the backend only (headless / standalone)
 suzent ui              # Start the desktop app against a running backend

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,6 +73,7 @@ suzent start
 ### **`suzent` 命令行**
 
 ```bash
+suzent --version       # 打印当前后端（及桌面应用）版本号
 suzent start           # 启动后端与桌面应用
 suzent serve           # 仅启动后端（无界面 / 独立模式）
 suzent ui              # 连接已运行的后端，仅启动桌面应用

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,7 +73,7 @@ suzent start
 ### **`suzent` 命令行**
 
 ```bash
-suzent --version       # 打印当前后端（及桌面应用）版本号
+suzent --version       # 打印后端版本号、提交哈希与桌面应用版本
 suzent start           # 启动后端与桌面应用
 suzent serve           # 仅启动后端（无界面 / 独立模式）
 suzent ui              # 连接已运行的后端，仅启动桌面应用

--- a/frontend/src/components/settings/AboutTab.test.tsx
+++ b/frontend/src/components/settings/AboutTab.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { I18nProvider } from '../../i18n';
+import { VersionCard } from './AboutTab';
+
+function render(props: React.ComponentProps<typeof VersionCard>): string {
+  return renderToStaticMarkup(
+    <I18nProvider>
+      <VersionCard {...props} />
+    </I18nProvider>
+  );
+}
+
+describe('VersionCard', () => {
+  it('shows the commit under the version, matching `suzent --version`', () => {
+    const html = render({
+      label: 'Python backend',
+      value: 'v0.10.0',
+      commit: '1234abcd',
+      tone: 'blue',
+    });
+
+    expect(html).toContain('v0.10.0');
+    expect(html).toContain('1234abcd');
+  });
+
+  it('marks a development build', () => {
+    const html = render({
+      label: 'Python backend',
+      value: 'v0.10.0',
+      commit: '1234abcd',
+      badge: 'Development build',
+      tone: 'blue',
+    });
+
+    expect(html).toContain('Development build');
+  });
+
+  it('renders the version alone when there is no commit or badge', () => {
+    const html = render({ label: 'Desktop frontend', value: 'v0.10.0', tone: 'yellow' });
+
+    expect(html).toContain('v0.10.0');
+    expect(html).not.toContain('Development build');
+  });
+
+  it('does not render an empty commit line', () => {
+    const html = render({
+      label: 'Python backend',
+      value: 'Unavailable',
+      commit: null,
+      badge: null,
+      tone: 'red',
+    });
+
+    expect(html).toContain('Unavailable');
+    expect(html).not.toContain('text-neutral-500');
+  });
+});

--- a/frontend/src/components/settings/AboutTab.tsx
+++ b/frontend/src/components/settings/AboutTab.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { useI18n } from '../../i18n';
-import { fetchSystemVersion } from '../../lib/api';
+import { fetchSystemVersion, shortCommit } from '../../lib/api';
 import {
   checkDesktopUpdate,
   startDesktopUpdateAndRestart,
@@ -11,16 +11,21 @@ import { SuzentLogo } from '../SuzentLogo';
 import { SettingsCard, SettingsPage } from './SettingsCard';
 import { SettingsHeader } from './SettingsHeader';
 
-type BackendVersionState =
-  | { status: 'loading'; version: null }
-  | { status: 'ready'; version: string }
-  | { status: 'unavailable'; version: null };
+type BackendVersionState = {
+  status: 'loading' | 'ready' | 'unavailable';
+  version: string | null;
+  /** Short commit, or null when the build carries no git identity. */
+  commit: string | null;
+  developmentMode: boolean;
+};
 
 export function AboutTab(): React.ReactElement {
   const { t } = useI18n();
   const [backend, setBackend] = useState<BackendVersionState>({
     status: 'loading',
     version: null,
+    commit: null,
+    developmentMode: false,
   });
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null);
   const [checkingUpdate, setCheckingUpdate] = useState(false);
@@ -52,11 +57,24 @@ export function AboutTab(): React.ReactElement {
     let active = true;
 
     fetchSystemVersion()
-      .then(({ backendVersion }) => {
-        if (active) setBackend({ status: 'ready', version: backendVersion });
+      .then(({ backendVersion, buildCommit, developmentMode }) => {
+        if (!active) return;
+        setBackend({
+          status: 'ready',
+          version: backendVersion,
+          commit: shortCommit(buildCommit),
+          developmentMode,
+        });
       })
       .catch(() => {
-        if (active) setBackend({ status: 'unavailable', version: null });
+        if (active) {
+          setBackend({
+            status: 'unavailable',
+            version: null,
+            commit: null,
+            developmentMode: false,
+          });
+        }
       });
 
     return () => {
@@ -111,11 +129,14 @@ export function AboutTab(): React.ReactElement {
           <VersionCard
             label={t('settings.about.frontendVersion')}
             value={frontendVersion}
+            commit={shortCommit(__FRONTEND_BUILD_COMMIT__)}
             tone="yellow"
           />
           <VersionCard
             label={t('settings.about.backendVersion')}
             value={backendVersion}
+            commit={backend.commit}
+            badge={backend.developmentMode ? t('settings.about.developmentBuild') : null}
             tone={backend.status === 'unavailable' ? 'red' : 'blue'}
           />
         </div>
@@ -174,10 +195,18 @@ export function AboutTab(): React.ReactElement {
 interface VersionCardProps {
   label: string;
   value: string;
+  commit?: string | null;
+  badge?: string | null;
   tone: 'yellow' | 'blue' | 'red';
 }
 
-function VersionCard({ label, value, tone }: VersionCardProps): React.ReactElement {
+export function VersionCard({
+  label,
+  value,
+  commit,
+  badge,
+  tone,
+}: VersionCardProps): React.ReactElement {
   const toneClass = {
     yellow: 'bg-brutal-yellow text-brutal-black',
     blue: 'bg-brutal-blue text-white',
@@ -191,7 +220,19 @@ function VersionCard({ label, value, tone }: VersionCardProps): React.ReactEleme
       >
         {label}
       </div>
-      <div className="px-4 py-5 font-mono text-2xl font-bold">{value}</div>
+      <div className="px-4 py-5">
+        <div className="font-mono text-2xl font-bold">{value}</div>
+        {commit && (
+          <div className="mt-1 font-mono text-xs text-neutral-500 dark:text-neutral-400">
+            {commit}
+          </div>
+        )}
+        {badge && (
+          <span className="mt-3 inline-block border-2 border-brutal-black bg-brutal-yellow px-2 py-0.5 text-[10px] font-black uppercase text-brutal-black">
+            {badge}
+          </span>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -572,6 +572,7 @@ export const en = {
       frontendVersion: 'Desktop frontend',
       backendVersion: 'Python backend',
       unavailable: 'Unavailable',
+      developmentBuild: 'Development build',
     },
     usage: {
       title: 'Usage',

--- a/frontend/src/i18n/messages/zh-CN.ts
+++ b/frontend/src/i18n/messages/zh-CN.ts
@@ -631,6 +631,7 @@ export const zhCN = {
       frontendVersion: '桌面前端',
       backendVersion: 'Python 后端',
       unavailable: '不可用',
+      developmentBuild: '开发版本',
     },
     usage: {
       title: '用量',

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -81,6 +81,23 @@ export interface SystemVersionResponse {
   developmentMode: boolean;
 }
 
+export const UNKNOWN_COMMIT = 'unknown';
+
+// Eight characters stay unambiguous well past the point where git's default
+// seven starts colliding. Mirrors SHORT_COMMIT_LENGTH in suzent/version.py.
+const SHORT_COMMIT_LENGTH = 8;
+
+/**
+ * Abbreviate a commit for display, or null when there is nothing to show.
+ *
+ * Matches `suzent --version`, which omits the commit rather than printing the
+ * unknown marker when the build carries no git identity.
+ */
+export function shortCommit(commit: string | null | undefined): string | null {
+  if (!commit || commit === UNKNOWN_COMMIT) return null;
+  return commit.slice(0, SHORT_COMMIT_LENGTH);
+}
+
 export class BackendVersionTimeoutError extends Error {
   constructor() {
     super('Backend version verification timed out');

--- a/frontend/src/lib/api.version.test.ts
+++ b/frontend/src/lib/api.version.test.ts
@@ -5,6 +5,7 @@ import {
   fetchServiceRuntimeStatus,
   fetchSystemVersion,
   getBackendCompatibilityIssue,
+  shortCommit,
 } from './api';
 
 const frontend = {
@@ -172,5 +173,25 @@ describe('backend compatibility', () => {
         frontend
       )
     ).toEqual({ kind: 'version', frontend: '1.2.3', backend: '1.2.2' });
+  });
+});
+
+describe('commit abbreviation', () => {
+  it('abbreviates a commit to the same width the CLI prints', () => {
+    expect(shortCommit('1234abcd5678ef901234abcd5678ef901234abcd')).toBe('1234abcd');
+  });
+
+  it('omits a commit the build could not identify', () => {
+    expect(shortCommit('unknown')).toBeNull();
+  });
+
+  it('omits a missing commit rather than rendering a placeholder', () => {
+    expect(shortCommit('')).toBeNull();
+    expect(shortCommit(null)).toBeNull();
+    expect(shortCommit(undefined)).toBeNull();
+  });
+
+  it('leaves an already-short commit alone', () => {
+    expect(shortCommit('abc123')).toBe('abc123');
   });
 });

--- a/src/suzent/cli/__init__.py
+++ b/src/suzent/cli/__init__.py
@@ -10,6 +10,9 @@ This package splits CLI commands into focused modules:
 
 import typer
 
+# Must precede every other suzent import: quiets logging that would otherwise
+# escape onto stderr while the modules below are imported.
+import suzent.cli._early_logging  # noqa: F401
 from suzent.cli.acp import register_acp_command
 from suzent.cli.agent import agent_app
 from suzent.cli.config import config_app

--- a/src/suzent/cli/__init__.py
+++ b/src/suzent/cli/__init__.py
@@ -14,6 +14,8 @@ from suzent.cli.acp import register_acp_command
 from suzent.cli.agent import agent_app
 from suzent.cli.config import config_app
 from suzent.cli.main import (
+    format_version_line,
+    get_project_root,
     register_commands,
     configure_logging,
     load_environment,
@@ -30,11 +32,27 @@ from suzent.cli.service import service_app
 app = typer.Typer(help="Suzent CLI - Your Digital Co-worker Manager")
 
 
+def _version_callback(value: bool) -> None:
+    """Print the version and exit before any subcommand is resolved."""
+    if not value:
+        return
+    typer.echo(format_version_line(get_project_root()))
+    raise typer.Exit()
+
+
 @app.callback()
 def main(
     ctx: typer.Context,
     verbose: bool = typer.Option(
         False, "--verbose", "-v", help="Enable verbose logging (DEBUG level)"
+    ),
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-V",
+        help="Show the Suzent version and exit",
+        callback=_version_callback,
+        is_eager=True,
     ),
 ):
     """

--- a/src/suzent/cli/_early_logging.py
+++ b/src/suzent/cli/_early_logging.py
@@ -1,0 +1,21 @@
+"""Replaces loguru's default handler before the CLI's remaining imports run.
+
+``suzent.config`` logs which override file it loaded while it is still being
+imported -- long before the Typer callback reaches ``configure_logging``. At
+that point loguru's default handler is the only one installed, so the line
+lands on stderr and corrupts commands that promise a single line of output,
+``--version`` most visibly.
+
+Importing this module first swaps that default for a WARNING-level handler.
+``setup_logging`` removes it and installs the configured handler when the CLI
+configures logging for real, so verbosity and the backend's own logging are
+unaffected. This module must therefore be imported before any other
+``suzent.*`` module in the CLI package.
+"""
+
+import sys
+
+from loguru import logger
+
+logger.remove()
+logger.add(sys.stderr, level="WARNING")

--- a/src/suzent/cli/main.py
+++ b/src/suzent/cli/main.py
@@ -352,6 +352,18 @@ def _normalize_version_tag(value: str) -> str:
     return value.strip().lstrip("vV")
 
 
+def format_version_line(root: Path) -> str:
+    """Render the one-line version banner shown by `suzent --version`.
+
+    The UI binary ships on its own release cadence and can lag the backend, so
+    report both when a managed UI is installed -- a mismatch is the first thing
+    worth knowing in a bug report.
+    """
+    backend = _normalize_version_tag(_current_version(root)) or "unknown"
+    ui = _normalize_version_tag(_local_ui_version(root))
+    return f"suzent {backend} (ui {ui})" if ui else f"suzent {backend}"
+
+
 def _version_key(value: str) -> tuple[int, ...]:
     """Build a simple comparable key for release tags like v0.6.2."""
     parts = re.findall(r"\d+", _normalize_version_tag(value))

--- a/src/suzent/cli/main.py
+++ b/src/suzent/cli/main.py
@@ -358,10 +358,18 @@ def format_version_line(root: Path) -> str:
     The UI binary ships on its own release cadence and can lag the backend, so
     report both when a managed UI is installed -- a mismatch is the first thing
     worth knowing in a bug report.
+
+    Developer and branch installs record the literal marker "latest" rather than
+    a resolved tag, which identifies nothing; those report the UI as unknown
+    instead of quoting the marker back as if it were a version.
     """
     backend = _normalize_version_tag(_current_version(root)) or "unknown"
-    ui = _normalize_version_tag(_local_ui_version(root))
-    return f"suzent {backend} (ui {ui})" if ui else f"suzent {backend}"
+    recorded = _local_ui_version(root)
+    if not recorded:
+        return f"suzent {backend}"
+
+    ui = _normalize_version_tag(recorded)
+    return f"suzent {backend} (ui {ui if _version_key(ui) else 'unknown'})"
 
 
 def _version_key(value: str) -> tuple[int, ...]:

--- a/src/suzent/cli/main.py
+++ b/src/suzent/cli/main.py
@@ -22,6 +22,12 @@ from pathlib import Path
 
 import typer
 from suzent.config import DEFAULT_PORT
+from suzent.version import (
+    UNKNOWN,
+    get_backend_commit,
+    read_project_version,
+    short_commit,
+)
 
 IS_WINDOWS = sys.platform == "win32"
 
@@ -335,12 +341,14 @@ def _local_ui_version(root: Path) -> str:
 
 
 def _current_version(root: Path) -> str:
-    """Return the source version first, then installed package metadata."""
-    pyproject = root / "pyproject.toml"
-    if pyproject.exists():
-        for line in pyproject.read_text(encoding="utf-8").splitlines():
-            if line.strip().startswith("version ="):
-                return line.split("=", 1)[1].strip().strip('"')
+    """Return the version declared by `root`, then installed package metadata.
+
+    Root-relative on purpose: `suzent update` asks about the workspace being
+    updated, which is not always the tree the running code was imported from.
+    """
+    declared = read_project_version(root / "pyproject.toml")
+    if declared:
+        return declared
 
     try:
         return version("suzent")
@@ -352,24 +360,47 @@ def _normalize_version_tag(value: str) -> str:
     return value.strip().lstrip("vV")
 
 
+def _ui_version_detail(root: Path) -> str | None:
+    """Describe the installed UI binary, or None when there is nothing to say.
+
+    Developer and branch installs record the literal marker "latest" rather
+    than a resolved tag (`scripts/setup.sh`), which identifies nothing, so a
+    recorded value carrying no digits is reported as unknown rather than quoted
+    back as if it were a version.
+    """
+    recorded = _local_ui_version(root)
+    if not recorded:
+        return None
+    ui = _normalize_version_tag(recorded)
+    return f"ui {ui if _version_key(ui) else 'unknown'}"
+
+
 def format_version_line(root: Path) -> str:
     """Render the one-line version banner shown by `suzent --version`.
 
-    The UI binary ships on its own release cadence and can lag the backend, so
-    report both when a managed UI is installed -- a mismatch is the first thing
-    worth knowing in a bug report.
+    The declared version alone does not identify a development install -- the
+    checked-out branch carries whatever version its pyproject happens to hold --
+    so the commit goes alongside it whenever it can be resolved.
 
-    Developer and branch installs record the literal marker "latest" rather than
-    a resolved tag, which identifies nothing; those report the UI as unknown
-    instead of quoting the marker back as if it were a version.
+    On the dev channel `start` builds the UI from source and never launches the
+    downloaded binary, so reporting that binary's version there would describe
+    something that does not run; the channel is named instead.
     """
     backend = _normalize_version_tag(_current_version(root)) or "unknown"
-    recorded = _local_ui_version(root)
-    if not recorded:
-        return f"suzent {backend}"
 
-    ui = _normalize_version_tag(recorded)
-    return f"suzent {backend} (ui {ui if _version_key(ui) else 'unknown'})"
+    details = []
+    commit = get_backend_commit()
+    if commit != UNKNOWN:
+        details.append(short_commit(commit))
+
+    if _read_update_channel(root) == _DEV_CHANNEL:
+        details.append(_DEV_CHANNEL)
+    elif ui_detail := _ui_version_detail(root):
+        details.append(ui_detail)
+
+    return (
+        f"suzent {backend} ({', '.join(details)})" if details else f"suzent {backend}"
+    )
 
 
 def _version_key(value: str) -> tuple[int, ...]:

--- a/src/suzent/routes/system_routes.py
+++ b/src/suzent/routes/system_routes.py
@@ -6,9 +6,6 @@ import os
 import sys
 import subprocess
 import platform
-import tomllib
-from functools import lru_cache
-from importlib.metadata import PackageNotFoundError, version as package_version
 from pathlib import Path
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -18,125 +15,14 @@ from suzent.tools.filesystem.path_resolver import PathResolver
 from suzent.database import get_database
 from suzent.config import get_effective_volumes
 
+# Re-exported: `suzent.version` is the light home for build identity, but
+# `service.state` and `server` reach for it here.
+from suzent.version import get_backend_commit as get_backend_commit
+from suzent.version import get_backend_version as get_backend_version
+
 logger = get_logger(__name__)
 
 API_VERSION = 1
-
-
-def _get_source_version(start: Path | None = None) -> str | None:
-    """Find the nearest Suzent pyproject version for a source checkout."""
-
-    source_file = (start or Path(__file__)).resolve()
-    for parent in source_file.parents:
-        pyproject = parent / "pyproject.toml"
-        if not pyproject.is_file():
-            continue
-        try:
-            project = tomllib.loads(pyproject.read_text(encoding="utf-8")).get(
-                "project", {}
-            )
-        except (OSError, tomllib.TOMLDecodeError):
-            continue
-        if project.get("name") == "suzent" and isinstance(project.get("version"), str):
-            return project["version"]
-    return None
-
-
-def get_backend_version() -> str:
-    """Return the running backend package version."""
-
-    source_version = _get_source_version()
-    if source_version:
-        return source_version
-    try:
-        return package_version("suzent")
-    except PackageNotFoundError:
-        return "unknown"
-
-
-def _git_directory(marker: Path) -> Path | None:
-    if marker.is_dir():
-        return marker
-    try:
-        prefix, value = marker.read_text(encoding="utf-8").strip().split(":", 1)
-    except (OSError, ValueError):
-        return None
-    if prefix.lower() != "gitdir":
-        return None
-    path = Path(value.strip())
-    return path if path.is_absolute() else (marker.parent / path).resolve()
-
-
-def _common_git_directory(git_dir: Path) -> Path:
-    try:
-        value = (git_dir / "commondir").read_text(encoding="utf-8").strip()
-    except OSError:
-        return git_dir
-    path = Path(value)
-    return path if path.is_absolute() else (git_dir / path).resolve()
-
-
-def _valid_commit(value: str) -> str | None:
-    commit = value.strip().lower()
-    if len(commit) in (40, 64) and all(char in "0123456789abcdef" for char in commit):
-        return commit
-    return None
-
-
-def _read_git_ref(git_dir: Path, ref: str) -> str | None:
-    common_dir = _common_git_directory(git_dir)
-    for root in (git_dir, common_dir):
-        try:
-            commit = _valid_commit((root / ref).read_text(encoding="utf-8"))
-        except OSError:
-            continue
-        if commit:
-            return commit
-
-    try:
-        packed_refs = (common_dir / "packed-refs").read_text(encoding="utf-8")
-    except OSError:
-        return None
-    for line in packed_refs.splitlines():
-        if not line or line.startswith(("#", "^")):
-            continue
-        try:
-            commit, packed_ref = line.split(" ", 1)
-        except ValueError:
-            continue
-        if packed_ref.strip() == ref:
-            return _valid_commit(commit)
-    return None
-
-
-@lru_cache(maxsize=8)
-def _read_source_commit(source_file: Path) -> str:
-    for parent in source_file.resolve().parents:
-        marker = parent / ".git"
-        if not marker.exists():
-            continue
-        git_dir = _git_directory(marker)
-        if git_dir is None:
-            return "unknown"
-        try:
-            head = (git_dir / "HEAD").read_text(encoding="utf-8").strip()
-        except OSError:
-            return "unknown"
-        if direct_commit := _valid_commit(head):
-            return direct_commit
-        if not head.startswith("ref:"):
-            return "unknown"
-        return _read_git_ref(git_dir, head.removeprefix("ref:").strip()) or "unknown"
-    return "unknown"
-
-
-def get_backend_commit(start: Path | None = None) -> str:
-    """Return the backend commit without spawning a process in the request path."""
-
-    configured = os.getenv("SUZENT_BUILD_COMMIT", "").strip()
-    if configured:
-        return configured
-    return _read_source_commit(start or Path(__file__))
 
 
 def get_system_identity() -> dict[str, str | int | bool]:

--- a/src/suzent/version.py
+++ b/src/suzent/version.py
@@ -1,0 +1,149 @@
+"""Version and build identity for the running Suzent source tree.
+
+Deliberately free of heavy imports. This is read on every `suzent --version`,
+and it previously lived in :mod:`suzent.routes.system_routes`, which pulls in
+the database and the filesystem tools -- roughly 200ms to answer a question
+that only needs `tomllib` and a few file reads.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from functools import lru_cache
+from importlib.metadata import PackageNotFoundError, version as package_version
+from pathlib import Path
+
+UNKNOWN = "unknown"
+
+# A short commit is what people paste into a bug report; eight characters stay
+# unambiguous well past the point where git's default seven starts colliding.
+SHORT_COMMIT_LENGTH = 8
+
+
+def read_project_version(pyproject: Path) -> str | None:
+    """Return the version a pyproject.toml declares for the suzent project."""
+    try:
+        project = tomllib.loads(pyproject.read_text(encoding="utf-8")).get(
+            "project", {}
+        )
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    if project.get("name") == "suzent" and isinstance(project.get("version"), str):
+        return project["version"]
+    return None
+
+
+def _get_source_version(start: Path | None = None) -> str | None:
+    """Find the nearest Suzent pyproject version for a source checkout."""
+
+    source_file = (start or Path(__file__)).resolve()
+    for parent in source_file.parents:
+        pyproject = parent / "pyproject.toml"
+        if not pyproject.is_file():
+            continue
+        if declared := read_project_version(pyproject):
+            return declared
+    return None
+
+
+def get_backend_version() -> str:
+    """Return the running backend package version."""
+
+    source_version = _get_source_version()
+    if source_version:
+        return source_version
+    try:
+        return package_version("suzent")
+    except PackageNotFoundError:
+        return UNKNOWN
+
+
+def _git_directory(marker: Path) -> Path | None:
+    if marker.is_dir():
+        return marker
+    try:
+        prefix, value = marker.read_text(encoding="utf-8").strip().split(":", 1)
+    except (OSError, ValueError):
+        return None
+    if prefix.lower() != "gitdir":
+        return None
+    path = Path(value.strip())
+    return path if path.is_absolute() else (marker.parent / path).resolve()
+
+
+def _common_git_directory(git_dir: Path) -> Path:
+    try:
+        value = (git_dir / "commondir").read_text(encoding="utf-8").strip()
+    except OSError:
+        return git_dir
+    path = Path(value)
+    return path if path.is_absolute() else (git_dir / path).resolve()
+
+
+def _valid_commit(value: str) -> str | None:
+    commit = value.strip().lower()
+    if len(commit) in (40, 64) and all(char in "0123456789abcdef" for char in commit):
+        return commit
+    return None
+
+
+def _read_git_ref(git_dir: Path, ref: str) -> str | None:
+    common_dir = _common_git_directory(git_dir)
+    for root in (git_dir, common_dir):
+        try:
+            commit = _valid_commit((root / ref).read_text(encoding="utf-8"))
+        except OSError:
+            continue
+        if commit:
+            return commit
+
+    try:
+        packed_refs = (common_dir / "packed-refs").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for line in packed_refs.splitlines():
+        if not line or line.startswith(("#", "^")):
+            continue
+        try:
+            commit, packed_ref = line.split(" ", 1)
+        except ValueError:
+            continue
+        if packed_ref.strip() == ref:
+            return _valid_commit(commit)
+    return None
+
+
+@lru_cache(maxsize=8)
+def _read_source_commit(source_file: Path) -> str:
+    for parent in source_file.resolve().parents:
+        marker = parent / ".git"
+        if not marker.exists():
+            continue
+        git_dir = _git_directory(marker)
+        if git_dir is None:
+            return UNKNOWN
+        try:
+            head = (git_dir / "HEAD").read_text(encoding="utf-8").strip()
+        except OSError:
+            return UNKNOWN
+        if direct_commit := _valid_commit(head):
+            return direct_commit
+        if not head.startswith("ref:"):
+            return UNKNOWN
+        return _read_git_ref(git_dir, head.removeprefix("ref:").strip()) or UNKNOWN
+    return UNKNOWN
+
+
+def get_backend_commit(start: Path | None = None) -> str:
+    """Return the backend commit without spawning a process in the request path."""
+
+    configured = os.getenv("SUZENT_BUILD_COMMIT", "").strip()
+    if configured:
+        return configured
+    return _read_source_commit(start or Path(__file__))
+
+
+def short_commit(commit: str) -> str:
+    """Abbreviate a commit for display, passing through the unknown marker."""
+    return commit if commit == UNKNOWN else commit[:SHORT_COMMIT_LENGTH]

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -855,7 +855,9 @@ def test_check_update_json_command(monkeypatch):
 
 
 def _macos_workspace(tmp_path: Path) -> Path:
-    (tmp_path / "pyproject.toml").write_text('version = "0.7.13"\n', encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "suzent"\nversion = "0.7.13"\n', encoding="utf-8"
+    )
     icons = tmp_path / "src-tauri" / "icons"
     icons.mkdir(parents=True)
     (icons / "icon.icns").write_bytes(b"icns-payload")

--- a/tests/cli/test_cli_version.py
+++ b/tests/cli/test_cli_version.py
@@ -11,28 +11,46 @@ cli = importlib.import_module("suzent.cli")
 cli_main = importlib.import_module("suzent.cli.main")
 runner = CliRunner()
 
+_COMMIT = "1234abcd5678ef901234abcd5678ef901234abcd"
 
-def _write_checkout(root, backend="0.4.2", ui="v0.4.1"):
+
+def _write_checkout(root, backend="0.4.2", ui="v0.4.1", channel="stable"):
     (root / "pyproject.toml").write_text(
         f'[project]\nname = "suzent"\nversion = "{backend}"\n', encoding="utf-8"
     )
     if ui is not None:
         (root / "bin").mkdir(exist_ok=True)
         (root / "bin" / "version.txt").write_text(ui, encoding="utf-8")
+    if channel is not None:
+        (root / ".suzent").mkdir(exist_ok=True)
+        (root / ".suzent" / "update-channel").write_text(channel, encoding="utf-8")
     return root
 
 
-def test_version_flag_reports_backend_and_ui(monkeypatch, tmp_path):
+@pytest.fixture
+def known_commit(monkeypatch):
+    """Pin the commit: it resolves from the real checkout, not the tmp root."""
+    monkeypatch.setattr(cli_main, "get_backend_commit", lambda: _COMMIT)
+
+
+@pytest.fixture
+def no_commit(monkeypatch):
+    monkeypatch.setattr(cli_main, "get_backend_commit", lambda: cli_main.UNKNOWN)
+
+
+def test_version_flag_reports_backend_commit_and_ui(
+    monkeypatch, tmp_path, known_commit
+):
     _write_checkout(tmp_path)
     monkeypatch.setattr(cli, "get_project_root", lambda: tmp_path)
 
     result = runner.invoke(cli.app, ["--version"])
 
     assert result.exit_code == 0
-    assert "suzent 0.4.2 (ui 0.4.1)" in result.stdout
+    assert "suzent 0.4.2 (1234abcd, ui 0.4.1)" in result.stdout
 
 
-def test_short_version_flag_matches_long_flag(monkeypatch, tmp_path):
+def test_short_version_flag_matches_long_flag(monkeypatch, tmp_path, known_commit):
     _write_checkout(tmp_path)
     monkeypatch.setattr(cli, "get_project_root", lambda: tmp_path)
 
@@ -42,29 +60,54 @@ def test_short_version_flag_matches_long_flag(monkeypatch, tmp_path):
     )
 
 
-def test_version_flag_does_not_require_a_subcommand(monkeypatch, tmp_path):
+def test_version_flag_does_not_require_a_subcommand(
+    monkeypatch, tmp_path, known_commit
+):
     _write_checkout(tmp_path)
     monkeypatch.setattr(cli, "get_project_root", lambda: tmp_path)
 
-    result = runner.invoke(cli.app, ["--version"])
-
-    assert "Missing command" not in result.stdout
+    assert "Missing command" not in runner.invoke(cli.app, ["--version"]).stdout
 
 
-def test_version_line_omits_ui_when_no_managed_binary(tmp_path):
+def test_dev_channel_is_named_instead_of_the_unused_ui_binary(tmp_path, known_commit):
+    """`start` builds the UI from source on the dev channel, so its tag is noise."""
+    _write_checkout(tmp_path, ui="latest", channel="dev")
+
+    assert cli_main.format_version_line(tmp_path) == "suzent 0.4.2 (1234abcd, dev)"
+
+
+def test_version_line_omits_ui_when_no_managed_binary(tmp_path, known_commit):
+    _write_checkout(tmp_path, ui=None)
+
+    assert cli_main.format_version_line(tmp_path) == "suzent 0.4.2 (1234abcd)"
+
+
+def test_version_line_carries_only_the_version_without_git_or_ui(tmp_path, no_commit):
     _write_checkout(tmp_path, ui=None)
 
     assert cli_main.format_version_line(tmp_path) == "suzent 0.4.2"
 
 
-def test_version_line_falls_back_to_package_metadata(monkeypatch, tmp_path):
+@pytest.mark.parametrize("marker", ["latest", "v", "main"])
+def test_version_line_reports_unknown_for_an_unresolved_ui_marker(
+    tmp_path, marker, known_commit
+):
+    """`setup.sh` records the literal "latest" for dev and branch installs."""
+    _write_checkout(tmp_path, ui=marker)
+
+    assert cli_main.format_version_line(tmp_path) == (
+        "suzent 0.4.2 (1234abcd, ui unknown)"
+    )
+
+
+def test_version_line_falls_back_to_package_metadata(monkeypatch, tmp_path, no_commit):
     monkeypatch.setattr(cli_main, "version", lambda name: "9.9.9")
 
     assert cli_main.format_version_line(tmp_path) == "suzent 9.9.9"
 
 
 def test_version_line_reports_unknown_when_version_is_undiscoverable(
-    monkeypatch, tmp_path
+    monkeypatch, tmp_path, no_commit
 ):
     def _missing(name):
         raise cli_main.PackageNotFoundError(name)
@@ -72,14 +115,6 @@ def test_version_line_reports_unknown_when_version_is_undiscoverable(
     monkeypatch.setattr(cli_main, "version", _missing)
 
     assert cli_main.format_version_line(tmp_path) == "suzent unknown"
-
-
-@pytest.mark.parametrize("marker", ["latest", "v", "main"])
-def test_version_line_reports_unknown_for_an_unresolved_ui_marker(tmp_path, marker):
-    """`setup.sh` records the literal "latest" for dev and branch installs."""
-    _write_checkout(tmp_path, ui=marker)
-
-    assert cli_main.format_version_line(tmp_path) == "suzent 0.4.2 (ui unknown)"
 
 
 def test_version_writes_nothing_to_stderr():

--- a/tests/cli/test_cli_version.py
+++ b/tests/cli/test_cli_version.py
@@ -1,7 +1,10 @@
 """Unit tests for `suzent --version`."""
 
 import importlib
+import subprocess
+import sys
 
+import pytest
 from typer.testing import CliRunner
 
 cli = importlib.import_module("suzent.cli")
@@ -69,3 +72,25 @@ def test_version_line_reports_unknown_when_version_is_undiscoverable(
     monkeypatch.setattr(cli_main, "version", _missing)
 
     assert cli_main.format_version_line(tmp_path) == "suzent unknown"
+
+
+@pytest.mark.parametrize("marker", ["latest", "v", "main"])
+def test_version_line_reports_unknown_for_an_unresolved_ui_marker(tmp_path, marker):
+    """`setup.sh` records the literal "latest" for dev and branch installs."""
+    _write_checkout(tmp_path, ui=marker)
+
+    assert cli_main.format_version_line(tmp_path) == "suzent 0.4.2 (ui unknown)"
+
+
+def test_version_writes_nothing_to_stderr():
+    """Regression: config logged its override file before logging was configured."""
+    result = subprocess.run(
+        [sys.executable, "-m", "suzent.cli", "--version"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert result.stderr == ""
+    assert len(result.stdout.strip().splitlines()) == 1
+    assert result.stdout.startswith("suzent ")

--- a/tests/cli/test_cli_version.py
+++ b/tests/cli/test_cli_version.py
@@ -1,0 +1,71 @@
+"""Unit tests for `suzent --version`."""
+
+import importlib
+
+from typer.testing import CliRunner
+
+cli = importlib.import_module("suzent.cli")
+cli_main = importlib.import_module("suzent.cli.main")
+runner = CliRunner()
+
+
+def _write_checkout(root, backend="0.4.2", ui="v0.4.1"):
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "suzent"\nversion = "{backend}"\n', encoding="utf-8"
+    )
+    if ui is not None:
+        (root / "bin").mkdir(exist_ok=True)
+        (root / "bin" / "version.txt").write_text(ui, encoding="utf-8")
+    return root
+
+
+def test_version_flag_reports_backend_and_ui(monkeypatch, tmp_path):
+    _write_checkout(tmp_path)
+    monkeypatch.setattr(cli, "get_project_root", lambda: tmp_path)
+
+    result = runner.invoke(cli.app, ["--version"])
+
+    assert result.exit_code == 0
+    assert "suzent 0.4.2 (ui 0.4.1)" in result.stdout
+
+
+def test_short_version_flag_matches_long_flag(monkeypatch, tmp_path):
+    _write_checkout(tmp_path)
+    monkeypatch.setattr(cli, "get_project_root", lambda: tmp_path)
+
+    assert (
+        runner.invoke(cli.app, ["-V"]).stdout
+        == runner.invoke(cli.app, ["--version"]).stdout
+    )
+
+
+def test_version_flag_does_not_require_a_subcommand(monkeypatch, tmp_path):
+    _write_checkout(tmp_path)
+    monkeypatch.setattr(cli, "get_project_root", lambda: tmp_path)
+
+    result = runner.invoke(cli.app, ["--version"])
+
+    assert "Missing command" not in result.stdout
+
+
+def test_version_line_omits_ui_when_no_managed_binary(tmp_path):
+    _write_checkout(tmp_path, ui=None)
+
+    assert cli_main.format_version_line(tmp_path) == "suzent 0.4.2"
+
+
+def test_version_line_falls_back_to_package_metadata(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli_main, "version", lambda name: "9.9.9")
+
+    assert cli_main.format_version_line(tmp_path) == "suzent 9.9.9"
+
+
+def test_version_line_reports_unknown_when_version_is_undiscoverable(
+    monkeypatch, tmp_path
+):
+    def _missing(name):
+        raise cli_main.PackageNotFoundError(name)
+
+    monkeypatch.setattr(cli_main, "version", _missing)
+
+    assert cli_main.format_version_line(tmp_path) == "suzent unknown"

--- a/tests/routes/test_system_routes.py
+++ b/tests/routes/test_system_routes.py
@@ -2,12 +2,13 @@ from starlette.applications import Starlette
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
+from suzent import version as suzent_version
 from suzent.routes import system_routes
 
 
 def test_system_version_reports_running_backend_package(monkeypatch) -> None:
-    monkeypatch.setattr(system_routes, "_get_source_version", lambda: None)
-    monkeypatch.setattr(system_routes, "package_version", lambda _name: "1.2.3")
+    monkeypatch.setattr(suzent_version, "_get_source_version", lambda: None)
+    monkeypatch.setattr(suzent_version, "package_version", lambda _name: "1.2.3")
     monkeypatch.setattr(system_routes, "get_backend_commit", lambda: "abc123")
     app = Starlette(routes=[Route("/system/version", system_routes.get_system_version)])
 
@@ -26,10 +27,10 @@ def test_backend_version_falls_back_when_package_metadata_is_missing(
     monkeypatch,
 ) -> None:
     def missing_package(_name: str) -> str:
-        raise system_routes.PackageNotFoundError
+        raise suzent_version.PackageNotFoundError
 
-    monkeypatch.setattr(system_routes, "package_version", missing_package)
-    monkeypatch.setattr(system_routes, "_get_source_version", lambda: None)
+    monkeypatch.setattr(suzent_version, "package_version", missing_package)
+    monkeypatch.setattr(suzent_version, "_get_source_version", lambda: None)
 
     assert system_routes.get_backend_version() == "unknown"
 
@@ -40,12 +41,12 @@ def test_backend_version_prefers_source_checkout(tmp_path, monkeypatch) -> None:
         '[project]\nname = "suzent"\nversion = "2.3.4"\n',
         encoding="utf-8",
     )
-    source_file = tmp_path / "src" / "suzent" / "routes" / "system_routes.py"
+    source_file = tmp_path / "src" / "suzent" / "version.py"
     source_file.parent.mkdir(parents=True)
     source_file.touch()
-    source_version = system_routes._get_source_version(source_file)
-    monkeypatch.setattr(system_routes, "_get_source_version", lambda: source_version)
-    monkeypatch.setattr(system_routes, "package_version", lambda _name: "1.2.3")
+    source_version = suzent_version._get_source_version(source_file)
+    monkeypatch.setattr(suzent_version, "_get_source_version", lambda: source_version)
+    monkeypatch.setattr(suzent_version, "package_version", lambda _name: "1.2.3")
 
     assert system_routes.get_backend_version() == "2.3.4"
 


### PR DESCRIPTION
## What

Adds `suzent --version` / `-V`, and makes the desktop About tab report the same identity.

```
$ suzent --version
suzent 0.10.0 (e5109eb0, ui 0.10.0)     # stable install
suzent 0.10.0 (e5109eb0, dev)           # dev channel
suzent 0.10.0                           # installed wheel, no git, no UI binary
```

## Why

There was no way to ask a local Suzent what version it is. `suzent check-update` was the closest thing, but it makes a network round-trip to the GitHub releases API to answer a question that lives entirely on disk — no good offline, and awkward to paste into a bug report.

Three things have to be reported for the answer to actually identify an install:

- **The commit.** The declared version does not identify a development install — a `SUZENT_BRANCH` checkout carries whatever version its pyproject happens to hold, so it would report `0.10.0` for arbitrary code.
- **The UI binary version.** Backend and Tauri UI ship on separate cadences; `_get_ui_binary` exists specifically to stop a stale UI from launching against a newer backend, so drift is worth surfacing.
- **The channel.** On the dev channel `start` builds the UI from source and never launches the downloaded binary ([cli/main.py:1178](../blob/HEAD/src/suzent/cli/main.py#L1178)), so reporting that binary's version there would describe something that doesn't run.

## How

**`suzent/version.py` (new).** The backend already resolved this correctly — `routes/system_routes.py` reads the commit straight out of git files (no subprocess), handling worktrees, `commondir`, packed-refs and `SUZENT_BUILD_COMMIT`, and serves it at `/system/version`. But that module imports the database and the filesystem tools (**220 ms**), so the CLI couldn't reach it and I initially wrote a weaker duplicate: a line-prefix scrape of pyproject. Those resolvers now live in a stdlib-only module (**~10 ms**); `system_routes` re-exports them for `service.state` and `server`.

`_current_version` shares the tomllib parser but keeps its `root` argument — `suzent update` asks about the workspace being updated, which isn't always the tree the running code came from.

**The flag** is registered as an eager option on the root Typer callback: Click runs eager parameter callbacks during `parse_args`, so `--version` prints and exits instead of tripping the group's "Missing command" error.

**Logging.** `suzent.config` logs which override file it loaded *while being imported*, before the callback reaches `configure_logging` (which already intends WARNING), so loguru's default handler leaked an INFO line onto stderr. `suzent/cli/_early_logging.py` is imported ahead of every other suzent module and swaps that default for a WARNING-level handler; `setup_logging` still replaces it later, so `-v` and the backend's own logging are untouched. Every command gets the quieter stderr, not just this one.

**The `latest` marker.** `scripts/setup.sh:289` and `scripts/setup.ps1:305` record the literal string `latest` when no release tag is resolved. A recorded value carrying no digits reports `ui unknown` rather than quoting the marker back as a version — still saying a managed UI is installed, which omitting it would not.

**Desktop frontend.** The About tab showed bare version numbers, so it misidentified a dev install exactly as the CLI did. `/system/version` has carried `build_commit` and `development_mode` all along — the frontend fetched, typed and parsed both, then used them only for compatibility gating and never displayed either. The frontend's own commit was likewise already baked in by vite as `__FRONTEND_BUILD_COMMIT__` and never rendered. Both cards now show their short commit, and the backend card is badged when the backend reports development mode. `shortCommit()` mirrors the CLI: eight characters, omitted rather than shown as `unknown`. New i18n key `settings.about.developmentBuild` in both locales.

## Testing

- `tests/cli/test_cli_version.py` — 12 cases: both flag spellings, no-subcommand path, dev channel naming, UI-absent, unresolved markers (`latest` / `v` / `main`), metadata fallback, undiscoverable version, and a clean-interpreter subprocess check that stderr is empty.
- `tests/routes/test_system_routes.py` repointed at the new module; `/system/version` payload unchanged.
- `frontend/src/lib/api.version.test.ts` — `shortCommit` width, unknown marker, empty/null/undefined, already-short input.
- `frontend/src/components/settings/AboutTab.test.tsx` (new) — `VersionCard` renders the commit, renders the badge, and omits both when absent.
- Backend `uv run pytest -m "not sandbox and not integration"` → **1399 passed**. Frontend `npm run test` → **199 passed**; `typecheck`, `lint` and `format:check` clean, and `i18n:check-ui` unchanged at its 144-item baseline with none of the touched files flagged.
- Smoke-tested all three output shapes against synthetic install roots, plus `get_system_identity()` and the `service.state` / `server` re-export paths.

**Not verified:** I could not get a pixel-level look at the About tab — the app refuses to render outside Tauri by design ([App.tsx:1163](../blob/HEAD/frontend/src/App.tsx#L1163)), and launching the full desktop app against a live install seemed the wrong trade for a card-layout check. The four `VersionCard` render tests cover the DOM output instead.

## Follow-ups, deliberately not here

- Bare `suzent` still exits 2 with a "Missing command" banner; `no_args_is_help=True` would fix that.
- `service/state.py` imports `get_backend_version` from `system_routes` and defers it to dodge the database import. Now that `suzent.version` exists it could import that directly at module scope — left alone because #132 touches that file.