### PR TITLE
fix(stream): handle the renamed REASONING_* events

### DIFF
--- a/frontend/src/hooks/useAGUI.reasoning.test.ts
+++ b/frontend/src/hooks/useAGUI.reasoning.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { processEvent } from './useAGUI';
+import { hasStreamedOutput } from '../lib/chatUtils';
+import type { AGUIPart } from '../types/agui';
+
+/**
+ * ag-ui-protocol 0.1.13 renamed the thinking family to REASONING_*, and
+ * pydantic-ai emits whichever family the negotiated version calls for. When
+ * only the legacy names were handled, every reasoning event was dropped: no
+ * reasoning part meant `hasStreamedOutput` stayed false, so the message sat in
+ * its collapsed "thinking" state — the assembly animation with the stream
+ * hidden behind it — until the first answer token arrived.
+ */
+const replay = (events: Array<{ type: string; delta?: string }>): AGUIPart[] =>
+  events.reduce<AGUIPart[]>(
+    (parts, event) =>
+      processEvent({ type: event.type, data: { ...event, messageId: 'm1' } }, parts).parts,
+    []
+  );
+
+describe('reasoning stream events', () => {
+  it('accumulates the REASONING_* family into one reasoning part', () => {
+    const parts = replay([
+      { type: 'REASONING_START' },
+      { type: 'REASONING_MESSAGE_START' },
+      { type: 'REASONING_MESSAGE_CONTENT', delta: 'Let me ' },
+      { type: 'REASONING_MESSAGE_CONTENT', delta: 'think.' },
+      { type: 'REASONING_MESSAGE_END' },
+      { type: 'REASONING_END' },
+    ]);
+
+    expect(parts).toEqual([{ type: 'reasoning', text: 'Let me think.' }]);
+  });
+
+  it('still accumulates the legacy THINKING_* family', () => {
+    const parts = replay([
+      { type: 'THINKING_START' },
+      { type: 'THINKING_TEXT_MESSAGE_START' },
+      { type: 'THINKING_TEXT_MESSAGE_CONTENT', delta: 'Let me ' },
+      { type: 'THINKING_TEXT_MESSAGE_CONTENT', delta: 'think.' },
+      { type: 'THINKING_TEXT_MESSAGE_END' },
+      { type: 'THINKING_END' },
+    ]);
+
+    expect(parts).toEqual([{ type: 'reasoning', text: 'Let me think.' }]);
+  });
+
+  it('opens a part for REASONING_MESSAGE_CHUNK, which carries no start event', () => {
+    const parts = replay([{ type: 'REASONING_MESSAGE_CHUNK', delta: 'Thinking.' }]);
+
+    expect(parts).toEqual([{ type: 'reasoning', text: 'Thinking.' }]);
+  });
+
+  it('counts a streamed thought as visible output, so the turn leaves its thinking state', () => {
+    // The whole point: this is what un-collapses the message and reveals the
+    // stream while the model is still reasoning.
+    const beforeAnyDelta = replay([{ type: 'REASONING_START' }]);
+    expect(hasStreamedOutput(beforeAnyDelta)).toBe(false);
+
+    const afterFirstDelta = replay([
+      { type: 'REASONING_START' },
+      { type: 'REASONING_MESSAGE_CONTENT', delta: 'Let me think.' },
+    ]);
+    expect(hasStreamedOutput(afterFirstDelta)).toBe(true);
+  });
+
+  it('ignores the encrypted reasoning blob, which carries nothing displayable', () => {
+    const parts = replay([
+      { type: 'REASONING_START' },
+      { type: 'REASONING_MESSAGE_CONTENT', delta: 'Let me think.' },
+      { type: 'REASONING_ENCRYPTED_VALUE' },
+    ]);
+
+    expect(parts).toEqual([{ type: 'reasoning', text: 'Let me think.' }]);
+  });
+});

