### PR TITLE
Show effective repository context in the sidebar

### DIFF
--- a/docs/02-concepts/skills/skills.md
+++ b/docs/02-concepts/skills/skills.md
@@ -50,15 +50,16 @@ Each skill is a directory containing a `SKILL.md` file and optional resource fol
 
 ```
 ~/.suzent/skills/
-├── official/             # Synced from the repo's built-in skills
-├── external/             # Synced from SKILLS_DIR, grouped by source
-└── user/
-    └── my-skill/
-        ├── SKILL.md      # Required: Main skill definition
-        ├── scripts/      # Optional: Helper scripts
-        ├── references/   # Optional: Reference documents
-        └── assets/       # Optional: Images, data files
+└── my-skill/
+    ├── SKILL.md          # Required: Main skill definition
+    ├── scripts/          # Optional: Helper scripts
+    ├── references/       # Optional: Reference documents
+    └── assets/           # Optional: Images, data files
 ```
+
+Built-in, external, and repository skills remain in their canonical source
+directories. Suzent discovers those directories directly instead of copying
+them below `~/.suzent/skills/`.
 
 ### SKILL.md Format
 
@@ -114,6 +115,18 @@ When enabled, skills are available to agents through the `SkillTool`:
 2. When a task matches a skill's description, agent loads it
 3. Skill content is injected into agent's context
 4. Agent gains specialized knowledge for the task
+
+### Repository Instructions and Project Context
+
+For each chat, Suzent also loads `AGENTS.md` and `CLAUDE.md` from the effective
+working directory and every ancestor up to the repository root. Instructions
+are applied ancestor-first, so the file closest to the working directory has
+final precedence. Identical files are deduplicated.
+
+These repository instructions are separate from the project's durable
+`context.md` core memory. The chat right sidebar's **Context** tab shows both:
+non-empty project context remains editable, while effective repository
+instructions are shown as collapsible read-only previews with their host paths.
 
 ### Skill Paths in Sandbox
 

--- a/frontend/src/components/chat/RightSidebar.tsx
+++ b/frontend/src/components/chat/RightSidebar.tsx
@@ -6,6 +6,7 @@ import { WebActivitiesView } from '../sidebar/WebActivitiesView';
 import { CanvasView } from '../sidebar/CanvasView';
 import { SubAgentView } from '../sidebar/SubAgentView';
 import { SubAgentList } from '../sidebar/SubAgentList';
+import { RepositoryContextView } from '../sidebar/RepositoryContextView';
 import type { Message, Goal, Task } from '../../types/api';
 import type { KanbanData } from '../../hooks/useGoalTasks';
 import type { CanvasState } from '../../hooks/useCanvas';
@@ -22,13 +23,14 @@ import {
   CpuChipIcon,
   ClipboardDocumentListIcon,
   WrenchScrewdriverIcon,
+  DocumentTextIcon,
 } from '@heroicons/react/24/outline';
 import { ToolsPanel } from './ToolsPanel';
 
 // Icon strip width in px — keep in sync with w-11 (2.75rem = 44px)
 const ICON_STRIP_WIDTH = 44;
 
