### PR TITLE
perf(frontend): cut chat scroll cost on macOS

### DIFF
--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -62,8 +62,14 @@ import type {
 } from '../lib/streamEvents';
 
 const INITIAL_VISIBLE_MESSAGES = 30;
-const LOAD_MORE_MESSAGES = 60;
-const LOAD_MORE_SCROLL_THRESHOLD_PX = 96;
+// A page of older messages renders synchronously, so the batch size is a
+// direct main-thread stall. Small enough that one page stays inside a frame
+// or two, rather than one 60-message page freezing the window.
+const LOAD_MORE_MESSAGES = 20;
+// Start that work while there is still a screenful of runway above the reader
+// instead of at the moment they hit the top, so the page lands before they
+// arrive rather than as a visible stall once they have nowhere left to scroll.
+const LOAD_MORE_SCROLL_THRESHOLD_PX = 600;
 
 interface ForkOrigin {
   chatId: string;
@@ -450,6 +456,30 @@ const MessageList: React.FC<{
     [messages]
   );
 
+  // A fresh `() => onFork(index)` per row would hand every AssistantMessage a
+  // new prop identity on each render and defeat its memo -- which is the whole
+  // reason a prepend used to re-render the entire history. Hand each row a
+  // callback that stays identical for as long as its fork index does; the
+  // handler itself is read through a ref so a new `onFork` cannot stale it.
+  const onForkRef = useRef(onFork);
+  onForkRef.current = onFork;
+  const forkHandlersRef = useRef(new Map<number, () => void>());
+  const forkHandlersChatRef = useRef(chatId);
+  if (forkHandlersChatRef.current !== chatId) {
+    // Drop the cache when the conversation changes rather than letting entries
+    // accumulate across every chat visited this session.
+    forkHandlersChatRef.current = chatId;
+    forkHandlersRef.current = new Map();
+  }
+  const getForkHandler = useCallback((messageEndIndex: number) => {
+    let handler = forkHandlersRef.current.get(messageEndIndex);
+    if (!handler) {
+      handler = () => onForkRef.current?.(messageEndIndex);
+      forkHandlersRef.current.set(messageEndIndex, handler);
+    }
+    return handler;
+  }, []);
+
   // Index of the last non-skipped assistant message — only it shows the retry button.
   const lastAssistantIdx = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -499,7 +529,7 @@ const MessageList: React.FC<{
             <div
               key={globalIdx}
               data-message-index={globalIdx}
-              className="chat-msg-row w-full flex flex-col group/message"
+              className="chat-msg-row chat-msg-row-assistant w-full flex flex-col group/message"
             >
               <div className="flex justify-start w-full">
                 <AssistantMessage
@@ -535,7 +565,7 @@ const MessageList: React.FC<{
             <div
               key={globalIdx}
               data-message-index={globalIdx}
-              className="chat-msg-row w-full flex justify-start pl-2 pr-2 min-w-0"
+              className="chat-msg-row chat-msg-row-compact w-full flex justify-start pl-2 pr-2 min-w-0"
             >
               <div className="max-w-full min-w-0 border-2 border-dashed border-brutal-black px-4 py-2 text-sm font-mono text-neutral-500 dark:text-neutral-400 italic bg-white dark:bg-zinc-800 whitespace-pre-wrap break-words break-all">
                 {m.content}
@@ -551,7 +581,7 @@ const MessageList: React.FC<{
             <div
               key={globalIdx}
               data-message-index={globalIdx}
-              className="chat-msg-row w-full flex justify-start"
+              className="chat-msg-row chat-msg-row-compact w-full flex justify-start"
             >
               <SystemTriggeredMessage message={m} />
             </div>
@@ -563,7 +593,7 @@ const MessageList: React.FC<{
             <div
               key={globalIdx}
               data-message-index={globalIdx}
-              className="chat-msg-row w-full flex justify-start"
+              className="chat-msg-row chat-msg-row-compact w-full flex justify-start"
             >
               <NoticeMessage message={m} />
             </div>
@@ -577,7 +607,9 @@ const MessageList: React.FC<{
           <React.Fragment key={globalIdx}>
             <div
               data-message-index={globalIdx}
-              className="chat-msg-row w-full flex flex-col group/message"
+              className={`chat-msg-row ${
+                isUser ? 'chat-msg-row-user' : 'chat-msg-row-assistant'
+              } w-full flex flex-col group/message`}
             >
               <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} w-full`}>
                 {isUser ? (
@@ -617,7 +649,7 @@ const MessageList: React.FC<{
                       onFork &&
                       !streamingForCurrentChat &&
                       typeof m.raw_message_end_index === 'number'
-                        ? () => onFork(m.raw_message_end_index)
+                        ? getForkHandler(m.raw_message_end_index)
                         : undefined
                     }
                     fileChangeChatId={m.file_changes?.length ? chatId : undefined}
@@ -1583,6 +1615,11 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   const loadOlderVisibleMessages = useCallback(() => {
     const el = scrollContainerRef.current;
     if (!el || !hasHiddenOlderMessages) return;
+    // Scroll fires many times per frame, and every event above the threshold
+    // would otherwise queue another page: several stacked into one render, each
+    // overwriting the snapshot the restore below depends on. One page at a
+    // time, released once it has been committed and the scroll restored.
+    if (prependScrollSnapshotRef.current) return;
 
     prependScrollSnapshotRef.current = {
       scrollHeight: el.scrollHeight,
@@ -1648,7 +1685,13 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   useLayoutEffect(() => {
     const snapshot = prependScrollSnapshotRef.current;
     const el = scrollContainerRef.current;
-    if (!el) return;
+    if (!el) {
+      // The snapshot doubles as the "a page is in flight" latch, so it has to
+      // be released on every path out of here or older messages stop loading
+      // for the rest of the chat.
+      prependScrollSnapshotRef.current = null;
+      return;
+    }
 
     const pendingJumpIndex = pendingMinimapJumpRef.current;
     if (pendingJumpIndex != null) {

--- a/frontend/src/components/chat/ActivityRail.tsx
+++ b/frontend/src/components/chat/ActivityRail.tsx
@@ -283,6 +283,9 @@ function formatActivityDuration(totalSeconds: number): string {
   return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
 }
 
+/** Matches the grid-rows transition below; they must stay in step. */
+const COLLAPSE_MS = 300;
+
 export const ActivityRail: React.FC<{
   children: React.ReactNode;
   itemCount: number;
@@ -347,6 +350,21 @@ export const ActivityRail: React.FC<{
     return () => window.clearInterval(timer);
   }, [isActive]);
 
+  // The collapsed body is invisible but was still mounted, laid out and
+  // painted: measured at 82% of all message DOM on a long chat, and it is the
+  // bulk of what makes a row expensive the first time it scrolls into view.
+  // Mount it only while open, held one transition longer so closing still
+  // animates rather than snapping shut on an empty box.
+  const [bodyMounted, setBodyMounted] = useState(expanded);
+  useEffect(() => {
+    if (expanded) {
+      setBodyMounted(true);
+      return undefined;
+    }
+    const timer = window.setTimeout(() => setBodyMounted(false), COLLAPSE_MS);
+    return () => window.clearTimeout(timer);
+  }, [expanded]);
+
   const displayedSeconds = durationSeconds ?? elapsedSeconds;
   const durationLabel = `Worked for ${formatActivityDuration(displayedSeconds)}`;
   // Only the turn's first rail reports the worked time. When assistant text
@@ -395,7 +413,7 @@ export const ActivityRail: React.FC<{
       >
         <div className="min-h-0 overflow-hidden">
           <div className="activity-rail-scroll min-w-0 w-full">
-            <div className="activity-rail min-w-0 w-full">{children}</div>
+            <div className="activity-rail min-w-0 w-full">{bodyMounted ? children : null}</div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/chat/ActivityRail.tsx
+++ b/frontend/src/components/chat/ActivityRail.tsx
@@ -361,9 +361,14 @@ export const ActivityRail: React.FC<{
       setBodyMounted(true);
       return undefined;
     }
+    // A pending approval can be holding a half-typed rejection reason in the
+    // tool block's own state. Unmounting would discard it silently, and the
+    // user would only find out after reopening the rail -- so hold the body
+    // until the approval resolves, however the rail got collapsed.
+    if (hasPending) return undefined;
     const timer = window.setTimeout(() => setBodyMounted(false), COLLAPSE_MS);
     return () => window.clearTimeout(timer);
-  }, [expanded]);
+  }, [expanded, hasPending]);
 
   const displayedSeconds = durationSeconds ?? elapsedSeconds;
   const durationLabel = `Worked for ${formatActivityDuration(displayedSeconds)}`;

--- a/frontend/src/components/chat/AssistantMessage.tsx
+++ b/frontend/src/components/chat/AssistantMessage.tsx
@@ -745,7 +745,7 @@ const ModelSignature: React.FC<{ model?: string }> = ({ model }) => {
   );
 };
 
-export const AssistantMessage: React.FC<AssistantMessageProps> = ({
+const AssistantMessageComponent: React.FC<AssistantMessageProps> = ({
   message,
   previousMessageTimestamp,
   messageIndex,
@@ -1353,3 +1353,8 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
     </CitationProvider>
   );
 };
+
+// Memoised so that loading a page of older messages renders only the new rows.
+// Without this, every prepend re-rendered the entire visible history -- the
+// whole markdown pipeline, per row -- and the stall grew with each page loaded.
+export const AssistantMessage = React.memo(AssistantMessageComponent);

--- a/frontend/src/components/chat/UserMessage.tsx
+++ b/frontend/src/components/chat/UserMessage.tsx
@@ -275,7 +275,7 @@ interface UserMessageProps {
   onRerun?: () => void;
 }
 
-export const UserMessage: React.FC<UserMessageProps> = ({
+const UserMessageComponent: React.FC<UserMessageProps> = ({
   message,
   chatId,
   onImageClick,
@@ -507,3 +507,6 @@ export const UserMessage: React.FC<UserMessageProps> = ({
     </div>
   );
 };
+
+// Memoised alongside AssistantMessage -- see the note there.
+export const UserMessage = React.memo(UserMessageComponent);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -17,10 +17,30 @@
     @apply shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-[1px] hover:shadow-[4px_4px_0_0_#000] active:translate-x-[1px] active:translate-y-[1px] active:shadow-none transition-all;
   }
 
-  /* Skips paint/composite for off-screen message rows, preventing GPU layer exhaustion on long histories. */
+  /* Skips layout/paint for off-screen message rows, keeping long histories
+     cheap to scroll. The placeholder size is per row type: `auto` remembers a
+     row's real height once it has been rendered, so these estimates only have
+     to carry the *first* reveal — but a flat estimate that is wrong by an
+     order of magnitude (a 120px guess for a 900px tool call) shoves the
+     content on every one of them. */
   .chat-msg-row {
     content-visibility: auto;
-    contain-intrinsic-block-size: auto 120px;
+    contain-intrinsic-block-size: auto 320px;
+  }
+
+  /* Single-line pills and cards: notices, canvas actions, system triggers. */
+  .chat-msg-row-compact {
+    contain-intrinsic-block-size: auto 72px;
+  }
+
+  /* A user bubble is a prompt — typically a few lines. */
+  .chat-msg-row-user {
+    contain-intrinsic-block-size: auto 96px;
+  }
+
+  /* An assistant turn carries prose plus tool blocks, and runs much taller. */
+  .chat-msg-row-assistant {
+    contain-intrinsic-block-size: auto 420px;
   }
 
   .chat-minimap {
@@ -348,8 +368,10 @@ code {
   /* Prevent text selection from being cleared during DOM updates */
   -webkit-user-select: text !important;
   user-select: text !important;
-  /* Hint to browser that content will change (helps with rendering optimization) */
-  will-change: contents;
+  /* No `will-change: contents` here: it does nothing for selection, and since
+     .select-text sits on every markdown block and user bubble it told the
+     engine not to cache any message's rendered contents — so every repaint
+     re-rasterized the whole visible history instead of reusing a tile. */
 }
 
 .select-none,


### PR DESCRIPTION
## Problem

Scrolling a long chat stalled on macOS (WKWebView) and went blank on fast scroll, while the same build was fine on Windows (WebView2).

I measured this inside the app's own WebKit rather than reasoning about it — three plausible-sounding diagnoses (scroll anchoring, hover/shadow repaints, syntax highlighting) were all wrong. The cause is **DOM volume on first reveal**, not paint, markdown, or scroll handlers. Forced layout measured 0.3ms; markdown prose is 13% of row nodes; code blocks are literally 0 (there is no syntax highlighting).

## Cause

The ActivityRail's collapsed body was **82% of all message DOM**. `grid-rows-[0fr]` collapses with CSS, so every settled turn kept its full rail subtree mounted, laid out and painted while invisible — 17,134 of 21,143 nodes on a 30-row chat.

Separately, prepending older messages re-rendered the entire visible history: the row components were not memoised, and an inline `onFork` closure would have defeated the memo anyway. Cost was O(visible) rather than O(new), so each page loaded froze longer than the last.

## Changes

- **ActivityRail** — mount the collapsed body only while expanded, held one transition (300ms) past close so the animation still plays
- **AssistantMessage / UserMessage** — `React.memo`, so a prepend renders only new rows
- **ChatWindow** — stable per-index fork handler (without it the memo never hits); load 20 messages at 600px of runway instead of 60 at 96px; guard against stacked prepends clobbering the scroll-restore snapshot
- **styles.css** — per-row-type `contain-intrinsic-block-size`; drop `will-change: contents`, which did nothing for selection but told the engine never to cache any message's rendered contents

## Measured

76-message chat, 30 rows in DOM, macOS WKWebView:

| | before | after | |
|---|---|---|---|
| nodes per row | 705 | **144** | −79.6% |
| document nodes | 22,113 | 5,280 | −76.1% |
| mounted-but-collapsed | 17,134 | 311 | −98.2% |
| SVGs | 1,673 | 253 | −84.9% |
| markdown prose | 2,748 | 2,748 | **0%** |
| scroll frames | p95 58–144, max 779 | p95 36–51, max 63 | |

Prose unchanged at exactly 2,748 confirms no visible content was lost. Node counts are exact; frame timings are indicative (different sessions, and the scroll is shorter once the DOM shrinks).

Both `contain-intrinsic-block-size` and the `will-change` removal measured **neutral** in a paired A/B and are kept on non-performance grounds, not perf claims.

## Trade-offs

- **First expand of a rail is slower** — it builds 500–3,000 nodes on click instead of a pure CSS reveal. This is the trade: cost moves from every reveal of every message, forever, to once when you actually open one. Not separately measured.
- **Copy / find-in-page** — collapsed rail text was in the DOM at zero height and would come along with a select-all copy. It won't now.
- **`SubAgentCallBlock` polling stops for collapsed rails.** Low risk: sub-agent status has two independent push channels that do not depend on the block being mounted — the shared `/subagents/stream` EventSource in `useSubAgentStatus`, and parent-chat SSE events feeding `subAgentTasks` down as a prop. The in-component poll is a third fallback for a component that is invisible while collapsed, and it resumes on expand.
- **`React.memo` is now a constraint**: mutating a live message object in place will no longer re-render. The one in-place mutation in the codebase (`useChatStore.tsx:1465`) happens during list construction before React sees the object, so it is unaffected.

## Verification

`tsc --noEmit` clean · 215/215 tests · build · prettier · lint diffed against baseline, **zero new problems**.

Measured in `tauri dev`, which carries its own overhead — worth a sanity pass on a release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)