### PR TITLE
feat(providers): add vLLM and SGLang support

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -150,6 +150,7 @@
     {
       "id": "zhipuai",
       "label": "Zhipu AI (GLM)",
+      "logo_url": "https://github.com/zai-org.png",
       "api_type": "openai",
       "base_url": "https://open.bigmodel.cn/api/paas/v4",
       "aliases": ["zai"],
@@ -173,8 +174,37 @@
       "default_models": []
     },
     {
+      "id": "vllm",
+      "label": "vLLM",
+      "logo_url": "https://github.com/vllm-project.png",
+      "api_type": "openai",
+      "base_url": "http://127.0.0.1:8000/v1",
+      "api_key_optional": true,
+      "env_keys": ["VLLM_API_KEY"],
+      "fields": [
+        {"key": "VLLM_BASE_URL", "label": "Base URL", "placeholder": "http://127.0.0.1:8000/v1", "type": "text"},
+        {"key": "VLLM_API_KEY", "label": "API Key (Optional)", "placeholder": "local", "type": "secret"}
+      ],
+      "default_models": []
+    },
+    {
+      "id": "sglang",
+      "label": "SGLang",
+      "logo_url": "https://github.com/sgl-project.png",
+      "api_type": "openai",
+      "base_url": "http://127.0.0.1:30000/v1",
+      "api_key_optional": true,
+      "env_keys": ["SGLANG_API_KEY"],
+      "fields": [
+        {"key": "SGLANG_BASE_URL", "label": "Base URL", "placeholder": "http://127.0.0.1:30000/v1", "type": "text"},
+        {"key": "SGLANG_API_KEY", "label": "API Key (Optional)", "placeholder": "local", "type": "secret"}
+      ],
+      "default_models": []
+    },
+    {
       "id": "litellm_proxy",
       "label": "LiteLLM Proxy",
+      "logo_url": "https://github.com/BerriAI.png",
       "api_type": "litellm_proxy",
       "env_keys": ["LITELLM_MASTER_KEY", "LITELLM_PROXY_API_KEY"],
       "fields": [

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -2159,7 +2159,14 @@ def _resolve_response_model(
     if not response_model_name:
         return run_model_id
     if "/" in response_model_name:
-        return response_model_name
+        response_prefix = response_model_name.split("/", 1)[0]
+        try:
+            from suzent.core.providers.catalog import PROVIDER_REGISTRY_BY_ID
+
+            if response_prefix in PROVIDER_REGISTRY_BY_ID:
+                return response_model_name
+        except Exception:
+            pass
     run_prefix = (
         run_model_id.split("/", 1)[0] if run_model_id and "/" in run_model_id else None
     )

--- a/src/suzent/core/model_factory.py
+++ b/src/suzent/core/model_factory.py
@@ -103,6 +103,65 @@ class _ChatGPTHTTPClient(httpx.AsyncClient):
         return await super().send(request, **kwargs)
 
 
+def _merge_system_content(messages: list[dict[str, Any]]) -> str | list[Any]:
+    contents = [message.get("content") for message in messages]
+    if all(content is None or isinstance(content, str) for content in contents):
+        return "\n\n".join(content for content in contents if content)
+
+    parts: list[Any] = []
+    for content in contents:
+        if isinstance(content, list):
+            parts.extend(content)
+        elif isinstance(content, str) and content:
+            parts.append({"type": "text", "text": content})
+    return parts
+
+
+def _rewrite_local_openai_request(request: httpx.Request) -> httpx.Request:
+    """Normalize system-message ordering for strict local chat templates."""
+    if not request.url.path.endswith("/chat/completions"):
+        return request
+
+    try:
+        body = json.loads(request.content)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return request
+    if not isinstance(body, dict) or not isinstance(body.get("messages"), list):
+        return request
+
+    messages = [message for message in body["messages"] if isinstance(message, dict)]
+    system_messages = [
+        message for message in messages if message.get("role") == "system"
+    ]
+    if not system_messages:
+        return request
+
+    non_system_messages = [
+        message for message in messages if message.get("role") != "system"
+    ]
+    merged_system = dict(system_messages[0])
+    merged_system["content"] = _merge_system_content(system_messages)
+    body["messages"] = [merged_system, *non_system_messages]
+
+    content = json.dumps(body).encode()
+    headers = dict(request.headers)
+    headers["content-type"] = "application/json"
+    headers["content-length"] = str(len(content))
+    return httpx.Request(
+        request.method,
+        request.url,
+        headers=headers,
+        content=content,
+        extensions=request.extensions,
+    )
+
+
+class _LocalOpenAIHTTPClient(httpx.AsyncClient):
+    async def send(self, request: httpx.Request, **kwargs: Any) -> httpx.Response:
+        request = _rewrite_local_openai_request(request)
+        return await super().send(request, **kwargs)
+
+
 # ---------------------------------------------------------------------------
 # API-type handler registry
 # ---------------------------------------------------------------------------
@@ -130,8 +189,22 @@ def _create_openai_model(model_name: str, api_key: str, spec: ProviderSpec) -> o
             break
 
     base_url = resolved_base_url or spec.base_url or os.environ.get("OPENAI_BASE_URL")
+    if spec.id in {"vllm", "sglang"}:
+        from openai import AsyncOpenAI
+
+        client = AsyncOpenAI(
+            api_key=api_key or "local",
+            base_url=base_url,
+            http_client=_LocalOpenAIHTTPClient(),
+        )
+        return OpenAIChatModel(
+            model_name,
+            provider=OpenAIProvider(openai_client=client),
+        )
+
     return OpenAIChatModel(
-        model_name, provider=OpenAIProvider(api_key=api_key, base_url=base_url)
+        model_name,
+        provider=OpenAIProvider(api_key=api_key or "local", base_url=base_url),
     )
 
 
@@ -330,7 +403,10 @@ def create_pydantic_ai_model(model_id: str) -> object:
 
     # Resolve API key (ollama / litellm_proxy / chatgpt_subscription manage their own auth)
     api_key = resolve_api_key(prefix)
-    requires_key = spec.api_type not in ("ollama", "chatgpt_subscription")
+    requires_key = (
+        spec.api_type not in ("ollama", "chatgpt_subscription")
+        and not spec.api_key_optional
+    )
 
     if requires_key and not api_key:
         raise RuntimeError(

--- a/src/suzent/core/providers/catalog.py
+++ b/src/suzent/core/providers/catalog.py
@@ -48,6 +48,7 @@ class ProviderSpec:
     aliases: list[str] = field(default_factory=list)
     model_settings: Optional[dict[str, Any]] = None  # pydantic-ai ModelSettings kwargs
     logo_url: Optional[str] = None
+    api_key_optional: bool = False
     user_defined: bool = False
 
     @property
@@ -80,6 +81,7 @@ def _parse_provider(raw: dict[str, Any], *, user_defined: bool = False) -> Provi
         aliases=raw.get("aliases", []),
         model_settings=raw.get("model_settings"),
         logo_url=raw.get("logo_url"),
+        api_key_optional=raw.get("api_key_optional", False),
         user_defined=user_defined,
     )
 

--- a/src/suzent/core/providers/helpers.py
+++ b/src/suzent/core/providers/helpers.py
@@ -98,7 +98,9 @@ def get_enabled_models_from_db() -> List[str]:
 
 
 def _provider_is_configured(spec) -> bool:
-    """Return True if the provider has usable credentials."""
+    """Return True if the provider has usable credentials or allows keyless access."""
+    if spec.api_key_optional:
+        return True
     if spec.env_keys:
         return resolve_api_key(spec.id) is not None
     if spec.api_type == "chatgpt_subscription":

--- a/src/suzent/core/providers/openai_compat.py
+++ b/src/suzent/core/providers/openai_compat.py
@@ -34,12 +34,18 @@ class OpenAICompatProvider(BaseProvider):
             ]
         return []
 
+    def _api_key_is_optional(self) -> bool:
+        from suzent.core.providers.catalog import PROVIDER_REGISTRY_BY_ID
+
+        spec = PROVIDER_REGISTRY_BY_ID.get(self.provider_id)
+        return bool(spec and spec.api_key_optional)
+
     async def list_models(self) -> List[Model]:
         api_key = resolve_api_key(self.provider_id, self.config)
-        if not api_key:
+        if not api_key and not self._api_key_is_optional():
             return []
 
-        headers = {"Authorization": f"Bearer {api_key}"}
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
         async with aiohttp.ClientSession() as session:
             try:
                 async with session.get(
@@ -74,7 +80,9 @@ class OpenAICompatProvider(BaseProvider):
         return self._catalog_defaults()
 
     async def validate_credentials(self) -> bool:
-        # Key must exist; model list (live or catalog) confirms the provider is reachable.
-        if not resolve_api_key(self.provider_id, self.config):
+        if (
+            not resolve_api_key(self.provider_id, self.config)
+            and not self._api_key_is_optional()
+        ):
             return False
         return await super().validate_credentials()

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -528,10 +528,9 @@ async def _refresh_provider_models() -> None:
 
         refreshed = 0
         for spec in PROVIDER_REGISTRY:
-            if not spec.env_keys:
-                continue
-            if not resolve_api_key(spec.id):
-                continue
+            if not spec.api_key_optional:
+                if not spec.env_keys or not resolve_api_key(spec.id):
+                    continue
             try:
                 provider = ProviderFactory.get_provider(spec.id, {})
                 models = await provider.list_models()

--- a/tests/core/test_local_openai_providers.py
+++ b/tests/core/test_local_openai_providers.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from suzent.core import model_factory
+from suzent.core.providers import openai_compat
+from suzent.core.providers.openai_compat import OpenAICompatProvider
+
+
+class _FakeResponse:
+    status = 200
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        return None
+
+    async def json(self) -> dict[str, Any]:
+        return {"data": [{"id": "local-model"}]}
+
+
+class _FakeSession:
+    last_headers: dict[str, str] | None = None
+
+    async def __aenter__(self) -> "_FakeSession":
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        return None
+
+    def get(self, _url: str, *, headers: dict[str, str], timeout: Any) -> _FakeResponse:
+        self.last_headers = headers
+        return _FakeResponse()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_id", ["vllm", "sglang"])
+async def test_keyless_local_provider_discovers_models(
+    monkeypatch, provider_id: str
+) -> None:
+    session = _FakeSession()
+    monkeypatch.setattr(openai_compat, "resolve_api_key", lambda *_args: None)
+    monkeypatch.setattr(openai_compat.aiohttp, "ClientSession", lambda: session)
+
+    provider = OpenAICompatProvider(provider_id, {}, "http://localhost:8000/v1")
+    models = await provider.list_models()
+
+    assert [model.id for model in models] == [f"{provider_id}/local-model"]
+    assert session.last_headers == {}
+
+
+def test_keyless_local_provider_creates_pydantic_model(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_handler(model_name: str, api_key: str, spec: Any) -> object:
+        captured.update(model_name=model_name, api_key=api_key, spec=spec)
+        return object()
+
+    monkeypatch.setattr(model_factory, "resolve_api_key", lambda _provider: None)
+    monkeypatch.setitem(model_factory._API_TYPE_HANDLERS, "openai", fake_handler)
+
+    model_factory.create_pydantic_ai_model("vllm/local-model")
+
+    assert captured["model_name"] == "local-model"
+    assert captured["api_key"] == ""
+    assert captured["spec"].api_key_optional is True
+
+
+def test_local_request_merges_and_moves_system_messages_first() -> None:
+    request = httpx.Request(
+        "POST",
+        "http://localhost:8000/v1/chat/completions",
+        content=json.dumps(
+            {
+                "model": "local-model",
+                "messages": [
+                    {"role": "user", "content": "first"},
+                    {"role": "system", "content": "base instructions"},
+                    {"role": "assistant", "content": "response"},
+                    {"role": "system", "content": "runtime reminder"},
+                    {"role": "user", "content": "second"},
+                ],
+            }
+        ).encode(),
+    )
+
+    rewritten = model_factory._rewrite_local_openai_request(request)
+    messages = json.loads(rewritten.content)["messages"]
+
+    assert [message["role"] for message in messages] == [
+        "system",
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert messages[0]["content"] == "base instructions\n\nruntime reminder"
+    assert [message["content"] for message in messages[1:]] == [
+        "first",
+        "response",
+        "second",
+    ]
+
+
+def test_local_request_without_system_message_is_unchanged() -> None:
+    request = httpx.Request(
+        "POST",
+        "http://localhost:8000/v1/chat/completions",
+        content=b'{"messages":[{"role":"user","content":"hello"}]}',
+    )
+
+    assert model_factory._rewrite_local_openai_request(request) is request

--- a/tests/core/test_provider_registry.py
+++ b/tests/core/test_provider_registry.py
@@ -79,6 +79,7 @@ class TestParseProvider:
             "native_provider": {"module": "test.mod", "class": "TestCls"},
             "fields": [{"key": "MY_KEY", "label": "Key", "type": "secret"}],
             "default_models": [{"id": "mycloud/m1", "name": "Model 1"}],
+            "api_key_optional": True,
         }
         spec = _parse_provider(raw, user_defined=True)
         assert spec.api_type == "anthropic"
@@ -87,6 +88,7 @@ class TestParseProvider:
         assert spec.user_defined is True
         assert spec.is_compat is True
         assert spec.has_native_provider is True
+        assert spec.api_key_optional is True
 
 
 class TestRegistryLoading:
@@ -96,7 +98,16 @@ class TestRegistryLoading:
         assert len(PROVIDER_REGISTRY) > 0
 
     def test_known_providers_exist(self):
-        known = ["openai", "anthropic", "gemini", "xai", "deepseek", "ollama"]
+        known = [
+            "openai",
+            "anthropic",
+            "gemini",
+            "xai",
+            "deepseek",
+            "ollama",
+            "vllm",
+            "sglang",
+        ]
         for pid in known:
             assert pid in PROVIDER_REGISTRY_BY_ID, f"Missing provider: {pid}"
 

--- a/tests/core/test_response_model_resolution.py
+++ b/tests/core/test_response_model_resolution.py
@@ -1,0 +1,34 @@
+from suzent.core.chat_processor import _resolve_response_model
+
+
+def test_huggingface_model_id_reuses_local_run_provider_prefix() -> None:
+    assert (
+        _resolve_response_model(
+            "Qwen/Qwen3-8B",
+            "vllm/Qwen/Qwen3-8B",
+            "openai",
+        )
+        == "vllm/Qwen/Qwen3-8B"
+    )
+
+
+def test_registered_provider_prefix_is_preserved() -> None:
+    assert (
+        _resolve_response_model(
+            "sglang/Qwen/Qwen3-8B",
+            "vllm/Qwen/Qwen3-8B",
+            "openai",
+        )
+        == "sglang/Qwen/Qwen3-8B"
+    )
+
+
+def test_huggingface_model_id_uses_response_provider_after_switch() -> None:
+    assert (
+        _resolve_response_model(
+            "Qwen/Qwen3-8B",
+            "vllm/Qwen/Qwen3-8B",
+            "anthropic",
+        )
+        == "anthropic/Qwen/Qwen3-8B"
+    )


### PR DESCRIPTION
## Summary

- add built-in vLLM and SGLang providers using the existing OpenAI-compatible provider path
- support configurable base URLs, optional API keys, `/v1/models` discovery, and background model refresh
- allow keyless local servers while preserving API-key requirements for existing hosted providers
- normalize strict local chat templates by merging all system messages and moving them to the beginning of the request
- add provider logos for vLLM, SGLang, LiteLLM, and Zhipu/GLM
- add regression tests for provider registration, keyless discovery, model creation, and system-message ordering

## Implementation notes

- no vLLM- or SGLang-specific SDK dependency is added
- inference continues through `OpenAIChatModel` and pydantic-ai's OpenAI provider
- only the `vllm` and `sglang` HTTP clients rewrite system-message ordering; hosted providers are unchanged
- when a local endpoint does not require authentication, model discovery omits the Authorization header and runtime inference uses a non-sensitive internal placeholder required by the OpenAI SDK

## Validation

- `uv run pytest tests/core -q` — **364 passed**
- targeted independent verification — **24 passed**
- `uv run ruff check ...` — **passed**
- `python -m json.tool config/providers.json` — **passed**
- `npm run build` in `frontend/` — **passed**
- live SGLang validation:
  - model discovery returned `sglang/qwen3.8-27b-sglang`
  - authenticated chat request succeeded
  - a request that previously failed with `System message must be at the beginning` succeeded after normalization

## Security

No API keys or local secret files are included in this PR.
