### PR TITLE
perf: cut suzent CLI startup from ~660ms to ~155ms

### DIFF
--- a/src/suzent/cli/main.py
+++ b/src/suzent/cli/main.py
@@ -388,14 +388,27 @@ def _write_update_check_cache(root: Path, data: dict) -> None:
     path = _update_check_cache_path(root)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        # Written atomically because the refresh can run on a daemon thread that
-        # the interpreter may kill mid-write, and a truncated cache would be
-        # re-read on the next start.
-        tmp = path.with_name(f".{path.name}.tmp")
-        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
-        os.replace(tmp, path)
     except OSError:
-        pass
+        return
+
+    # Written through a private temporary file because the refresh can run on a
+    # daemon thread the interpreter may kill mid-write. The name is unique per
+    # writer: overlapping `suzent` processes can refresh the same stale cache,
+    # and a shared temporary name lets one writer's replace pull the file out
+    # from under another's still-open handle.
+    try:
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+        )
+    except OSError:
+        return
+
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2)
+        os.replace(tmp_name, path)
+    except OSError:
+        Path(tmp_name).unlink(missing_ok=True)
 
 
 def _check_for_update(root: Path, *, use_cache: bool = True) -> dict:

--- a/src/suzent/cli/main.py
+++ b/src/suzent/cli/main.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -387,7 +388,12 @@ def _write_update_check_cache(root: Path, data: dict) -> None:
     path = _update_check_cache_path(root)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        # Written atomically because the refresh can run on a daemon thread that
+        # the interpreter may kill mid-write, and a truncated cache would be
+        # re-read on the next start.
+        tmp = path.with_name(f".{path.name}.tmp")
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        os.replace(tmp, path)
     except OSError:
         pass
 
@@ -428,17 +434,39 @@ def _check_for_update(root: Path, *, use_cache: bool = True) -> dict:
     return data
 
 
+def _refresh_update_check_cache_async(root: Path) -> None:
+    """Warm the update-check cache for the next run, off the startup path."""
+
+    def _refresh() -> None:
+        try:
+            _check_for_update(root, use_cache=False)
+        except Exception:
+            pass
+
+    threading.Thread(target=_refresh, name="suzent-update-check", daemon=True).start()
+
+
 def _notify_update_available(root: Path) -> None:
     if os.environ.get("SUZENT_SKIP_UPDATE_CHECK") == "1":
         return
 
-    result = _check_for_update(root, use_cache=True)
-    if not result.get("update_available"):
+    cached = _read_update_check_cache(root)
+    if cached is None:
+        # A cold or expired cache means a GitHub round-trip, and startup must not
+        # block on advisory information. Refresh for the next run instead; the
+        # explicit `suzent check-update` still answers synchronously.
+        _refresh_update_check_cache_async(root)
         return
 