--- a/frontend/src/hooks/useAGUI.ts
+++ b/frontend/src/hooks/useAGUI.ts
@@ -182,8 +182,16 @@ export function processEvent(
       // No-op: text already accumulated
       break;
 
+    // AG-UI renamed the thinking family to REASONING_* in ag-ui-protocol
+    // 0.1.13. pydantic-ai emits whichever family the negotiated version calls
+    // for, so both have to map onto the same reasoning part -- when only the
+    // legacy names were handled, every reasoning event from the new family was
+    // dropped and the message sat in its "thinking" state, hiding the whole
+    // stream, until the first answer token arrived.
     case 'THINKING_START':
-    case 'THINKING_TEXT_MESSAGE_START': {
+    case 'THINKING_TEXT_MESSAGE_START':
+    case 'REASONING_START':
+    case 'REASONING_MESSAGE_START': {
       // Only push a new reasoning part if the last one isn't an empty reasoning part
       const lastPart = next[next.length - 1];
       if (
@@ -196,19 +204,31 @@ export function processEvent(
       break;
     }
 
-    case 'THINKING_TEXT_MESSAGE_CONTENT': {
+    // REASONING_MESSAGE_CHUNK is the new family's combined start+content
+    // event, so it has to open a part when none is streaming yet.
+    case 'THINKING_TEXT_MESSAGE_CONTENT':
+    case 'REASONING_MESSAGE_CONTENT':
+    case 'REASONING_MESSAGE_CHUNK': {
       const delta = (data.delta as string) || '';
+      let appended = false;
       for (let i = next.length - 1; i >= 0; i--) {
         if (next[i].type === 'reasoning') {
           next[i] = { ...next[i], text: (next[i].text || '') + delta };
+          appended = true;
           break;
         }
       }
+      if (!appended) next.push({ type: 'reasoning', text: delta });
       break;
     }
 
+    // REASONING_ENCRYPTED_VALUE carries the provider's opaque reasoning blob
+    // for history replay, so it has nothing displayable either.
     case 'THINKING_TEXT_MESSAGE_END':
     case 'THINKING_END':
+    case 'REASONING_MESSAGE_END':
+    case 'REASONING_END':
+    case 'REASONING_ENCRYPTED_VALUE':
       // No-op
       break;
 

--- a/frontend/src/lib/streamEvents.ts
+++ b/frontend/src/lib/streamEvents.ts
@@ -14,12 +14,23 @@ export enum StreamEventType {
   TEXT_MESSAGE_CONTENT = 'TEXT_MESSAGE_CONTENT',
   TEXT_MESSAGE_END = 'TEXT_MESSAGE_END',
 
-  // Thinking/reasoning events
+  // Thinking/reasoning events (ag-ui-protocol <= 0.1.12)
   THINKING_START = 'THINKING_START',
   THINKING_TEXT_MESSAGE_START = 'THINKING_TEXT_MESSAGE_START',
   THINKING_TEXT_MESSAGE_CONTENT = 'THINKING_TEXT_MESSAGE_CONTENT',
   THINKING_TEXT_MESSAGE_END = 'THINKING_TEXT_MESSAGE_END',
   THINKING_END = 'THINKING_END',
+
+  // The same events under the names ag-ui-protocol 0.1.13 renamed them to.
+  // Which family arrives depends on the protocol version pydantic-ai
+  // negotiates, so both are live and both must be handled.
+  REASONING_START = 'REASONING_START',
+  REASONING_MESSAGE_START = 'REASONING_MESSAGE_START',
+  REASONING_MESSAGE_CONTENT = 'REASONING_MESSAGE_CONTENT',
+  REASONING_MESSAGE_CHUNK = 'REASONING_MESSAGE_CHUNK',
+  REASONING_MESSAGE_END = 'REASONING_MESSAGE_END',
+  REASONING_END = 'REASONING_END',
+  REASONING_ENCRYPTED_VALUE = 'REASONING_ENCRYPTED_VALUE',
 
   // Tool call events
   TOOL_CALL_START = 'TOOL_CALL_START',
@@ -119,6 +130,13 @@ export function isThinkingEvent(eventType: string): boolean {
     StreamEventType.THINKING_TEXT_MESSAGE_CONTENT,
     StreamEventType.THINKING_TEXT_MESSAGE_END,
     StreamEventType.THINKING_END,
+    StreamEventType.REASONING_START,
+    StreamEventType.REASONING_MESSAGE_START,
+    StreamEventType.REASONING_MESSAGE_CONTENT,
+    StreamEventType.REASONING_MESSAGE_CHUNK,
+    StreamEventType.REASONING_MESSAGE_END,
+    StreamEventType.REASONING_END,
+    StreamEventType.REASONING_ENCRYPTED_VALUE,
   ].includes(eventType as StreamEventType);
 }
 

--- a/src/suzent/acp/server.py
+++ b/src/suzent/acp/server.py
@@ -239,7 +239,13 @@ class TurnTranslator:
                     }
                 )
 
-        elif kind == "THINKING_TEXT_MESSAGE_CONTENT":
+        # ag-ui-protocol 0.1.13 renamed the thinking family to REASONING_*, so
+        # an ACP client sees this agent's thoughts only if both are translated.
+        elif kind in {
+            "THINKING_TEXT_MESSAGE_CONTENT",
+            "REASONING_MESSAGE_CONTENT",
+            "REASONING_MESSAGE_CHUNK",
+        }:
             if delta := str(event.get("delta") or ""):
                 yield Update(
                     {

--- a/src/suzent/core/stream_events.py
+++ b/src/suzent/core/stream_events.py
@@ -29,6 +29,16 @@ class StreamEventType(str, Enum):
     THINKING_TEXT_MESSAGE_CONTENT = "THINKING_TEXT_MESSAGE_CONTENT"
     THINKING_TEXT_MESSAGE_END = "THINKING_TEXT_MESSAGE_END"
     THINKING_END = "THINKING_END"
+    # ag-ui-protocol 0.1.13 renamed the thinking family to REASONING_*.
+    # pydantic-ai emits whichever family the negotiated protocol version calls
+    # for, so both names are live and both must be recognised.
+    REASONING_START = "REASONING_START"
+    REASONING_MESSAGE_START = "REASONING_MESSAGE_START"
+    REASONING_MESSAGE_CONTENT = "REASONING_MESSAGE_CONTENT"
+    REASONING_MESSAGE_CHUNK = "REASONING_MESSAGE_CHUNK"
+    REASONING_MESSAGE_END = "REASONING_MESSAGE_END"
+    REASONING_END = "REASONING_END"
+    REASONING_ENCRYPTED_VALUE = "REASONING_ENCRYPTED_VALUE"
 
     # Tool call events
     TOOL_CALL_START = "TOOL_CALL_START"
@@ -111,6 +121,13 @@ def is_thinking_event(event_type: str) -> bool:
         StreamEventType.THINKING_TEXT_MESSAGE_CONTENT,
         StreamEventType.THINKING_TEXT_MESSAGE_END,
         StreamEventType.THINKING_END,
+        StreamEventType.REASONING_START,
+        StreamEventType.REASONING_MESSAGE_START,
+        StreamEventType.REASONING_MESSAGE_CONTENT,
+        StreamEventType.REASONING_MESSAGE_CHUNK,
+        StreamEventType.REASONING_MESSAGE_END,
+        StreamEventType.REASONING_END,
+        StreamEventType.REASONING_ENCRYPTED_VALUE,
     }
 
 

--- a/src/suzent/streaming.py
+++ b/src/suzent/streaming.py
@@ -223,14 +223,28 @@ class _DraftDisplayAccumulator:
             self.dirty = True
             return
 
-        if event_type in {"THINKING_START", "THINKING_TEXT_MESSAGE_START"}:
+        # ag-ui-protocol 0.1.13 renamed the thinking family to REASONING_*, and
+        # pydantic-ai emits whichever family the negotiated version calls for.
+        # Accumulating only the legacy names dropped reasoning from the draft,
+        # so a refresh mid-turn lost the thought the user was watching.
+        if event_type in {
+            "THINKING_START",
+            "THINKING_TEXT_MESSAGE_START",
+            "REASONING_START",
+            "REASONING_MESSAGE_START",
+        }:
             last = self.parts[-1] if self.parts else None
             if not last or last.get("type") != "reasoning" or last.get("text"):
                 self.parts.append({"type": "reasoning", "text": ""})
                 self.dirty = True
             return
 
-        if event_type == "THINKING_TEXT_MESSAGE_CONTENT":
+        if event_type in {
+            "THINKING_TEXT_MESSAGE_CONTENT",
+            "REASONING_MESSAGE_CONTENT",
+            # The new family's combined start+content event.
+            "REASONING_MESSAGE_CHUNK",
+        }:
             delta = getattr(event, "delta", "") or ""
             for index in range(len(self.parts) - 1, -1, -1):
                 part = self.parts[index]


### PR DESCRIPTION
## The symptom

Starting a chat with a Gemini model, the assembly animation holds the whole message collapsed for the entire turn — no activity rail, no thought, no streaming text — and everything appears at once when the turn ends.

## The cause

`ag-ui-protocol` 0.1.13 renamed the thinking event family to `REASONING_*`, and pydantic-ai's AG-UI adapter picks a family by negotiated version:

```python
self._use_reasoning = parse_ag_ui_version(self.ag_ui_version) >= REASONING_VERSION
```

At `pydantic-ai-slim 2.18.0` + `ag-ui-protocol 0.1.13` we get the new family. Every consumer in this repo only knew the legacy `THINKING_*` names, so reasoning events fell through their switches and were dropped — silently, since both families still exist in the `ag_ui.core` enum and nothing raised.

With no reasoning part ever created, `hasStreamedOutput` stayed false, `isThinking` stayed true, and the content sat at `grid-rows-[0fr]` behind the badge until `TEXT_MESSAGE_START`.

Measured on the real chat path, `gemini/gemini-3.1-pro-preview`:

```
  3.49s  RUN_STARTED
  6.90s  REASONING_START             <- dropped
  6.90s  REASONING_MESSAGE_START     <- dropped
  6.90s  REASONING_MESSAGE_CONTENT   <- dropped
  9.39s  REASONING_MESSAGE_CONTENT   <- dropped
 10.38s  REASONING_MESSAGE_END       <- dropped
 10.38s  REASONING_END               <- dropped
 10.42s  TEXT_MESSAGE_START          <- first thing the UI reacted to
```

Not a Gemini bug — the events were always correct, the consumers were deaf to them. It shows up on Gemini because thinking dominates the turn there; on models that start answering early the blind window is short enough to miss.

The thought still appeared complete once the turn ended, because the finalized message reconstructs reasoning parts from the run result (`chat_processor.py:2365`) rather than from the stream. That is what made this look like a rendering quirk rather than dropped events.

## The change

Map both families onto the same reasoning part:

- `frontend/src/hooks/useAGUI.ts` — `processEvent` opens a part on `REASONING_START` / `REASONING_MESSAGE_START`, appends on `REASONING_MESSAGE_CONTENT` / `REASONING_MESSAGE_CHUNK`, no-ops the end events and `REASONING_ENCRYPTED_VALUE`
- `src/suzent/streaming.py` — `_DraftDisplayAccumulator` accumulates them, so a refresh mid-turn no longer loses the thought from the persisted draft
- `frontend/src/lib/streamEvents.ts`, `src/suzent/core/stream_events.py` — both enums and both `isThinkingEvent` guards
- `src/suzent/acp/server.py` — Suzent-as-an-ACP-agent translates them to `agent_thought_chunk`

`REASONING_MESSAGE_CHUNK` is the new family's combined start+content event and arrives with no start of its own, so the content branch opens a part when none is streaming. That is the only behavioral addition beyond renaming.

## Verification

- New `frontend/src/hooks/useAGUI.reasoning.test.ts` replays the exact event names and shapes captured off the wire, and asserts what actually matters: a streamed thought makes `hasStreamedOutput` true, which is what un-collapses the message mid-turn. Confirmed red without the fix (4 of 5 cases fail; the legacy-family case passes, as it should).
- Frontend: 34 files / 204 tests pass, `tsc --noEmit` clean, eslint clean on changed files.
- Backend: full suite, 1447 passed.
- Draft accumulator checked directly against the same sequence.

## Not included

`ReasoningRailItem` still starts collapsed — it has no auto-expand while streaming, so the live thought is a `THOUGHT` pill you click to open. Left as-is deliberately; the rail itself now appears and updates live, which is the reported problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)