### PR TITLE
feat(frontend): activity, sidebar and minimap refinements

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { ChatWindow } from './components/ChatWindow';
 import { BackendLoadingScreen } from './components/BackendLoadingScreen';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { RobotAvatar } from './components/chat/RobotAvatar';
+import { SidebarToggleIcon } from './components/SidebarToggleIcon';
 import { SuzentLogo } from './components/SuzentLogo';
 import { RobotShowcase } from './components/chat/RobotShowcase';
 import { MemoryView } from './components/memory/MemoryView';
@@ -634,17 +635,11 @@ function AppInner(): React.ReactElement {
                     <SuzentLogo className="h-7 w-7" interactive />
                   </div>
                   <div className="hidden h-full w-full items-center justify-center group-hover:flex">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
+                    <SidebarToggleIcon
+                      side="left"
+                      open={false}
                       className="h-6 w-6 text-brutal-black dark:text-white"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <rect x="4" y="4" width="16" height="16" rx="2" />
-                      <line x1="9" y1="4" x2="9" y2="20" />
-                    </svg>
+                    />
                   </div>
                 </div>
               )}
@@ -723,17 +718,7 @@ function AppInner(): React.ReactElement {
                   aria-label={isRightSidebarOpen ? t('sidebar.close') : t('sidebar.open')}
                   title={isRightSidebarOpen ? t('sidebar.close') : t('sidebar.open')}
                 >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="h-6 w-6"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={2}
-                  >
-                    <rect x="4" y="4" width="16" height="16" rx="2" />
-                    <line x1="15" y1="4" x2="15" y2="20" />
-                  </svg>
+                  <SidebarToggleIcon side="right" open={isRightSidebarOpen} />
                 </button>
               ) : (
                 <div className="h-10 w-10" aria-hidden="true" />

--- a/frontend/src/components/ChatList.tsx
+++ b/frontend/src/components/ChatList.tsx
@@ -7,6 +7,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { useChatStore } from '../hooks/useChatStore';
 import { useProjects } from '../hooks/useProjects';
+import { useEventBus } from '../hooks/useEventBus';
 import type { ChatKindCounts, ChatSummary, Project } from '../types/api';
 import { RobotAvatar } from './chat/RobotAvatar';
 import { useI18n } from '../i18n';
@@ -109,6 +110,17 @@ export const ChatList: React.FC<ChatListProps> = ({ onOpenAutomation }) => {
     refreshChatList,
     loadMoreChats,
   } = useChatStore();
+
+  // `isRunning` on a chat summary is a snapshot from whenever the list was
+  // last fetched, so a run that starts or ends afterwards leaves a stale badge
+  // in the sidebar. The event bus carries the same signal live, so prefer it
+  // once its snapshot has landed and fall back to the fetched flag until then.
+  const { activeStreams, snapshotReady } = useEventBus();
+  const isChatRunning = useCallback(
+    (chatId: string, fetched?: boolean): boolean =>
+      snapshotReady ? activeStreams.has(chatId) : !!fetched,
+    [activeStreams, snapshotReady]
+  );
 
   const {
     projects,
@@ -768,7 +780,10 @@ export const ChatList: React.FC<ChatListProps> = ({ onOpenAutomation }) => {
             </h3>
           </div>
           <div className="flex items-center gap-1.5 overflow-hidden">
-            <SessionStatusBadges running={chat.isRunning} unreadCount={unread} />
+            <SessionStatusBadges
+              running={isChatRunning(chat.id, chat.isRunning)}
+              unreadCount={unread}
+            />
             {/* Project chip — always shown so the user knows which workspace */}
             {showProject && chat.projectName && (
               <span
@@ -1151,7 +1166,7 @@ export const ChatList: React.FC<ChatListProps> = ({ onOpenAutomation }) => {
                                         </span>
                                         <span className="mt-1 flex min-w-0 items-center gap-1.5">
                                           <SessionStatusBadges
-                                            running={job.is_running}
+                                            running={isChatRunning(chatId, job.is_running)}
                                             unreadCount={
                                               currentChatId === chatId ? 0 : job.unread_count
                                             }
@@ -1230,7 +1245,7 @@ export const ChatList: React.FC<ChatListProps> = ({ onOpenAutomation }) => {
                                 </span>
                                 <span className="mt-1 flex min-w-0 items-center gap-1.5">
                                   <SessionStatusBadges
-                                    running={session.is_running}
+                                    running={isChatRunning(session.chat_id, session.is_running)}
                                     unreadCount={
                                       currentChatId === session.chat_id ? 0 : session.unread_count
                                     }

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -2480,7 +2480,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       <div className="flex flex-col flex-1 min-w-0 min-h-0 h-full relative">
         {/* Project board full-screen overlay */}
         {isBoardFullscreen && (
-          <div className="absolute inset-0 z-20 bg-neutral-50 dark:bg-zinc-900 overflow-hidden">
+          <div className="absolute inset-0 z-30 bg-neutral-50 dark:bg-zinc-900 overflow-hidden">
             <ProjectKanbanView
               projectName={chats.find((c) => c.id === currentChatId)?.projectName ?? null}
               projectId={chats.find((c) => c.id === currentChatId)?.projectId ?? null}
@@ -2606,7 +2606,9 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
             <div ref={bottomRef} className="h-0" />
           </div>
 
-          {safeMessages.length > 0 && (
+          {/* The board overlay covers the chat, so the rail would otherwise
+              float on top of a view it cannot scroll. */}
+          {safeMessages.length > 0 && !isBoardFullscreen && (
             <ChatMinimap
               messages={safeMessages}
               scrollContainerRef={scrollContainerRef}

--- a/frontend/src/components/SidebarToggleIcon.tsx
+++ b/frontend/src/components/SidebarToggleIcon.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+interface SidebarToggleIconProps {
+  /** Which edge of the window the panel this icon controls lives on. */
+  side: 'left' | 'right';
+  /** Whether that panel is currently open. */
+  open: boolean;
+  className?: string;
+}
+
+const EASE = 'cubic-bezier(0.4, 0, 0.2, 1)';
+
+/**
+ * The panel glyph shared by both sidebar toggles.
+ *
+ * Both rails used to render the same static outline, so the button said which
+ * panel it controlled but never whether that panel was open. Here the panel
+ * column fills in and its divider slides outward as the sidebar opens, in step
+ * with the 300ms slide of the sidebar itself — so the icon reads as the same
+ * motion, just smaller.
+ *
+ * Geometry is fixed and the state change is expressed with transforms only:
+ * `x1`/`x2` are SVG attributes, not CSS properties, so a line moved by
+ * attribute would jump rather than slide.
+ */
+export function SidebarToggleIcon({
+  side,
+  open,
+  className = 'h-6 w-6',
+}: SidebarToggleIconProps): React.ReactElement {
+  const isLeft = side === 'left';
+  // Closed: the divider tucks toward its frame edge. Open: full panel width.
+  const slide = open ? 0 : isLeft ? -1.5 : 1.5;
+  const dividerX = isLeft ? 9 : 15;
+
+  const slideStyle: React.CSSProperties = {
+    transform: `translateX(${slide}px)`,
+    transition: `transform 300ms ${EASE}`,
+  };
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+      aria-hidden="true"
+    >
+      <rect
+        x={isLeft ? 4 : dividerX}
+        y={4}
+        width={5}
+        height={16}
+        fill="currentColor"
+        stroke="none"
+        style={{
+          ...slideStyle,
+          transformBox: 'fill-box',
+          transformOrigin: isLeft ? 'left center' : 'right center',
+          transform: `translateX(${slide}px) scaleX(${open ? 1 : 0.7})`,
+          opacity: open ? 0.22 : 0,
+          transition: `transform 300ms ${EASE}, opacity 220ms ease`,
+        }}
+      />
+      <rect x="4" y="4" width="16" height="16" rx="2" />
+      <line x1={dividerX} y1="4" x2={dividerX} y2="20" style={slideStyle} />
+    </svg>
+  );
+}

--- a/frontend/src/components/chat/ActivityRail.tsx
+++ b/frontend/src/components/chat/ActivityRail.tsx
@@ -457,9 +457,9 @@ const ReasoningRailItemComponent: React.FC<{
           className="group/thought-header inline-flex items-center gap-1.5 px-2.5 cursor-pointer select-none min-w-0 max-w-full"
         >
           {/* A thought carries the same two states as a tool call — in flight
-              and finished — and the rail header already says "Thinking" vs
-              "Thought". Saying only "Thought" here made a reasoning block that
-              is still arriving look like one that had already landed. */}
+              and finished. Saying only "Thought" made a reasoning block that
+              was still arriving look like one that had already landed; the
+              label animates while it streams and settles when it lands. */}
           <span
             className={`text-[11px] font-mono font-bold uppercase tracking-wide shrink-0 ${
               thinking
@@ -469,13 +469,6 @@ const ReasoningRailItemComponent: React.FC<{
           >
             {thinking ? t('activityRail.thinking') : t('activityRail.thought')}
           </span>
-          {thinking && (
-            <span className="reasoning-thinking-pulse shrink-0" aria-hidden="true">
-              <i />
-              <i />
-              <i />
-            </span>
-          )}
           <svg
             className={`w-3 h-3 text-neutral-400 opacity-0 transition-all duration-150 shrink-0 group-hover/thought-header:opacity-100 ${expanded ? 'rotate-90' : ''}`}
             fill="none"

--- a/frontend/src/components/chat/ActivityRail.tsx
+++ b/frontend/src/components/chat/ActivityRail.tsx
@@ -5,7 +5,7 @@ import { MarkdownRenderer } from './MarkdownRenderer';
 import { getRepeatedToolLabel, getToolSummary, normalizeToolName } from './toolSummary';
 import type { ToolTense } from './toolSummary';
 import { useTypewriter } from '../../hooks/useTypewriter';
-import { tForLocale } from '../../i18n';
+import { tForLocale, useI18n } from '../../i18n';
 
 export type ActivityRenderGroup<T> =
   | { type: 'activity'; chunks: Array<{ chunk: T; index: number }> }
@@ -442,6 +442,7 @@ const ReasoningRailItemComponent: React.FC<{
   isStreaming?: boolean;
   onFileClick?: (filePath: string, fileName: string, shiftKey?: boolean) => void;
 }> = ({ text, isStreaming, onFileClick }) => {
+  const { t } = useI18n();
   const [expanded, setExpanded] = useState(false);
   // Reasoning arrives in the same uneven bursts as the answer; reveal it at a
   // steady rate so an expanded thought reads as flowing text.
@@ -466,7 +467,7 @@ const ReasoningRailItemComponent: React.FC<{
                 : 'text-neutral-500 dark:text-neutral-400'
             }`}
           >
-            {thinking ? 'Thinking' : 'Thought'}
+            {thinking ? t('activityRail.thinking') : t('activityRail.thought')}
           </span>
           {thinking && (
             <span className="reasoning-thinking-pulse shrink-0" aria-hidden="true">

--- a/frontend/src/components/chat/ActivityRail.tsx
+++ b/frontend/src/components/chat/ActivityRail.tsx
@@ -446,17 +446,35 @@ const ReasoningRailItemComponent: React.FC<{
   // Reasoning arrives in the same uneven bursts as the answer; reveal it at a
   // steady rate so an expanded thought reads as flowing text.
   const revealedText = useTypewriter(text, Boolean(isStreaming) && expanded);
+  const thinking = Boolean(isStreaming);
   return (
-    <ActivityRailItem state={isStreaming ? 'active' : 'done'}>
+    <ActivityRailItem state={thinking ? 'active' : 'done'}>
       <div className="min-w-0">
         <button
           type="button"
           onClick={() => setExpanded((value) => !value)}
           className="group/thought-header inline-flex items-center gap-1.5 px-2.5 cursor-pointer select-none min-w-0 max-w-full"
         >
-          <span className="text-[11px] font-mono font-bold uppercase tracking-wide text-neutral-500 dark:text-neutral-400 shrink-0">
-            Thought
+          {/* A thought carries the same two states as a tool call — in flight
+              and finished — and the rail header already says "Thinking" vs
+              "Thought". Saying only "Thought" here made a reasoning block that
+              is still arriving look like one that had already landed. */}
+          <span
+            className={`text-[11px] font-mono font-bold uppercase tracking-wide shrink-0 ${
+              thinking
+                ? 'reasoning-thinking-label text-brutal-black dark:text-neutral-100'
+                : 'text-neutral-500 dark:text-neutral-400'
+            }`}
+          >
+            {thinking ? 'Thinking' : 'Thought'}
           </span>
+          {thinking && (
+            <span className="reasoning-thinking-pulse shrink-0" aria-hidden="true">
+              <i />
+              <i />
+              <i />
+            </span>
+          )}
           <svg
             className={`w-3 h-3 text-neutral-400 opacity-0 transition-all duration-150 shrink-0 group-hover/thought-header:opacity-100 ${expanded ? 'rotate-90' : ''}`}
             fill="none"

--- a/frontend/src/components/chat/AssistantMessage.tsx
+++ b/frontend/src/components/chat/AssistantMessage.tsx
@@ -865,11 +865,11 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
 
   // 1. 抓取当前正在跑的 Tool 和 错误状态
   let currentToolName: string | undefined = undefined;
-  let hasError: boolean = false;
+  let errorCount: number = 0;
   let isPendingApproval: boolean = false;
 
   if (effectiveParts && effectiveParts.length > 0) {
-    hasError = effectiveParts.some((p) => p.type === 'tool' && p.state === 'error');
+    errorCount = effectiveParts.filter((p) => p.type === 'tool' && p.state === 'error').length;
     isPendingApproval = effectiveParts.some(
       (p) => p.type === 'tool' && p.state === 'approval-requested' && !p.output && !!p.approvalId
     );
@@ -939,7 +939,7 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
           isThinking={isThinking}
           isStreaming={isStreamingThis}
           currentToolName={currentToolName}
-          hasError={hasError}
+          errorCount={errorCount}
           isPendingApproval={isPendingApproval}
           icon={isAcp ? <AcpAgentIcon id={acpAgent} className="w-6 h-6 shrink-0" /> : undefined}
         />

--- a/frontend/src/components/chat/ChatMinimap.tsx
+++ b/frontend/src/components/chat/ChatMinimap.tsx
@@ -17,12 +17,17 @@ interface ChatMinimapMarker {
 }
 
 const MIN_MARKERS_TO_SHOW = 4;
-// Ticks sit a fixed distance apart and the whole stack is centered in the
-// rail, so a short conversation stays compact instead of being flung across
-// the full height. Past MAX_RAIL_PX the interval shrinks to keep dense
-// conversations bounded.
+// Ticks always sit this far apart, whatever the conversation's length. A long
+// chat used to squeeze every tick into MAX_RAIL_PX until they merged into one
+// solid smear that could be neither read nor aimed at; past that height the
+// track slides under the rail instead of compressing, so a tick stays a tick.
 const TICK_INTERVAL_PX = 11;
 const MAX_RAIL_PX = 272;
+// Breathing room at both ends of the track: ticks are drawn centered on their
+// offset, so the first and last would otherwise be clipped by the viewport.
+const TRACK_PADDING_PX = 4;
+// How far the hover wave reaches, in track pixels.
+const HOVER_WAVE_PX = 30;
 
 interface ChatMinimapProps {
   messages: Message[];
@@ -188,10 +193,11 @@ const ChatMinimapComponent: React.FC<ChatMinimapProps> = ({
   onJumpToMessage,
 }) => {
   const { t } = useI18n();
-  const railRef = useRef<HTMLDivElement | null>(null);
-  const [scrollCenterTop, setScrollCenterTop] = useState(50);
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const [scrollCenterRatio, setScrollCenterRatio] = useState(0.5);
+  const [railOffsetPx, setRailOffsetPx] = useState(0);
   const [hoveredMarkerId, setHoveredMarkerId] = useState<string | null>(null);
-  const [hoverPercent, setHoverPercent] = useState<number | null>(null);
+  const [hoverPx, setHoverPx] = useState<number | null>(null);
 
   const labels = useMemo<MinimapLabels>(
     () => ({
@@ -207,50 +213,56 @@ const ChatMinimapComponent: React.FC<ChatMinimapProps> = ({
 
   const markers = useMemo(() => buildMarkers(messages, labels), [messages, labels]);
 
-  // The rail's pixel height grows with the marker count up to a cap, so
-  // ticks land a fixed distance apart and the centered stack stays compact
-  // when sparse. Within that height, ticks are spaced evenly by list order.
-  const railHeightPx =
-    markers.length < 2 ? 0 : Math.min(MAX_RAIL_PX, (markers.length - 1) * TICK_INTERVAL_PX);
+  // The track holds every tick at full spacing; the viewport shows as much of
+  // it as fits and scrolls for the rest.
+  const trackHeightPx =
+    markers.length < 2 ? 0 : (markers.length - 1) * TICK_INTERVAL_PX + TRACK_PADDING_PX * 2;
+  const viewportHeightPx = Math.min(MAX_RAIL_PX, trackHeightPx);
+  const isScrollable = trackHeightPx > viewportHeightPx;
 
-  const getMarkerTop = useCallback(
+  const getMarkerTopPx = useCallback(
     (marker: ChatMinimapMarker): number => {
       const order = markers.indexOf(marker);
-      if (order < 0 || markers.length === 1) return 50;
-      return (order / (markers.length - 1)) * 100;
+      if (order < 0) return TRACK_PADDING_PX;
+      return TRACK_PADDING_PX + order * TICK_INTERVAL_PX;
     },
     [markers]
   );
 
-  const getNearestMarkerAtPercent = useCallback(
-    (percent: number): ChatMinimapMarker | null => {
+  const getNearestMarkerAtPx = useCallback(
+    (px: number): ChatMinimapMarker | null => {
       if (markers.length === 0) return null;
       return markers.reduce((nearest, marker) => {
-        const nearestDistance = Math.abs(getMarkerTop(nearest) - percent);
-        const markerDistance = Math.abs(getMarkerTop(marker) - percent);
+        const nearestDistance = Math.abs(getMarkerTopPx(nearest) - px);
+        const markerDistance = Math.abs(getMarkerTopPx(marker) - px);
         return markerDistance < nearestDistance ? marker : nearest;
       }, markers[0]);
     },
-    [getMarkerTop, markers]
+    [getMarkerTopPx, markers]
   );
 
   const hoveredMarker =
     hoveredMarkerId == null
       ? null
       : (markers.find((marker) => marker.id === hoveredMarkerId) ?? null);
-  // Aligned to the hovered tick within the (short, centered) rail; the
-  // card is translateY(-50%) centered on it and the container doesn't clip.
-  const previewTop = hoveredMarker ? getMarkerTop(hoveredMarker) : 50;
+  // The preview sits outside the clipped viewport, so it is placed in viewport
+  // coordinates: the tick's offset in the track less how far the track has
+  // been slid up.
+  const previewTop = hoveredMarker
+    ? getMarkerTopPx(hoveredMarker) - railOffsetPx
+    : viewportHeightPx / 2;
+  const scrollCenterPx =
+    TRACK_PADDING_PX + scrollCenterRatio * Math.max(0, trackHeightPx - TRACK_PADDING_PX * 2);
 
   const updateMetrics = useCallback(() => {
     const el = scrollContainerRef.current;
     if (!el || el.scrollHeight <= el.clientHeight) {
-      setScrollCenterTop(50);
+      setScrollCenterRatio(0.5);
       return;
     }
 
-    setScrollCenterTop(
-      Math.max(0, Math.min(100, ((el.scrollTop + el.clientHeight / 2) / el.scrollHeight) * 100))
+    setScrollCenterRatio(
+      Math.max(0, Math.min(1, (el.scrollTop + el.clientHeight / 2) / el.scrollHeight))
     );
   }, [scrollContainerRef]);
 
@@ -283,13 +295,34 @@ const ChatMinimapComponent: React.FC<ChatMinimapProps> = ({
     };
   }, [markers.length, scrollContainerRef, updateMetrics]);
 
+  // Keep the stretch of conversation being read inside the rail's window. The
+  // track is *slid* rather than scrolled: no scrollbar to put next to a rail
+  // this thin, and the move is a transition, so a long chat's ticks glide into
+  // place with the same motion the rail has when it fits on screen.
+  // Suspended while the pointer is over the rail: pulling ticks out from under
+  // the cursor mid-aim would make the rail impossible to use.
+  useEffect(() => {
+    if (!isScrollable) {
+      setRailOffsetPx(0);
+      return;
+    }
+    if (hoverPx !== null) return;
+    const target = Math.max(
+      0,
+      Math.min(trackHeightPx - viewportHeightPx, scrollCenterPx - viewportHeightPx / 2)
+    );
+    setRailOffsetPx((previous) => (Math.abs(previous - target) < 1 ? previous : target));
+  }, [hoverPx, isScrollable, scrollCenterPx, trackHeightPx, viewportHeightPx]);
+
   const scrollFromRailPointer = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
-      const rail = railRef.current;
+      const track = trackRef.current;
       const el = scrollContainerRef.current;
-      if (!rail || !el || el.scrollHeight <= el.clientHeight) return;
+      if (!track || !el || el.scrollHeight <= el.clientHeight) return;
 
-      const rect = rail.getBoundingClientRect();
+      // Measured against the track rather than the viewport, so a click means
+      // the same place in the conversation however the rail is scrolled.
+      const rect = track.getBoundingClientRect();
       const ratio = Math.max(0, Math.min(1, (event.clientY - rect.top) / rect.height));
       el.scrollTo({ top: ratio * (el.scrollHeight - el.clientHeight), behavior: 'smooth' });
     },
@@ -298,16 +331,21 @@ const ChatMinimapComponent: React.FC<ChatMinimapProps> = ({
 
   const updateHoverFromPointer = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
-      const rail = railRef.current;
-      if (!rail) return;
+      const track = trackRef.current;
+      if (!track) return;
 
-      const rect = rail.getBoundingClientRect();
-      const percent = Math.max(0, Math.min(100, ((event.clientY - rect.top) / rect.height) * 100));
-      setHoverPercent(percent);
-      setHoveredMarkerId(getNearestMarkerAtPercent(percent)?.id ?? null);
+      const rect = track.getBoundingClientRect();
+      const px = Math.max(0, Math.min(rect.height, event.clientY - rect.top));
+      setHoverPx(px);
+      setHoveredMarkerId(getNearestMarkerAtPx(px)?.id ?? null);
     },
-    [getNearestMarkerAtPercent]
+    [getNearestMarkerAtPx]
   );
+
+  const clearHover = useCallback(() => {
+    setHoveredMarkerId(null);
+    setHoverPx(null);
+  }, []);
 
   // Below this, the conversation fits on screen and a near-empty rail
   // just looks sparse — skip the minimap entirely until it earns its place.
@@ -319,25 +357,14 @@ const ChatMinimapComponent: React.FC<ChatMinimapProps> = ({
     <div
       className="chat-minimap absolute right-3 top-1/2 z-20 hidden -translate-y-1/2 md:block pointer-events-none"
       aria-label={t('chatWindow.minimapLabel')}
-      onMouseLeave={() => {
-        setHoveredMarkerId(null);
-        setHoverPercent(null);
-      }}
+      onMouseLeave={clearHover}
     >
-      <div
-        ref={railRef}
-        className="chat-minimap-rail pointer-events-auto"
-        style={{ height: `${railHeightPx}px` }}
-        onPointerDown={scrollFromRailPointer}
-        onPointerMove={updateHoverFromPointer}
-        onPointerEnter={updateHoverFromPointer}
-        title={t('chatWindow.minimapLabel')}
-      >
+      <div className="chat-minimap-rail" style={{ height: `${viewportHeightPx}px` }}>
         {hoveredMarker && (
           <InformationPopover
             className="chat-minimap-preview pointer-events-none"
             style={{
-              top: `${previewTop}%`,
+              top: `${previewTop}px`,
             }}
           >
             <div className="min-w-0">
@@ -362,43 +389,61 @@ const ChatMinimapComponent: React.FC<ChatMinimapProps> = ({
           </InformationPopover>
         )}
 
-        {markers.map((marker) => {
-          const top = getMarkerTop(marker);
-          const hoverDistance = hoverPercent == null ? null : Math.abs(top - hoverPercent);
-          const influence = hoverDistance == null ? 0 : Math.max(0, 1 - hoverDistance / 12);
-          const isHovered = hoveredMarker?.id === marker.id;
-          const isNearScrollCenter = hoverPercent == null && Math.abs(top - scrollCenterTop) < 3;
-          return (
-            <button
-              key={marker.id}
-              type="button"
-              className={`chat-minimap-marker ${markerToneClass[marker.tone]}${isHovered ? ' chat-minimap-marker-hovered' : ''}${isNearScrollCenter ? ' chat-minimap-marker-current' : ''}`}
-              style={{
-                top: `${top}%`,
-                ['--minimap-wave' as string]: influence.toFixed(3),
-              }}
-              onPointerDown={(event) => event.stopPropagation()}
-              onMouseEnter={() => {
-                setHoveredMarkerId(marker.id);
-                setHoverPercent(top);
-              }}
-              onFocus={() => {
-                setHoveredMarkerId(marker.id);
-                setHoverPercent(top);
-              }}
-              onBlur={() => {
-                setHoveredMarkerId(null);
-                setHoverPercent(null);
-              }}
-              onClick={(event) => {
-                event.stopPropagation();
-                onJumpToMessage(marker.targetIndex);
-              }}
-              title={t('chatWindow.jumpToMessage', { count: marker.targetIndex + 1 })}
-              aria-label={t('chatWindow.jumpToMessage', { count: marker.targetIndex + 1 })}
-            />
-          );
-        })}
+        <div
+          className={`chat-minimap-viewport pointer-events-auto${
+            isScrollable ? ' chat-minimap-viewport-clipped' : ''
+          }`}
+          onPointerDown={scrollFromRailPointer}
+          onPointerMove={updateHoverFromPointer}
+          onPointerEnter={updateHoverFromPointer}
+          title={t('chatWindow.minimapLabel')}
+        >
+          <div
+            ref={trackRef}
+            className="chat-minimap-track"
+            style={{
+              height: `${trackHeightPx}px`,
+              transform: `translateY(${-railOffsetPx}px)`,
+            }}
+          >
+            {markers.map((marker) => {
+              const top = getMarkerTopPx(marker);
+              const hoverDistance = hoverPx == null ? null : Math.abs(top - hoverPx);
+              const influence =
+                hoverDistance == null ? 0 : Math.max(0, 1 - hoverDistance / HOVER_WAVE_PX);
+              const isHovered = hoveredMarker?.id === marker.id;
+              const isNearScrollCenter =
+                hoverPx == null && Math.abs(top - scrollCenterPx) < TICK_INTERVAL_PX / 2;
+              return (
+                <button
+                  key={marker.id}
+                  type="button"
+                  className={`chat-minimap-marker ${markerToneClass[marker.tone]}${isHovered ? ' chat-minimap-marker-hovered' : ''}${isNearScrollCenter ? ' chat-minimap-marker-current' : ''}`}
+                  style={{
+                    top: `${top}px`,
+                    ['--minimap-wave' as string]: influence.toFixed(3),
+                  }}
+                  onPointerDown={(event) => event.stopPropagation()}
+                  onMouseEnter={() => {
+                    setHoveredMarkerId(marker.id);
+                    setHoverPx(top);
+                  }}
+                  onFocus={() => {
+                    setHoveredMarkerId(marker.id);
+                    setHoverPx(top);
+                  }}
+                  onBlur={clearHover}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onJumpToMessage(marker.targetIndex);
+                  }}
+                  title={t('chatWindow.jumpToMessage', { count: marker.targetIndex + 1 })}
+                  aria-label={t('chatWindow.jumpToMessage', { count: marker.targetIndex + 1 })}
+                />
+              );
+            })}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/chat/ThinkingAnimation.tsx
+++ b/frontend/src/components/chat/ThinkingAnimation.tsx
@@ -27,6 +27,9 @@ const BADGE_WEIGHTS: { variant: RobotVariant; weight: number }[] = [
   { variant: 'dj', weight: 2 }, // Very rare music
 ];
 
+// How long the robot stays startled after a tool call fails.
+const ERROR_FLASH_MS = 2600;
+
 const selectWeightedVariant = (
   weights: { variant: RobotVariant; weight: number }[]
 ): RobotVariant => {
@@ -124,7 +127,12 @@ interface AgentBadgeProps {
   isThinking: boolean;
   isStreaming: boolean;
   currentToolName?: string;
-  hasError?: boolean;
+  /**
+   * How many tool calls in this turn have failed. A count rather than a flag:
+   * the robot reacts to a *new* failure and then settles, so a turn that
+   * errored once must not freeze the badge on the startled face forever.
+   */
+  errorCount?: number;
   isPendingApproval?: boolean;
   eyeClass?: string;
   /**
@@ -140,7 +148,7 @@ const AgentBadgeComponent: React.FC<AgentBadgeProps> = ({
   isThinking,
   isStreaming,
   currentToolName,
-  hasError,
+  errorCount = 0,
   isPendingApproval,
   icon,
 }) => {
@@ -148,6 +156,23 @@ const AgentBadgeComponent: React.FC<AgentBadgeProps> = ({
   const [baseVariant, setBaseVariant] = useState<RobotVariant>(() =>
     selectWeightedVariant(BADGE_WEIGHTS)
   );
+
+  // The startled reaction is a beat, not a mode: it fires when the error count
+  // goes up and clears itself, so the badge returns to whatever the agent is
+  // doing now instead of staying frozen on the last failure.
+  const [errorFlash, setErrorFlash] = useState(false);
+  const seenErrorCountRef = React.useRef(errorCount);
+
+  useEffect(() => {
+    if (errorCount <= seenErrorCountRef.current) {
+      seenErrorCountRef.current = errorCount;
+      return;
+    }
+    seenErrorCountRef.current = errorCount;
+    setErrorFlash(true);
+    const timeout = setTimeout(() => setErrorFlash(false), ERROR_FLASH_MS);
+    return () => clearTimeout(timeout);
+  }, [errorCount]);
 
   // Effect to handle snoozing
   useEffect(() => {
@@ -170,7 +195,7 @@ const AgentBadgeComponent: React.FC<AgentBadgeProps> = ({
 
   let variant: RobotVariant = baseVariant;
 
-  if (hasError) {
+  if (errorFlash) {
     variant = 'shaker'; // shaking when there's an error
   } else if (isPendingApproval) {
     variant = 'skeptic'; // skeptical when waiting for user approval

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useI18n } from '../../i18n';
 import { detectDesktopPlatform } from '../../lib/titleBarPlatform';
 import { SuzentLogo } from '../SuzentLogo';
+import { SidebarToggleIcon } from '../SidebarToggleIcon';
 
 interface SidebarProps {
   chatsContent: React.ReactNode;
@@ -50,7 +51,7 @@ export function Sidebar({
         className={`
         fixed lg:relative z-50 h-full shrink-0
         w-80 border-r-3 border-brutal-black flex flex-col bg-neutral-50 dark:bg-zinc-900
-        transform-gpu will-change-transform transition-transform duration-300 ease-in-out
+        transform-gpu will-change-transform transition-[transform,margin-left] duration-300 ease-in-out
         ${isOpen ? 'translate-x-0 lg:ml-0' : '-translate-x-full lg:translate-x-0 lg:-ml-80'}
       `}
       >
@@ -67,17 +68,7 @@ export function Sidebar({
             aria-label={t('sidebar.close')}
             title={t('sidebar.close')}
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-6 w-6"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <rect x="4" y="4" width="16" height="16" rx="2" />
-              <line x1="9" y1="4" x2="9" y2="20" />
-            </svg>
+            <SidebarToggleIcon side="left" open />
           </button>
 
           {/* Vertical Separator */}

--- a/frontend/src/hooks/useEventBus.ts
+++ b/frontend/src/hooks/useEventBus.ts
@@ -18,6 +18,11 @@ import { getApiBase } from '../lib/api';
 // ─── Module-level shared state ────────────────────────────────────────────────
 
 let _activeStreams: Set<string> = new Set();
+// True once the server's snapshot has landed. Until then `_activeStreams` is
+// empty because nothing has been reported yet, which is not the same as
+// "nothing is running" — callers that render live state need to tell those
+// apart so a running badge doesn't blink off while the SSE connects.
+let _snapshotReceived = false;
 const _listeners: Set<() => void> = new Set();
 let _es: EventSource | null = null;
 
@@ -47,6 +52,7 @@ function _handleMessage(evt: MessageEvent) {
     _busPayloadHandlers.forEach((fn) => fn(msg));
     if (msg.event === 'snapshot') {
       _activeStreams = new Set(msg.streams ?? []);
+      _snapshotReceived = true;
       notify();
       _activeStreams.forEach((chatId) => {
         _streamEventListeners.get(chatId)?.forEach((cb) => cb.onStart?.());
@@ -107,11 +113,17 @@ function subscribe(fn: () => void): () => void {
     if (!_hasSubscribers()) {
       _closeEventSource();
       _activeStreams = new Set();
+      _snapshotReceived = false;
     }
   };
 }
 
 // ─── Standalone helpers (usable outside React) ────────────────────────────────
+
+/** True once the bus has reported which streams are active. */
+export function isBusSnapshotReady(): boolean {
+  return _snapshotReceived;
+}
 
 /** Returns true if a background stream for this chat is currently active. */
 export function isBusStreaming(chatId: string): boolean {
@@ -188,5 +200,6 @@ export function useEventBus() {
   return {
     isStreaming: isBusStreaming,
     activeStreams: _activeStreams,
+    snapshotReady: _snapshotReceived,
   };
 }

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -1491,6 +1491,10 @@ export const en = {
     feedbackPlaceholder: 'No, and tell Suzent what to do differently',
     submit: 'Submit',
   },
+  activityRail: {
+    thinking: 'Thinking',
+    thought: 'Thought',
+  },
   codeStepBlock: {
     thought: 'Thought',
     code: 'Code',

--- a/frontend/src/i18n/messages/zh-CN.ts
+++ b/frontend/src/i18n/messages/zh-CN.ts
@@ -1464,6 +1464,10 @@ export const zhCN = {
     feedbackPlaceholder: '否，并告诉 Suzent 应该如何调整',
     submit: '提交',
   },
+  activityRail: {
+    thinking: '思考中',
+    thought: '思考',
+  },
   codeStepBlock: {
     thought: '思考',
     code: '代码',

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -739,55 +739,88 @@ code {
  */
 .reasoning-thinking-label {
   position: relative;
+  /*
+   * A slice of the word is simply not there. Hard stops, no falloff: the ink
+   * is gone across that span rather than faded, so the word reads as damaged
+   * for as long as the slice is over it.
+   *
+   * The geometry is set so the missing slice tracks the bar below. With the
+   * image four times the box wide, the gap's centre sits at (2 - 3p) of the
+   * box for a background-position of p, which is where the percentages in
+   * the keyframes come from — they put the gap exactly where the bar is.
+   */
   background-image: linear-gradient(
-    100deg,
-    currentColor 0 40%,
-    color-mix(in srgb, currentColor 15%, transparent) 47%,
-    color-mix(in srgb, currentColor 15%, transparent) 53%,
-    currentColor 60% 100%
+    90deg,
+    currentColor 0 45.25%,
+    transparent 45.25% 54.75%,
+    currentColor 54.75% 100%
   );
-  background-size: 320% 100%;
-  background-position: 100% 0;
+  background-size: 400% 100%;
+  background-position: 66.667% 0;
   background-clip: text;
   -webkit-background-clip: text;
   /* Not `color`, which the label's own utility class owns — and which the
      gradient reads through currentColor. */
   -webkit-text-fill-color: transparent;
-  animation: reasoning-thinking-sweep 1.3s linear infinite;
+  animation: reasoning-thinking-gap 1.15s steps(8, end) infinite;
 }
 
-/* The travelling bar. `currentColor` is still the label's own ink: the
-   transparent fill above governs the glyphs, not the color property. The bar
-   is a full-cover box with a moving window cut out of it, so it is clipped to
-   the label and never hangs off either end. */
+/*
+ * The bar riding in that slice. `currentColor` is still the label's own ink:
+ * the transparent fill above governs the glyphs, not the color property.
+ *
+ * A full-cover box with a moving window cut out of it, so the bar is clipped
+ * to the label and never hangs off either end. Its box is inset horizontally
+ * by zero on purpose — any horizontal inset would widen it relative to the
+ * background box and pull the bar out of register with the gap.
+ *
+ * It is narrower than the gap, which leaves a sliver of bare ground showing
+ * along each edge: the word is not merely covered, it has been scraped off
+ * ahead of the bar and laid back down behind it.
+ */
 .reasoning-thinking-label::after {
   content: '';
   position: absolute;
-  inset: -0.15em -0.2em;
+  inset: -0.15em 0;
   background: currentColor;
-  animation: reasoning-thinking-redact 1.3s steps(9, end) infinite;
+  animation: reasoning-thinking-redact 1.15s steps(8, end) infinite;
 }
 
-@keyframes reasoning-thinking-sweep {
-  to {
-    background-position: -60% 0;
+/*
+ * Both halves share these four stops so they step together. Between any pair
+ * of keyframes the steps() timing runs afresh, so a differing keyframe
+ * structure would put the bar and the gap on different beats — which is what
+ * made the earlier pairing read as two effects rather than one.
+ */
+@keyframes reasoning-thinking-gap {
+  0% {
+    background-position: 66.667% 0;
+  }
+  12% {
+    background-position: 61.667% 0;
+  }
+  88% {
+    background-position: 38.333% 0;
+  }
+  100% {
+    background-position: 33.333% 0;
   }
 }
 
 @keyframes reasoning-thinking-redact {
-  /* Grows in at the right edge, crosses at a constant third of the width
-     (the two insets always sum to 70), then shrinks out at the left edge. */
+  /* Grows in at the left edge, crosses at a constant 30% of the width (the
+     two insets always sum to 70), then shrinks out at the right edge. */
   0% {
-    clip-path: inset(0 0 0 100%);
+    clip-path: inset(0 100% 0 0);
   }
   12% {
-    clip-path: inset(0 0 0 70%);
-  }
-  88% {
     clip-path: inset(0 70% 0 0);
   }
+  88% {
+    clip-path: inset(0 0 0 70%);
+  }
   100% {
-    clip-path: inset(0 100% 0 0);
+    clip-path: inset(0 0 0 100%);
   }
 }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -721,71 +721,42 @@ code {
   box-shadow: none;
 }
 
-/* A thought still arriving gets the same restless treatment as a running
-   tool: the label is underlined by the rail's diagonal stripe, and three
-   square beats march beside it. Squares and stripes only — no glow, no
-   rounded spinner — so it stays inside the neo-brutalist vocabulary. */
+/*
+ * A thought still arriving: ink sweeping across the word itself.
+ *
+ * This used to be three separate tells at once — a moving striped underline,
+ * three blinking squares, and the label — which read as clutter rather than as
+ * one state. The word carries it alone now, so the rail gains no extra marks
+ * while a thought streams.
+ */
 .reasoning-thinking-label {
-  position: relative;
-}
-
-.reasoning-thinking-label::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: -0.15rem;
-  height: 2px;
-  opacity: 0.55;
-  background-image: repeating-linear-gradient(
-    -45deg,
-    currentColor,
-    currentColor 3px,
-    transparent 3px,
-    transparent 6px
+  background-image: linear-gradient(
+    100deg,
+    currentColor 0 40%,
+    color-mix(in srgb, currentColor 15%, transparent) 47%,
+    color-mix(in srgb, currentColor 15%, transparent) 53%,
+    currentColor 60% 100%
   );
-  animation: brutal-stripes-move 1s linear infinite;
+  background-size: 320% 100%;
+  background-position: 100% 0;
+  background-clip: text;
+  -webkit-background-clip: text;
+  /* Not `color`, which the label's own utility class owns — and which the
+     gradient reads through currentColor. */
+  -webkit-text-fill-color: transparent;
+  animation: reasoning-thinking-sweep 1.3s linear infinite;
 }
 
-.reasoning-thinking-pulse {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-}
-
-.reasoning-thinking-pulse i {
-  width: 3px;
-  height: 3px;
-  background: currentColor;
-  opacity: 0.25;
-  animation: reasoning-thinking-beat 1.05s steps(1, end) infinite;
-}
-
-.reasoning-thinking-pulse i:nth-child(2) {
-  animation-delay: 0.35s;
-}
-
-.reasoning-thinking-pulse i:nth-child(3) {
-  animation-delay: 0.7s;
-}
-
-@keyframes reasoning-thinking-beat {
-  0%,
-  33% {
-    opacity: 1;
-    transform: scale(1.6);
-  }
-
-  34%,
-  100% {
-    opacity: 0.25;
-    transform: scale(1);
+@keyframes reasoning-thinking-sweep {
+  to {
+    background-position: -60% 0;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .reasoning-thinking-label::after,
-  .reasoning-thinking-pulse i {
+  .reasoning-thinking-label {
+    background-image: none;
+    -webkit-text-fill-color: currentColor;
     animation: none;
   }
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -763,7 +763,7 @@ code {
   /* Not `color`, which the label's own utility class owns — and which the
      gradient reads through currentColor. */
   -webkit-text-fill-color: transparent;
-  animation: reasoning-thinking-sweep 2.4s linear infinite;
+  animation: reasoning-thinking-sweep 1.8s linear infinite;
 }
 
 /*
@@ -786,7 +786,7 @@ code {
   position: absolute;
   inset: -0.15em 0;
   background: currentColor;
-  animation: reasoning-thinking-redact 2.4s infinite;
+  animation: reasoning-thinking-redact 1.8s infinite;
 }
 
 /*
@@ -803,7 +803,7 @@ code {
     background-position: 20% 0;
     animation-timing-function: steps(1, end);
   }
-  50% {
+  60% {
     background-position: 80% 0;
     animation-timing-function: linear;
   }
@@ -821,12 +821,12 @@ code {
     clip-path: inset(0 100% 0 0);
     animation-timing-function: steps(6, end);
   }
-  18%,
-  27% {
+  24%,
+  36% {
     clip-path: inset(0 0 0 0);
     animation-timing-function: steps(6, end);
   }
-  45%,
+  56%,
   100% {
     clip-path: inset(0 0 0 100%);
   }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -740,85 +740,90 @@ code {
 .reasoning-thinking-label {
   position: relative;
   /*
-   * A slice of the word is simply not there. Hard stops, no falloff: the ink
-   * is gone across that span rather than faded, so the word reads as damaged
-   * for as long as the slice is over it.
+   * The pale notch of the sweep. It only ever shows in the back half of the
+   * cycle; for the front half it is parked off the right edge, so the word is
+   * solid ink while the bar crosses it.
    *
-   * The geometry is set so the missing slice tracks the bar below. With the
-   * image four times the box wide, the gap's centre sits at (2 - 3p) of the
-   * box for a background-position of p, which is where the percentages in
-   * the keyframes come from — they put the gap exactly where the bar is.
+   * With the image four times the box wide, the notch's centre sits at
+   * (2 - 3p) of the box for a background-position of p. The soft shoulders
+   * reach 0.4 of the box either side of that centre, so p = 20% holds the
+   * whole notch clear of the right edge and p = 80% holds it clear of the
+   * left — which is where the two parked positions come from.
    */
   background-image: linear-gradient(
     90deg,
-    currentColor 0 45.25%,
-    transparent 45.25% 54.75%,
-    currentColor 54.75% 100%
+    currentColor 0 40%,
+    color-mix(in srgb, currentColor 15%, transparent) 47% 53%,
+    currentColor 60% 100%
   );
   background-size: 400% 100%;
-  background-position: 66.667% 0;
+  background-position: 20% 0;
   background-clip: text;
   -webkit-background-clip: text;
   /* Not `color`, which the label's own utility class owns — and which the
      gradient reads through currentColor. */
   -webkit-text-fill-color: transparent;
-  animation: reasoning-thinking-gap 1.15s steps(8, end) infinite;
+  animation: reasoning-thinking-sweep 2.4s linear infinite;
 }
 
 /*
- * The bar riding in that slice. `currentColor` is still the label's own ink:
- * the transparent fill above governs the glyphs, not the color property.
+ * The redaction bar. `currentColor` is still the label's own ink: the
+ * transparent fill above governs the glyphs, not the color property. Bar and
+ * glyphs are therefore the same ink, so the word is not covered so much as
+ * swallowed for as long as the bar is over it.
  *
  * A full-cover box with a moving window cut out of it, so the bar is clipped
- * to the label and never hangs off either end. Its box is inset horizontally
- * by zero on purpose — any horizontal inset would widen it relative to the
- * background box and pull the bar out of register with the gap.
- *
- * It is narrower than the gap, which leaves a sliver of bare ground showing
- * along each edge: the word is not merely covered, it has been scraped off
- * ahead of the bar and laid back down behind it.
+ * to the label and never hangs off either end. Inset horizontally by zero on
+ * purpose: any inset would widen it past the word it is meant to eat.
  */
 .reasoning-thinking-label::after {
   content: '';
   position: absolute;
   inset: -0.15em 0;
   background: currentColor;
-  animation: reasoning-thinking-redact 1.15s steps(8, end) infinite;
+  animation: reasoning-thinking-redact 2.4s infinite;
 }
 
 /*
- * Both halves share these four stops so they step together. Between any pair
- * of keyframes the steps() timing runs afresh, so a differing keyframe
- * structure would put the bar and the gap on different beats — which is what
- * made the earlier pairing read as two effects rather than one.
+ * The two halves take turns rather than running at once. Together they read as
+ * clutter — a bar and a travelling gap competing for the same word — but in
+ * sequence each gets a clear beat: the bar eats the word, then the sweep runs
+ * back over what it gave back.
  */
-@keyframes reasoning-thinking-gap {
+@keyframes reasoning-thinking-sweep {
+  /* Parked off the right edge while the bar has the word. The step is what
+     returns it to the left edge: interpolating would drag the notch back
+     across the word, which is the sweep running backwards. */
   0% {
-    background-position: 66.667% 0;
+    background-position: 20% 0;
+    animation-timing-function: steps(1, end);
   }
-  12% {
-    background-position: 61.667% 0;
-  }
-  88% {
-    background-position: 38.333% 0;
+  50% {
+    background-position: 80% 0;
+    animation-timing-function: linear;
   }
   100% {
-    background-position: 33.333% 0;
+    background-position: 20% 0;
   }
 }
 
 @keyframes reasoning-thinking-redact {
-  /* Grows in at the left edge, crosses at a constant 30% of the width (the
-     two insets always sum to 70), then shrinks out at the right edge. */
+  /* Grows in at the left edge, crosses in hard steps at a constant 30% of the
+     width (the two insets always sum to 70), shrinks out at the right, then
+     stays gone for the back half of the cycle while the sweep runs. */
   0% {
     clip-path: inset(0 100% 0 0);
+    animation-timing-function: linear;
   }
-  12% {
+  6% {
     clip-path: inset(0 70% 0 0);
+    animation-timing-function: steps(6, end);
   }
-  88% {
+  40% {
     clip-path: inset(0 0 0 70%);
+    animation-timing-function: linear;
   }
+  46%,
   100% {
     clip-path: inset(0 0 0 100%);
   }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -722,19 +722,20 @@ code {
 }
 
 /*
- * A thought still arriving: ink sweeping across the word, and every other
- * cycle a hard bar redacting it outright.
+ * A thought still arriving: ink sweeping across the word, with a hard bar
+ * riding the sweep.
  *
  * This used to be three separate tells at once — a moving striped underline,
  * three blinking squares, and the label — which read as clutter rather than as
  * one state. The word carries it alone now, so the rail gains no extra marks
  * while a thought streams.
  *
- * The sweep alone was too soft to register at 11px. The bar is the loud half:
- * it wipes across in hard steps, holds over the word, and wipes off the far
- * side, so the label is briefly *gone* rather than merely shaded. It runs at
- * twice the sweep's period — phase-locked, so the two read as one rhythm, and
- * rare enough that the pass punctuates the sweep instead of strobing.
+ * The sweep alone was too soft to register at 11px, so a hard-edged bar of ink
+ * travels with it. The bar covers about a third of the word at a time and
+ * moves in visible steps, never blanketing the label: what the sweep says in
+ * shading, the bar says by blacking out the letters it is passing. Same
+ * direction and same period as the sweep, so the two are one gesture rather
+ * than two animations sharing a word.
  */
 .reasoning-thinking-label {
   position: relative;
@@ -755,14 +756,16 @@ code {
   animation: reasoning-thinking-sweep 1.3s linear infinite;
 }
 
-/* The redaction bar. `currentColor` is still the label's own ink: the
-   transparent fill above governs the glyphs, not the color property. */
+/* The travelling bar. `currentColor` is still the label's own ink: the
+   transparent fill above governs the glyphs, not the color property. The bar
+   is a full-cover box with a moving window cut out of it, so it is clipped to
+   the label and never hangs off either end. */
 .reasoning-thinking-label::after {
   content: '';
   position: absolute;
   inset: -0.15em -0.2em;
   background: currentColor;
-  animation: reasoning-thinking-redact 2.6s steps(8, end) infinite;
+  animation: reasoning-thinking-redact 1.3s steps(9, end) infinite;
 }
 
 @keyframes reasoning-thinking-sweep {
@@ -772,18 +775,19 @@ code {
 }
 
 @keyframes reasoning-thinking-redact {
-  /* Off the word for most of the cycle, so the sweep is the resting state. */
-  0%,
-  42% {
-    clip-path: inset(0 100% 0 0);
+  /* Grows in at the right edge, crosses at a constant third of the width
+     (the two insets always sum to 70), then shrinks out at the left edge. */
+  0% {
+    clip-path: inset(0 0 0 100%);
   }
-  /* Wipes on from the left, holds, then wipes off past the right edge. */
-  58%,
-  72% {
-    clip-path: inset(0 0 0 0);
+  12% {
+    clip-path: inset(0 0 0 70%);
+  }
+  88% {
+    clip-path: inset(0 70% 0 0);
   }
   100% {
-    clip-path: inset(0 0 0 100%);
+    clip-path: inset(0 100% 0 0);
   }
 }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -772,9 +772,14 @@ code {
  * glyphs are therefore the same ink, so the word is not covered so much as
  * swallowed for as long as the bar is over it.
  *
- * A full-cover box with a moving window cut out of it, so the bar is clipped
- * to the label and never hangs off either end. Inset horizontally by zero on
- * purpose: any inset would widen it past the word it is meant to eat.
+ * It wipes on across the whole word rather than travelling over it as a narrow
+ * window: a window leaves most of the label legible at all times, which is a
+ * decoration passing over a word. Blanketing it is a state — for that beat
+ * there is no label at all.
+ *
+ * Clipped to the label so it never hangs off either end, and inset
+ * horizontally by zero on purpose: any inset would widen it past the word it
+ * is meant to eat.
  */
 .reasoning-thinking-label::after {
   content: '';
@@ -808,22 +813,20 @@ code {
 }
 
 @keyframes reasoning-thinking-redact {
-  /* Grows in at the left edge, crosses in hard steps at a constant 30% of the
-     width (the two insets always sum to 70), shrinks out at the right, then
-     stays gone for the back half of the cycle while the sweep runs. */
+  /* Wipes on from the left until the word is entirely gone, holds it gone,
+     then wipes off the same way, and stays away for the back half of the
+     cycle while the sweep runs. Both wipes are stepped; the hold is what
+     makes it land, so it is not stepped at all. */
   0% {
     clip-path: inset(0 100% 0 0);
-    animation-timing-function: linear;
-  }
-  6% {
-    clip-path: inset(0 70% 0 0);
     animation-timing-function: steps(6, end);
   }
-  40% {
-    clip-path: inset(0 0 0 70%);
-    animation-timing-function: linear;
+  18%,
+  27% {
+    clip-path: inset(0 0 0 0);
+    animation-timing-function: steps(6, end);
   }
-  46%,
+  45%,
   100% {
     clip-path: inset(0 0 0 100%);
   }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -722,14 +722,22 @@ code {
 }
 
 /*
- * A thought still arriving: ink sweeping across the word itself.
+ * A thought still arriving: ink sweeping across the word, and every other
+ * cycle a hard bar redacting it outright.
  *
  * This used to be three separate tells at once — a moving striped underline,
  * three blinking squares, and the label — which read as clutter rather than as
  * one state. The word carries it alone now, so the rail gains no extra marks
  * while a thought streams.
+ *
+ * The sweep alone was too soft to register at 11px. The bar is the loud half:
+ * it wipes across in hard steps, holds over the word, and wipes off the far
+ * side, so the label is briefly *gone* rather than merely shaded. It runs at
+ * twice the sweep's period — phase-locked, so the two read as one rhythm, and
+ * rare enough that the pass punctuates the sweep instead of strobing.
  */
 .reasoning-thinking-label {
+  position: relative;
   background-image: linear-gradient(
     100deg,
     currentColor 0 40%,
@@ -747,9 +755,35 @@ code {
   animation: reasoning-thinking-sweep 1.3s linear infinite;
 }
 
+/* The redaction bar. `currentColor` is still the label's own ink: the
+   transparent fill above governs the glyphs, not the color property. */
+.reasoning-thinking-label::after {
+  content: '';
+  position: absolute;
+  inset: -0.15em -0.2em;
+  background: currentColor;
+  animation: reasoning-thinking-redact 2.6s steps(8, end) infinite;
+}
+
 @keyframes reasoning-thinking-sweep {
   to {
     background-position: -60% 0;
+  }
+}
+
+@keyframes reasoning-thinking-redact {
+  /* Off the word for most of the cycle, so the sweep is the resting state. */
+  0%,
+  42% {
+    clip-path: inset(0 100% 0 0);
+  }
+  /* Wipes on from the left, holds, then wipes off past the right edge. */
+  58%,
+  72% {
+    clip-path: inset(0 0 0 0);
+  }
+  100% {
+    clip-path: inset(0 0 0 100%);
   }
 }
 
@@ -758,6 +792,10 @@ code {
     background-image: none;
     -webkit-text-fill-color: currentColor;
     animation: none;
+  }
+
+  .reasoning-thinking-label::after {
+    content: none;
   }
 }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -24,20 +24,61 @@
   }
 
   .chat-minimap {
-    width: 2rem;
+    /* Wide enough for the longest tick at full hover extension (1.2rem base +
+       0.75rem wave), so clipping the track vertically never cuts a tick's
+       hover growth off horizontally. */
+    width: 2.5rem;
     height: min(18rem, calc(100% - 4rem));
   }
 
   /* Rail height is set inline from the marker count and the rail is
      centered in the container, so a sparse stack stays compact and
-     vertically centered rather than stretched edge to edge. */
+     vertically centered rather than stretched edge to edge. The rail is the
+     positioning frame; the viewport inside it is the window, and the
+     hover preview stays out of it so the viewport's clip does not cut the
+     card off. */
   .chat-minimap-rail {
     position: absolute;
     top: 50%;
     right: 0.25rem;
     transform: translateY(-50%);
-    width: 1.6rem;
+    width: 2rem;
+  }
+
+  .chat-minimap-viewport {
+    position: relative;
+    height: 100%;
+    width: 100%;
     cursor: pointer;
+  }
+
+  /* Once the ticks outgrow the rail the viewport becomes a window onto a
+     longer track: the track slides under it, with no scrollbar — a rail this
+     thin has nowhere to put one, and it would sit right where the ticks are.
+     The edges fade instead, which says "there is more" without any chrome. */
+  .chat-minimap-viewport-clipped {
+    overflow: hidden;
+    mask-image: linear-gradient(
+      to bottom,
+      transparent 0,
+      #000 0.75rem,
+      #000 calc(100% - 0.75rem),
+      transparent 100%
+    );
+  }
+
+  .chat-minimap-track {
+    position: relative;
+    width: 100%;
+    /* Slid, not scrolled. Same easing as the ticks' hover wave so the rail
+       reads as one animated object however long the conversation gets. */
+    transition: transform 260ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .chat-minimap-track {
+      transition: none;
+    }
   }
 
   /* Codex-style tick rail: each marker is a thin monochrome tick whose
@@ -678,6 +719,75 @@ code {
 .dark .activity-rail-card-active {
   background: transparent;
   box-shadow: none;
+}
+
+/* A thought still arriving gets the same restless treatment as a running
+   tool: the label is underlined by the rail's diagonal stripe, and three
+   square beats march beside it. Squares and stripes only — no glow, no
+   rounded spinner — so it stays inside the neo-brutalist vocabulary. */
+.reasoning-thinking-label {
+  position: relative;
+}
+
+.reasoning-thinking-label::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -0.15rem;
+  height: 2px;
+  opacity: 0.55;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    currentColor,
+    currentColor 3px,
+    transparent 3px,
+    transparent 6px
+  );
+  animation: brutal-stripes-move 1s linear infinite;
+}
+
+.reasoning-thinking-pulse {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.reasoning-thinking-pulse i {
+  width: 3px;
+  height: 3px;
+  background: currentColor;
+  opacity: 0.25;
+  animation: reasoning-thinking-beat 1.05s steps(1, end) infinite;
+}
+
+.reasoning-thinking-pulse i:nth-child(2) {
+  animation-delay: 0.35s;
+}
+
+.reasoning-thinking-pulse i:nth-child(3) {
+  animation-delay: 0.7s;
+}
+
+@keyframes reasoning-thinking-beat {
+  0%,
+  33% {
+    opacity: 1;
+    transform: scale(1.6);
+  }
+
+  34%,
+  100% {
+    opacity: 0.25;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reasoning-thinking-label::after,
+  .reasoning-thinking-pulse i {
+    animation: none;
+  }
 }
 
 .activity-rail-card-error {


### PR DESCRIPTION
> **Stacked on #144** — this PR targets `perf/frontend-streaming-render`, because both touch `ActivityRail.tsx` and `AssistantMessage.tsx`. Merge #144 first; the base will retarget to `main` automatically.

Six items from the Aug 2026 frontend review.

## Minimap

- Denser marker layout, and **no scrollbar of its own**. The track slides under a clipped viewport with a `mask-image` edge fade, so the position animation survives scrolling instead of being discarded the moment the content outgrows the rail.
- Hidden while the project board is open. The board overlay covers the chat, so the rail would otherwise float over a view it cannot scroll. (The overlay's z-index moves up accordingly.)

## Sidebar

- Collapse/expand animates, with dedicated toggle icons that read as the direction they move (`SidebarToggleIcon`).
- Per-chat running indicator, driven by the event bus. `useEventBus` now reports whether the server snapshot has landed, so "nothing reported yet" is distinguishable from "nothing running" — without it a running badge blinks off while the SSE connects.

## Activity trail

- The agent icon no longer stays frozen in the error state. It tracks an error *count* rather than a boolean, so a later failure re-triggers the state and a recovered turn leaves it.
- Reasoning distinguishes in-flight from finished: **Thinking** with a pulse while it arrives, **Thought** once it has landed. Previously a thought still streaming looked identical to one already complete.

## Verification

`npm run typecheck` clean, `npm test` 36 files / 212 tests passing, prettier clean, eslint unchanged from `main` (6 pre-existing errors).

Styling follows the existing neo-brutalist system — hard borders, mono uppercase labels, existing motion primitives.
