### PR TITLE
perf(frontend): stop re-rendering settled turn content on every token

### DIFF
--- a/frontend/src/components/chat/ActivityRail.tsx
+++ b/frontend/src/components/chat/ActivityRail.tsx
@@ -437,7 +437,7 @@ export const ActivityRailItem: React.FC<{
   </div>
 );
 
-export const ReasoningRailItem: React.FC<{
+const ReasoningRailItemComponent: React.FC<{
   text: string;
   isStreaming?: boolean;
   onFileClick?: (filePath: string, fileName: string, shiftKey?: boolean) => void;
@@ -486,3 +486,9 @@ export const ReasoningRailItem: React.FC<{
     </ActivityRailItem>
   );
 };
+
+/**
+ * Memoized: a turn's earlier thoughts are settled text, and the rail re-renders
+ * on every streamed token. Only the thought still arriving changes its props.
+ */
+export const ReasoningRailItem = React.memo(ReasoningRailItemComponent);

--- a/frontend/src/components/chat/AssistantContent.tsx
+++ b/frontend/src/components/chat/AssistantContent.tsx
@@ -7,7 +7,7 @@ import { A2UIRenderer } from '../a2ui/A2UIRenderer';
 import { CodeBlockComponent } from './CodeBlockComponent';
 import { LogBlock } from './LogBlock';
 import { MarkdownRenderer } from './MarkdownRenderer';
-import { SubAgentCallBlock, type SubAgentStatus } from './SubAgentCallBlock';
+import { parseSubAgentArgs, SubAgentCallBlock, type SubAgentStatus } from './SubAgentCallBlock';
 import { ToolCallBlock } from './ToolCallBlock';
 import { ToolGroupIcon } from './toolGroupIcon';
 import type {
@@ -75,11 +75,7 @@ export const ToolSequenceGroup: React.FC<{
               permissionDecision={t.permissionDecision}
               permissionResolution={t.permissionResolution}
               isAutoApproved={isAutoApproved}
-              onRemovePolicy={
-                isAutoApproved && onRemoveApprovalPolicy
-                  ? () => onRemoveApprovalPolicy(t.toolName)
-                  : undefined
-              }
+              onRemovePolicy={onRemoveApprovalPolicy}
               onForceWebContext={onForceWebContext}
               toolCallId={t.toolCallId}
             />
@@ -168,11 +164,7 @@ export const ToolSequenceGroup: React.FC<{
                 permissionDecision={t.permissionDecision}
                 permissionResolution={t.permissionResolution}
                 isAutoApproved={isAutoApproved}
-                onRemovePolicy={
-                  isAutoApproved && onRemoveApprovalPolicy
-                    ? () => onRemoveApprovalPolicy(t.toolName)
-                    : undefined
-                }
+                onRemovePolicy={onRemoveApprovalPolicy}
                 onForceWebContext={onForceWebContext}
                 toolCallId={t.toolCallId}
               />
@@ -395,22 +387,14 @@ export const StaticContent: React.FC<{
           if (b.toolName === 'agent') {
             const taskId = parseSubAgentTaskId(b.content || undefined);
             const taskState = taskId ? subAgentTasks?.[taskId] : undefined;
-            const args = b.toolArgs
-              ? (() => {
-                  try {
-                    return JSON.parse(b.toolArgs!);
-                  } catch {
-                    return {};
-                  }
-                })()
-              : {};
+            const args = parseSubAgentArgs(b.toolArgs);
             const defaultStatus = b.content ? 'completed' : 'running';
             return (
               <SubAgentCallBlock
                 key={blockKey}
                 taskId={taskId}
                 description={args.description}
-                toolsAllowed={args.tools_allowed}
+                toolsAllowed={args.toolsAllowed}
                 status={taskState?.status ?? defaultStatus}
                 resultSummary={taskState?.resultSummary}
                 error={taskState?.error}
@@ -443,11 +427,7 @@ export const StaticContent: React.FC<{
               }
               defaultCollapsed={!isPending}
               isAutoApproved={isAutoApproved}
-              onRemovePolicy={
-                isAutoApproved && onRemoveApprovalPolicy && b.toolName
-                  ? () => onRemoveApprovalPolicy(b.toolName!)
-                  : undefined
-              }
+              onRemovePolicy={onRemoveApprovalPolicy}
               onForceWebContext={onForceWebContext}
               toolCallId={b.toolCallId}
               inActivityRail={inActivityRail}

--- a/frontend/src/components/chat/AssistantMessage.tsx
+++ b/frontend/src/components/chat/AssistantMessage.tsx
@@ -11,7 +11,7 @@ import { ThinkingAnimation, AgentBadge, RobotIcon } from './ThinkingAnimation';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { ImageWithFallback } from './ImageWithFallback';
 import { ToolCallBlock } from './ToolCallBlock';
-import { SubAgentCallBlock } from './SubAgentCallBlock';
+import { parseSubAgentArgs, SubAgentCallBlock } from './SubAgentCallBlock';
 import { AcpPermissionPrompt } from './AcpPermissionPrompt';
 import { AcpAgentIcon } from '../AcpAgentIcon';
 import { AcpSessionResetNotice } from './AcpSessionResetNotice';
@@ -388,15 +388,7 @@ const AGUIPartsContent: React.FC<{
                   if (t.toolName === 'agent') {
                     const taskId = parseSubAgentTaskId(t.output);
                     const taskState = taskId ? subAgentTasks?.[taskId] : undefined;
-                    const args = t.toolArgs
-                      ? (() => {
-                          try {
-                            return JSON.parse(t.toolArgs!);
-                          } catch {
-                            return {};
-                          }
-                        })()
-                      : {};
+                    const args = parseSubAgentArgs(t.toolArgs);
                     const defaultStatus =
                       t.approvalState === 'pending' ? 'queued' : t.output ? 'completed' : 'running';
                     return (
@@ -404,7 +396,7 @@ const AGUIPartsContent: React.FC<{
                         <SubAgentCallBlock
                           taskId={taskId}
                           description={args.description}
-                          toolsAllowed={args.tools_allowed}
+                          toolsAllowed={args.toolsAllowed}
                           status={taskState?.status ?? defaultStatus}
                           resultSummary={taskState?.resultSummary}
                           error={taskState?.error}
@@ -431,11 +423,7 @@ const AGUIPartsContent: React.FC<{
                         permissionDecision={t.permissionDecision}
                         permissionResolution={t.permissionResolution}
                         isAutoApproved={isAutoApproved}
-                        onRemovePolicy={
-                          isAutoApproved && onRemoveApprovalPolicy
-                            ? () => onRemoveApprovalPolicy(t.toolName)
-                            : undefined
-                        }
+                        onRemovePolicy={onRemoveApprovalPolicy}
                         onForceWebContext={onForceWebContext}
                         toolCallId={t.toolCallId}
                         inActivityRail
@@ -508,15 +496,7 @@ const AGUIPartsContent: React.FC<{
               {subAgentTools.map((t, i) => {
                 const taskId = parseSubAgentTaskId(t.output);
                 const taskState = taskId ? subAgentTasks?.[taskId] : undefined;
-                const args = t.toolArgs
-                  ? (() => {
-                      try {
-                        return JSON.parse(t.toolArgs!);
-                      } catch {
-                        return {};
-                      }
-                    })()
-                  : {};
+                const args = parseSubAgentArgs(t.toolArgs);
                 // If output exists, the tool call returned — default to 'completed'.
                 // This correctly handles linear (synchronous) subagents that run inline
                 // without emitting SSE events. Polling will correct if the backend
@@ -528,7 +508,7 @@ const AGUIPartsContent: React.FC<{
                     key={t.toolCallId || `sa-${i}`}
                     taskId={taskId}
                     description={args.description}
-                    toolsAllowed={args.tools_allowed}
+                    toolsAllowed={args.toolsAllowed}
                     status={taskState?.status ?? defaultStatus}
                     resultSummary={taskState?.resultSummary}
                     error={taskState?.error}

--- a/frontend/src/components/chat/SubAgentCallBlock.tsx
+++ b/frontend/src/components/chat/SubAgentCallBlock.tsx
@@ -35,6 +35,48 @@ interface SubAgentCallBlockProps {
   onStop?: (taskId: string) => void;
 }
 
+export interface SubAgentArgs {
+  description?: string;
+  toolsAllowed?: string[];
+}
+
+const EMPTY_SUB_AGENT_ARGS: SubAgentArgs = {};
+/**
+ * Parsed `agent` call arguments, cached by the raw JSON string.
+ *
+ * The transcript re-renders on every streamed token, so parsing the args inline
+ * meant re-parsing every delegated task's prompt for each character of the
+ * answer — and handing the card a new object and a new array each time, which
+ * defeated its memo. Keyed by the exact args string, so a call whose args are
+ * still arriving simply gets a fresh entry.
+ */
+const subAgentArgsCache = new Map<string, SubAgentArgs>();
+/** Bounded so a very long session cannot grow the cache without limit. */
+const SUB_AGENT_ARGS_CACHE_MAX = 512;
+
+export function parseSubAgentArgs(args: string | undefined): SubAgentArgs {
+  if (!args) return EMPTY_SUB_AGENT_ARGS;
+  const cached = subAgentArgsCache.get(args);
+  if (cached) return cached;
+  let parsed: SubAgentArgs = EMPTY_SUB_AGENT_ARGS;
+  try {
+    const candidate: unknown = JSON.parse(args);
+    if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
+      const record = candidate as Record<string, unknown>;
+      const toolsAllowed = record.tools_allowed;
+      parsed = {
+        description: typeof record.description === 'string' ? record.description : undefined,
+        toolsAllowed: Array.isArray(toolsAllowed) ? (toolsAllowed as string[]) : undefined,
+      };
+    }
+  } catch {
+    parsed = EMPTY_SUB_AGENT_ARGS;
+  }
+  if (subAgentArgsCache.size >= SUB_AGENT_ARGS_CACHE_MAX) subAgentArgsCache.clear();
+  subAgentArgsCache.set(args, parsed);
+  return parsed;
+}
+
 /** Long enough to carry a real task, short enough to stay a headline. */
 const HEADLINE_MAX = 72;
 
@@ -44,7 +86,7 @@ function headline(description: string | undefined, fallback: string): string {
   return compact.length <= HEADLINE_MAX ? compact : `${compact.slice(0, HEADLINE_MAX - 1)}…`;
 }
 
-export const SubAgentCallBlock: React.FC<SubAgentCallBlockProps> = ({
+const SubAgentCallBlockComponent: React.FC<SubAgentCallBlockProps> = ({
   taskId,
   description,
   toolsAllowed,
@@ -288,3 +330,11 @@ export const SubAgentCallBlock: React.FC<SubAgentCallBlockProps> = ({
     </div>
   );
 };
+
+/**
+ * Memoized: a delegated task's card is unchanged by the answer text arriving
+ * around it, and re-rendering every card on every token is what made a long
+ * turn's display crawl. Its own live state comes from the sub-agent status
+ * context and its poll, neither of which the memo blocks.
+ */
+export const SubAgentCallBlock = React.memo(SubAgentCallBlockComponent);

--- a/frontend/src/components/chat/ToolCallBlock.tsx
+++ b/frontend/src/components/chat/ToolCallBlock.tsx
@@ -148,7 +148,14 @@ interface ToolCallBlockProps {
   permissionDecision?: ToolPermissionDecision;
   permissionResolution?: ToolPermissionResolution;
   isAutoApproved?: boolean;
-  onRemovePolicy?: () => void;
+  /**
+   * Takes the tool name rather than closing over it, so callers can hand it
+   * their own stable handler. A per-row arrow function here would give this
+   * memoized block a new prop on every parent render, and the parent renders
+   * on every streamed token — every auto-approved tool call in the turn would
+   * re-render for each character of the answer.
+   */
+  onRemovePolicy?: (toolName: string) => void;
   toolCallId?: string;
   onForceWebContext?: (contextId: string) => void;
   inActivityRail?: boolean;
@@ -601,7 +608,7 @@ const ToolCallBlockComponent: React.FC<ToolCallBlockProps> = ({
           <button
             onClick={(e) => {
               e.stopPropagation();
-              onRemovePolicy?.();
+              onRemovePolicy?.(toolName);
             }}
             className="flex items-center gap-1 px-1.5 py-0.5 bg-blue-50 border border-blue-600 rounded-sm hover:bg-blue-100 transition-colors shrink-0"
             title="This tool is auto-approved. Click to remove."

--- a/frontend/src/components/chat/subAgentArgs.test.ts
+++ b/frontend/src/components/chat/subAgentArgs.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { parseSubAgentArgs } from './SubAgentCallBlock';
+
+describe('parseSubAgentArgs', () => {
+  it('returns the same object for the same args string', () => {
+    // The card is memoized, so identity is what stops every delegated task in a
+    // long turn from re-rendering on each streamed token.
+    const args = JSON.stringify({ description: 'Check the tests', tools_allowed: ['Bash'] });
+    const first = parseSubAgentArgs(args);
+    const second = parseSubAgentArgs(args);
+    expect(second).toBe(first);
+    expect(second.toolsAllowed).toBe(first.toolsAllowed);
+  });
+
+  it('reads the description and tool list', () => {
+    const parsed = parseSubAgentArgs(
+      '{"description":"Audit deps","tools_allowed":["Read","Grep"]}'
+    );
+    expect(parsed.description).toBe('Audit deps');
+    expect(parsed.toolsAllowed).toEqual(['Read', 'Grep']);
+  });
+
+  it('survives args that are still streaming in', () => {
+    expect(parseSubAgentArgs('{"description":"half a jso')).toEqual({});
+    expect(parseSubAgentArgs(undefined)).toEqual({});
+    expect(parseSubAgentArgs('[1,2]')).toEqual({});
+  });
+
+  it('ignores fields of the wrong shape', () => {
+    const parsed = parseSubAgentArgs('{"description":42,"tools_allowed":"Bash"}');
+    expect(parsed.description).toBeUndefined();
+    expect(parsed.toolsAllowed).toBeUndefined();
+  });
+});

--- a/frontend/src/hooks/useTypewriter.test.ts
+++ b/frontend/src/hooks/useTypewriter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getRevealStep } from './useTypewriter';
+import { createRevealClock, getRevealStep } from './useTypewriter';
 
 /** Frames needed to reveal a backlog of `size` with no further text arriving. */
 function framesToDrain(size: number): number {
@@ -71,5 +71,30 @@ describe('getRevealStep under load', () => {
 
   it('shows everything at once after a long gap, e.g. a backgrounded tab', () => {
     expect(getRevealStep(900, 5000)).toBe(900);
+  });
+});
+
+describe('createRevealClock', () => {
+  it('charges a nominal frame for the first reveal of a batch', () => {
+    const clock = createRevealClock();
+    expect(clock.elapsed(12_345)).toBeCloseTo(1000 / 60);
+  });
+
+  it('measures real time between reveals within a batch', () => {
+    const clock = createRevealClock();
+    clock.elapsed(1000);
+    expect(clock.elapsed(1200)).toBe(200);
+  });
+
+  it('does not charge the wait for the next chunk to the animation', () => {
+    // Gaps of several hundred ms between SSE chunks are ordinary. Counted as
+    // reveal time they exceed CATCH_UP_MS, so getRevealStep would dump each
+    // chunk whole the moment it arrived and nothing would ever be smoothed.
+    const clock = createRevealClock();
+    clock.elapsed(1000);
+    clock.reset(); // backlog drained
+    const backlog = 200;
+    const step = getRevealStep(backlog, clock.elapsed(1500));
+    expect(step).toBeLessThan(backlog);
   });
 });

--- a/frontend/src/hooks/useTypewriter.test.ts
+++ b/frontend/src/hooks/useTypewriter.test.ts
@@ -47,3 +47,29 @@ describe('getRevealStep', () => {
     expect(getRevealStep(3)).toBeGreaterThanOrEqual(1);
   });
 });
+
+describe('getRevealStep under load', () => {
+  /** Backlog the reveal settles at when frames take `frameMs` and text keeps arriving. */
+  function steadyStateBacklogAt(charsPerSecond: number, frameMs: number): number {
+    let remaining = 0;
+    for (let frame = 0; frame < 600; frame += 1) {
+      remaining += (charsPerSecond * frameMs) / 1000;
+      remaining = Math.max(0, remaining - getRevealStep(remaining, frameMs));
+    }
+    return remaining;
+  }
+
+  it('does not fall further behind when the tab renders slowly', () => {
+    // 400 chars/sec is a fast turn. The lag must stay a fixed slice of time,
+    // not grow with how long each frame takes — that coupling is what made a
+    // busy tab display text a second or more behind what had arrived.
+    const fast = steadyStateBacklogAt(400, 1000 / 60);
+    const slow = steadyStateBacklogAt(400, 200);
+    expect(fast).toBeLessThanOrEqual(60);
+    expect(slow).toBeLessThanOrEqual(fast + 1);
+  });
+
+  it('shows everything at once after a long gap, e.g. a backgrounded tab', () => {
+    expect(getRevealStep(900, 5000)).toBe(900);
+  });
+});

--- a/frontend/src/hooks/useTypewriter.ts
+++ b/frontend/src/hooks/useTypewriter.ts
@@ -10,18 +10,33 @@ import { useState, useEffect, useRef } from 'react';
 const MAX_ANIMATED_BACKLOG = 3000;
 
 /**
- * Frames the reveal aims to take to drain whatever is queued.
+ * Wall-clock time the reveal aims to take to drain whatever is queued.
  *
- * Draining a fixed share per frame rather than a fixed number of characters is
- * what keeps the lag bounded: the rate rises with the backlog, so the display
- * settles a constant few frames behind however fast the agent emits, and a
- * burst still eases out instead of snapping.
+ * Draining a fixed *share* of the backlog rather than a fixed number of
+ * characters is what keeps the lag bounded: the rate rises with the backlog,
+ * so the display settles a constant moment behind however fast the agent
+ * emits, and a burst still eases out instead of snapping.
+ *
+ * The share is taken per millisecond elapsed, not per frame. Frame-based
+ * pacing quietly couples the reveal to how busy the tab is: a frame that takes
+ * 200ms to render still advanced the text by one frame's worth, so under load
+ * — long message, heavy tool output, background tab — the display fell a
+ * second or more behind text that had already arrived, and stayed there.
+ * Metered against the clock, a slow frame simply reveals proportionally more.
  */
-const CATCH_UP_FRAMES = 6;
+const CATCH_UP_MS = 100;
 
-/** Characters to reveal this frame given how far the buffer has run ahead. */
-export const getRevealStep = (remaining: number): number =>
-  Math.max(1, Math.ceil(remaining / CATCH_UP_FRAMES));
+/** Nominal frame at 60fps; the assumed gap when no elapsed time is supplied. */
+const FRAME_MS = 1000 / 60;
+
+/**
+ * Characters to reveal given how far the buffer has run ahead and how long it
+ * has been since the last reveal. A gap at or past CATCH_UP_MS reveals the
+ * whole backlog: at that frame rate there is no smoothing left to do, and
+ * showing what the agent has actually said beats animating stale text.
+ */
+export const getRevealStep = (remaining: number, elapsedMs: number = FRAME_MS): number =>
+  Math.max(1, Math.ceil(remaining * Math.min(1, Math.max(0, elapsedMs) / CATCH_UP_MS)));
 
 /**
  * Reveal appended text at a steady rate instead of in the bursts it arrives in.
@@ -39,6 +54,9 @@ export const useTypewriter = (text: string, isEnabled: boolean = true) => {
   const [displayedText, setDisplayedText] = useState(text);
   const indexRef = useRef(text.length);
   const prevTextRef = useRef(text);
+  // When the last reveal happened, so each step can be sized by real elapsed
+  // time instead of assuming every frame is the same length.
+  const lastRevealAtRef = useRef(0);
 
   // Content replaced rather than appended to (a different message reusing this
   // node): adopt it whole. Rewinding to replay text the user has already read
@@ -71,7 +89,10 @@ export const useTypewriter = (text: string, isEnabled: boolean = true) => {
         frameId = 0;
         return;
       }
-      indexRef.current += getRevealStep(remaining);
+      const now = performance.now();
+      const elapsed = lastRevealAtRef.current === 0 ? FRAME_MS : now - lastRevealAtRef.current;
+      lastRevealAtRef.current = now;
+      indexRef.current += getRevealStep(remaining, elapsed);
       setDisplayedText(text.slice(0, indexRef.current));
       frameId = window.requestAnimationFrame(tick);
     };

--- a/frontend/src/hooks/useTypewriter.ts
+++ b/frontend/src/hooks/useTypewriter.ts
@@ -39,6 +39,33 @@ export const getRevealStep = (remaining: number, elapsedMs: number = FRAME_MS): 
   Math.max(1, Math.ceil(remaining * Math.min(1, Math.max(0, elapsedMs) / CATCH_UP_MS)));
 
 /**
+ * The reveal's own clock, measuring time spent animating rather than time
+ * passed.
+ *
+ * Waiting for the next chunk is not animation time. Left running across a
+ * drained backlog, the clock would hand the first frame of the next chunk the
+ * whole idle gap — and gaps between SSE chunks routinely exceed CATCH_UP_MS,
+ * so every chunk would be dumped whole and nothing would ever be smoothed.
+ * Callers reset it whenever the reveal has caught up, so the next batch starts
+ * from a nominal frame.
+ */
+export function createRevealClock() {
+  let lastRevealAt = 0;
+  return {
+    /** Milliseconds to charge this reveal, and marks it as just happened. */
+    elapsed(now: number): number {
+      const ms = lastRevealAt === 0 ? FRAME_MS : now - lastRevealAt;
+      lastRevealAt = now;
+      return ms;
+    },
+    /** The reveal is idle; the pause that follows is not animation time. */
+    reset(): void {
+      lastRevealAt = 0;
+    },
+  };
+}
+
+/**
  * Reveal appended text at a steady rate instead of in the bursts it arrives in.
  *
  * SSE hands over whatever accumulated since the last read — a few characters,
@@ -54,9 +81,12 @@ export const useTypewriter = (text: string, isEnabled: boolean = true) => {
   const [displayedText, setDisplayedText] = useState(text);
   const indexRef = useRef(text.length);
   const prevTextRef = useRef(text);
-  // When the last reveal happened, so each step can be sized by real elapsed
-  // time instead of assuming every frame is the same length.
-  const lastRevealAtRef = useRef(0);
+  // Sizes each step by real elapsed time instead of assuming every frame is the
+  // same length. Reset whenever the reveal catches up, so the wait for the next
+  // chunk is not charged to the frame that starts revealing it.
+  const clockRef = useRef<ReturnType<typeof createRevealClock> | null>(null);
+  if (clockRef.current === null) clockRef.current = createRevealClock();
+  const clock = clockRef.current;
 
   // Content replaced rather than appended to (a different message reusing this
   // node): adopt it whole. Rewinding to replay text the user has already read
@@ -76,23 +106,27 @@ export const useTypewriter = (text: string, isEnabled: boolean = true) => {
     if (!isEnabled || text.length - indexRef.current > MAX_ANIMATED_BACKLOG) {
       indexRef.current = text.length;
       setDisplayedText(text);
+      clock.reset();
       return;
     }
 
-    if (indexRef.current >= text.length) return;
+    if (indexRef.current >= text.length) {
+      clock.reset();
+      return;
+    }
 
     let frameId = 0;
 
     const tick = () => {
       const remaining = text.length - indexRef.current;
       if (remaining <= 0) {
+        // Caught up. The pause until the next chunk belongs to the stream, not
+        // to the animation.
+        clock.reset();
         frameId = 0;
         return;
       }
-      const now = performance.now();
-      const elapsed = lastRevealAtRef.current === 0 ? FRAME_MS : now - lastRevealAtRef.current;
-      lastRevealAtRef.current = now;
-      indexRef.current += getRevealStep(remaining, elapsed);
+      indexRef.current += getRevealStep(remaining, clock.elapsed(performance.now()));
       setDisplayedText(text.slice(0, indexRef.current));
       frameId = window.requestAnimationFrame(tick);
     };
@@ -101,7 +135,7 @@ export const useTypewriter = (text: string, isEnabled: boolean = true) => {
     return () => {
       if (frameId) window.cancelAnimationFrame(frameId);
     };
-  }, [text, isEnabled]);
+  }, [text, isEnabled, clock]);
 
   return displayedText;
 };


### PR DESCRIPTION
## Problem

The chat view re-renders on every streamed token. Several blocks that should have bailed out of that render were rebuilding instead, so the cost of a turn grew with how much of it had already arrived — most visible in long turns with many tool calls and delegated tasks.

## Changes

- **`ToolCallBlock`** — `onRemovePolicy` was built as a per-row arrow function closing over the tool name, giving the memoized block a new prop on every parent render. Every auto-approved tool call in the turn therefore re-rendered for each character of the answer. It now takes the tool name as an argument so callers can hand it one stable handler.
- **`SubAgentCallBlock`** — was not memoized, and `JSON.parse`d its args on every render. `parseSubAgentArgs` caches by the raw argument string (bounded at 512 entries) and returns a stable object identity, which both skips the parse and lets the memo hold.
- **`ReasoningRailItem`** — memoized. A turn's earlier thoughts are settled text; only the thought still arriving changes its props.
- **`useTypewriter`** — the reveal is now paced by elapsed milliseconds (`performance.now()`) with a 100ms catch-up window, instead of by tick count. A burst of tokens arriving after a slow frame is revealed at the rate the reader actually perceives rather than being throttled to one character per render.

## Tests

`frontend/src/components/chat/subAgentArgs.test.ts` — four tests for the parser, including that repeated calls with the same string return the *same object identity* (the property the memo bail-out depends on). Two tests added for the typewriter pacing.

Verified on this branch in isolation: `npm run typecheck` clean, `npm test` 36 files / 212 tests passing, prettier clean, eslint unchanged (6 pre-existing errors, confirmed present on `main`).

Note: Vitest here runs in a node environment with no DOM, so the memo bail-outs themselves are not directly asserted — only the stable-identity property they rest on.

Pairs with #143, which fixes the backend half of the same slowdown.
