### PR TITLE
fix: address repository context review feedback

### DIFF
--- a/frontend/src/components/sidebar/RepositoryContextView.tsx
+++ b/frontend/src/components/sidebar/RepositoryContextView.tsx
@@ -50,12 +50,12 @@ function ContextFileCard({
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(content);
   const [saving, setSaving] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveFailed, setSaveFailed] = useState(false);
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     setDraft(content);
-    setSaveError(null);
+    setSaveFailed(false);
   }, [content]);
 
   const copy = async () => {
@@ -70,12 +70,12 @@ function ContextFileCard({
       return;
     }
     setSaving(true);
-    setSaveError(null);
+    setSaveFailed(false);
     try {
       await onSave(draft);
       setEditing(false);
-    } catch (error) {
-      setSaveError(error instanceof Error ? error.message : t('repositoryContext.saveFailed'));
+    } catch {
+      setSaveFailed(true);
     } finally {
       setSaving(false);
     }
@@ -83,7 +83,7 @@ function ContextFileCard({
 
   const cancel = () => {
     setDraft(content);
-    setSaveError(null);
+    setSaveFailed(false);
     setEditing(false);
   };
 
@@ -131,7 +131,7 @@ function ContextFileCard({
               <BrutalIconButton
                 label={t('common.edit')}
                 onClick={() => {
-                  setSaveError(null);
+                  setSaveFailed(false);
                   setEditing(true);
                 }}
               >
@@ -146,13 +146,12 @@ function ContextFileCard({
         <div className="border-t-2 border-brutal-black bg-neutral-50 dark:bg-zinc-900">
           {editing ? (
             <div className="space-y-2 p-2.5">
-              {saveError && (
+              {saveFailed && (
                 <div
                   role="alert"
                   className="border-2 border-brutal-red bg-white px-2.5 py-2 font-mono text-xs text-brutal-red dark:bg-zinc-800"
                 >
-                  <span className="font-bold">{t('repositoryContext.saveFailed')}:</span>{' '}
-                  {saveError}
+                  {t('repositoryContext.saveFailed')}
                 </div>
               )}
               <textarea

--- a/frontend/src/components/sidebar/RepositoryContextView.tsx
+++ b/frontend/src/components/sidebar/RepositoryContextView.tsx
@@ -18,6 +18,16 @@ interface RepositoryContextViewProps {
   chatId: string;
 }
 
+interface LoadedRepositoryContext {
+  chatId: string;
+  data: RepositoryContextResponse;
+}
+
+interface RepositoryContextError {
+  chatId: string;
+  message: string;
+}
+
 interface ContextFileCardProps {
   name: string;
   content: string;
@@ -40,10 +50,12 @@ function ContextFileCard({
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(content);
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     setDraft(content);
+    setSaveError(null);
   }, [content]);
 
   const copy = async () => {
@@ -58,9 +70,12 @@ function ContextFileCard({
       return;
     }
     setSaving(true);
+    setSaveError(null);
     try {
       await onSave(draft);
       setEditing(false);
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : t('repositoryContext.saveFailed'));
     } finally {
       setSaving(false);
     }
@@ -68,6 +83,7 @@ function ContextFileCard({
 
   const cancel = () => {
     setDraft(content);
+    setSaveError(null);
     setEditing(false);
   };
 
@@ -112,7 +128,13 @@ function ContextFileCard({
               )}
             </BrutalIconButton>
             {editable && (
-              <BrutalIconButton label={t('common.edit')} onClick={() => setEditing(true)}>
+              <BrutalIconButton
+                label={t('common.edit')}
+                onClick={() => {
+                  setSaveError(null);
+                  setEditing(true);
+                }}
+              >
                 <PencilIcon className="h-4 w-4 stroke-2" />
               </BrutalIconButton>
             )}
@@ -124,6 +146,15 @@ function ContextFileCard({
         <div className="border-t-2 border-brutal-black bg-neutral-50 dark:bg-zinc-900">
           {editing ? (
             <div className="space-y-2 p-2.5">
+              {saveError && (
+                <div
+                  role="alert"
+                  className="border-2 border-brutal-red bg-white px-2.5 py-2 font-mono text-xs text-brutal-red dark:bg-zinc-800"
+                >
+                  <span className="font-bold">{t('repositoryContext.saveFailed')}:</span>{' '}
+                  {saveError}
+                </div>
+              )}
               <textarea
                 value={draft}
                 onChange={(event) => setDraft(event.target.value)}
@@ -158,24 +189,39 @@ export function RepositoryContextView({ chatId }: RepositoryContextViewProps) {
   const { t } = useI18n();
   const { isStreaming } = useChatStreamingStore();
   const previousStreaming = useRef(isStreaming);
-  const [data, setData] = useState<RepositoryContextResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const requestSequence = useRef(0);
+  const [loadedContext, setLoadedContext] = useState<LoadedRepositoryContext | null>(null);
+  const [loadingChatId, setLoadingChatId] = useState<string | null>(chatId);
+  const [loadError, setLoadError] = useState<RepositoryContextError | null>(null);
+  const data = loadedContext?.chatId === chatId ? loadedContext.data : null;
+  const error = loadError?.chatId === chatId ? loadError.message : null;
+  const loading = loadingChatId === chatId || (!data && !error);
 
   const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
+    const requestId = ++requestSequence.current;
+    const requestedChatId = chatId;
+    setLoadingChatId(requestedChatId);
+    setLoadError((current) => (current?.chatId === requestedChatId ? null : current));
     try {
-      setData(await memoryApi.getRepositoryContext(chatId));
+      const response = await memoryApi.getRepositoryContext(requestedChatId);
+      if (requestSequence.current !== requestId) return;
+      setLoadedContext({ chatId: requestedChatId, data: response });
     } catch (loadError) {
-      setError(loadError instanceof Error ? loadError.message : t('repositoryContext.loadFailed'));
+      if (requestSequence.current !== requestId) return;
+      setLoadError({
+        chatId: requestedChatId,
+        message: loadError instanceof Error ? loadError.message : t('repositoryContext.loadFailed'),
+      });
     } finally {
-      setLoading(false);
+      if (requestSequence.current === requestId) setLoadingChatId(null);
     }
   }, [chatId, t]);
 
   useEffect(() => {
     void load();
+    return () => {
+      requestSequence.current += 1;
+    };
   }, [load]);
 
   useEffect(() => {
@@ -187,11 +233,14 @@ export function RepositoryContextView({ chatId }: RepositoryContextViewProps) {
     const projectId = data?.project.projectId;
     if (!projectId) return;
     await memoryApi.updateProjectContext(projectId, content);
-    setData((current) =>
-      current
+    setLoadedContext((current) =>
+      current?.chatId === chatId && current.data.project.projectId === projectId
         ? {
             ...current,
-            project: { ...current.project, content, exists: true },
+            data: {
+              ...current.data,
+              project: { ...current.data.project, content, exists: true },
+            },
           }
         : current
     );

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -93,6 +93,7 @@ export const en = {
       chats: 'Chats',
       config: 'Config',
       files: 'Files',
+      tools: 'Tools',
       context: 'Context',
       browser: 'Web',
       canvas: 'Canvas',
@@ -112,6 +113,7 @@ export const en = {
     repositoryInstructionsDesc: 'Loaded ancestor-first; the closest file has final precedence.',
     empty: 'No project context or repository instructions found.',
     loadFailed: 'Failed to load repository context',
+    saveFailed: 'Failed to save project context',
     sources: {
       repository: 'Repository',
       working: 'Working directory',

--- a/frontend/src/i18n/messages/zh-CN.ts
+++ b/frontend/src/i18n/messages/zh-CN.ts
@@ -89,6 +89,7 @@ export const zhCN = {
       chats: '对话列表',
       config: '配置',
       files: '文件',
+      tools: '工具',
       context: '上下文',
       browser: '网页',
       canvas: '画布',
@@ -108,6 +109,7 @@ export const zhCN = {
     repositoryInstructionsDesc: '按祖先目录优先加载，最近的文件具有最终优先级。',
     empty: '未找到项目上下文或代码仓库指令。',
     loadFailed: '加载代码仓库上下文失败',
+    saveFailed: '保存项目上下文失败',
     sources: {
       repository: '代码仓库',
       working: '工作目录',

--- a/src/suzent/routes/memory_routes.py
+++ b/src/suzent/routes/memory_routes.py
@@ -229,11 +229,6 @@ async def get_repository_context(request: Request) -> JSONResponse:
 
         project_id = database.get_chat_project_id(chat_id)
         project = database.get_project(project_id) if project_id else None
-        manager = await _get_or_initialize_memory_manager()
-        if not manager:
-            return JSONResponse(
-                {"error": "Memory system not initialized"}, status_code=503
-            )
 
         from suzent.config import get_effective_volumes
         from suzent.core.repository_context import (
@@ -281,9 +276,17 @@ async def get_repository_context(request: Request) -> JSONResponse:
                 }
             )
 
+        manager = None
+        if CONFIG.memory_enabled:
+            try:
+                manager = await _get_or_initialize_memory_manager()
+            except Exception as exc:
+                logger.warning(
+                    "Repository context is unavailable from the memory store: {}", exc
+                )
         context = (
             await manager.markdown_store.read_project_context(project_id)
-            if project_id
+            if manager and project_id
             else None
         )
         context_path = roots.project_dir / "context.md"

--- a/tests/routes/test_project_context_routes.py
+++ b/tests/routes/test_project_context_routes.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from pathlib import Path
 
+import pytest
 from starlette.applications import Starlette
 from starlette.routing import Route
 from starlette.testclient import TestClient
@@ -177,3 +178,57 @@ def test_repository_context_returns_project_memory_and_walk_up_instructions(
         "# Root rules\n",
         "# API rules\n",
     ]
+
+
+@pytest.mark.parametrize("memory_enabled", [False, True])
+def test_repository_context_returns_instructions_when_memory_unavailable(
+    monkeypatch, tmp_path: Path, memory_enabled: bool
+):
+    repository = tmp_path / "repository"
+    working = repository / "packages" / "api"
+    project_dir = tmp_path / "projects" / "one"
+    working.mkdir(parents=True)
+    project_dir.mkdir(parents=True)
+    (repository / ".git").mkdir()
+    (repository / "AGENTS.md").write_text("# Root rules\n", encoding="utf-8")
+    project = SimpleNamespace(id="project-1", name="One", slug="one", archived=False)
+    chat = SimpleNamespace(
+        id="chat-1",
+        project_id=project.id,
+        working_directory=str(working),
+        config={"sandbox_enabled": False},
+    )
+    database = SimpleNamespace(
+        get_chat=lambda _chat_id: chat,
+        get_chat_project_id=lambda _chat_id: project.id,
+        get_chat_project_slug=lambda _chat_id: project.slug,
+        get_project=lambda _project_id: project,
+        get_project_dir=lambda _chat_id: project_dir,
+    )
+
+    async def get_manager():
+        raise AssertionError("memory initialization must be skipped when disabled")
+
+    monkeypatch.setattr(memory_routes.CONFIG, "memory_enabled", memory_enabled)
+    monkeypatch.setattr(memory_routes, "get_database", lambda: database)
+    monkeypatch.setattr("suzent.database.get_database", lambda: database)
+    monkeypatch.setattr(memory_routes, "_get_or_initialize_memory_manager", get_manager)
+    app = Starlette(
+        routes=[
+            Route(
+                "/memory/repository-context",
+                memory_routes.get_repository_context,
+                methods=["GET"],
+            )
+        ]
+    )
+
+    response = TestClient(app).get(
+        "/memory/repository-context", params={"chat_id": "chat-1"}
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["project"]["content"] == ""
+    assert payload["project"]["exists"] is False
+    assert [item["name"] for item in payload["instructions"]] == ["AGENTS.md"]


### PR DESCRIPTION
## Summary
- scope loaded repository context and request completion to the active chat
- return repository instructions even when memory is disabled or unavailable
- add the missing Tools tab translations in both locales
- show localized project-context save errors while keeping the editor open

Addresses the delayed automated review feedback on #136 and #137.

## Validation
- frontend build
- 206 frontend tests
- 1,475 non-sandbox backend tests
- 6 focused route tests
- formatting and lint checks