### PR TITLE
perf(streaming): keep draft writes off the token loop and out of the index

### DIFF
--- a/src/suzent/database/chats.py
+++ b/src/suzent/database/chats.py
@@ -278,8 +278,17 @@ class ChatOperationsMixin:
         agent_state: bytes = None,
         working_directory: str = None,
         context_usage: Dict[str, Any] = None,
+        reindex: bool = True,
     ) -> bool:
-        """Update an existing chat."""
+        """Update an existing chat.
+
+        ``reindex=False`` skips the full-text reindex. The reindex rewrites every
+        FTS row for the chat, so it costs time proportional to the whole
+        conversation — fine for a turn that has landed, ruinous for a write that
+        repeats every fraction of a second. Use it only for transient writes that
+        a later write will supersede (the streaming draft), never for content
+        that must be findable.
+        """
         with self._session() as session:
             chat = session.get(ChatModel, chat_id)
             if not chat:
@@ -319,7 +328,7 @@ class ChatOperationsMixin:
                 chat.updated_at = datetime.now()
 
             session.add(chat)
-            if messages is not None:
+            if messages is not None and reindex:
                 self._reindex_in_session(session, chat_id, messages)
             session.commit()
             return True

--- a/src/suzent/streaming.py
+++ b/src/suzent/streaming.py
@@ -195,6 +195,9 @@ class _DraftDisplayAccumulator:
         self._tool_index: dict[str, dict[str, Any]] = {}
         self.last_persisted_at = 0.0
         self.dirty = False
+        # The draft write runs off the token loop, one at a time. Kept here so
+        # the final forced persist can wait for it instead of racing it.
+        self._persist_task: Optional["asyncio.Task[None]"] = None
 
     def apply(self, event: Any) -> None:
         event_type = _event_type_value(event)
@@ -306,6 +309,15 @@ class _DraftDisplayAccumulator:
         if not force and now - self.last_persisted_at < _DRAFT_PERSIST_INTERVAL_SECONDS:
             return
 
+        # A write already in flight is reason enough to skip this round: the
+        # draft stays dirty and a later event persists the newer state. Waiting
+        # would put the disk back in front of the token stream, which is the
+        # whole thing this avoids.
+        if self._persist_task is not None and not self._persist_task.done():
+            if not force:
+                return
+            await self._persist_task
+
         snapshot = [dict(part) for part in self.parts]
         content = "\n\n".join(
             text
@@ -313,15 +325,30 @@ class _DraftDisplayAccumulator:
             if part.get("type") == "text"
             and (text := str(part.get("text") or "").strip())
         )