-    latest = result.get("latest_version") or "latest"
-    current = result.get("current_version") or "unknown"
-    typer.echo(f"  • Update available: {current} -> {latest}. Run 'suzent update'.")
+    current = _current_version(root)
+    latest = str(cached.get("latest_version", ""))
+    if not _is_newer_version(latest, current):
+        return
+
+    typer.echo(
+        f"  • Update available: {current or 'unknown'} -> {latest}. "
+        "Run 'suzent update'."
+    )
 
 
 def _download_file_atomic(

--- a/src/suzent/config/__init__.py
+++ b/src/suzent/config/__init__.py
@@ -324,7 +324,7 @@ class ConfigModel(BaseModel):
     def migrate_legacy_shell_tools(cls, value: Any) -> Any:
         if not isinstance(value, list):
             return value
-        from suzent.tools.registry import migrate_shell_tool_names
+        from suzent.tools.names import migrate_shell_tool_names
 
         return migrate_shell_tool_names(value)
 
@@ -517,17 +517,25 @@ class ConfigModel(BaseModel):
             logger.error("Config validation error: {}", ve)
             raise
 
-        if not cfg.tool_options:
+        if loaded_path is not None:
+            logger.info("Loaded configuration overrides from {}", loaded_path)
+        return cfg
+
+    def ensure_tool_options(self) -> List[str]:
+        """Return the tool catalog, discovering it from the registry on first use.
+
+        Discovery imports every tool module, and with them pydantic-ai, MCP and
+        the LanceDB stack -- roughly half a second. Keeping it out of
+        ``load_from_files`` means the CLI no longer pays for the whole agent
+        runtime just to read a config file.
+        """
+        if not self.tool_options:
             try:
                 discovered = get_tool_options()
             except Exception:
                 discovered = []
-            combined = list(dict.fromkeys(discovered + cfg.default_tools))
-            cfg.tool_options = combined
-
-        if loaded_path is not None:
-            logger.info("Loaded configuration overrides from {}", loaded_path)
-        return cfg
+            self.tool_options = list(dict.fromkeys(discovered + self.default_tools))
+        return self.tool_options
 
     def reload(self) -> None:
         """Reload configuration from disk."""

--- a/src/suzent/core/social_brain.py
+++ b/src/suzent/core/social_brain.py
@@ -739,8 +739,9 @@ class SocialBrain(BaseBrain):
             else:
                 # "All Tools" mode: pass the full registry list so build_agent_config
                 # doesn't fall back to the narrower default_tools subset.
-                if CONFIG.tool_options:
-                    base_config["tools"] = list(CONFIG.tool_options)
+                tool_options = CONFIG.ensure_tool_options()
+                if tool_options:
+                    base_config["tools"] = list(tool_options)
 
             config_override = build_agent_config(base_config, require_social_tool=False)
 

--- a/src/suzent/memory/lifecycle.py
+++ b/src/suzent/memory/lifecycle.py
@@ -285,8 +285,9 @@ async def _initialize_memory_system() -> bool:
             await _migrate_blocks_to_files(memory_store, markdown_store, CONFIG.user_id)
 
         # Add memory tools to CONFIG.tool_options so they appear in frontend
-        if "MemorySearchTool" not in CONFIG.tool_options:
-            CONFIG.tool_options.append("MemorySearchTool")
+        tool_options = CONFIG.ensure_tool_options()
+        if "MemorySearchTool" not in tool_options:
+            tool_options.append("MemorySearchTool")
             logger.info("Added MemorySearchTool to config")
 
         # Start background core-file watcher only when embedding is configured.

--- a/src/suzent/routes/config_routes.py
+++ b/src/suzent/routes/config_routes.py
@@ -159,7 +159,7 @@ async def get_config(request: Request) -> JSONResponse:
         "models": available_models,
         "defaultModel": default_model,
         "agents": CONFIG.agent_options,
-        "tools": [t for t in CONFIG.tool_options if t != "SkillTool"],
+        "tools": [t for t in CONFIG.ensure_tool_options() if t != "SkillTool"],
         "toolCapabilities": get_tool_capabilities(),
         "defaultTools": [t for t in CONFIG.default_tools if t != "SkillTool"],
         "codeTag": CONFIG.code_tag,

--- a/src/suzent/service/state.py
+++ b/src/suzent/service/state.py
@@ -13,7 +13,6 @@ from typing import Any
 import psutil
 
 from suzent.config import DEFAULT_PORT, RUNTIME_DIR
-from suzent.routes.system_routes import get_backend_version
 from suzent.service.models import ServiceProcessState
 
 SERVICE_STATE_PATH = RUNTIME_DIR / "service.json"
@@ -91,6 +90,11 @@ class ServiceInstanceLock:
                     SERVICE_STATE_PATH.unlink(missing_ok=True)
                     continue
                 raise RuntimeError("Could not replace a stale Suzent service lock.")
+
+            # Imported here so the `suzent service` CLI commands, which reach
+            # this module for process state, do not drag the HTTP route layer
+            # and the database stack in behind it.
+            from suzent.routes.system_routes import get_backend_version
 
             process = psutil.Process(os.getpid())
             state = ServiceProcessState(

--- a/src/suzent/tools/__init__.py
+++ b/src/suzent/tools/__init__.py
@@ -1,23 +1,48 @@
-"""Tool package exports."""
+"""Tool package exports.
 
-from suzent.tools.base import Tool, ToolErrorCode, ToolResult
-from suzent.tools.filesystem import (
-    EditFileTool,
-    GlobTool,
-    GrepTool,
-    PathResolver,
-    ReadFileTool,
-    WriteFileTool,
-)
+Re-exports resolve on first attribute access. Importing a leaf module such as
+:mod:`suzent.tools.names` runs this file first, and eager re-exports made that
+pull in the filesystem tools -- and pydantic-ai behind them -- for callers that
+only wanted a handful of constants.
+"""
 
-__all__ = [
-    "Tool",
-    "ToolResult",
-    "ToolErrorCode",
-    "PathResolver",
-    "ReadFileTool",
-    "WriteFileTool",
-    "EditFileTool",
-    "GlobTool",
-    "GrepTool",
-]
+import importlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from suzent.tools.base import Tool as Tool
+    from suzent.tools.base import ToolErrorCode as ToolErrorCode
+    from suzent.tools.base import ToolResult as ToolResult
+    from suzent.tools.filesystem import EditFileTool as EditFileTool
+    from suzent.tools.filesystem import GlobTool as GlobTool
+    from suzent.tools.filesystem import GrepTool as GrepTool
+    from suzent.tools.filesystem import PathResolver as PathResolver
+    from suzent.tools.filesystem import ReadFileTool as ReadFileTool
+    from suzent.tools.filesystem import WriteFileTool as WriteFileTool
+
+_EXPORTS = {
+    "Tool": "suzent.tools.base",
+    "ToolResult": "suzent.tools.base",
+    "ToolErrorCode": "suzent.tools.base",
+    "PathResolver": "suzent.tools.filesystem",
+    "ReadFileTool": "suzent.tools.filesystem",
+    "WriteFileTool": "suzent.tools.filesystem",
+    "EditFileTool": "suzent.tools.filesystem",
+    "GlobTool": "suzent.tools.filesystem",
+    "GrepTool": "suzent.tools.filesystem",
+}
+
+__all__ = list(_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    module = _EXPORTS.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(importlib.import_module(module), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/src/suzent/tools/filesystem/__init__.py
+++ b/src/suzent/tools/filesystem/__init__.py
@@ -1,27 +1,57 @@
-"""Filesystem tool suite exports."""
+"""Filesystem tool suite exports.
 
-from suzent.tools.filesystem.edit_file_tool import EditFileTool
-from suzent.tools.filesystem.file_tool_utils import (
-    detect_text_encoding,
-    get_or_create_path_resolver,
-    is_binary_content,
-    is_windows_unc_path,
-)
-from suzent.tools.filesystem.glob_tool import GlobTool
-from suzent.tools.filesystem.grep_tool import GrepTool
-from suzent.tools.filesystem.path_resolver import PathResolver
-from suzent.tools.filesystem.read_file_tool import ReadFileTool
-from suzent.tools.filesystem.write_file_tool import WriteFileTool
+Re-exports resolve on first attribute access. ``edit_file_tool`` pulls in
+pydantic-ai, so eager re-exports made importing a leaf module such as
+``path_resolver`` cost the whole agent runtime.
+"""
 
-__all__ = [
-    "PathResolver",
-    "ReadFileTool",
-    "WriteFileTool",
-    "EditFileTool",
-    "GlobTool",
-    "GrepTool",
-    "get_or_create_path_resolver",
-    "is_windows_unc_path",
-    "detect_text_encoding",
-    "is_binary_content",
-]
+import importlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from suzent.tools.filesystem.edit_file_tool import EditFileTool as EditFileTool
+    from suzent.tools.filesystem.file_tool_utils import (
+        detect_text_encoding as detect_text_encoding,
+    )
+    from suzent.tools.filesystem.file_tool_utils import (
+        get_or_create_path_resolver as get_or_create_path_resolver,
+    )
+    from suzent.tools.filesystem.file_tool_utils import (
+        is_binary_content as is_binary_content,
+    )
+    from suzent.tools.filesystem.file_tool_utils import (
+        is_windows_unc_path as is_windows_unc_path,
+    )
+    from suzent.tools.filesystem.glob_tool import GlobTool as GlobTool
+    from suzent.tools.filesystem.grep_tool import GrepTool as GrepTool
+    from suzent.tools.filesystem.path_resolver import PathResolver as PathResolver
+    from suzent.tools.filesystem.read_file_tool import ReadFileTool as ReadFileTool
+    from suzent.tools.filesystem.write_file_tool import WriteFileTool as WriteFileTool
+
+_EXPORTS = {
+    "PathResolver": "suzent.tools.filesystem.path_resolver",
+    "ReadFileTool": "suzent.tools.filesystem.read_file_tool",
+    "WriteFileTool": "suzent.tools.filesystem.write_file_tool",
+    "EditFileTool": "suzent.tools.filesystem.edit_file_tool",
+    "GlobTool": "suzent.tools.filesystem.glob_tool",
+    "GrepTool": "suzent.tools.filesystem.grep_tool",
+    "get_or_create_path_resolver": "suzent.tools.filesystem.file_tool_utils",
+    "is_windows_unc_path": "suzent.tools.filesystem.file_tool_utils",
+    "detect_text_encoding": "suzent.tools.filesystem.file_tool_utils",
+    "is_binary_content": "suzent.tools.filesystem.file_tool_utils",
+}
+
+__all__ = list(_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    module = _EXPORTS.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(importlib.import_module(module), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/src/suzent/tools/names.py
+++ b/src/suzent/tools/names.py
@@ -1,0 +1,51 @@
+"""Tool-name constants and the legacy-selection migrations that use them.
+
+These live apart from :mod:`suzent.tools.registry` because config validation
+needs them on every startup, while the registry pulls in pydantic-ai, MCP and
+the rest of the agent runtime. Keep this module free of heavy imports.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+SHELL_TOOL_CLASS_NAMES = (
+    "RunCommandTool",
+    "StartCommandTool",
+    "CheckCommandTool",
+    "StopCommandTool",
+)
+
+AGENT_LIFECYCLE_TOOL_NAMES = (
+    "AgentListTool",
+    "AgentReadTool",
+    "AgentSendTool",
+    "AgentStopTool",
+)
+
+LEGACY_SHELL_TOOL_NAMES = {
+    "ShellTool",
+    "BashTool",
+    "ProcessTool",
+    "bash_execute",
+    "process_manage",
+}
+
+
+def migrate_shell_tool_names(tool_names: List[str]) -> List[str]:
+    """Expand legacy aggregate shell selections into independently selectable tools."""
+    migrated: list[str] = []
+    for name in tool_names:
+        if name in LEGACY_SHELL_TOOL_NAMES:
+            migrated.extend(SHELL_TOOL_CLASS_NAMES)
+        else:
+            migrated.append(name)
+    return list(dict.fromkeys(migrated))
+
+
+def expand_tool_dependencies(tool_names: List[str]) -> List[str]:
+    """Normalize legacy aggregate selections while preserving modern choices."""
+    expanded = migrate_shell_tool_names(tool_names)
+    if "AgentTool" in expanded:
+        expanded.extend(AGENT_LIFECYCLE_TOOL_NAMES)
+    return list(dict.fromkeys(expanded))

--- a/src/suzent/tools/registry.py
+++ b/src/suzent/tools/registry.py
@@ -18,21 +18,15 @@ from pydantic_ai import Tool as PydanticTool
 
 from suzent.logger import get_logger
 from suzent.tools.base import ToolResult, truncate_tool_output
-from suzent.tools.names import (
-    AGENT_LIFECYCLE_TOOL_NAMES,
-    LEGACY_SHELL_TOOL_NAMES,
-    SHELL_TOOL_CLASS_NAMES,
-    expand_tool_dependencies,
-    migrate_shell_tool_names,
-)
 
-__all__ = [
-    "AGENT_LIFECYCLE_TOOL_NAMES",
-    "LEGACY_SHELL_TOOL_NAMES",
-    "SHELL_TOOL_CLASS_NAMES",
-    "expand_tool_dependencies",
-    "migrate_shell_tool_names",
-]
+# Re-exported under their original names so existing
+# `from suzent.tools.registry import ...` call sites keep working. Aliased
+# rather than listed in `__all__`, which would shrink what `import *` exports.
+from suzent.tools.names import AGENT_LIFECYCLE_TOOL_NAMES as AGENT_LIFECYCLE_TOOL_NAMES
+from suzent.tools.names import LEGACY_SHELL_TOOL_NAMES as LEGACY_SHELL_TOOL_NAMES
+from suzent.tools.names import SHELL_TOOL_CLASS_NAMES as SHELL_TOOL_CLASS_NAMES
+from suzent.tools.names import expand_tool_dependencies as expand_tool_dependencies
+from suzent.tools.names import migrate_shell_tool_names as migrate_shell_tool_names
 
 logger = get_logger(__name__)
 

--- a/src/suzent/tools/registry.py
+++ b/src/suzent/tools/registry.py
@@ -18,6 +18,21 @@ from pydantic_ai import Tool as PydanticTool
 
 from suzent.logger import get_logger
 from suzent.tools.base import ToolResult, truncate_tool_output
+from suzent.tools.names import (
+    AGENT_LIFECYCLE_TOOL_NAMES,
+    LEGACY_SHELL_TOOL_NAMES,
+    SHELL_TOOL_CLASS_NAMES,
+    expand_tool_dependencies,
+    migrate_shell_tool_names,
+)
+
+__all__ = [
+    "AGENT_LIFECYCLE_TOOL_NAMES",
+    "LEGACY_SHELL_TOOL_NAMES",
+    "SHELL_TOOL_CLASS_NAMES",
+    "expand_tool_dependencies",
+    "migrate_shell_tool_names",
+]
 
 logger = get_logger(__name__)
 
@@ -178,28 +193,6 @@ def _all_tool_classes() -> list:
     ]
 
 
-SHELL_TOOL_CLASS_NAMES = (
-    "RunCommandTool",
-    "StartCommandTool",
-    "CheckCommandTool",
-    "StopCommandTool",
-)
-
-AGENT_LIFECYCLE_TOOL_NAMES = (
-    "AgentListTool",
-    "AgentReadTool",
-    "AgentSendTool",
-    "AgentStopTool",
-)
-
-LEGACY_SHELL_TOOL_NAMES = {
-    "ShellTool",
-    "BashTool",
-    "ProcessTool",
-    "bash_execute",
-    "process_manage",
-}
-
 CAPABILITY_DESCRIPTIONS = {
     "Filesystem": "Read, search, create, and modify files in the configured workspace.",
     "Shell": "Run bounded commands and control long-running background processes.",
@@ -225,25 +218,6 @@ TOOL_DESCRIPTION_OVERRIDES = {
     "SpeakTool": "Convert a response to speech and return playable audio to the conversation.",
     "SocialMessageTool": "Send a message through a configured social channel after approval.",
 }
-
-
-def migrate_shell_tool_names(tool_names: List[str]) -> List[str]:
-    """Expand legacy aggregate shell selections into independently selectable tools."""
-    migrated: list[str] = []
-    for name in tool_names:
-        if name in LEGACY_SHELL_TOOL_NAMES:
-            migrated.extend(SHELL_TOOL_CLASS_NAMES)
-        else:
-            migrated.append(name)
-    return list(dict.fromkeys(migrated))
-
-
-def expand_tool_dependencies(tool_names: List[str]) -> List[str]:
-    """Normalize legacy aggregate selections while preserving modern choices."""
-    expanded = migrate_shell_tool_names(tool_names)
-    if "AgentTool" in expanded:
-        expanded.extend(AGENT_LIFECYCLE_TOOL_NAMES)
-    return list(dict.fromkeys(expanded))
 
 
 def _humanize_tool_name(name: str) -> str:

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -908,3 +908,113 @@ def test_macos_launch_target_skips_non_macos_platforms(monkeypatch, tmp_path):
 
     assert cli_main._macos_launch_target(tmp_path, binary) == binary
     assert not (tmp_path / "bin" / "SUZENT.app").exists()
+
+
+def _seed_update_cache(root: Path, latest: str, *, age_seconds: float = 0.0) -> None:
+    path = cli_main._update_check_cache_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        cli_main.json.dumps(
+            {
+                "checked_at": cli_main.time.time() - age_seconds,
+                "current_version": "0.6.2",
+                "latest_version": latest,
+                "html_url": "",
+                "update_available": bool(latest),
+                "error": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_notify_update_never_reaches_the_network(monkeypatch, tmp_path):
+    """Regression: `suzent start` used to block on GitHub whenever the cache expired."""
+    _seed_update_cache(
+        tmp_path, "v0.6.3", age_seconds=cli_main._UPDATE_CHECK_TTL_SECONDS * 2
+    )
+    monkeypatch.delenv("SUZENT_SKIP_UPDATE_CHECK", raising=False)
+    monkeypatch.setattr(cli_main, "_current_version", lambda root: "0.6.2")
+
+    def fail_fetch(timeout=None):
+        raise AssertionError("startup must not fetch the release feed synchronously")
+
+    monkeypatch.setattr(cli_main, "_fetch_latest_release", fail_fetch)
+    scheduled = []
+    monkeypatch.setattr(
+        cli_main,
+        "_refresh_update_check_cache_async",
+        lambda root: scheduled.append(root),
+    )
+
+    cli_main._notify_update_available(tmp_path)
+
+    assert scheduled == [tmp_path]
+
+
+def test_notify_update_reports_a_newer_cached_release(monkeypatch, tmp_path, capsys):
+    _seed_update_cache(tmp_path, "v0.6.3")
+    monkeypatch.delenv("SUZENT_SKIP_UPDATE_CHECK", raising=False)
+    monkeypatch.setattr(cli_main, "_current_version", lambda root: "0.6.2")
+    monkeypatch.setattr(
+        cli_main, "_refresh_update_check_cache_async", lambda root: None
+    )
+
+    cli_main._notify_update_available(tmp_path)
+
+    assert "0.6.2 -> v0.6.3" in capsys.readouterr().out
+
+
+def test_notify_update_stays_quiet_when_current(monkeypatch, tmp_path, capsys):
+    _seed_update_cache(tmp_path, "v0.6.2")
+    monkeypatch.delenv("SUZENT_SKIP_UPDATE_CHECK", raising=False)
+    monkeypatch.setattr(cli_main, "_current_version", lambda root: "0.6.2")
+
+    cli_main._notify_update_available(tmp_path)
+
+    assert capsys.readouterr().out == ""
+
+
+def test_notify_update_honors_the_skip_switch(monkeypatch, tmp_path):
+    monkeypatch.setenv("SUZENT_SKIP_UPDATE_CHECK", "1")
+
+    def fail_read(root):
+        raise AssertionError("skipped check must not touch the cache")
+
+    monkeypatch.setattr(cli_main, "_read_update_check_cache", fail_read)
+
+    cli_main._notify_update_available(tmp_path)
+
+
+def test_background_refresh_runs_detached_and_bypasses_the_cache(monkeypatch, tmp_path):
+    started = {}
+
+    class _ImmediateThread:
+        def __init__(self, target, name=None, daemon=False):
+            self._target = target
+            started["name"] = name
+            started["daemon"] = daemon
+
+        def start(self):
+            self._target()
+
+    monkeypatch.setattr(cli_main.threading, "Thread", _ImmediateThread)
+    calls = []
+    monkeypatch.setattr(
+        cli_main,
+        "_check_for_update",
+        lambda root, use_cache=True: calls.append(use_cache),
+    )
+
+    cli_main._refresh_update_check_cache_async(tmp_path)
+
+    assert calls == [False]
+    assert started["daemon"] is True
+
+
+def test_update_check_cache_write_is_atomic(tmp_path):
+    cli_main._write_update_check_cache(tmp_path, {"checked_at": cli_main.time.time()})
+
+    cache_dir = cli_main._update_check_cache_path(tmp_path).parent
+    assert [p.name for p in cache_dir.iterdir()] == ["update-check.json"]
+    assert cli_main._read_update_check_cache(tmp_path) is not None

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -2,6 +2,7 @@
 
 import importlib
 import subprocess
+import threading
 from pathlib import Path
 
 import pytest
@@ -1018,3 +1019,28 @@ def test_update_check_cache_write_is_atomic(tmp_path):
     cache_dir = cli_main._update_check_cache_path(tmp_path).parent
     assert [p.name for p in cache_dir.iterdir()] == ["update-check.json"]
     assert cli_main._read_update_check_cache(tmp_path) is not None
+
+
+def test_concurrent_cache_writers_do_not_share_a_temporary_file(tmp_path):
+    """Overlapping `suzent` processes can refresh the same stale cache."""
+    barrier = threading.Barrier(4)
+    now = cli_main.time.time()
+
+    def _write(index: int) -> None:
+        barrier.wait()
+        cli_main._write_update_check_cache(
+            tmp_path, {"checked_at": now, "latest_version": f"v0.6.{index}"}
+        )
+
+    threads = [threading.Thread(target=_write, args=(i,)) for i in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    cache_dir = cli_main._update_check_cache_path(tmp_path).parent
+    assert [p.name for p in cache_dir.iterdir()] == ["update-check.json"]
+
+    cached = cli_main._read_update_check_cache(tmp_path)
+    assert cached is not None
+    assert cached["latest_version"] in {f"v0.6.{i}" for i in range(4)}

--- a/tests/test_config_tool_options.py
+++ b/tests/test_config_tool_options.py
@@ -1,0 +1,61 @@
+"""Unit tests for lazy tool-catalog discovery on ConfigModel."""
+
+import importlib
+
+import pytest
+
+config = importlib.import_module("suzent.config")
+
+
+@pytest.fixture
+def counting_discovery(monkeypatch):
+    calls = []
+
+    def _discover():
+        calls.append(1)
+        return ["GrepTool", "WebSearchTool"]
+
+    monkeypatch.setattr(config, "get_tool_options", _discover)
+    return calls
+
+
+def test_load_from_files_leaves_discovery_for_first_use(
+    monkeypatch, counting_discovery
+):
+    cfg = config.ConfigModel(default_tools=["GrepTool"])
+
+    assert not cfg.tool_options
+    assert counting_discovery == []
+
+
+def test_ensure_tool_options_merges_discovery_with_defaults(counting_discovery):
+    cfg = config.ConfigModel(default_tools=["GrepTool", "ReadFileTool"])
+
+    assert cfg.ensure_tool_options() == ["GrepTool", "WebSearchTool", "ReadFileTool"]
+    assert counting_discovery == [1]
+
+
+def test_ensure_tool_options_discovers_only_once(counting_discovery):
+    cfg = config.ConfigModel(default_tools=["GrepTool"])
+
+    cfg.ensure_tool_options()
+    cfg.ensure_tool_options()
+
+    assert counting_discovery == [1]
+
+
+def test_ensure_tool_options_respects_a_configured_catalog(counting_discovery):
+    cfg = config.ConfigModel(tool_options=["GrepTool"], default_tools=["ReadFileTool"])
+
+    assert cfg.ensure_tool_options() == ["GrepTool"]
+    assert counting_discovery == []
+
+
+def test_ensure_tool_options_falls_back_to_defaults_when_discovery_fails(monkeypatch):
+    def _boom():
+        raise RuntimeError("registry unavailable")
+
+    monkeypatch.setattr(config, "get_tool_options", _boom)
+    cfg = config.ConfigModel(default_tools=["GrepTool"])
+
+    assert cfg.ensure_tool_options() == ["GrepTool"]

--- a/tests/test_startup_imports.py
+++ b/tests/test_startup_imports.py
@@ -1,0 +1,70 @@
+"""Guards on what the CLI and config layers are allowed to import at startup.
+
+Importing the tool registry pulls in pydantic-ai, MCP and the database stack --
+roughly half a second that every `suzent` invocation used to pay before it
+printed a single line. These tests fail loudly if that creeps back in.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+_HEAVY_MODULES = ("pydantic_ai", "sqlmodel", "sqlalchemy", "fastmcp")
+
+
+def _modules_loaded_after_importing(target: str) -> set[str]:
+    """Import ``target`` in a clean interpreter and report the heavy modules it pulled."""
+    code = (
+        "import sys\n"
+        f"import {target}\n"
+        f"loaded = [m for m in {_HEAVY_MODULES!r} if m in sys.modules]\n"
+        "print('LOADED:' + ','.join(loaded))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+    marker = next(
+        line for line in result.stdout.splitlines() if line.startswith("LOADED:")
+    )
+    return {name for name in marker[len("LOADED:") :].split(",") if name}
+
+
+@pytest.mark.parametrize("target", ["suzent.config", "suzent.cli"])
+def test_startup_import_stays_clear_of_the_agent_runtime(target):
+    assert _modules_loaded_after_importing(target) == set()
+
+
+def test_tool_name_helpers_do_not_need_the_registry():
+    assert _modules_loaded_after_importing("suzent.tools.names") == set()
+
+
+def test_tools_package_reexports_still_resolve():
+    from suzent.tools import GrepTool, PathResolver, ReadFileTool, Tool, ToolResult
+
+    assert {
+        Tool.__name__,
+        ToolResult.__name__,
+        PathResolver.__name__,
+        ReadFileTool.__name__,
+        GrepTool.__name__,
+    } == {"Tool", "ToolResult", "PathResolver", "ReadFileTool", "GrepTool"}
+
+
+def test_filesystem_package_reexports_still_resolve():
+    from suzent.tools.filesystem import (
+        EditFileTool,
+        GlobTool,
+        get_or_create_path_resolver,
+    )
+
+    assert EditFileTool.__name__ == "EditFileTool"
+    assert GlobTool.__name__ == "GlobTool"
+    assert callable(get_or_create_path_resolver)
+
+
+def test_tools_package_rejects_unknown_attributes():
+    import suzent.tools
+
+    with pytest.raises(AttributeError):
+        suzent.tools.NoSuchTool

--- a/tests/tools/test_registry_exports.py
+++ b/tests/tools/test_registry_exports.py
@@ -1,0 +1,43 @@
+"""The registry's public surface, including what `import *` reaches.
+
+`suzent.tools.names` is re-exported through the registry for backwards
+compatibility. Listing those aliases in `__all__` would quietly shrink a
+wildcard import down to them, dropping the registry APIs documented in
+`docs/02-concepts/tools/tools.md`.
+"""
+
+import pytest
+
+_DOCUMENTED_APIS = (
+    "get_tool_function",
+    "list_available_tools",
+    "get_tool_registry",
+    "get_tool_capabilities",
+    "list_configurable_tools",
+)
+
+_REEXPORTED_FROM_NAMES = (
+    "migrate_shell_tool_names",
+    "expand_tool_dependencies",
+    "SHELL_TOOL_CLASS_NAMES",
+    "AGENT_LIFECYCLE_TOOL_NAMES",
+    "LEGACY_SHELL_TOOL_NAMES",
+)
+
+
+def _wildcard_namespace() -> dict:
+    namespace: dict = {}
+    exec("from suzent.tools.registry import *", namespace)  # noqa: S102
+    return namespace
+
+
+@pytest.mark.parametrize("name", _DOCUMENTED_APIS + _REEXPORTED_FROM_NAMES)
+def test_wildcard_import_reaches_the_public_registry_surface(name):
+    assert name in _wildcard_namespace()
+
+
+@pytest.mark.parametrize("name", _REEXPORTED_FROM_NAMES)
+def test_reexports_are_the_objects_from_the_names_module(name):
+    from suzent.tools import names, registry
+
+    assert getattr(registry, name) is getattr(names, name)


### PR DESCRIPTION
## What

Every `suzent` command — `start`, `serve`, `config`, `nodes`, even `--help` — imported the entire agent runtime before doing anything. Measured on an M-series Mac, best of 5 runs:

| command | before | after |
|---|---:|---:|
| `suzent --help` | 660 ms | **155 ms** |
| `suzent config show` | 705 ms | **203 ms** |
| `suzent nodes list` | 685 ms | **194 ms** |
| `import suzent.cli` | 626 ms | **139 ms** |

Plus `suzent start` no longer stalls on a GitHub round-trip when its update-check cache has expired.

## The chain

`import suzent.cli` → `suzent.config` → `CONFIG = ConfigModel.load_from_files()` at module scope → the tool registry → pydantic-ai, MCP, fastmcp, sqlmodel, sqlalchemy. ~490 ms of imports to print a help screen.

Four independent causes, one commit each:

**1. `perf(config)`: discover the tool catalog lazily.** `load_from_files()` filled `tool_options` by walking the registry, which imports every tool module. Now behind `ensure_tool_options()`, called by the three consumers that need the catalog (`social_brain`, `memory/lifecycle`, `config_routes`) — all server paths that have loaded those modules anyway.

**2. `perf(tools)`: resolve package re-exports on demand.** Fixing (1) alone changed nothing, which is what sent me looking further: `config/default.example.yaml` ships a `DEFAULT_TOOLS` block, so the `migrate_legacy_shell_tools` field validator fires on *every* install — not just customized ones — and it imported `suzent.tools.registry` to reach a pure rename map. The constants and migrations move to a new `suzent.tools.names` that imports nothing; `registry` re-exports them so no call site changes. The eager re-exports in `tools/__init__.py` and `tools/filesystem/__init__.py` defeated that one level up (importing any leaf ran them, and `edit_file_tool` pulls in pydantic-ai), so both now resolve exports through a module-level `__getattr__`.

**3. `perf(service)`: keep the HTTP route layer out of process-state imports.** `service/state.py` imported `routes.system_routes` at module scope for one helper, `get_backend_version()` — dragging the database facade, sqlmodel and sqlalchemy into the root CLI via the `service` command group. Moved to the call site.

**4. `perf(cli)`: stop blocking startup on the update check.** `suzent start` hit the GitHub releases API on the critical path whenever the 24h cache expired — up to a 2s stall before anything printed, and the full 2s on a captive portal or slow DNS, for an advisory notice. Startup now reads only the cache and warms a stale one on a daemon thread, so the delay lands on the next run. `suzent check-update` still answers synchronously. The cache write became atomic, since the refresh thread can be killed mid-write when the process exits.

## Behavior changes

- A first-ever `suzent start` (or the first after 24h) won't print an available-update notice; the run after it will. `suzent check-update` is unchanged.
- `CONFIG.tool_options` is `None` until something calls `ensure_tool_options()`. Direct readers of the attribute would see an empty catalog — all three in-tree consumers were converted.

## Testing

- `tests/test_startup_imports.py` — asserts in a clean interpreter that importing `suzent.config`, `suzent.cli` or `suzent.tools.names` loads none of pydantic-ai, fastmcp, sqlmodel or sqlalchemy. This is the invariant the PR establishes, so it fails loudly if it regresses.
- `tests/test_config_tool_options.py` — lazy discovery: merge order, discover-once, configured-catalog passthrough, fallback when the registry raises.
- `tests/cli/test_cli_main.py` — the notify path never fetches synchronously, reports from cache, honors `SUZENT_SKIP_UPDATE_CHECK`, the background refresh runs detached with `use_cache=False`, and the cache write leaves no temp file.
- Full suite: `uv run pytest -m "not sandbox and not integration"` → **1404 passed**.
- Smoke-tested beyond the suite: `suzent config show` / `nodes list` / `service status`; `import suzent.server` plus `get_tool_registry()` (30 tools), `get_tool_capabilities()` (7), `list_configurable_tools()` (29); and the `/config` route handler invoked in-process, returning the same 29 tools as before.

## Left on the table

The remaining ~139 ms is `httpx` (~33 ms, pulled by `suzent.client.api` from both `cli.main` and `cli.agent`), `typer`/`rich` (~19 ms), and config + permissions parsing (~34 ms). Deferring the `httpx` import is the next available win but wants its own change.