-type TabId = 'files' | 'browser' | 'canvas' | 'agents' | 'plan' | 'project' | 'tools';
+type TabId = 'files' | 'context' | 'browser' | 'canvas' | 'agents' | 'plan' | 'project' | 'tools';
 
 interface RightSidebarProps {
   isOpen: boolean;
@@ -103,7 +105,7 @@ export const RightSidebar: React.FC<RightSidebarProps> = ({
   onClearForcedWebContext,
   isNewChat = false,
 }) => {
-  useI18n();
+  const { t } = useI18n();
   const [activeTab, setActiveTab] = useState<TabId>('browser');
   const [isFileExpanded, setIsFileExpanded] = useState(false);
   const [isBrowserStreamActive, setIsBrowserStreamActive] = useState(false);
@@ -159,6 +161,14 @@ export const RightSidebar: React.FC<RightSidebarProps> = ({
       fallbackLabel: 'Files',
       hasContent: !!fileToPreview,
       hasActivity: !!fileToPreview,
+    },
+    {
+      id: 'context',
+      icon: DocumentTextIcon,
+      labelKey: 'sidebar.tabs.context',
+      fallbackLabel: 'Context',
+      hasContent: Boolean(currentChatId),
+      hasActivity: false,
     },
     {
       id: 'browser',
@@ -476,6 +486,11 @@ export const RightSidebar: React.FC<RightSidebarProps> = ({
                 />
               </div>
               <div
+                className={`flex-1 h-full flex-col min-h-0 ${activeTab === 'context' ? 'flex' : 'hidden'}`}
+              >
+                {currentChatId && <RepositoryContextView chatId={currentChatId} />}
+              </div>
+              <div
                 className={`flex-1 h-full flex flex-col ${activeTab === 'browser' ? 'flex' : 'hidden'}`}
               >
                 <WebActivitiesView
@@ -550,6 +565,11 @@ export const RightSidebar: React.FC<RightSidebarProps> = ({
                 />
               </div>
               <div
+                className={`flex-1 h-full flex-col min-h-0 ${activeTab === 'context' ? 'flex' : 'hidden'}`}
+              >
+                {currentChatId && <RepositoryContextView chatId={currentChatId} />}
+              </div>
+              <div
                 className={`flex-1 h-full flex flex-col ${activeTab === 'browser' ? 'flex' : 'hidden'}`}
               >
                 <WebActivitiesView
@@ -617,7 +637,7 @@ export const RightSidebar: React.FC<RightSidebarProps> = ({
               key={tab.id}
               disabled={isDisabled}
               onClick={() => handleTabClick(tab.id)}
-              title={tab.fallbackLabel}
+              title={t(tab.labelKey) || tab.fallbackLabel}
               aria-disabled={isDisabled}
               className={`
                 relative flex items-center justify-center w-9 h-9 rounded transition-colors

--- a/frontend/src/components/sidebar/RepositoryContextView.tsx
+++ b/frontend/src/components/sidebar/RepositoryContextView.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ArrowPathIcon, ChevronDownIcon } from '@heroicons/react/24/outline';
+import { useI18n } from '../../i18n';
+import { useChatStreamingStore } from '../../hooks/useChatStore';
+import { memoryApi } from '../../lib/memoryApi';
+import type { RepositoryContextResponse, RepositoryInstruction } from '../../types/memory';
+import { BrutalButton } from '../BrutalButton';
+import { MarkdownRenderer } from '../chat/MarkdownRenderer';
+import { CoreMemoryBlock } from '../memory/CoreMemoryBlock';
+
+interface RepositoryContextViewProps {
+  chatId: string;
+}
+
+function InstructionCard({ instruction }: { instruction: RepositoryInstruction }) {
+  const { t } = useI18n();
+  const [collapsed, setCollapsed] = useState(true);
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(instruction.content);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <section className="border-2 border-brutal-black bg-white shadow-brutal-sm dark:bg-zinc-800">
+      <header className="flex items-start justify-between gap-2 border-b-2 border-brutal-black px-3 py-2">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="font-brutal text-sm uppercase text-brutal-black dark:text-white">
+              {instruction.name}
+            </h3>
+            <span className="border border-brutal-black px-1 font-mono text-[9px] uppercase dark:border-white">
+              {t(`repositoryContext.sources.${instruction.source}`)}
+            </span>
+          </div>
+          <p
+            className="mt-1 truncate font-mono text-[10px] text-neutral-500 dark:text-neutral-400"
+            title={instruction.path}
+          >
+            {instruction.path}
+          </p>
+        </div>
+        <div className="flex shrink-0 gap-1">
+          <BrutalButton size="xs" onClick={copy} disabled={!instruction.content}>
+            {copied ? t('coreMemory.copiedText') : t('common.copy')}
+          </BrutalButton>
+          <BrutalButton
+            size="icon"
+            onClick={() => setCollapsed((value) => !value)}
+            aria-expanded={!collapsed}
+            title={collapsed ? t('memoryView.expandSection') : t('memoryView.collapseSection')}
+          >
+            <ChevronDownIcon
+              className={`h-4 w-4 stroke-2 transition-transform ${collapsed ? '-rotate-90' : ''}`}
+            />
+          </BrutalButton>
+        </div>
+      </header>
+      {!collapsed && instruction.content && (
+        <div className="max-h-[420px] overflow-y-auto overflow-x-hidden break-words bg-neutral-50 px-3 py-2 text-sm leading-6 dark:bg-zinc-900 [&_h1]:mb-1 [&_h1]:mt-3 [&_h2]:mb-1 [&_h2]:mt-3 [&_li]:my-0 [&_ol]:my-1 [&_p]:my-1 [&_ul]:my-1">
+          <MarkdownRenderer content={instruction.content} streamingLite />
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function RepositoryContextView({ chatId }: RepositoryContextViewProps) {
+  const { t } = useI18n();
+  const { isStreaming } = useChatStreamingStore();
+  const previousStreaming = useRef(isStreaming);
+  const [data, setData] = useState<RepositoryContextResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setData(await memoryApi.getRepositoryContext(chatId));
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : t('repositoryContext.loadFailed'));
+    } finally {
+      setLoading(false);
+    }
+  }, [chatId, t]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    if (previousStreaming.current && !isStreaming) void load();
+    previousStreaming.current = isStreaming;
+  }, [isStreaming, load]);
+
+  const updateProjectContext = async (_label: string, content: string) => {
+    const projectId = data?.project.projectId;
+    if (!projectId) return;
+    await memoryApi.updateProjectContext(projectId, content);
+    setData((current) =>
+      current
+        ? {
+            ...current,
+            project: { ...current.project, content, exists: true },
+          }
+        : current
+    );
+  };
+
+  const hasProjectContext = Boolean(data?.project.content.trim());
+  const hasInstructions = Boolean(data?.instructions.length);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-neutral-50 dark:bg-zinc-900">
+      <header className="flex items-center justify-between border-b-3 border-brutal-black bg-white px-3 py-3 dark:bg-zinc-800">
+        <div className="min-w-0">
+          <h2 className="font-brutal text-base uppercase text-brutal-black dark:text-white">
+            {t('repositoryContext.title')}
+          </h2>
+          <p className="truncate font-mono text-[10px] text-neutral-500 dark:text-neutral-400">
+            {t('repositoryContext.description')}
+          </p>
+        </div>
+        <BrutalButton
+          size="icon"
+          onClick={() => void load()}
+          disabled={loading}
+          title={t('common.refresh')}
+        >
+          <ArrowPathIcon className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+        </BrutalButton>
+      </header>
+
+      <div className="scrollbar-thin flex-1 space-y-4 overflow-y-auto p-3">
+        {error && (
+          <div className="border-2 border-brutal-red bg-white p-3 font-mono text-xs text-brutal-red dark:bg-zinc-800">
+            {error}
+          </div>
+        )}
+
+        {loading && !data && (
+          <div className="border-2 border-brutal-black bg-white p-4 font-mono text-xs uppercase animate-brutal-blink dark:bg-zinc-800">
+            {t('common.loading')}
+          </div>
+        )}
+
+        {data && hasProjectContext && (
+          <section className="space-y-2">
+            <h3 className="border-b-2 border-brutal-black pb-1 font-brutal text-xs uppercase dark:border-white">
+              {t('repositoryContext.projectContext')}
+            </h3>
+            <div title={data.project.path}>
+              <CoreMemoryBlock
+                label="context"
+                content={data.project.content}
+                titleOverride="context.md"
+                descriptionOverride={data.project.projectName}
+                collapsible
+                onUpdate={updateProjectContext}
+              />
+            </div>
+          </section>
+        )}
+
+        {data && hasInstructions && (
+          <section className="space-y-2">
+            <div className="border-b-2 border-brutal-black pb-1 dark:border-white">
+              <h3 className="font-brutal text-xs uppercase">
+                {t('repositoryContext.repositoryInstructions')}
+              </h3>
+              <p className="font-mono text-[10px] text-neutral-500 dark:text-neutral-400">
+                {t('repositoryContext.repositoryInstructionsDesc')}
+              </p>
+            </div>
+            {data.instructions.map((instruction) => (
+              <InstructionCard key={instruction.path} instruction={instruction} />
+            ))}
+          </section>
+        )}
+
+        {data && !hasProjectContext && !hasInstructions && (
+          <div className="border-2 border-dashed border-neutral-400 px-4 py-8 text-center font-mono text-xs text-neutral-500 dark:border-zinc-600 dark:text-neutral-400">
+            {t('repositoryContext.empty')}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -93,6 +93,7 @@ export const en = {
       chats: 'Chats',
       config: 'Config',
       files: 'Files',
+      context: 'Context',
       browser: 'Web',
       canvas: 'Canvas',
       agents: 'Agents',
@@ -101,6 +102,19 @@ export const en = {
     },
     settings: 'Settings',
     settingsDesc: '',
+  },
+  repositoryContext: {
+    title: 'Context',
+    description: 'Project memory and effective repository instructions',
+    projectContext: 'Project context',
+    repositoryInstructions: 'Repository instructions',
+    repositoryInstructionsDesc: 'Loaded ancestor-first; the closest file has final precedence.',
+    empty: 'No project context or repository instructions found.',
+    loadFailed: 'Failed to load repository context',
+    sources: {
+      repository: 'Repository',
+      working: 'Working directory',
+    },
   },
   subAgents: {
     model: 'Model',

--- a/frontend/src/i18n/messages/zh-CN.ts
+++ b/frontend/src/i18n/messages/zh-CN.ts
@@ -89,6 +89,7 @@ export const zhCN = {
       chats: '对话列表',
       config: '配置',
       files: '文件',
+      context: '上下文',
       browser: '网页',
       canvas: '画布',
       agents: '子代理',
@@ -97,6 +98,19 @@ export const zhCN = {
     },
     settings: '设置',
     settingsDesc: '',
+  },
+  repositoryContext: {
+    title: '上下文',
+    description: '项目记忆与当前生效的代码仓库指令',
+    projectContext: '项目上下文',
+    repositoryInstructions: '代码仓库指令',
+    repositoryInstructionsDesc: '按祖先目录优先加载，最近的文件具有最终优先级。',
+    empty: '未找到项目上下文或代码仓库指令。',
+    loadFailed: '加载代码仓库上下文失败',
+    sources: {
+      repository: '代码仓库',
+      working: '工作目录',
+    },
   },
   subAgents: {
     model: '模型',

--- a/frontend/src/lib/memoryApi.ts
+++ b/frontend/src/lib/memoryApi.ts
@@ -19,6 +19,7 @@ import type {
   DreamStatus,
   ProjectContext,
   ProjectContextsResponse,
+  RepositoryContextResponse,
 } from '../types/memory';
 import { getApiBase } from './api';
 
@@ -92,6 +93,16 @@ export const memoryApi = {
       const error = await response.json().catch(() => ({ error: response.statusText }));
       throw new Error(error.error || 'Failed to update project context');
     }
+  },
+
+  async getRepositoryContext(chatId: string): Promise<RepositoryContextResponse> {
+    const response = await fetch(
+      `${memoryEndpoint()}/repository-context?chat_id=${encodeURIComponent(chatId)}`
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to fetch repository context: ${response.statusText}`);
+    }
+    return await response.json();
   },
 
   /**

--- a/frontend/src/types/memory.ts
+++ b/frontend/src/types/memory.ts
@@ -21,6 +21,28 @@ export interface ProjectContextsResponse {
   projects: ProjectContext[];
 }
 
+export interface RepositoryContextProject {
+  projectId: string | null;
+  projectName: string;
+  content: string;
+  exists: boolean;
+  path: string;
+  virtualPath: string;
+}
+
+export interface RepositoryInstruction {
+  name: string;
+  content: string;
+  source: 'repository' | 'working';
+  path: string;
+  virtualPath: string | null;
+}
+
+export interface RepositoryContextResponse {
+  project: RepositoryContextProject;
+  instructions: RepositoryInstruction[];
+}
+
 export interface ArchivalMemory {
   id: string;
   content: string;

--- a/src/suzent/config/model.py
+++ b/src/suzent/config/model.py
@@ -51,12 +51,13 @@ def get_effective_volumes(custom_volumes: Optional[List[str]] = None) -> List[st
     from suzent.tools.filesystem.path_resolver import PathResolver
 
     for vol in raw_volumes:
-        parsed = PathResolver.parse_volume_string(vol)
+        parsed = PathResolver.parse_volume_spec(vol)
         if parsed:
-            host, container = parsed
+            host, container, mode = parsed
             if not Path(host).is_absolute():
                 host = str((PROJECT_DIR / host).resolve())
-                vol = f"{host}:{container}"
+                mode_suffix = ":ro" if mode == "ro" else ""
+                vol = f"{host}:{container}{mode_suffix}"
 
         volumes.append(vol)
 

--- a/src/suzent/core/repository_context.py
+++ b/src/suzent/core/repository_context.py
@@ -80,6 +80,14 @@ class DiscoveredAgentFile:
     source_id: str
 
 
+@dataclass(frozen=True)
+class DiscoveredInstructionFile:
+    """One instruction file loaded by RepoContext's walk-up strategy."""
+
+    path: Path
+    source: str
+
+
 def find_repository_root(start: Path) -> Path | None:
     """Find the nearest Git repository containing *start*."""
     current = start.resolve()
@@ -254,6 +262,49 @@ def discover_agent_files(roots: RepositoryContextRoots) -> list[DiscoveredAgentF
     return discovered
 
 
+def discover_instruction_files(
+    roots: RepositoryContextRoots,
+) -> list[DiscoveredInstructionFile]:
+    """Mirror RepoContext's ancestor-first instruction-file discovery."""
+    workspace = roots.working_dir.resolve()
+    repository_root = roots.repository_root.resolve() if roots.repository_root else None
+    directories = [workspace]
+    if repository_root is not None and (
+        workspace == repository_root or repository_root in workspace.parents
+    ):
+        directories = []
+        current = workspace
+        while True:
+            directories.append(current)
+            if current == repository_root:
+                break
+            current = current.parent
+        directories.reverse()
+
+    discovered: list[DiscoveredInstructionFile] = []
+    seen_paths: set[Path] = set()
+    seen_content: set[str] = set()
+    for directory in directories:
+        source = "working" if directory == workspace else "repository"
+        for filename in INSTRUCTION_FILENAMES:
+            path = directory / filename
+            if not path.is_file():
+                continue
+            resolved = path.resolve()
+            if resolved in seen_paths:
+                continue
+            try:
+                content_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+            except OSError:
+                continue
+            if content_hash in seen_content:
+                continue
+            seen_paths.add(resolved)
+            seen_content.add(content_hash)
+            discovered.append(DiscoveredInstructionFile(path=resolved, source=source))
+    return discovered
+
+
 def build_repo_context_capabilities(roots: RepositoryContextRoots) -> list[object]:
     """Create a RepoContext capability for working-tree instructions."""
     from pydantic_ai_harness import RepoContext
@@ -277,17 +328,13 @@ async def repository_agents_reminder_hook(chat_id: str, deps: object) -> str | N
     if not agent_files:
         return None
 
-    project_dir = Path(deps.path_resolver.get_working_dir()).resolve()
     sandbox_enabled = bool(getattr(deps, "sandbox_enabled", True))
     lines: list[str] = []
     for agent_file in agent_files:
         path = agent_file.path.resolve()
         location = str(path)
         if sandbox_enabled:
-            try:
-                location = f"/workspace/{path.relative_to(project_dir).as_posix()}"
-            except ValueError:
-                location = str(path)
+            location = deps.path_resolver.to_virtual_path(path) or str(path)
         lines.append(f"- {path.stem} ({agent_file.source}): {location}")
     return (
         "Repository agent definitions are available. Read the matching definition "

--- a/src/suzent/routes/memory_routes.py
+++ b/src/suzent/routes/memory_routes.py
@@ -215,6 +215,96 @@ async def update_project_context(request: Request) -> JSONResponse:
         return JSONResponse({"error": str(e)}, status_code=500)
 
 
+async def get_repository_context(request: Request) -> JSONResponse:
+    """Return the current chat's project memory and effective repo instructions."""
+    try:
+        chat_id = str(request.query_params.get("chat_id") or "").strip()
+        if not chat_id:
+            return JSONResponse({"error": "Missing chat_id"}, status_code=400)
+
+        database = get_database()
+        chat = database.get_chat(chat_id)
+        if chat is None:
+            return JSONResponse({"error": "Chat not found"}, status_code=404)
+
+        project_id = database.get_chat_project_id(chat_id)
+        project = database.get_project(project_id) if project_id else None
+        manager = await _get_or_initialize_memory_manager()
+        if not manager:
+            return JSONResponse(
+                {"error": "Memory system not initialized"}, status_code=503
+            )
+
+        from suzent.config import get_effective_volumes
+        from suzent.core.repository_context import (
+            discover_instruction_files,
+            resolve_repository_context,
+        )
+        from suzent.tools.filesystem.path_resolver import PathResolver
+
+        chat_config = chat.config or {}
+        volumes = get_effective_volumes(chat_config.get("sandbox_volumes") or [])
+        roots = resolve_repository_context(
+            chat_id,
+            chat_config.get("cwd"),
+            custom_volumes=volumes,
+        )
+        sandbox_enabled = bool(
+            chat_config.get("sandbox_enabled", CONFIG.sandbox_enabled)
+        )
+        resolver = PathResolver(
+            chat_id,
+            sandbox_enabled,
+            sandbox_data_path=CONFIG.sandbox_data_path,
+            custom_volumes=volumes,
+            workspace_root=CONFIG.workspace_root,
+        )
+
+        instructions = []
+        for instruction in discover_instruction_files(roots):
+            try:
+                content = instruction.path.read_text(encoding="utf-8")
+            except OSError as exc:
+                logger.warning(
+                    "Failed to read repository instruction file {}: {}",
+                    instruction.path,
+                    exc,
+                )
+                continue
+            instructions.append(
+                {
+                    "name": instruction.path.name,
+                    "content": content,
+                    "source": instruction.source,
+                    "path": str(instruction.path),
+                    "virtualPath": resolver.to_virtual_path(instruction.path),
+                }
+            )
+
+        context = (
+            await manager.markdown_store.read_project_context(project_id)
+            if project_id
+            else None
+        )
+        context_path = roots.project_dir / "context.md"
+        return JSONResponse(
+            {
+                "project": {
+                    "projectId": project_id,
+                    "projectName": project.name if project else "",
+                    "content": context or "",
+                    "exists": context is not None,
+                    "path": str(context_path.resolve()),
+                    "virtualPath": "/workspace/context.md",
+                },
+                "instructions": instructions,
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error getting repository context: {e}")
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
 async def search_archival_memory(request: Request) -> JSONResponse:
     """
     Search archival memories with semantic search.

--- a/src/suzent/routes/sandbox_routes.py
+++ b/src/suzent/routes/sandbox_routes.py
@@ -151,10 +151,38 @@ def _get_resolver_for_request(
     if override_volumes is not None and "sandbox_enabled" not in locals():
         sandbox_enabled = CONFIG.sandbox_enabled
 
+    custom_volumes = _with_discovered_skill_volumes(
+        chat_id, custom_volumes, sandbox_enabled=sandbox_enabled
+    )
+
     # Create resolver for virtual paths such as /workspace, /shared, and custom mounts.
     return PathResolver(
         chat_id=chat_id, sandbox_enabled=sandbox_enabled, custom_volumes=custom_volumes
     )
+
+
+def _with_discovered_skill_volumes(
+    chat_id: str | None,
+    volumes: list[str],
+    *,
+    sandbox_enabled: bool = True,
+) -> list[str]:
+    """Add canonical skill mounts needed by this chat's effective context."""
+    if not chat_id:
+        return list(volumes)
+
+    from suzent.skills.manager import get_skill_manager_for_chat
+
+    effective = list(volumes)
+    manager = get_skill_manager_for_chat(
+        chat_id,
+        custom_volumes=effective,
+        sandbox_enabled=sandbox_enabled,
+    )
+    for volume in manager.required_mounts:
+        if volume not in effective:
+            effective.append(volume)
+    return effective
 
 
 async def get_sandbox_volumes(request: Request) -> JSONResponse:
@@ -181,7 +209,9 @@ async def get_sandbox_volumes(request: Request) -> JSONResponse:
         except Exception as e:
             logger.warning(f"Failed to fetch chat config for volumes: {e}")
 
-    return JSONResponse({"volumes": get_effective_volumes(custom_volumes)})
+    effective_volumes = get_effective_volumes(custom_volumes)
+    effective_volumes = _with_discovered_skill_volumes(chat_id, effective_volumes)
+    return JSONResponse({"volumes": effective_volumes})
 
 
 async def list_sandbox_files(request: Request) -> JSONResponse:

--- a/src/suzent/sandbox/manager.py
+++ b/src/suzent/sandbox/manager.py
@@ -396,11 +396,11 @@ class DockerSession:
         from suzent.tools.filesystem.path_resolver import PathResolver
 
         for vol in self.custom_volumes:
-            parsed = PathResolver.parse_volume_string(vol)
+            parsed = PathResolver.parse_volume_spec(vol)
             if not parsed:
                 logger.warning(f"Skipping invalid volume: {vol}")
                 continue
-            host, container = parsed
+            host, container, mode = parsed
             if not Path(host).is_absolute():
                 from suzent.config import PROJECT_DIR
 
@@ -410,7 +410,7 @@ class DockerSession:
             except ValueError as e:
                 logger.error(str(e))
                 continue
-            volumes[host] = {"bind": container, "mode": "rw"}
+            volumes[host] = {"bind": container, "mode": mode}
 
         return volumes
 

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -135,6 +135,7 @@ from suzent.routes.memory_routes import (
     get_core_memory,
     update_core_memory_block,
     list_project_contexts,
+    get_repository_context,
     update_project_context,
     search_archival_memory,
     delete_archival_memory,
@@ -1159,6 +1160,7 @@ app = Starlette(
         Route("/memory/core", get_core_memory, methods=["GET"]),
         Route("/memory/core", update_core_memory_block, methods=["PUT"]),
         Route("/memory/project-contexts", list_project_contexts, methods=["GET"]),
+        Route("/memory/repository-context", get_repository_context, methods=["GET"]),
         Route(
             "/memory/project-contexts/{project_id}",
             update_project_context,

--- a/src/suzent/skills/manager.py
+++ b/src/suzent/skills/manager.py
@@ -133,7 +133,7 @@ class SkillManager:
                     continue
                 preferred = preferred_virtual_roots.get(root)
                 if preferred:
-                    self.required_mounts.append(f"{root.resolve()}:{preferred}")
+                    self.required_mounts.append(f"{root.resolve()}:{preferred}:ro")
                     mount_mappings.append((root.resolve(), preferred))
 
         self.skills_dir = self.skills_dirs[-1]

--- a/src/suzent/tools/filesystem/path_resolver.py
+++ b/src/suzent/tools/filesystem/path_resolver.py
@@ -121,23 +121,35 @@ class PathResolver:
             return ChatDatabase.DEFAULT_PROJECT_SLUG
 
     @staticmethod
+    def parse_volume_spec(vol: str) -> Optional[Tuple[str, str, str]]:
+        """Parse ``host:container[:mode]`` while preserving Windows drives."""
+        mode = "rw"
+        volume = vol
+        suffix = vol.rsplit(":", 1)[-1].lower()
+        if suffix in {"ro", "rw"}:
+            volume, mode = vol.rsplit(":", 1)
+
+        if ":" not in volume:
+            return None
+
+        last_colon = volume.rfind(":")
+        host_part = volume[:last_colon]
+        container_part = volume[last_colon + 1 :]
+        if not host_part or not container_part:
+            return None
+        return host_part, container_part, mode
+
+    @staticmethod
     def parse_volume_string(vol: str) -> Optional[Tuple[str, str]]:
         """
         Parse a volume string 'host:container' into components.
         Handles Windows drive letters (e.g. D:/path:/container).
         Returns (host_path, container_path) or None if invalid.
         """
-        if ":" not in vol:
+        parsed = PathResolver.parse_volume_spec(vol)
+        if parsed is None:
             return None
-
-        # Handle Windows drive letters (e.g. D:/host:/container)
-        # Find the LAST colon which separates host and container
-        last_colon = vol.rfind(":")
-        if last_colon == -1:
-            return None
-
-        host_part = vol[:last_colon]
-        container_part = vol[last_colon + 1 :]
+        host_part, container_part, _mode = parsed
         return host_part, container_part
 
     @staticmethod

--- a/tests/core/test_repository_context.py
+++ b/tests/core/test_repository_context.py
@@ -7,6 +7,7 @@ from suzent.core.repository_context import (
     RepositoryContextRoots,
     build_repo_context_capabilities,
     discover_agent_files,
+    discover_instruction_files,
     discover_skill_roots,
     find_repository_root,
     repository_agents_reminder_hook,
@@ -158,6 +159,32 @@ def test_existing_repository_mount_is_reused_for_skill_paths(tmp_path: Path):
     )
 
 
+def test_uncovered_canonical_skill_source_is_mounted_read_only(tmp_path: Path):
+    canonical = tmp_path / "skills"
+    project_dir = tmp_path / "project"
+    empty_global = tmp_path / "empty-global"
+    project_dir.mkdir()
+    _write_skill(canonical, "shared", "shared", "body")
+
+    manager = SkillManager(
+        skills_dir=empty_global,
+        discovered_roots=[
+            SimpleNamespace(
+                path=canonical,
+                source="repository",
+                source_id="repository:test:skills",
+                virtual_root=None,
+                default_enabled=True,
+            )
+        ],
+        project_dir=project_dir,
+    )
+
+    assert manager.required_mounts == [
+        f"{canonical.resolve()}:/mnt/skills/discovered/repository-test-skills:ro"
+    ]
+
+
 def test_chat_repository_context_comes_from_its_volume_not_process_cwd(
     tmp_path: Path, monkeypatch
 ):
@@ -224,6 +251,57 @@ def test_context_roots_deduplicate_project_that_is_also_repository(tmp_path: Pat
     assert capabilities[0].home_dir == tmp_path.resolve()
 
 
+def test_discovers_walk_up_instruction_files_ancestor_first(tmp_path: Path):
+    repository = tmp_path / "repository"
+    working = repository / "packages" / "api"
+    working.mkdir(parents=True)
+    (repository / ".git").mkdir()
+    root_agents = repository / "AGENTS.md"
+    package_claude = repository / "packages" / "CLAUDE.md"
+    working_agents = working / "AGENTS.md"
+    root_agents.write_text("root", encoding="utf-8")
+    package_claude.write_text("package", encoding="utf-8")
+    working_agents.write_text("working", encoding="utf-8")
+    roots = RepositoryContextRoots(
+        tmp_path / "project",
+        working,
+        repository,
+        home_dir=None,
+    )
+
+    discovered = discover_instruction_files(roots)
+
+    assert [item.path for item in discovered] == [
+        root_agents.resolve(),
+        package_claude.resolve(),
+        working_agents.resolve(),
+    ]
+    assert [item.source for item in discovered] == [
+        "repository",
+        "repository",
+        "working",
+    ]
+
+
+def test_instruction_discovery_deduplicates_identical_content(tmp_path: Path):
+    repository = tmp_path / "repository"
+    working = repository / "package"
+    working.mkdir(parents=True)
+    (repository / ".git").mkdir()
+    (repository / "AGENTS.md").write_text("same", encoding="utf-8")
+    (working / "CLAUDE.md").write_text("same", encoding="utf-8")
+    roots = RepositoryContextRoots(
+        tmp_path / "project",
+        working,
+        repository,
+        home_dir=None,
+    )
+
+    discovered = discover_instruction_files(roots)
+
+    assert [item.path for item in discovered] == [(repository / "AGENTS.md").resolve()]
+
+
 @pytest.mark.asyncio
 async def test_repository_agent_files_are_surfaced_with_workspace_paths(tmp_path: Path):
     agent_file = tmp_path / ".agents" / "agents" / "reviewer.md"
@@ -233,7 +311,11 @@ async def test_repository_agent_files_are_surfaced_with_workspace_paths(tmp_path
     deps = SimpleNamespace(
         repository_agent_files=discover_agent_files(roots),
         sandbox_enabled=True,
-        path_resolver=SimpleNamespace(get_working_dir=lambda: tmp_path),
+        path_resolver=SimpleNamespace(
+            to_virtual_path=lambda path: (
+                f"/workspace/{path.relative_to(tmp_path).as_posix()}"
+            )
+        ),
     )
 
     reminder = await repository_agents_reminder_hook("chat", deps)
@@ -241,3 +323,38 @@ async def test_repository_agent_files_are_surfaced_with_workspace_paths(tmp_path
     assert reminder is not None
     assert "reviewer (repository)" in reminder
     assert "/workspace/.agents/agents/reviewer.md" in reminder
+
+
+@pytest.mark.asyncio
+async def test_repository_agent_files_use_custom_mount_paths(tmp_path: Path):
+    project_dir = tmp_path / "project"
+    repository = tmp_path / "repository"
+    project_dir.mkdir()
+    agent_file = repository / ".agents" / "agents" / "reviewer.md"
+    agent_file.parent.mkdir(parents=True)
+    agent_file.write_text("# Reviewer\n", encoding="utf-8")
+    roots = RepositoryContextRoots(
+        project_dir,
+        repository,
+        repository,
+        home_dir=None,
+    )
+    from suzent.tools.filesystem.path_resolver import PathResolver
+
+    deps = SimpleNamespace(
+        repository_agent_files=discover_agent_files(roots),
+        sandbox_enabled=True,
+        path_resolver=PathResolver(
+            "chat",
+            True,
+            project_slug="project",
+            sandbox_data_path=tmp_path / "sandbox",
+            custom_volumes=[f"{repository}:/mnt/repository"],
+        ),
+    )
+
+    reminder = await repository_agents_reminder_hook("chat", deps)
+
+    assert reminder is not None
+    assert "/mnt/repository/.agents/agents/reviewer.md" in reminder
+    assert str(repository) not in reminder

--- a/tests/routes/test_project_context_routes.py
+++ b/tests/routes/test_project_context_routes.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from pathlib import Path
 
 from starlette.applications import Starlette
 from starlette.routing import Route
@@ -109,3 +110,70 @@ def test_rejects_unknown_project_context(monkeypatch):
     response = client.put("/memory/project-contexts/missing", json={"content": "nope"})
 
     assert response.status_code == 404
+
+
+def test_repository_context_returns_project_memory_and_walk_up_instructions(
+    monkeypatch, tmp_path: Path
+):
+    repository = tmp_path / "repository"
+    working = repository / "packages" / "api"
+    project_dir = tmp_path / "projects" / "one"
+    working.mkdir(parents=True)
+    project_dir.mkdir(parents=True)
+    (repository / ".git").mkdir()
+    (repository / "AGENTS.md").write_text("# Root rules\n", encoding="utf-8")
+    (working / "CLAUDE.md").write_text("# API rules\n", encoding="utf-8")
+    project = SimpleNamespace(id="project-1", name="One", slug="one", archived=False)
+    chat = SimpleNamespace(
+        id="chat-1",
+        project_id=project.id,
+        working_directory=str(working),
+        config={"sandbox_enabled": False},
+    )
+    database = SimpleNamespace(
+        get_chat=lambda _chat_id: chat,
+        get_chat_project_id=lambda _chat_id: project.id,
+        get_chat_project_slug=lambda _chat_id: project.slug,
+        get_project=lambda _project_id: project,
+        get_project_dir=lambda _chat_id: project_dir,
+    )
+    markdown_store = _FakeMarkdownStore()
+
+    async def get_manager():
+        return SimpleNamespace(markdown_store=markdown_store)
+
+    monkeypatch.setattr(memory_routes, "get_database", lambda: database)
+    monkeypatch.setattr("suzent.database.get_database", lambda: database)
+    monkeypatch.setattr(memory_routes, "_get_or_initialize_memory_manager", get_manager)
+    app = Starlette(
+        routes=[
+            Route(
+                "/memory/repository-context",
+                memory_routes.get_repository_context,
+                methods=["GET"],
+            )
+        ]
+    )
+
+    response = TestClient(app).get(
+        "/memory/repository-context", params={"chat_id": "chat-1"}
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["project"] == {
+        "projectId": "project-1",
+        "projectName": "One",
+        "content": "# One\n",
+        "exists": True,
+        "path": str((project_dir / "context.md").resolve()),
+        "virtualPath": "/workspace/context.md",
+    }
+    assert [item["name"] for item in payload["instructions"]] == [
+        "AGENTS.md",
+        "CLAUDE.md",
+    ]
+    assert [item["content"] for item in payload["instructions"]] == [
+        "# Root rules\n",
+        "# API rules\n",
+    ]

--- a/tests/routes/test_sandbox_skill_volumes.py
+++ b/tests/routes/test_sandbox_skill_volumes.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from suzent.routes import sandbox_routes
+
+
+@pytest.mark.asyncio
+async def test_get_sandbox_volumes_includes_discovered_skill_mounts(monkeypatch):
+    chat = {"config": {"sandbox_volumes": ["/repo:/mnt/repository"]}}
+    monkeypatch.setattr(
+        sandbox_routes,
+        "get_database",
+        lambda: SimpleNamespace(get_chat=lambda _chat_id: chat),
+    )
+    monkeypatch.setattr(
+        sandbox_routes,
+        "get_effective_volumes",
+        lambda volumes: list(volumes),
+    )
+    monkeypatch.setattr(
+        "suzent.skills.manager.get_skill_manager_for_chat",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            required_mounts=["/skills:/mnt/skills/discovered/repository:ro"]
+        ),
+    )
+    request = SimpleNamespace(query_params={"chat_id": "chat-1"})
+
+    response = await sandbox_routes.get_sandbox_volumes(request)
+
+    assert response.status_code == 200
+    assert response.body == (
+        b'{"volumes":["/repo:/mnt/repository",'
+        b'"/skills:/mnt/skills/discovered/repository:ro"]}'
+    )
+
+
+def test_request_resolver_includes_discovered_skill_mounts(monkeypatch):
+    monkeypatch.setattr(
+        sandbox_routes,
+        "get_effective_volumes",
+        lambda volumes: list(volumes),
+    )
+    monkeypatch.setattr(
+        sandbox_routes,
+        "get_database",
+        lambda: SimpleNamespace(
+            get_chat=lambda _chat_id: {
+                "config": {
+                    "sandbox_enabled": True,
+                    "sandbox_volumes": ["/repo:/mnt/repository"],
+                }
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "suzent.skills.manager.get_skill_manager_for_chat",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            required_mounts=["/skills:/mnt/skills/discovered/repository:ro"]
+        ),
+    )
+
+    resolver = sandbox_routes._get_resolver_for_request("chat-1")
+
+    assert (
+        resolver.custom_mounts["/mnt/skills/discovered/repository"]
+        == Path("/skills").resolve()
+    )

--- a/tests/sandbox/test_sandbox_manager_unit.py
+++ b/tests/sandbox/test_sandbox_manager_unit.py
@@ -104,3 +104,26 @@ def test_sandbox_manager_singleton_per_volume_key(monkeypatch):
 
     assert m1 is m2
     assert m1 is not m3
+
+
+def test_docker_session_honors_read_only_custom_volume(tmp_path):
+    source = tmp_path / "skills"
+    source.mkdir()
+    session = DockerSession(
+        session_id="chat-skills",
+        client=None,
+        data_path=str(tmp_path / "sandbox"),
+        image="python:3.11-slim",
+        memory_mb=512,
+        cpus=1,
+        network="bridge",
+        project_slug="default",
+        custom_volumes=[f"{source}:/mnt/skills/official:ro"],
+    )
+
+    volumes = session._build_volumes()
+
+    assert volumes[str(source.resolve())] == {
+        "bind": "/mnt/skills/official",
+        "mode": "ro",
+    }


### PR DESCRIPTION
## Summary
- add a right-sidebar Context tab for non-empty project context and effective AGENTS.md/CLAUDE.md instructions
- mirror RepoContext ancestor-first discovery and show actual host paths on hover
- mount uncovered canonical skill sources read-only
- translate discovered agent definitions through active sandbox mounts
- include dynamically discovered skill mounts in sandbox file APIs
- update repository-context and skill documentation

## Prior review feedback addressed
- https://github.com/cyzus/suzent/pull/135#discussion_r3866058792
- https://github.com/cyzus/suzent/pull/135#discussion_r3866058801
- https://github.com/cyzus/suzent/pull/135#discussion_r3866058811

## Validation
- uv run --no-sync pytest -m not-sandbox (1474 passed)
- uv run --no-sync pre-commit run --all-files
- npm test (204 passed)
- npm run build
- npm run format:check