### PR TITLE
refactor(frontend): share fixed icon buttons

### DIFF
--- a/frontend/src/components/BrutalButton.test.tsx
+++ b/frontend/src/components/BrutalButton.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { BrutalIconButton } from './BrutalButton';
+
+describe('BrutalIconButton', () => {
+  it('provides an accessible label and disables button translation', () => {
+    const html = renderToStaticMarkup(
+      <BrutalIconButton label="Copy">
+        <span>icon</span>
+      </BrutalIconButton>
+    );
+
+    expect(html).toContain('aria-label="Copy"');
+    expect(html).toContain('title="Copy"');
+    expect(html).toContain('active:!translate-x-0');
+    expect(html).toContain('active:!translate-y-0');
+  });
+});

--- a/frontend/src/components/BrutalButton.tsx
+++ b/frontend/src/components/BrutalButton.tsx
@@ -109,6 +109,31 @@ export const BrutalButton: React.FC<BrutalButtonProps> = ({
   );
 };
 
+interface BrutalIconButtonProps extends Omit<BrutalButtonProps, 'size' | 'aria-label'> {
+  label: string;
+  size?: Extract<ButtonSize, 'icon' | 'icon-lg'>;
+}
+
+/** Compact icon-only action that keeps its position fixed when pressed. */
+export const BrutalIconButton: React.FC<BrutalIconButtonProps> = ({
+  label,
+  size = 'icon',
+  title,
+  className = '',
+  children,
+  ...props
+}) => (
+  <BrutalButton
+    size={size}
+    title={title ?? label}
+    aria-label={label}
+    className={`active:!translate-x-0 active:!translate-y-0 ${className}`}
+    {...props}
+  >
+    {children}
+  </BrutalButton>
+);
+
 interface BrutalLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   variant?: ButtonVariant;
   size?: ButtonSize;

--- a/frontend/src/components/memory/CoreMemoryBlock.tsx
+++ b/frontend/src/components/memory/CoreMemoryBlock.tsx
@@ -5,9 +5,15 @@
 
 import React, { useState, useEffect } from 'react';
 import { useI18n } from '../../i18n';
-import { BrutalButton } from '../BrutalButton';
+import { BrutalButton, BrutalIconButton } from '../BrutalButton';
 import { MarkdownRenderer } from '../chat/MarkdownRenderer';