-        await asyncio.to_thread(
+        self.last_persisted_at = now
+        self.dirty = False
+        coro = asyncio.to_thread(
             _persist_draft_display_message,
             self.chat_id,
             self.run_id,
             snapshot,
             content,
         )
-        self.last_persisted_at = now
-        self.dirty = False
+        if force:
+            # The last write of a turn has to land before the stream reports
+            # itself finished, so this one is waited on.
+            await coro
+            return
+        self._persist_task = asyncio.create_task(self._persist_quietly(coro))
+
+    @staticmethod
+    async def _persist_quietly(coro: Any) -> None:
+        """Run a draft write, logging rather than raising: a draft that fails
+        to save must not take the stream down with it."""
+        try:
+            await coro
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug(f"[Streaming] Draft persist failed: {exc}")
 
     def _find_tool(self, tool_call_id: str) -> Optional[dict[str, Any]]:
         return self._tool_index.get(tool_call_id)
@@ -455,7 +482,11 @@ def _persist_draft_display_message(
     else:
         messages.append(draft)
 
-    db.update_chat(chat_id, messages=messages)
+    # The draft is transient: every 0.75s it is overwritten, and the turn's real
+    # write reindexes it when it lands. Reindexing here re-wrote every FTS row of
+    # the whole conversation on each draft — 0.5s per write on a 1MB chat, with
+    # the token stream waiting behind it.
+    db.update_chat(chat_id, messages=messages, reindex=False)
 
 
 def _encode_custom(name: str, value: Any) -> str:

--- a/src/suzent/streaming.py
+++ b/src/suzent/streaming.py
@@ -303,8 +303,24 @@ class _DraftDisplayAccumulator:
         self._merge_citation_sources(sources)
 
     async def maybe_persist(self, *, force: bool = False) -> None:
-        if not self.chat_id or not self.parts or not self.dirty:
+        if not self.chat_id or not self.parts:
             return
+
+        if force:
+            # A background write can still be in flight with the newest state
+            # already in it — scheduling one clears ``dirty``, so a clean draft
+            # is not the same as "nothing left to write". The turn is not
+            # finished until that write lands: returning here would let the
+            # encoder emit ``done`` while the draft is still going to disk,
+            # where a reload could read stale content and the late write could
+            # race the finalizer and restore a draft over the finished
+            # response.
+            await self._await_persist_task()
+            if not self.dirty:
+                return
+        elif not self.dirty:
+            return
+
         now = time.monotonic()
         if not force and now - self.last_persisted_at < _DRAFT_PERSIST_INTERVAL_SECONDS:
             return
@@ -312,11 +328,13 @@ class _DraftDisplayAccumulator:
         # A write already in flight is reason enough to skip this round: the
         # draft stays dirty and a later event persists the newer state. Waiting
         # would put the disk back in front of the token stream, which is the
-        # whole thing this avoids.
-        if self._persist_task is not None and not self._persist_task.done():
-            if not force:
-                return
-            await self._persist_task
+        # whole thing this avoids. (The forced path waited for it above.)
+        if (
+            not force
+            and self._persist_task is not None
+            and not self._persist_task.done()
+        ):
+            return
 
         snapshot = [dict(part) for part in self.parts]
         content = "\n\n".join(
@@ -340,6 +358,12 @@ class _DraftDisplayAccumulator:
             await coro
             return
         self._persist_task = asyncio.create_task(self._persist_quietly(coro))
+
+    async def _await_persist_task(self) -> None:
+        """Wait for a background draft write to finish, if one is running."""
+        task = self._persist_task
+        if task is not None and not task.done():
+            await task
 
     @staticmethod
     async def _persist_quietly(coro: Any) -> None:

--- a/tests/integration/test_chat_search.py
+++ b/tests/integration/test_chat_search.py
@@ -288,3 +288,44 @@ def test_browse_counts_visible_messages_not_stale_sidebar_count(tool_db):
     res = asyncio.run(SessionSearchTool().forward(_ctx(tool_db)))
     assert "0 messages" not in res.message
     assert "2 messages" in res.message
+
+
+# --------------------------------------------------------------------------
+# Draft writes must not pay for the index
+# --------------------------------------------------------------------------
+
+
+def test_update_chat_can_skip_reindex(db):
+    """`reindex=False` leaves the index untouched.
+
+    The streaming draft is rewritten every fraction of a second, and a reindex
+    rewrites every FTS row of the whole conversation — on a megabyte-sized chat
+    that took half a second per write, with the token stream waiting behind it.
+    """
+    cid = db.create_chat("Draft", {}, [{"role": "user", "content": "indexedword"}])
+    assert db.fts_match_chat_ids("indexedword")
+
+    db.update_chat(
+        cid,
+        messages=[
+            {"role": "user", "content": "indexedword"},
+            {"role": "assistant", "parts": [{"type": "text", "text": "draftword"}]},
+        ],
+        reindex=False,
+    )
+    # The new text is stored but deliberately not searchable yet...
+    assert not db.fts_match_chat_ids("draftword")
+    # ...and the skip must not have dropped what was already indexed.
+    assert db.fts_match_chat_ids("indexedword")
+
+
+def test_finalizing_write_indexes_what_the_draft_skipped(db):
+    """The turn's real write still indexes, so nothing stays unsearchable."""
+    cid = db.create_chat("Draft", {}, [{"role": "user", "content": "indexedword"}])
+    messages = [
+        {"role": "user", "content": "indexedword"},
+        {"role": "assistant", "parts": [{"type": "text", "text": "draftword"}]},
+    ]
+    db.update_chat(cid, messages=messages, reindex=False)
+    db.update_chat(cid, messages=messages)
+    assert db.fts_match_chat_ids("draftword")

--- a/tests/test_streaming_timeout.py
+++ b/tests/test_streaming_timeout.py
@@ -387,3 +387,41 @@ def test_permission_decision_payload_and_resolution_are_persisted():
     assert payload["confidence"] == "high"
     assert acc.parts[0]["permissionDecision"] == payload
     assert acc.parts[0]["permissionResolution"] == resolution
+
+
+# A finished turn must be on disk before the stream says so
+
+
+@pytest.mark.asyncio
+async def test_forced_persist_waits_for_a_write_already_in_flight(monkeypatch):
+    """The draft write runs in the background, and scheduling one clears
+    ``dirty``. The forced flush at the end of a turn must still wait for it:
+    reporting the stream finished while the write is in flight lets a reload
+    read stale content, and lets the late write race the turn finalizer."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+    finished = []
+
+    async def slow_write(*args, **kwargs):
+        started.set()
+        await release.wait()
+        finished.append(args)
+
+    monkeypatch.setattr(streaming.asyncio, "to_thread", slow_write)
+    monkeypatch.setattr(streaming, "_DRAFT_PERSIST_INTERVAL_SECONDS", 0)
+
+    acc = streaming._DraftDisplayAccumulator(chat_id="chat-1", run_id="run-1")
+    acc.parts = [{"type": "text", "text": "hello"}]
+    acc.dirty = True
+
+    await acc.maybe_persist()
+    await asyncio.wait_for(started.wait(), timeout=1)
+    assert acc.dirty is False  # scheduling the write cleared it
+
+    forced = asyncio.create_task(acc.maybe_persist(force=True))
+    await asyncio.sleep(0)
+    assert not forced.done(), "forced flush returned while a write was in flight"
+
+    release.set()
+    await asyncio.wait_for(forced, timeout=1)
+    assert finished, "the in-flight write did not land"


### PR DESCRIPTION
## Problem

Streaming display slowed to a crawl as a conversation grew — visibly far behind what the model was actually producing.

The cause is the streaming draft write. Every 0.75s `_persist_draft_display_message` was awaited **inline in the token encode loop**, and `update_chat()` triggered `_reindex_chat_fts`, which DELETEs and re-INSERTs every FTS5 row for the whole chat.

Measured cost of one draft persist, by conversation size:

| conversation | before | after |
| --- | --- | --- |
| 0.17 MB | 126 ms | 15 ms |
| 1.0 MB | 851 ms | 35 ms |
| 3.0 MB | 1925 ms | 43 ms |

cProfile attributed **535 ms of a 608 ms** sample to the reindex (`json.dumps` was 2 ms, `get_chat` 3.5 ms). Past ~1 MB the write outlasts its own 0.75s interval, so throughput roughly halves; at 3 MB it drops to about 30%.

## Changes

- `update_chat(..., reindex=False)` — the draft is transient. The next draft overwrites it, and the turn's real write indexes the content when it lands, so the draft does not need to pay for a full index rebuild. The flag is documented as being for transient writes only, never for content that must be findable.
- The draft write is now a **single-flight background task** rather than an inline await. If a write is already in flight the round is skipped: the draft stays dirty and a later event persists the newer state. The final forced persist still awaits, so a finished turn is on disk before the stream reports itself done. Failures are logged, not raised — a draft that fails to save must not take the stream down.

## Tests

Two regression tests in `tests/integration/test_chat_search.py`: that `reindex=False` genuinely skips the index, and that the finalizing write indexes what the draft skipped (so nothing becomes unsearchable).

`pytest tests` — 1476 passed. `ruff check` and `ruff format --check` clean.

## Known remaining issue (not in this PR)

The same full reindex still runs on **every ordinary chat write** — ~535 ms per appended message on a 1 MB chat. Incremental FTS updates would be the real fix.