-import { ChevronDownIcon } from '@heroicons/react/24/outline';
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  ClipboardDocumentIcon,
+  PencilIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
 import type { CoreMemoryLabel } from '../../types/memory';
 
 interface CoreMemoryBlockProps {
@@ -155,42 +161,50 @@ export const CoreMemoryBlock: React.FC<CoreMemoryBlockProps> = ({
 
         <div className="flex shrink-0 gap-2">
           {collapsible && !isEditing && (
-            <BrutalButton
+            <BrutalIconButton
               onClick={() => setIsCollapsed((value) => !value)}
-              size="icon"
               aria-expanded={!isCollapsed}
-              title={isCollapsed ? t('memoryView.expandSection') : t('memoryView.collapseSection')}
-              aria-label={
-                isCollapsed ? t('memoryView.expandSection') : t('memoryView.collapseSection')
-              }
+              label={isCollapsed ? t('memoryView.expandSection') : t('memoryView.collapseSection')}
             >
               <ChevronDownIcon
                 className={`h-4 w-4 stroke-2 transition-transform ${isCollapsed ? '-rotate-90' : ''}`}
               />
-            </BrutalButton>
+            </BrutalIconButton>
           )}
           {!isEditing ? (
             <>
-              <BrutalButton onClick={handleCopy} size="xs" disabled={!content}>
-                {copied ? t('coreMemory.copiedText') : t('common.copy')}
-              </BrutalButton>
-              <BrutalButton onClick={() => setIsEditing(true)} size="xs">
-                {t('common.edit')}
-              </BrutalButton>
+              <BrutalIconButton
+                onClick={handleCopy}
+                disabled={!content}
+                label={copied ? t('coreMemory.copiedText') : t('common.copy')}
+              >
+                {copied ? (
+                  <CheckIcon className="h-4 w-4 stroke-[2.5]" />
+                ) : (
+                  <ClipboardDocumentIcon className="h-4 w-4 stroke-2" />
+                )}
+              </BrutalIconButton>
+              <BrutalIconButton onClick={() => setIsEditing(true)} label={t('common.edit')}>
+                <PencilIcon className="h-4 w-4 stroke-2" />
+              </BrutalIconButton>
             </>
           ) : (
             <>
-              <BrutalButton onClick={handleCancel} size="xs" disabled={isSaving}>
-                {t('common.cancel')}
-              </BrutalButton>
-              <BrutalButton
+              <BrutalIconButton
+                onClick={handleCancel}
+                disabled={isSaving}
+                label={t('common.cancel')}
+              >
+                <XMarkIcon className="h-4 w-4 stroke-[2.5]" />
+              </BrutalIconButton>
+              <BrutalIconButton
                 onClick={handleSave}
-                size="xs"
                 variant="dark"
                 disabled={isSaving || !hasUnsavedChanges}
+                label={isSaving ? t('common.saving') : t('common.save')}
               >
-                {isSaving ? t('common.saving') : t('common.save')}
-              </BrutalButton>
+                <CheckIcon className="h-4 w-4 stroke-[2.5]" />
+              </BrutalIconButton>
             </>
           )}
         </div>

--- a/frontend/src/components/memory/MemoryStats.tsx
+++ b/frontend/src/components/memory/MemoryStats.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { ArrowPathIcon } from '@heroicons/react/24/outline';
 import { useI18n } from '../../i18n';
-import { BrutalButton } from '../BrutalButton';
+import { BrutalIconButton } from '../BrutalButton';
 import type { MemoryStats } from '../../types/memory';
 
 interface MemoryStatsProps {
@@ -130,15 +130,13 @@ export const MemoryStatsComponent: React.FC<MemoryStatsProps> = ({
         />
 
         {onRefresh && (
-          <BrutalButton
+          <BrutalIconButton
             onClick={onRefresh}
-            size="icon"
-            title={t('memoryStats.refresh')}
-            aria-label={t('memoryStats.refresh')}
+            label={t('memoryStats.refresh')}
             className="ml-auto"
           >
             <ArrowPathIcon className={`h-4 w-4 stroke-2 ${isLoading ? 'animate-spin' : ''}`} />
-          </BrutalButton>
+          </BrutalIconButton>
         )}
       </div>
 

--- a/frontend/src/components/memory/MemoryView.tsx
+++ b/frontend/src/components/memory/MemoryView.tsx
@@ -14,7 +14,7 @@ import { DailyLogsPanel } from './DailyLogsPanel';
 import { TranscriptPanel } from './TranscriptPanel';
 import { DreamingPanel } from './DreamingPanel';
 import { BrutalSegmentedTabs } from '../BrutalSegmentedTabs';
-import { BrutalButton } from '../BrutalButton';
+import { BrutalIconButton } from '../BrutalButton';
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
 import type { CoreMemoryLabel } from '../../types/memory';
 
@@ -134,21 +134,17 @@ export const MemoryView: React.FC<{ initialTab?: MemoryTab }> = ({ initialTab })
                     {t('memoryView.coreMemoryDesc')}
                   </p>
                 </div>
-                <BrutalButton
+                <BrutalIconButton
                   onClick={() => setShowCoreMemory(!showCoreMemory)}
-                  size="icon"
                   aria-expanded={showCoreMemory}
-                  title={
-                    showCoreMemory ? t('memoryView.collapseSection') : t('memoryView.expandSection')
-                  }
-                  aria-label={
+                  label={
                     showCoreMemory ? t('memoryView.collapseSection') : t('memoryView.expandSection')
                   }
                 >
                   <ChevronDownIcon
                     className={`h-4 w-4 stroke-2 transition-transform ${showCoreMemory ? '' : '-rotate-90'}`}
                   />
-                </BrutalButton>
+                </BrutalIconButton>
               </div>
 
               {showCoreMemory && (

--- a/frontend/src/components/settings/AutomationTab.tsx
+++ b/frontend/src/components/settings/AutomationTab.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { CheckIcon, PencilIcon, PlayIcon, TrashIcon, XMarkIcon } from '@heroicons/react/24/outline';
 
 import { useI18n } from '../../i18n';
 import {
@@ -23,11 +24,10 @@ import {
   SettingsCard,
   SectionCardHeader,
   SettingsListItem,
-  SettingsListAction,
   SettingsPage,
 } from './SettingsCard';
 import { BrutalOnOff } from '../BrutalOnOff';
-import { BrutalButton } from '../BrutalButton';
+import { BrutalButton, BrutalIconButton } from '../BrutalButton';
 
 interface AutomationTabProps {
   models: string[];
@@ -471,12 +471,21 @@ export function AutomationTab({ models, tools = [] }: AutomationTabProps): React
                         />
                       </div>
                       <div className="flex gap-2">
-                        <SettingsListAction tone="blue" onClick={handleSaveEdit} disabled={loading}>
-                          {t('common.save')}
-                        </SettingsListAction>
-                        <SettingsListAction onClick={cancelEdit} disabled={loading}>
-                          {t('common.cancel')}
-                        </SettingsListAction>
+                        <BrutalIconButton
+                          variant="primary"
+                          onClick={handleSaveEdit}
+                          disabled={loading}
+                          label={t('common.save')}
+                        >
+                          <CheckIcon className="h-4 w-4 stroke-[2.5]" />
+                        </BrutalIconButton>
+                        <BrutalIconButton
+                          onClick={cancelEdit}
+                          disabled={loading}
+                          label={t('common.cancel')}
+                        >
+                          <XMarkIcon className="h-4 w-4 stroke-[2.5]" />
+                        </BrutalIconButton>
                       </div>
                     </div>
                   ) : (
@@ -509,23 +518,29 @@ export function AutomationTab({ models, tools = [] }: AutomationTabProps): React
                           </div>
                         </div>
                         <div className="flex gap-2 shrink-0 md:self-start mt-3 md:mt-0 md:ml-4">
-                          <SettingsListAction
-                            tone="blue"
+                          <BrutalIconButton
+                            variant="primary"
                             onClick={() => handleTrigger(job)}
                             disabled={loading}
+                            label={t('settings.automation.run')}
                           >
-                            {t('settings.automation.run')}
-                          </SettingsListAction>
-                          <SettingsListAction onClick={() => startEdit(job)} disabled={loading}>
-                            {t('common.edit')}
-                          </SettingsListAction>
-                          <SettingsListAction
-                            tone="red"
+                            <PlayIcon className="h-4 w-4 stroke-2" />
+                          </BrutalIconButton>
+                          <BrutalIconButton
+                            onClick={() => startEdit(job)}
+                            disabled={loading}
+                            label={t('common.edit')}
+                          >
+                            <PencilIcon className="h-4 w-4 stroke-2" />
+                          </BrutalIconButton>
+                          <BrutalIconButton
+                            variant="danger"
                             onClick={() => handleDelete(job)}
                             disabled={loading}
+                            label={t('common.remove')}
                           >
-                            {t('common.remove')}
-                          </SettingsListAction>
+                            <TrashIcon className="h-4 w-4 stroke-2" />
+                          </BrutalIconButton>
                         </div>
                       </div>
 

--- a/frontend/src/components/settings/CopyButton.tsx
+++ b/frontend/src/components/settings/CopyButton.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { SettingsListAction } from './SettingsCard';
+import { CheckIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline';
+import { BrutalIconButton } from '../BrutalButton';
 
 /** A small button that confirms it copied to the clipboard. */
 export function CopyButton({
@@ -13,9 +14,10 @@ export function CopyButton({
 }): React.ReactElement {
   const [copied, setCopied] = useState(false);
   return (
-    <SettingsListAction
-      tone={tone}
+    <BrutalIconButton
+      variant={tone === 'blue' ? 'primary' : tone === 'red' ? 'danger' : 'default'}
       disabled={!value}
+      label={copied ? 'Copied' : label}
       onClick={() => {
         if (!value) return;
         navigator.clipboard?.writeText(value);
@@ -23,7 +25,11 @@ export function CopyButton({
         setTimeout(() => setCopied(false), 1500);
       }}
     >
-      {copied ? 'Copied' : label}
-    </SettingsListAction>
+      {copied ? (
+        <CheckIcon className="h-4 w-4 stroke-[2.5]" />
+      ) : (
+        <ClipboardDocumentIcon className="h-4 w-4 stroke-2" />
+      )}
+    </BrutalIconButton>
   );
 }

--- a/frontend/src/components/settings/McpTab.tsx
+++ b/frontend/src/components/settings/McpTab.tsx
@@ -1,4 +1,11 @@
 import React, { useState } from 'react';
+import {
+  BeakerIcon,
+  CheckIcon,
+  PencilIcon,
+  TrashIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
 
 import { useI18n } from '../../i18n';
 import {
@@ -17,12 +24,11 @@ import {
   SectionCardHeader,
   SettingsCard,
   SettingsListItem,
-  SettingsListAction,
   Badge,
   SettingsPage,
 } from './SettingsCard';
 import { BrutalOnOff } from '../BrutalOnOff';
-import { BrutalButton } from '../BrutalButton';
+import { BrutalButton, BrutalIconButton } from '../BrutalButton';
 
 type MCPUrlServer = {
   type: 'url';
@@ -477,27 +483,31 @@ export function McpTab({
                       )}
                   </div>
                   <div className="flex gap-2 shrink-0 relative z-10 w-full md:w-auto mt-3 md:mt-0 justify-end md:self-start md:ml-4">
-                    <SettingsListAction
+                    <BrutalIconButton
                       onClick={() => handleTestServer(server)}
                       disabled={loading || probes[server.name]?.testing}
+                      label={t('settings.mcp.test')}
                     >
-                      {t('settings.mcp.test')}
-                    </SettingsListAction>
-                    <SettingsListAction
-                      active={editDraft?.name === server.name}
+                      <BeakerIcon className="h-4 w-4 stroke-2" />
+                    </BrutalIconButton>
+                    <BrutalIconButton
+                      isActive={editDraft?.name === server.name}
                       onClick={() =>
                         editDraft?.name === server.name ? setEditDraft(null) : startEdit(server)
                       }
                       disabled={loading}
+                      label={t('common.edit')}
                     >
-                      {t('common.edit')}
-                    </SettingsListAction>
-                    <SettingsListAction
+                      <PencilIcon className="h-4 w-4 stroke-2" />
+                    </BrutalIconButton>
+                    <BrutalIconButton
+                      variant="danger"
                       onClick={() => handleRemoveServer(server)}
                       disabled={loading}
+                      label={t('common.remove')}
                     >
-                      {t('common.remove')}
-                    </SettingsListAction>
+                      <TrashIcon className="h-4 w-4 stroke-2" />
+                    </BrutalIconButton>
                   </div>
                 </div>
 
@@ -546,7 +556,8 @@ export function McpTab({
                       </div>
                     )}
                     <div className="flex gap-3 pt-2">
-                      <SettingsListAction
+                      <BrutalIconButton
+                        variant="primary"
                         onClick={handleSaveEdit}
                         disabled={
                           editLoading ||
@@ -554,12 +565,19 @@ export function McpTab({
                             ? !editDraft.url.trim()
                             : !editDraft.command.trim())
                         }
+                        label={
+                          editLoading ? t('settings.mcp.saving') : t('settings.mcp.saveServer')
+                        }
                       >
-                        {editLoading ? t('settings.mcp.saving') : t('settings.mcp.saveServer')}
-                      </SettingsListAction>
-                      <SettingsListAction onClick={() => setEditDraft(null)} disabled={editLoading}>
-                        {t('common.cancel')}
-                      </SettingsListAction>
+                        <CheckIcon className="h-4 w-4 stroke-[2.5]" />
+                      </BrutalIconButton>
+                      <BrutalIconButton
+                        onClick={() => setEditDraft(null)}
+                        disabled={editLoading}
+                        label={t('common.cancel')}
+                      >
+                        <XMarkIcon className="h-4 w-4 stroke-[2.5]" />
+                      </BrutalIconButton>
                     </div>
                   </div>
                 )}

--- a/frontend/src/components/settings/SettingsNavigation.tsx
+++ b/frontend/src/components/settings/SettingsNavigation.tsx
@@ -20,7 +20,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 import { useI18n } from '../../i18n';
-import { BrutalButton } from '../BrutalButton';
+import { BrutalIconButton } from '../BrutalButton';
 import { BrutalSelect } from '../BrutalSelect';
 
 export type SettingsCategory =
@@ -105,17 +105,16 @@ function SettingsTitle({ onClose }: { onClose: () => void }): React.ReactElement
           {t('settings.title')}
         </h1>
       </div>
-      <BrutalButton
+      <BrutalIconButton
         type="button"
         variant="light"
         size="icon-lg"
         onClick={onClose}
-        aria-label={t('common.close')}
-        title={t('common.close')}
+        label={t('common.close')}
         className="shrink-0"
       >
         <XMarkIcon className="h-5 w-5" aria-hidden="true" />
-      </BrutalButton>
+      </BrutalIconButton>
     </div>
   );
 }

--- a/frontend/src/components/sidebar/RepositoryContextView.tsx
+++ b/frontend/src/components/sidebar/RepositoryContextView.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ArrowPathIcon,
   CheckIcon,
@@ -11,6 +11,7 @@ import { useI18n } from '../../i18n';
 import { useChatStreamingStore } from '../../hooks/useChatStore';
 import { memoryApi } from '../../lib/memoryApi';
 import type { RepositoryContextResponse, RepositoryInstruction } from '../../types/memory';
+import { BrutalIconButton } from '../BrutalButton';
 import { MarkdownRenderer } from '../chat/MarkdownRenderer';
 
 interface RepositoryContextViewProps {
@@ -24,31 +25,6 @@ interface ContextFileCardProps {
   path: string;
   editable?: boolean;
   onSave?: (content: string) => Promise<void>;
-}
-
-function IconButton({
-  label,
-  onClick,
-  children,
-  disabled = false,
-}: {
-  label: string;
-  onClick: () => void;
-  children: ReactNode;
-  disabled?: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      title={label}
-      aria-label={label}
-      className="flex h-8 w-8 shrink-0 items-center justify-center border-2 border-brutal-black bg-white text-brutal-black shadow-[2px_2px_0_0_#000] transition-transform hover:-translate-y-0.5 active:translate-x-0.5 active:translate-y-0.5 active:shadow-none disabled:cursor-not-allowed disabled:opacity-40 dark:bg-zinc-700 dark:text-white"
-    >
-      {children}
-    </button>
-  );
 }
 
 function ContextFileCard({
@@ -125,7 +101,7 @@ function ContextFileCard({
 
         {expanded && !editing && (
           <div className="flex shrink-0 gap-1.5">
-            <IconButton
+            <BrutalIconButton
               label={copied ? t('coreMemory.copiedText') : t('common.copy')}
               onClick={copy}
             >
@@ -134,11 +110,11 @@ function ContextFileCard({
               ) : (
                 <ClipboardDocumentIcon className="h-4 w-4 stroke-2" />
               )}
-            </IconButton>
+            </BrutalIconButton>
             {editable && (
-              <IconButton label={t('common.edit')} onClick={() => setEditing(true)}>
+              <BrutalIconButton label={t('common.edit')} onClick={() => setEditing(true)}>
                 <PencilIcon className="h-4 w-4 stroke-2" />
-              </IconButton>
+              </BrutalIconButton>
             )}
           </div>
         )}
@@ -155,16 +131,16 @@ function ContextFileCard({
                 autoFocus
               />
               <div className="flex justify-end gap-2">
-                <IconButton label={t('common.cancel')} onClick={cancel} disabled={saving}>
+                <BrutalIconButton label={t('common.cancel')} onClick={cancel} disabled={saving}>
                   <XMarkIcon className="h-4 w-4 stroke-[2.5]" />
-                </IconButton>
-                <IconButton
+                </BrutalIconButton>
+                <BrutalIconButton
                   label={saving ? t('common.saving') : t('common.save')}
                   onClick={() => void save()}
                   disabled={saving || draft === content}
                 >
                   <CheckIcon className="h-4 w-4 stroke-[2.5]" />
-                </IconButton>
+                </BrutalIconButton>
               </div>
             </div>
           ) : (
@@ -235,9 +211,13 @@ export function RepositoryContextView({ chatId }: RepositoryContextViewProps) {
             {data?.project.projectName || t('repositoryContext.description')}
           </p>
         </div>
-        <IconButton label={t('common.refresh')} onClick={() => void load()} disabled={loading}>
+        <BrutalIconButton
+          label={t('common.refresh')}
+          onClick={() => void load()}
+          disabled={loading}
+        >
           <ArrowPathIcon className={`h-4 w-4 stroke-2 ${loading ? 'animate-spin' : ''}`} />
-        </IconButton>
+        </BrutalIconButton>
       </header>
 
       <div className="scrollbar-thin flex-1 space-y-5 overflow-y-auto overflow-x-hidden p-3">


### PR DESCRIPTION
## Summary
- add a shared accessible BrutalIconButton whose press state never translates the control
- reuse the icon control throughout repository context and memory views
- apply consistent icon actions to Settings copy/close controls and Automation/MCP action rows
- add a regression test for fixed-position press styling and accessible labels

## Validation
- npm run build
- npm test (206 tests)
- npm run format:check
- eslint on all changed frontend files (no errors)