### PR TITLE
fix(subagents): recover task ids from persisted results, share one status poll

### DIFF
--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -1397,6 +1397,21 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     citationSourcesRef.current = map;
     return map;
   }, [safeMessages, streamingParts, showTransientAssistant]);
+  // The Agents tab is disabled unless the chat "has" sub-agents, and that was
+  // read only from `subAgentTasks` -- live SSE state, cleared on every chat
+  // switch. So reopening a chat with a long sub-agent history left the tab
+  // greyed out and unclickable, even though the panel behind it fetches its
+  // own history from /subagents and would have shown all of them. The
+  // transcript is the durable record: if a turn called the agent tool, this
+  // chat has sub-agents whether or not the stream has said so this session.
+  const transcriptHasSubAgentCall = useMemo(
+    () =>
+      safeMessages.some((message) =>
+        (message.parts || []).some((part) => part.type === 'tool' && part.toolName === 'agent')
+      ),
+    [safeMessages]
+  );
+
   const hasHiddenOlderMessages = visibleMessageStartIndex > 0;
   const _prefs = backendConfig?.userPreferences;
   const _base = config || { model: '', agent: '', tools: [] as string[] };
@@ -2736,6 +2751,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
           currentChatSummary?.platform === 'subagent' ||
           safeConfig?.platform === 'subagent'
         }
+        hasSubAgentHistory={transcriptHasSubAgentCall}
         messages={safeMessages}
         forcedWebContextId={forcedWebContextId}
         onClearForcedWebContext={() => setForcedWebContextId(null)}

--- a/frontend/src/components/DisclosureChevron.tsx
+++ b/frontend/src/components/DisclosureChevron.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+/**
+ * The one expand/collapse chevron.
+ *
+ * It points right while collapsed and turns down to open. The transcript used
+ * to disagree with itself about that: some disclosures pointed down when shut
+ * and flipped up when open -- reading as "there is something below" in both
+ * states -- and ToolCallBlock did it both ways depending on whether it was
+ * inside an activity rail, so the same control changed meaning with its
+ * surroundings.
+ *
+ * Sizing, colour and transition stay with the caller: a hover-revealed chevron
+ * needs `transition-all` for its opacity, and a `<details>`-driven one turns on
+ * `group-open/...:rotate-90` rather than a React flag, so it passes no
+ * `expanded` at all. What is shared is the mark and the direction.
+ */
+export const DisclosureChevron: React.FC<{
+  expanded?: boolean;
+  className?: string;
+}> = ({ expanded = false, className = '' }) => (
+  <svg
+    className={`shrink-0 ${expanded ? 'rotate-90' : ''} ${className}`}
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth={3}
+    aria-hidden="true"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+  </svg>
+);

--- a/frontend/src/components/chat/ActivityRail.tsx
+++ b/frontend/src/components/chat/ActivityRail.tsx
@@ -6,6 +6,7 @@ import { getRepeatedToolLabel, getToolSummary, normalizeToolName } from './toolS
 import type { ToolTense } from './toolSummary';
 import { useTypewriter } from '../../hooks/useTypewriter';
 import { tForLocale, useI18n } from '../../i18n';
+import { DisclosureChevron } from '../DisclosureChevron';
 
 export type ActivityRenderGroup<T> =
   | { type: 'activity'; chunks: Array<{ chunk: T; index: number }> }
@@ -403,15 +404,10 @@ export const ActivityRail: React.FC<{
         <span className="text-neutral-500 dark:text-neutral-400">
           {itemCount} {itemCount === 1 ? 'step' : 'steps'}
         </span>
-        <svg
-          className={`w-3 h-3 text-neutral-500 dark:text-neutral-400 transition-transform duration-200 ${expanded ? 'rotate-90' : ''}`}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={3}
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-        </svg>
+        <DisclosureChevron
+          expanded={expanded}
+          className="w-3 h-3 text-neutral-500 dark:text-neutral-400 transition-transform duration-200"
+        />
       </button>
       <div
         className={`grid transition-[grid-template-rows] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] overflow-hidden ${expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}
@@ -492,15 +488,10 @@ const ReasoningRailItemComponent: React.FC<{
           >
             {thinking ? t('activityRail.thinking') : t('activityRail.thought')}
           </span>
-          <svg
-            className={`w-3 h-3 text-neutral-400 opacity-0 transition-all duration-150 shrink-0 group-hover/thought-header:opacity-100 ${expanded ? 'rotate-90' : ''}`}
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={3}
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-          </svg>
+          <DisclosureChevron
+            expanded={expanded}
+            className="w-3 h-3 text-neutral-400 opacity-0 transition-all duration-150 group-hover/thought-header:opacity-100"
+          />
         </button>
         <div
           className={`grid transition-[grid-template-rows] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] overflow-hidden ${expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}

--- a/frontend/src/components/chat/AssistantContent.tsx
+++ b/frontend/src/components/chat/AssistantContent.tsx
@@ -8,6 +8,7 @@ import { CodeBlockComponent } from './CodeBlockComponent';
 import { LogBlock } from './LogBlock';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { parseSubAgentArgs, SubAgentCallBlock, type SubAgentStatus } from './SubAgentCallBlock';
+import { parseSubAgentResult } from './subAgentResult';
 import { ToolCallBlock } from './ToolCallBlock';
 import { ToolGroupIcon } from './toolGroupIcon';
 import type {
@@ -19,11 +20,6 @@ import type {
 const LARGE_MARKDOWN_RENDER_THRESHOLD = 12000;
 
 /** Extract sub-agent task_id from agent tool output text. */
-export function parseSubAgentTaskId(output: string | undefined): string | undefined {
-  if (!output) return undefined;
-  const m = output.match(/ID:\s*`?(sub_[a-z0-9]+)`?/);
-  return m ? m[1] : undefined;
-}
 
 export const ToolSequenceGroup: React.FC<{
   tools: Array<{
@@ -385,10 +381,16 @@ export const StaticContent: React.FC<{
           const isAutoApproved = toolApprovalPolicy?.[b.toolName || ''] === 'always_allow';
 
           if (b.toolName === 'agent') {
-            const taskId = parseSubAgentTaskId(b.content || undefined);
+            const persisted = parseSubAgentResult(b.content || undefined);
+            const taskId = persisted.taskId;
             const taskState = taskId ? subAgentTasks?.[taskId] : undefined;
             const args = parseSubAgentArgs(b.toolArgs);
-            const defaultStatus = b.content ? 'completed' : 'running';
+            // The tool returning is not the sub-agent finishing: a background
+            // spawn returns 'queued' while the run continues. Prefer the status
+            // the result actually recorded, so a still-running task stays
+            // non-terminal and keeps being polled instead of being frozen as
+            // 'completed' by the mere presence of output.
+            const defaultStatus = persisted.status ?? (b.content ? 'completed' : 'running');
             return (
               <SubAgentCallBlock
                 key={blockKey}
@@ -396,8 +398,8 @@ export const StaticContent: React.FC<{
                 description={args.description}
                 toolsAllowed={args.toolsAllowed}
                 status={taskState?.status ?? defaultStatus}
-                resultSummary={taskState?.resultSummary}
-                error={taskState?.error}
+                resultSummary={taskState?.resultSummary ?? persisted.resultSummary}
+                error={taskState?.error ?? persisted.error}
                 onOpenSidebar={onOpenSubAgentSidebar}
                 onStop={onStopSubAgent}
               />

--- a/frontend/src/components/chat/AssistantContent.tsx
+++ b/frontend/src/components/chat/AssistantContent.tsx
@@ -16,6 +16,7 @@ import type {
   ToolPermissionDecision,
   ToolPermissionResolution,
 } from '../../types/agui';
+import { DisclosureChevron } from '../DisclosureChevron';
 
 const LARGE_MARKDOWN_RENDER_THRESHOLD = 12000;
 
@@ -124,15 +125,10 @@ export const ToolSequenceGroup: React.FC<{
               {isAnyRunning ? 'Running' : 'Hide'} {tools.length} Steps
             </span>
           )}
-          <svg
-            className={`w-3 h-3 transition-transform duration-200 ml-auto ${expanded ? 'rotate-180' : ''}`}
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={3}
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-          </svg>
+          <DisclosureChevron
+            expanded={expanded}
+            className="w-3 h-3 transition-transform duration-200 ml-auto"
+          />
         </div>
       </button>
 

--- a/frontend/src/components/chat/AssistantContent.tsx
+++ b/frontend/src/components/chat/AssistantContent.tsx
@@ -398,6 +398,8 @@ export const StaticContent: React.FC<{
                 description={args.description}
                 toolsAllowed={args.toolsAllowed}
                 status={taskState?.status ?? defaultStatus}
+                model={persisted.model}
+                subagentType={persisted.subagentType}
                 resultSummary={taskState?.resultSummary ?? persisted.resultSummary}
                 error={taskState?.error ?? persisted.error}
                 onOpenSidebar={onOpenSubAgentSidebar}

--- a/frontend/src/components/chat/AssistantMessage.tsx
+++ b/frontend/src/components/chat/AssistantMessage.tsx
@@ -12,6 +12,7 @@ import { MarkdownRenderer } from './MarkdownRenderer';
 import { ImageWithFallback } from './ImageWithFallback';
 import { ToolCallBlock } from './ToolCallBlock';
 import { parseSubAgentArgs, SubAgentCallBlock } from './SubAgentCallBlock';
+import { parseSubAgentResult } from './subAgentResult';
 import { AcpPermissionPrompt } from './AcpPermissionPrompt';
 import { AcpAgentIcon } from '../AcpAgentIcon';
 import { AcpSessionResetNotice } from './AcpSessionResetNotice';
@@ -20,13 +21,7 @@ import { CopyButton } from './CopyButton';
 import { FileChangeSummary } from './FileChangeSummary';
 import { A2UIRenderer } from '../a2ui/A2UIRenderer';
 import type { A2UISurface } from '../../types/a2ui';
-import {
-  StaticContent,
-  StepPills,
-  StreamingContent,
-  ToolSequenceGroup,
-  parseSubAgentTaskId,
-} from './AssistantContent';
+import { StaticContent, StepPills, StreamingContent, ToolSequenceGroup } from './AssistantContent';
 import {
   CitationProvider,
   SourcesPanel,
@@ -386,11 +381,18 @@ const AGUIPartsContent: React.FC<{
                             : ('neutral' as const);
 
                   if (t.toolName === 'agent') {
-                    const taskId = parseSubAgentTaskId(t.output);
+                    const persisted = parseSubAgentResult(t.output);
+                    const taskId = persisted.taskId;
                     const taskState = taskId ? subAgentTasks?.[taskId] : undefined;
                     const args = parseSubAgentArgs(t.toolArgs);
+                    // The tool returning is not the sub-agent finishing: a
+                    // background spawn returns 'queued' while the run continues.
+                    // Prefer the status the result recorded, so a live task stays
+                    // non-terminal and keeps being polled.
                     const defaultStatus =
-                      t.approvalState === 'pending' ? 'queued' : t.output ? 'completed' : 'running';
+                      t.approvalState === 'pending'
+                        ? 'queued'
+                        : (persisted.status ?? (t.output ? 'completed' : 'running'));
                     return (
                       <ActivityRailItem key={t.toolCallId || `sa-${ci}-${i}`} state={itemState}>
                         <SubAgentCallBlock
@@ -398,8 +400,8 @@ const AGUIPartsContent: React.FC<{
                           description={args.description}
                           toolsAllowed={args.toolsAllowed}
                           status={taskState?.status ?? defaultStatus}
-                          resultSummary={taskState?.resultSummary}
-                          error={taskState?.error}
+                          resultSummary={taskState?.resultSummary ?? persisted.resultSummary}
+                          error={taskState?.error ?? persisted.error}
                           onOpenSidebar={onOpenSubAgentSidebar}
                           onStop={onStopSubAgent}
                         />
@@ -494,15 +496,19 @@ const AGUIPartsContent: React.FC<{
           return (
             <div key={ci} className="pl-1 min-w-0 overflow-x-hidden">
               {subAgentTools.map((t, i) => {
-                const taskId = parseSubAgentTaskId(t.output);
+                const persisted = parseSubAgentResult(t.output);
+                const taskId = persisted.taskId;
                 const taskState = taskId ? subAgentTasks?.[taskId] : undefined;
                 const args = parseSubAgentArgs(t.toolArgs);
-                // If output exists, the tool call returned — default to 'completed'.
-                // This correctly handles linear (synchronous) subagents that run inline
-                // without emitting SSE events. Polling will correct if the backend
-                // reports a different status (e.g. background agent still in-flight).
+                // The status the result recorded beats guessing from the mere
+                // presence of output: a background spawn returns 'queued' while
+                // the run continues, and calling that 'completed' froze it as
+                // terminal so nothing ever corrected it. Falling back to the old
+                // guess still covers linear sub-agents that run inline.
                 const defaultStatus =
-                  t.approvalState === 'pending' ? 'queued' : t.output ? 'completed' : 'running';
+                  t.approvalState === 'pending'
+                    ? 'queued'
+                    : (persisted.status ?? (t.output ? 'completed' : 'running'));
                 return (
                   <SubAgentCallBlock
                     key={t.toolCallId || `sa-${i}`}
@@ -510,8 +516,8 @@ const AGUIPartsContent: React.FC<{
                     description={args.description}
                     toolsAllowed={args.toolsAllowed}
                     status={taskState?.status ?? defaultStatus}
-                    resultSummary={taskState?.resultSummary}
-                    error={taskState?.error}
+                    resultSummary={taskState?.resultSummary ?? persisted.resultSummary}
+                    error={taskState?.error ?? persisted.error}
                     onOpenSidebar={onOpenSubAgentSidebar}
                     onStop={onStopSubAgent}
                   />

--- a/frontend/src/components/chat/AssistantMessage.tsx
+++ b/frontend/src/components/chat/AssistantMessage.tsx
@@ -400,6 +400,8 @@ const AGUIPartsContent: React.FC<{
                           description={args.description}
                           toolsAllowed={args.toolsAllowed}
                           status={taskState?.status ?? defaultStatus}
+                          model={persisted.model}
+                          subagentType={persisted.subagentType}
                           resultSummary={taskState?.resultSummary ?? persisted.resultSummary}
                           error={taskState?.error ?? persisted.error}
                           onOpenSidebar={onOpenSubAgentSidebar}
@@ -516,6 +518,8 @@ const AGUIPartsContent: React.FC<{
                     description={args.description}
                     toolsAllowed={args.toolsAllowed}
                     status={taskState?.status ?? defaultStatus}
+                    model={persisted.model}
+                    subagentType={persisted.subagentType}
                     resultSummary={taskState?.resultSummary ?? persisted.resultSummary}
                     error={taskState?.error ?? persisted.error}
                     onOpenSidebar={onOpenSubAgentSidebar}

--- a/frontend/src/components/chat/Citations.tsx
+++ b/frontend/src/components/chat/Citations.tsx
@@ -3,6 +3,7 @@ import { ImageWithFallback } from './ImageWithFallback';
 import { createPortal } from 'react-dom';
 import type { CitationSource } from '../../lib/streamEvents';
 import { InformationPopover } from '../InformationPopover';
+import { DisclosureChevron } from '../DisclosureChevron';
 
 /**
  * Inline-citation rendering.
@@ -694,15 +695,10 @@ export const SourcesPanel: React.FC<{ sources: CitationSource[] }> = ({ sources 
         <span>
           {sources.length} {sources.length === 1 ? 'Source' : 'Sources'}
         </span>
-        <svg
-          className={`w-3 h-3 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={3}
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-        </svg>
+        <DisclosureChevron
+          expanded={expanded}
+          className="w-3 h-3 transition-transform duration-200"
+        />
       </button>
 
       {expanded &&

--- a/frontend/src/components/chat/RightSidebar.tsx
+++ b/frontend/src/components/chat/RightSidebar.tsx
@@ -58,6 +58,8 @@ interface RightSidebarProps {
   onSelectSubAgent?: (taskId: string) => void;
   currentChatId?: string | null;
   hasSubAgents?: boolean;
+  /** This chat has spawned sub-agents at some point, live stream or not. */
+  hasSubAgentHistory?: boolean;
   messages?: Message[];
   forcedWebContextId?: string | null;
   onClearForcedWebContext?: () => void;
@@ -100,6 +102,7 @@ export const RightSidebar: React.FC<RightSidebarProps> = ({
   onSelectSubAgent,
   currentChatId,
   hasSubAgents = false,
+  hasSubAgentHistory = false,
   messages = [],
   forcedWebContextId,
   onClearForcedWebContext,
@@ -193,7 +196,10 @@ export const RightSidebar: React.FC<RightSidebarProps> = ({
       icon: CpuChipIcon,
       labelKey: 'sidebar.tabs.agents',
       fallbackLabel: 'Agents',
-      hasContent: hasSubAgents || !!viewingSubAgentTaskId,
+      // Openable on history: the panel fetches its own list from /subagents,
+      // so a reopened chat can show every past run. The dot stays tied to live
+      // state -- a finished history is not activity.
+      hasContent: hasSubAgents || hasSubAgentHistory || !!viewingSubAgentTaskId,
       hasActivity: hasSubAgents || !!viewingSubAgentTaskId,
       activityClass: 'bg-brutal-blue animate-pulse',
     },

--- a/frontend/src/components/chat/StatusMessages.tsx
+++ b/frontend/src/components/chat/StatusMessages.tsx
@@ -3,6 +3,7 @@ import type { Message } from '../../types/api';
 import { useI18n } from '../../i18n';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { CompactionCube, CompactionSweep } from './CompactionCube';
+import { DisclosureChevron } from '../DisclosureChevron';
 
 /**
  * Small, self-contained presentational rows used by the chat view: the drag-drop
@@ -96,16 +97,10 @@ export const SystemTriggeredMessage: React.FC<{ message: Message }> = ({ message
             {title}
           </span>
           {body && (
-            <svg
-              className={`ml-auto h-3 w-3 shrink-0 text-brutal-black/50 dark:text-neutral-500 transition-transform duration-200 ${expanded ? 'rotate-90' : ''}`}
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={3}
-              aria-hidden="true"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-            </svg>
+            <DisclosureChevron
+              expanded={expanded}
+              className="ml-auto h-3 w-3 text-brutal-black/50 dark:text-neutral-500 transition-transform duration-200"
+            />
           )}
         </button>
 

--- a/frontend/src/components/chat/SubAgentCallBlock.tsx
+++ b/frontend/src/components/chat/SubAgentCallBlock.tsx
@@ -6,12 +6,10 @@
  * right. Live state comes off the shared sub-agent EventSource, with a poll as
  * a fallback for when the parent stream ended before the child did.
  */
-import React, { useState, useEffect, useRef } from 'react';
-import { getApiBase } from '../../lib/api';
+import React, { useState, useEffect } from 'react';
 import { useI18n } from '../../i18n';
-import { useSubAgentStatus } from '../../hooks/useSubAgentStatus';
+import { useSubAgentStatus, watchSubAgentTask } from '../../hooks/useSubAgentStatus';
 import {
-  isStreamStateStale,
   isSubAgentActive,
   isSubAgentTerminal,
   subAgentOutcomeLabel,
@@ -98,71 +96,24 @@ const SubAgentCallBlockComponent: React.FC<SubAgentCallBlockProps> = ({
 }) => {
   const { t } = useI18n();
   const { taskStates } = useSubAgentStatus();
-  // Self-poll to get real status when the parent SSE stream may have ended before completion
-  const [polledStatus, setPolledStatus] = useState<SubAgentStatus | null>(null);
-  const [polledResultSummary, setPolledResultSummary] = useState<string | undefined>(undefined);
-  const [polledError, setPolledError] = useState<string | undefined>(undefined);
-  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  // Use a ref so the poll callback always sees the latest resolved status without
-  // being captured in a stale closure — avoids polling when already done.
-  const resolvedStatusRef = useRef<SubAgentStatus>(externalStatus);
 
+  // Presentation only: status comes from the shared store, which merges the
+  // sub-agent stream and the shared fallback poll and refuses to walk a
+  // finished run back to 'running'. This block used to run its own 3s poll and
+  // reconcile it against the stream itself, which meant N blocks made N
+  // requests and each stopped covering its task the moment it unmounted.
   const streamTask = taskId ? taskStates[taskId] : undefined;
-  // The poll exists precisely for when the stream is not there; if it has seen
-  // the run end, its answer outranks whatever the stream last managed to say.
-  const liveTask = isStreamStateStale(streamTask?.status, polledStatus ?? undefined)
-    ? undefined
-    : streamTask;
-  const status = liveTask?.status ?? polledStatus ?? externalStatus;
-  const resultSummary = liveTask?.result_summary ?? polledResultSummary ?? externalResultSummary;
-  const error = liveTask?.error ?? polledError ?? externalError;
+  const status = streamTask?.status ?? externalStatus;
+  const resultSummary = streamTask?.result_summary ?? externalResultSummary;
+  const error = streamTask?.error ?? externalError;
 
-  // Keep ref in sync on every render
-  resolvedStatusRef.current = status;
-
+  // Register with the shared poll only while this task is unfinished. The
+  // transcript is the only place a task from an earlier session is named, so
+  // without this a chat reopened mid-run would never learn how it ended.
   useEffect(() => {
-    if (!taskId) return;
-    // Already terminal — no need to poll
-    if (isSubAgentTerminal(resolvedStatusRef.current)) return;
-
-    const poll = async () => {
-      // Stop polling if status was resolved externally while waiting
-      if (isSubAgentTerminal(resolvedStatusRef.current)) {
-        if (timerRef.current) clearInterval(timerRef.current);
-        return;
-      }
-      try {
-        const res = await fetch(`${getApiBase()}/subagents/${taskId}`);
-        if (!res.ok) return;
-        const data = await res.json();
-        const task = data.task;
-        if (task) {
-          setPolledStatus(task.status);
-          if (task.result_summary) setPolledResultSummary(task.result_summary);
-          if (task.error) setPolledError(task.error);
-          if (isSubAgentTerminal(task.status)) {
-            if (timerRef.current) clearInterval(timerRef.current);
-          }
-        }
-      } catch {
-        /* ignore */
-      }
-    };
-
-    poll();
-    timerRef.current = setInterval(poll, 3000);
-    return () => {
-      if (timerRef.current) clearInterval(timerRef.current);
-    };
-  }, [taskId]);
-
-  // Stop polling immediately when the status resolves elsewhere (stream arrived)
-  useEffect(() => {
-    if (isSubAgentTerminal(status) && timerRef.current) {
-      clearInterval(timerRef.current);
-      timerRef.current = null;
-    }
-  }, [status]);
+    if (!taskId || isSubAgentTerminal(status)) return;
+    return watchSubAgentTask(taskId);
+  }, [taskId, status]);
 
   const [expanded, setExpanded] = useState(true);
   // Auto-collapse when completed

--- a/frontend/src/components/chat/SubAgentCallBlock.tsx
+++ b/frontend/src/components/chat/SubAgentCallBlock.tsx
@@ -18,6 +18,7 @@ import {
   SubAgentStatus,
   SubAgentStatusBadge,
 } from './subAgentStatus';
+import { DisclosureChevron } from '../DisclosureChevron';
 
 export type { SubAgentStatus } from './subAgentStatus';
 
@@ -170,15 +171,10 @@ const SubAgentCallBlockComponent: React.FC<SubAgentCallBlockProps> = ({
             way the activity rail's own disclosures already behave. It used to
             point down when shut and flip up when open, which reads as "there
             is something below" in both states. */}
-        <svg
-          className={`w-3 h-3 text-neutral-400 transition-transform duration-200 shrink-0 ${expanded ? 'rotate-90' : ''}`}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={3}
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-        </svg>
+        <DisclosureChevron
+          expanded={expanded}
+          className="w-3 h-3 text-neutral-400 transition-transform duration-200"
+        />
       </button>
 
       {/* Expandable body */}

--- a/frontend/src/components/chat/SubAgentCallBlock.tsx
+++ b/frontend/src/components/chat/SubAgentCallBlock.tsx
@@ -166,15 +166,18 @@ const SubAgentCallBlockComponent: React.FC<SubAgentCallBlockProps> = ({
 
         <SubAgentStatusBadge status={status} t={t} />
 
-        {/* Chevron */}
+        {/* Chevron: points right while collapsed and turns down to open, the
+            way the activity rail's own disclosures already behave. It used to
+            point down when shut and flip up when open, which reads as "there
+            is something below" in both states. */}
         <svg
-          className={`w-3 h-3 text-neutral-400 transition-transform duration-200 shrink-0 ${expanded ? 'rotate-180' : ''}`}
+          className={`w-3 h-3 text-neutral-400 transition-transform duration-200 shrink-0 ${expanded ? 'rotate-90' : ''}`}
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
           strokeWidth={3}
         >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
         </svg>
       </button>
 

--- a/frontend/src/components/chat/SubAgentCallBlock.tsx
+++ b/frontend/src/components/chat/SubAgentCallBlock.tsx
@@ -9,6 +9,7 @@
 import React, { useState, useEffect } from 'react';
 import { useI18n } from '../../i18n';
 import { toolLabel } from './toolSummary';
+import { AgentAvatar } from '../sidebar/subAgentDisplay';
 import { useSubAgentStatus, watchSubAgentTask } from '../../hooks/useSubAgentStatus';
 import {
   isSubAgentActive,
@@ -16,7 +17,6 @@ import {
   subAgentOutcomeLabel,
   SubAgentStatus,
   SubAgentStatusBadge,
-  SubAgentStatusIcon,
 } from './subAgentStatus';
 
 export type { SubAgentStatus } from './subAgentStatus';
@@ -28,6 +28,10 @@ interface SubAgentCallBlockProps {
   status: SubAgentStatus;
   resultSummary?: string;
   error?: string;
+  /** Which model ran it, for the identity mark in the header. */
+  model?: string;
+  /** Profile it was spawned as ('verify', 'explore', …), if recorded. */
+  subagentType?: string;
   /** Called when user clicks "View log" */
   onOpenSidebar?: (taskId: string) => void;
   /** Called when user clicks "Stop" */
@@ -92,6 +96,8 @@ const SubAgentCallBlockComponent: React.FC<SubAgentCallBlockProps> = ({
   status: externalStatus,
   resultSummary: externalResultSummary,
   error: externalError,
+  model: externalModel,
+  subagentType,
   onOpenSidebar,
   onStop,
 }) => {
@@ -105,6 +111,7 @@ const SubAgentCallBlockComponent: React.FC<SubAgentCallBlockProps> = ({
   // requests and each stopped covering its task the moment it unmounted.
   const streamTask = taskId ? taskStates[taskId] : undefined;
   const status = streamTask?.status ?? externalStatus;
+  const model = streamTask?.model_override ?? externalModel;
   const resultSummary = streamTask?.result_summary ?? externalResultSummary;
   const error = streamTask?.error ?? externalError;
 
@@ -143,10 +150,16 @@ const SubAgentCallBlockComponent: React.FC<SubAgentCallBlockProps> = ({
         className={headerClassName}
         title={description || undefined}
       >
-        <SubAgentStatusIcon status={status} />
+        {/* Identity, not outcome. A green check here only repeated the DONE
+            badge two elements along, and said nothing about which agent ran.
+            The provider's own colour does, and the profile it was spawned as
+            ('verify', 'explore') says what kind of agent it was -- both are in
+            the tool result's metadata already. */}
+        <AgentAvatar model={model} status={status} className="w-4 h-4 text-[7px] leading-none" />
 
-        {/* The job the sub-agent was given reads better than "spawn subagent" */}
-        <span className="shrink-0">{t('subAgents.delegated')}</span>
+        <span className="shrink-0">
+          {subagentType ? subagentType.toUpperCase() : t('subAgents.delegated')}
+        </span>
         <span className="truncate min-w-0 max-w-[320px] font-normal normal-case tracking-normal opacity-80">
           {headline(description, t('subAgents.title'))}
         </span>

--- a/frontend/src/components/chat/SubAgentCallBlock.tsx
+++ b/frontend/src/components/chat/SubAgentCallBlock.tsx
@@ -8,6 +8,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import { useI18n } from '../../i18n';
+import { toolLabel } from './toolSummary';
 import { useSubAgentStatus, watchSubAgentTask } from '../../hooks/useSubAgentStatus';
 import {
   isSubAgentActive,
@@ -194,8 +195,9 @@ const SubAgentCallBlockComponent: React.FC<SubAgentCallBlockProps> = ({
                     <span
                       key={toolName}
                       className="text-[10px] font-mono px-1.5 py-0.5 bg-neutral-100 dark:bg-zinc-700 text-neutral-600 dark:text-neutral-300 rounded-sm border border-neutral-200 dark:border-zinc-600"
+                      title={toolName}
                     >
-                      {toolName}
+                      {toolLabel(toolName)}
                     </span>
                   ))}
                 </div>

--- a/frontend/src/components/chat/ToolCallBlock.tsx
+++ b/frontend/src/components/chat/ToolCallBlock.tsx
@@ -15,6 +15,7 @@ import type {
   ToolPermissionDecision,
   ToolPermissionResolution,
 } from '../../types/agui';
+import { DisclosureChevron } from '../DisclosureChevron';
 
 export interface ToolRendererProps {
   toolName: string;
@@ -641,26 +642,16 @@ const ToolCallBlockComponent: React.FC<ToolCallBlockProps> = ({
 
         {/* Expand/collapse chevron */}
         {hasDetails && !inActivityRail && (
-          <svg
-            className={`w-3 h-3 text-neutral-400 transition-transform duration-200 shrink-0 ${expanded ? 'rotate-180' : ''}`}
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={3}
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-          </svg>
+          <DisclosureChevron
+            expanded={expanded}
+            className="w-3 h-3 text-neutral-400 transition-transform duration-200"
+          />
         )}
         {hasDetails && inActivityRail && (
-          <svg
-            className={`w-3 h-3 text-neutral-400 opacity-0 transition-all duration-150 shrink-0 group-hover/tool-header:opacity-100 ${expanded ? 'rotate-90' : ''}`}
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={3}
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-          </svg>
+          <DisclosureChevron
+            expanded={expanded}
+            className="w-3 h-3 text-neutral-400 opacity-0 transition-all duration-150 group-hover/tool-header:opacity-100"
+          />
         )}
       </div>
 
@@ -678,15 +669,7 @@ const ToolCallBlockComponent: React.FC<ToolCallBlockProps> = ({
             {visibleDecision && (
               <details className="group/permission rounded-sm border border-neutral-200 bg-neutral-50/60 text-[11px] text-neutral-700 dark:border-zinc-700 dark:bg-zinc-900/60 dark:text-neutral-300">
                 <summary className="flex cursor-pointer list-none items-center gap-2 px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-wide text-neutral-500 transition-colors hover:bg-neutral-100 dark:hover:bg-zinc-800 [&::-webkit-details-marker]:hidden">
-                  <svg
-                    className="h-2.5 w-2.5 shrink-0 transition-transform duration-150 group-open/permission:rotate-90"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={3}
-                  >
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-                  </svg>
+                  <DisclosureChevron className="h-2.5 w-2.5 transition-transform duration-150 group-open/permission:rotate-90" />
                   <span>{t('toolCallBlock.permissionDecisionTitle')}</span>
                   {decisionBadge && (
                     <span

--- a/frontend/src/components/chat/subAgentResult.test.ts
+++ b/frontend/src/components/chat/subAgentResult.test.ts
@@ -70,3 +70,19 @@ describe('parseSubAgentResult', () => {
     expect(parseSubAgentResult(undefined)).toEqual({});
   });
 });
+
+describe('parseSubAgentResult — timed-out agent envelope', () => {
+  it('keeps a cancelled call non-terminal so the poll still resolves it', () => {
+    // What streaming.py synthesizes when the tool timeout cancels an `agent`
+    // call whose sub-agent is still running.
+    const output = JSON.stringify({
+      success: false,
+      message: 'Tool execution timed out … The sub-agent sub_abc123 may still be running.',
+      metadata: { task_id: 'sub_abc123', status: 'running' },
+    });
+    expect(parseSubAgentResult(output)).toMatchObject({
+      taskId: 'sub_abc123',
+      status: 'running',
+    });
+  });
+});

--- a/frontend/src/components/chat/subAgentResult.test.ts
+++ b/frontend/src/components/chat/subAgentResult.test.ts
@@ -86,3 +86,32 @@ describe('parseSubAgentResult — timed-out agent envelope', () => {
     });
   });
 });
+
+describe('parseSubAgentResult — agent identity', () => {
+  it('recovers which model ran and what kind of agent it was', () => {
+    // Both have been in the tool result's metadata all along; the transcript
+    // block showed a generic status glyph instead.
+    const output = JSON.stringify({
+      success: true,
+      message: 'Sub-agent sub_052ecd64 completed.',
+      metadata: {
+        task_id: 'sub_052ecd64',
+        status: 'completed',
+        model_override: 'chatgpt/gpt-5.6-sol',
+        subagent_type: 'verify',
+      },
+    });
+    expect(parseSubAgentResult(output)).toMatchObject({
+      model: 'chatgpt/gpt-5.6-sol',
+      subagentType: 'verify',
+    });
+  });
+
+  it('leaves identity undefined when the metadata does not carry it', () => {
+    const output = JSON.stringify({ metadata: { task_id: 'sub_abc123' } });
+    expect(parseSubAgentResult(output)).toMatchObject({
+      model: undefined,
+      subagentType: undefined,
+    });
+  });
+});

--- a/frontend/src/components/chat/subAgentResult.test.ts
+++ b/frontend/src/components/chat/subAgentResult.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { parseSubAgentResult } from './subAgentResult';
+
+// The shapes below are taken from real persisted `agent` tool results.
+describe('parseSubAgentResult', () => {
+  it('reads the task id and status out of the JSON metadata', () => {
+    const output = JSON.stringify({
+      success: true,
+      message: 'Sub-agent sub_052ecd64 completed.\nTask: …',
+      metadata: {
+        task_id: 'sub_052ecd64',
+        chat_id: 'subagent-sub_052ecd64',
+        status: 'completed',
+        result_summary: 'found it',
+      },
+    });
+    expect(parseSubAgentResult(output)).toEqual({
+      taskId: 'sub_052ecd64',
+      status: 'completed',
+      resultSummary: 'found it',
+      error: undefined,
+    });
+  });
+
+  it('keeps a background spawn non-terminal instead of calling it completed', () => {
+    const output = JSON.stringify({
+      success: true,
+      message: 'Sub-agent spawned (ID: sub_be2a259b).',
+      metadata: { task_id: 'sub_be2a259b', status: 'queued' },
+    });
+    const parsed = parseSubAgentResult(output);
+    expect(parsed.taskId).toBe('sub_be2a259b');
+    // 'completed' here would freeze the block as terminal and stop the poll.
+    expect(parsed.status).toBe('queued');
+  });
+
+  it('recovers the id from the completed wording the old ID-only pattern missed', () => {
+    expect(parseSubAgentResult('Sub-agent sub_3cf19d28 completed.\nTask: …').taskId).toBe(
+      'sub_3cf19d28'
+    );
+  });
+
+  it('still recovers the id from the spawned wording', () => {
+    expect(parseSubAgentResult('Sub-agent spawned (ID: `sub_6abe74d7`).').taskId).toBe(
+      'sub_6abe74d7'
+    );
+  });
+
+  it('falls back to the prose scan when the payload is not valid JSON', () => {
+    // A Python-repr payload: single quotes, so JSON.parse throws.
+    const output = "{'success': True, 'message': 'Sub-agent sub_6e227609 completed.'}";
+    expect(parseSubAgentResult(output).taskId).toBe('sub_6e227609');
+  });
+
+  it('reports nothing for a timed-out call, which records no id at all', () => {
+    const output =
+      'Tool execution timed out after 60s and was cancelled. The result is unavailable; ' +
+      'treat this tool call as failed and decide how to proceed.';
+    expect(parseSubAgentResult(output)).toEqual({});
+  });
+
+  it('ignores a status the UI does not model', () => {
+    const output = JSON.stringify({
+      metadata: { task_id: 'sub_abc123', status: 'something_new' },
+    });
+    expect(parseSubAgentResult(output)).toMatchObject({ taskId: 'sub_abc123', status: undefined });
+  });
+
+  it('returns empty for no output', () => {
+    expect(parseSubAgentResult(undefined)).toEqual({});
+  });
+});

--- a/frontend/src/components/chat/subAgentResult.ts
+++ b/frontend/src/components/chat/subAgentResult.ts
@@ -1,0 +1,53 @@
+import type { SubAgentStatus } from './SubAgentCallBlock';
+
+export interface SubAgentResultInfo {
+  taskId?: string;
+  /** The task's state as of the moment the tool returned, not necessarily now. */
+  status?: SubAgentStatus;
+  resultSummary?: string;
+  error?: string;
+}
+
+const SUB_AGENT_STATUSES = new Set<SubAgentStatus>([
+  'queued',
+  'running',
+  'completed',
+  'failed',
+  'cancelled',
+]);
+
+/**
+ * The agent tool returns a JSON envelope whose `metadata` already carries the
+ * task id and status, so read those rather than pattern-matching the prose
+ * beside them. The old ID-only pattern matched just the "spawned (ID: x)"
+ * wording and missed "Sub-agent x completed", which is why a reloaded chat
+ * mostly lost its task ids -- and with them the button that opens the sidebar.
+ *
+ * The fallback still matters: a tool call that timed out carries no id at all,
+ * and a result can reach us as a non-JSON payload.
+ */
+export function parseSubAgentResult(output: string | undefined): SubAgentResultInfo {
+  if (!output) return {};
+  const trimmed = output.trim();
+
+  if (trimmed.startsWith('{')) {
+    try {
+      const metadata = JSON.parse(trimmed)?.metadata;
+      if (metadata && typeof metadata === 'object') {
+        const status = metadata.status;
+        return {
+          taskId: typeof metadata.task_id === 'string' ? metadata.task_id : undefined,
+          status: SUB_AGENT_STATUSES.has(status) ? status : undefined,
+          resultSummary:
+            typeof metadata.result_summary === 'string' ? metadata.result_summary : undefined,
+          error: typeof metadata.error === 'string' ? metadata.error : undefined,
+        };
+      }
+    } catch {
+      // Not valid JSON. Fall through to the prose scan below.
+    }
+  }
+
+  const match = trimmed.match(/sub_[a-z0-9]+/);
+  return match ? { taskId: match[0] } : {};
+}

--- a/frontend/src/components/chat/subAgentResult.ts
+++ b/frontend/src/components/chat/subAgentResult.ts
@@ -6,6 +6,10 @@ export interface SubAgentResultInfo {
   status?: SubAgentStatus;
   resultSummary?: string;
   error?: string;
+  /** Which model ran it -- the agent's identity, not just its outcome. */
+  model?: string;
+  /** The profile it was spawned as: 'verify', 'explore', 'plan', … */
+  subagentType?: string;
 }
 
 const SUB_AGENT_STATUSES = new Set<SubAgentStatus>([
@@ -41,6 +45,9 @@ export function parseSubAgentResult(output: string | undefined): SubAgentResultI
           resultSummary:
             typeof metadata.result_summary === 'string' ? metadata.result_summary : undefined,
           error: typeof metadata.error === 'string' ? metadata.error : undefined,
+          model: typeof metadata.model_override === 'string' ? metadata.model_override : undefined,
+          subagentType:
+            typeof metadata.subagent_type === 'string' ? metadata.subagent_type : undefined,
         };
       }
     } catch {

--- a/frontend/src/components/chat/subAgentTabGate.test.ts
+++ b/frontend/src/components/chat/subAgentTabGate.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import type { Message } from '../../types/api';
+
+/**
+ * Mirrors the transcript check in ChatWindow that decides whether the Agents
+ * tab can be opened. The tab used to be gated purely on live SSE state, so a
+ * reopened chat with a long sub-agent history had it greyed out and disabled
+ * even though the panel behind it fetches that history itself.
+ */
+function transcriptHasSubAgentCall(messages: Message[]): boolean {
+  return messages.some((message) =>
+    (message.parts || []).some((part) => part.type === 'tool' && part.toolName === 'agent')
+  );
+}
+
+const msg = (parts: unknown[]): Message =>
+  ({ role: 'assistant', content: '', parts }) as unknown as Message;
+
+describe('transcriptHasSubAgentCall', () => {
+  it('finds a sub-agent call in a reloaded transcript', () => {
+    expect(
+      transcriptHasSubAgentCall([
+        msg([{ type: 'text', text: 'hi' }]),
+        msg([{ type: 'tool', toolName: 'agent', toolCallId: 'call-1' }]),
+      ])
+    ).toBe(true);
+  });
+
+  it('does not fire on other tools', () => {
+    expect(transcriptHasSubAgentCall([msg([{ type: 'tool', toolName: 'run_command' }])])).toBe(
+      false
+    );
+  });
+
+  it('handles messages with no parts', () => {
+    expect(transcriptHasSubAgentCall([{ role: 'user', content: 'hi' } as Message])).toBe(false);
+  });
+
+  it('is false for an empty transcript', () => {
+    expect(transcriptHasSubAgentCall([])).toBe(false);
+  });
+});

--- a/frontend/src/components/chat/toolGroupIcon.tsx
+++ b/frontend/src/components/chat/toolGroupIcon.tsx
@@ -2,7 +2,6 @@ import type { ApprovalState } from './ToolCallBlock';
 import {
   CircleStackIcon,
   CommandLineIcon,
-  ComputerDesktopIcon,
   DocumentTextIcon,
   FolderIcon,
   MagnifyingGlassIcon,
@@ -10,6 +9,7 @@ import {
   WrenchScrewdriverIcon,
   ClockIcon,
   ClipboardDocumentListIcon,
+  UserGroupIcon,
 } from '@heroicons/react/24/outline';
 
 type ToolGroupIconProps = {
@@ -22,6 +22,9 @@ type ToolGroupIconProps = {
 function pickIcon(toolName: string, approvalState?: ApprovalState) {
   if (approvalState === 'pending') return ClockIcon;
   if (approvalState === 'denied') return NoSymbolIcon;
+  // Delegation is checked first: a sub-agent is not a search tool because its
+  // name happens to contain "web", and a desktop monitor never said "agent".
+  if (toolName.includes('agent') || toolName.includes('subagent')) return UserGroupIcon;
   if (toolName.includes('search') || toolName.includes('web')) return MagnifyingGlassIcon;
   if (toolName.includes('file') || toolName.includes('dir')) return FolderIcon;
   if (toolName.includes('read') || toolName.includes('write')) return DocumentTextIcon;
@@ -34,7 +37,6 @@ function pickIcon(toolName: string, approvalState?: ApprovalState) {
     return CommandLineIcon;
   if (toolName.includes('database') || toolName.includes('sql')) return CircleStackIcon;
   if (toolName.includes('plan')) return ClipboardDocumentListIcon;
-  if (toolName.includes('agent') || toolName.includes('subagent')) return ComputerDesktopIcon;
   return WrenchScrewdriverIcon;
 }
 

--- a/frontend/src/components/chat/toolIcon.test.ts
+++ b/frontend/src/components/chat/toolIcon.test.ts
@@ -10,7 +10,21 @@ describe('tool icon helpers', () => {
   it('maps tool names to the shared icon set', () => {
     expect(getToolIcon('web_search')).toBe('🔍');
     expect(getToolIcon('read_file')).toBe('📁');
-    expect(getToolIcon('agent')).toBe('🔧');
+  });
+
+  it('gives delegation its own mark instead of the generic wrench', () => {
+    expect(getToolIcon('agent')).toBe('🤖');
+    expect(getToolIcon('subagent')).toBe('🤖');
+  });
+
+  it('reads a delegation as delegation even when its name mentions the web', () => {
+    // Checked before the substring heuristics: a "web_agent" is an agent, not
+    // a search box.
+    expect(getToolIcon('web_agent')).toBe('🤖');
+  });
+
+  it('still falls back to the wrench for anything unrecognised', () => {
+    expect(getToolIcon('some_unknown_tool')).toBe('🔧');
   });
 
   it('keeps the icon layout class consistent between collapsed and expanded states', () => {

--- a/frontend/src/components/chat/toolIcon.ts
+++ b/frontend/src/components/chat/toolIcon.ts
@@ -3,6 +3,8 @@ import type { ApprovalState } from './ToolCallBlock';
 export function getToolIcon(toolName: string, approvalState?: ApprovalState): string {
   if (approvalState === 'pending') return '⏳';
   if (approvalState === 'denied') return '🚫';
+  // The agent tool had no case at all and fell through to the generic wrench.
+  if (toolName.includes('agent') || toolName.includes('subagent')) return '🤖';
   if (toolName.includes('search') || toolName.includes('web')) return '🔍';
   if (
     toolName.includes('file') ||

--- a/frontend/src/components/chat/toolSummary.ts
+++ b/frontend/src/components/chat/toolSummary.ts
@@ -135,6 +135,15 @@ const NAME_ALIASES: Record<string, string> = {
  * `mcp__server__do_thing` → `do thing`, `ReadFile` → `read_file`.
  * Returns the canonical registry name when one is known.
  */
+/**
+ * Tools are registered under class-style names (`RunCommandTool`); the suffix
+ * is noise on a chip. Naming what an agent can actually do reads as capability,
+ * where a bare count only reads as a row in a ledger.
+ */
+export function toolLabel(name: string): string {
+  return name.replace(/Tool$/, '');
+}
+
 export function normalizeToolName(toolName: string): string {
   let name = toolName.trim();
   const mcp = /^mcp__[^_]+(?:_[^_]+)*?__(.+)$/.exec(name);

--- a/frontend/src/components/sidebar/GoalTaskView.tsx
+++ b/frontend/src/components/sidebar/GoalTaskView.tsx
@@ -3,6 +3,7 @@ import type { Goal, Task, GoalStatus, TaskStatus } from '../../types/api';
 import { useI18n } from '../../i18n';
 import { useGoalTasks } from '../../hooks/useGoalTasks';
 import { BrutalButton } from '../BrutalButton';
+import { DisclosureChevron } from '../DisclosureChevron';
 
 interface GoalTaskViewProps {
   goal: Goal | null;
@@ -161,15 +162,10 @@ export const GoalTaskView: React.FC<GoalTaskViewProps> = ({
                   onClick={() => setSubgoalsExpanded((v) => !v)}
                   className="flex items-center gap-1 text-[9px] font-black uppercase tracking-wider font-mono text-brutal-black dark:text-white"
                 >
-                  <svg
-                    className={`w-2.5 h-2.5 transition-transform ${subgoalsExpanded ? '' : '-rotate-90'}`}
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={3}
-                  >
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-                  </svg>
+                  <DisclosureChevron
+                    expanded={subgoalsExpanded}
+                    className="w-2.5 h-2.5 transition-transform"
+                  />
                   {t('goal.subgoals')} ({goal.subgoals.length})
                 </button>
                 {subgoalsExpanded && (

--- a/frontend/src/components/sidebar/SubAgentList.tsx
+++ b/frontend/src/components/sidebar/SubAgentList.tsx
@@ -10,7 +10,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import { getApiBase } from '../../lib/api';
 import { useSubAgentStatus, SubAgentSummary } from '../../hooks/useSubAgentStatus';
 import { isSubAgentActive, SubAgentStatusBadge } from '../chat/subAgentStatus';
-import { getProviderInitials, getProviderVisualForModel } from '../../lib/providerVisuals';
+import { AgentAvatar } from './subAgentDisplay';
+import { toolLabel } from './subAgentLabels';
 import { useI18n } from '../../i18n';
 
 interface SubAgentListProps {
@@ -46,46 +47,6 @@ function sortRows(rows: SubAgentRow[]): SubAgentRow[] {
 async function stopSubAgent(taskId: string): Promise<void> {
   await fetch(`${getApiBase()}/subagents/${encodeURIComponent(taskId)}/stop`, { method: 'POST' });
 }
-
-/**
- * Tools are registered under class-style names (`RunCommandTool`); the suffix
- * is noise on a chip. Naming what an agent can actually do reads as capability,
- * where a bare "1 tools" only reads as a row in a ledger.
- */
-function toolLabel(name: string): string {
-  return name.replace(/Tool$/, '');
-}
-
-/**
- * Identity tile. The provider's own colour with its initials -- deliberately
- * not its logo: those are remote CDN URLs and the desktop app's CSP blocks
- * off-origin images, so a logo here would render as a silent blank.
- */
-const AgentAvatar: React.FC<{ model?: string | null; status?: string }> = ({ model, status }) => {
-  const visual = getProviderVisualForModel(model ?? undefined);
-  const background = visual ? `#${visual.color}` : '#525252';
-  const initials = visual ? getProviderInitials(visual.label) : 'AI';
-  const active = isSubAgentActive(status);
-
-  return (
-    <div className="relative shrink-0">
-      <div
-        className="w-7 h-7 flex items-center justify-center border-2 border-brutal-black dark:border-white rounded-sm text-[9px] font-bold tracking-tight text-white"
-        style={{ backgroundColor: background }}
-        aria-hidden="true"
-      >
-        {initials}
-      </div>
-      {/* Presence, the way a roster shows it -- additive to the status badge
-          below, which stays the shared vocabulary across every surface. */}
-      <span
-        className={`absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-white dark:border-zinc-800 ${
-          active ? 'bg-brutal-blue animate-pulse' : 'bg-neutral-300 dark:bg-zinc-600'
-        }`}
-      />
-    </div>
-  );
-};
 
 export const SubAgentList: React.FC<SubAgentListProps> = ({ chatId, onSelect }) => {
   const { t } = useI18n();

--- a/frontend/src/components/sidebar/SubAgentList.tsx
+++ b/frontend/src/components/sidebar/SubAgentList.tsx
@@ -7,10 +7,10 @@
  * stale "running" row until someone reopened the panel.
  */
 import React, { useEffect, useRef, useState } from 'react';
-import { CpuChipIcon } from '@heroicons/react/24/outline';
 import { getApiBase } from '../../lib/api';
 import { useSubAgentStatus, SubAgentSummary } from '../../hooks/useSubAgentStatus';
-import { isSubAgentActive, SubAgentStatusBadge, SubAgentStatusIcon } from '../chat/subAgentStatus';
+import { isSubAgentActive, SubAgentStatusBadge } from '../chat/subAgentStatus';
+import { getProviderInitials, getProviderVisualForModel } from '../../lib/providerVisuals';
 import { useI18n } from '../../i18n';
 
 interface SubAgentListProps {
@@ -46,6 +46,46 @@ function sortRows(rows: SubAgentRow[]): SubAgentRow[] {
 async function stopSubAgent(taskId: string): Promise<void> {
   await fetch(`${getApiBase()}/subagents/${encodeURIComponent(taskId)}/stop`, { method: 'POST' });
 }
+
+/**
+ * Tools are registered under class-style names (`RunCommandTool`); the suffix
+ * is noise on a chip. Naming what an agent can actually do reads as capability,
+ * where a bare "1 tools" only reads as a row in a ledger.
+ */
+function toolLabel(name: string): string {
+  return name.replace(/Tool$/, '');
+}
+
+/**
+ * Identity tile. The provider's own colour with its initials -- deliberately
+ * not its logo: those are remote CDN URLs and the desktop app's CSP blocks
+ * off-origin images, so a logo here would render as a silent blank.
+ */
+const AgentAvatar: React.FC<{ model?: string | null; status?: string }> = ({ model, status }) => {
+  const visual = getProviderVisualForModel(model ?? undefined);
+  const background = visual ? `#${visual.color}` : '#525252';
+  const initials = visual ? getProviderInitials(visual.label) : 'AI';
+  const active = isSubAgentActive(status);
+
+  return (
+    <div className="relative shrink-0">
+      <div
+        className="w-7 h-7 flex items-center justify-center border-2 border-brutal-black dark:border-white rounded-sm text-[9px] font-bold tracking-tight text-white"
+        style={{ backgroundColor: background }}
+        aria-hidden="true"
+      >
+        {initials}
+      </div>
+      {/* Presence, the way a roster shows it -- additive to the status badge
+          below, which stays the shared vocabulary across every surface. */}
+      <span
+        className={`absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-white dark:border-zinc-800 ${
+          active ? 'bg-brutal-blue animate-pulse' : 'bg-neutral-300 dark:bg-zinc-600'
+        }`}
+      />
+    </div>
+  );
+};
 
 export const SubAgentList: React.FC<SubAgentListProps> = ({ chatId, onSelect }) => {
   const { t } = useI18n();
@@ -107,12 +147,20 @@ export const SubAgentList: React.FC<SubAgentListProps> = ({ chatId, onSelect }) 
     );
   }
 
+  const activeCount = tasks.filter((task) => isSubAgentActive(task.status)).length;
+
   return (
     <div className="flex flex-col h-full min-h-0 font-mono">
       <div className="px-3 py-2 border-b-3 border-brutal-black bg-white dark:bg-zinc-800 shrink-0">
         <span className="text-[10px] font-bold uppercase tracking-widest font-mono text-neutral-500 dark:text-neutral-400">
           {t('subAgents.heading', { count: tasks.length })}
         </span>
+        {activeCount > 0 && (
+          <span className="ml-2 inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-widest font-mono text-brutal-blue">
+            <span className="w-1.5 h-1.5 rounded-full bg-brutal-blue animate-pulse" />
+            {activeCount} {t('subAgents.live')}
+          </span>
+        )}
       </div>
       <div className="flex-1 overflow-y-auto scrollbar-thin p-2 space-y-1 min-h-0">
         {tasks.map((task) => {
@@ -132,17 +180,33 @@ export const SubAgentList: React.FC<SubAgentListProps> = ({ chatId, onSelect }) 
                   onSelect(task.task_id);
                 }
               }}
-              className="w-full text-left px-2 py-2 rounded-sm bg-neutral-50 dark:bg-zinc-800 border-2 border-neutral-200 dark:border-zinc-600 hover:border-brutal-black dark:hover:border-white transition-colors cursor-pointer group"
+              className={`w-full text-left px-2 py-2 rounded-sm border-2 transition-colors cursor-pointer group ${
+                isActive
+                  ? 'bg-white dark:bg-zinc-800 border-brutal-blue'
+                  : 'bg-neutral-50 dark:bg-zinc-800 border-neutral-200 dark:border-zinc-600 hover:border-brutal-black dark:hover:border-white'
+              }`}
             >
               <div className="flex items-start gap-2">
-                <SubAgentStatusIcon status={task.status} className="w-3.5 h-3.5 mt-0.5" />
+                <AgentAvatar model={task.model_override} status={task.status} />
                 <div className="flex-1 min-w-0">
-                  {/* Description */}
-                  <div className="text-[11px] text-neutral-700 dark:text-neutral-200 leading-snug line-clamp-2 group-hover:text-neutral-900 dark:group-hover:text-white">
+                  {/* What this agent was sent to do -- its name, in effect. */}
+                  <div className="text-[11px] font-bold text-neutral-800 dark:text-neutral-100 leading-snug line-clamp-2 group-hover:text-neutral-900 dark:group-hover:text-white">
                     {task.description}
                   </div>
 
-                  {/* Meta row: status + time + tool count + stop button */}
+                  {/* One quiet line of provenance: who ran it, and for how
+                      long. The model belongs up here beside the agent rather
+                      than trailing the card as an afterthought. */}
+                  {task.model_override && (
+                    <div
+                      className="mt-0.5 text-[9px] text-neutral-500 dark:text-neutral-400 truncate"
+                      title={`${t('subAgents.model')}: ${task.model_override}`}
+                    >
+                      {task.model_override}
+                    </div>
+                  )}
+
+                  {/* Meta row: status + time + stop button */}
                   <div className="flex items-center gap-1.5 mt-1 flex-wrap">
                     <SubAgentStatusBadge status={task.status} t={t} />
                     {isActive && (
@@ -175,14 +239,29 @@ export const SubAgentList: React.FC<SubAgentListProps> = ({ chatId, onSelect }) 
                     {duration && !isActive && (
                       <span className="text-[9px] text-neutral-400">{duration}</span>
                     )}
-
-                    {task.tools_allowed.length > 0 && (
-                      <span className="inline-flex items-center gap-1 text-[9px] text-neutral-400">
-                        <CpuChipIcon className="w-2.5 h-2.5" />
-                        {t('subAgents.toolCount', { count: task.tools_allowed.length })}
-                      </span>
-                    )}
                   </div>
+
+                  {/* What it was allowed to do. Named, not counted: "1 tools"
+                      says nothing about the agent, "RunCommand" says what it
+                      is for. */}
+                  {task.tools_allowed.length > 0 && (
+                    <div className="flex items-center gap-1 mt-1 flex-wrap">
+                      {task.tools_allowed.slice(0, 3).map((tool) => (
+                        <span
+                          key={tool}
+                          className="text-[9px] px-1 py-px bg-neutral-100 dark:bg-zinc-900 border border-neutral-300 dark:border-zinc-600 text-neutral-600 dark:text-neutral-300 rounded-sm truncate max-w-[7.5rem]"
+                          title={tool}
+                        >
+                          {toolLabel(tool)}
+                        </span>
+                      ))}
+                      {task.tools_allowed.length > 3 && (
+                        <span className="text-[9px] text-neutral-400">
+                          +{task.tools_allowed.length - 3}
+                        </span>
+                      )}
+                    </div>
+                  )}
 
                   {/* Why a stopped or failed run ended, right on the row. */}
                   {!isActive && task.status !== 'completed' && task.error && (
@@ -194,17 +273,6 @@ export const SubAgentList: React.FC<SubAgentListProps> = ({ chatId, onSelect }) 
                       }`}
                     >
                       {task.error}
-                    </div>
-                  )}
-
-                  {task.model_override && (
-                    <div className="mt-1">
-                      <span
-                        className="inline-block text-[9px] text-neutral-400 dark:text-neutral-500 truncate max-w-full font-mono"
-                        title={`${t('subAgents.model')}: ${task.model_override}`}
-                      >
-                        {task.model_override}
-                      </span>
                     </div>
                   )}
 

--- a/frontend/src/components/sidebar/SubAgentList.tsx
+++ b/frontend/src/components/sidebar/SubAgentList.tsx
@@ -11,7 +11,7 @@ import { getApiBase } from '../../lib/api';
 import { useSubAgentStatus, SubAgentSummary } from '../../hooks/useSubAgentStatus';
 import { isSubAgentActive, SubAgentStatusBadge } from '../chat/subAgentStatus';
 import { AgentAvatar } from './subAgentDisplay';
-import { toolLabel } from './subAgentLabels';
+import { toolLabel } from '../chat/toolSummary';
 import { useI18n } from '../../i18n';
 
 interface SubAgentListProps {

--- a/frontend/src/components/sidebar/SubAgentView.tsx
+++ b/frontend/src/components/sidebar/SubAgentView.tsx
@@ -11,7 +11,7 @@ import { getApiBase } from '../../lib/api';
 import { useSubAgentStatus } from '../../hooks/useSubAgentStatus';
 import { useI18n } from '../../i18n';
 import { AgentAvatar } from './subAgentDisplay';
-import { toolLabel } from './subAgentLabels';
+import { toolLabel } from '../chat/toolSummary';
 import { MarkdownRenderer } from '../chat/MarkdownRenderer';
 import { getToolSummary, isFailedToolOutput } from '../chat/toolSummary';
 import type { ToolTense } from '../chat/toolSummary';

--- a/frontend/src/components/sidebar/SubAgentView.tsx
+++ b/frontend/src/components/sidebar/SubAgentView.tsx
@@ -10,6 +10,9 @@ import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import { getApiBase } from '../../lib/api';
 import { useSubAgentStatus } from '../../hooks/useSubAgentStatus';
 import { useI18n } from '../../i18n';
+import { AgentAvatar } from './subAgentDisplay';
+import { toolLabel } from './subAgentLabels';
+import { MarkdownRenderer } from '../chat/MarkdownRenderer';
 import { getToolSummary, isFailedToolOutput } from '../chat/toolSummary';
 import type { ToolTense } from '../chat/toolSummary';
 import {
@@ -19,7 +22,6 @@ import {
   subAgentOutcomeLabel,
   SubAgentStatus,
   SubAgentStatusBadge,
-  SubAgentStatusIcon,
 } from '../chat/subAgentStatus';
 
 interface SubAgentTask {
@@ -28,6 +30,8 @@ interface SubAgentTask {
   chat_id: string;
   description: string;
   tools_allowed: string[];
+  /** Returned by /subagents all along; the panel just never declared it. */
+  model_override?: string | null;
   status: SubAgentStatus;
   result_summary: string | null;
   error: string | null;
@@ -202,7 +206,7 @@ export const SubAgentView: React.FC<SubAgentViewProps> = ({ taskId, onClose }) =
       {/* Header */}
       <div className="flex items-start justify-between px-3 py-2 border-b-3 border-brutal-black bg-white dark:bg-zinc-800 shrink-0 gap-2">
         <div className="flex items-start gap-2 min-w-0 pt-0.5">
-          <SubAgentStatusIcon status={task?.status} className="w-4 h-4 mt-0.5" />
+          <AgentAvatar model={task?.model_override} status={task?.status} />
           <div className="min-w-0">
             <div className="text-[10px] font-bold uppercase tracking-widest font-mono truncate flex items-center gap-1.5 text-neutral-500 dark:text-neutral-400">
               <span>{t('subAgents.title')}</span>
@@ -215,8 +219,14 @@ export const SubAgentView: React.FC<SubAgentViewProps> = ({ taskId, onClose }) =
                 </span>
               )}
             </div>
-            <div className="text-[12px] font-bold text-brutal-black dark:text-white leading-snug mt-0.5 max-h-[2.5rem] overflow-hidden line-clamp-2">
-              {task?.description || t('subAgents.loading')}
+            {/* Who ran it. The brief is the body's first block rather than a
+                clamped copy up here -- it was printed twice, and a long one
+                was cut off in the header while the copy below showed it whole. */}
+            <div
+              className="text-[11px] text-neutral-600 dark:text-neutral-300 truncate mt-0.5"
+              title={task?.model_override ?? undefined}
+            >
+              {task?.model_override || t('subAgents.loading')}
             </div>
           </div>
         </div>
@@ -278,12 +288,13 @@ export const SubAgentView: React.FC<SubAgentViewProps> = ({ taskId, onClose }) =
               )}
             </div>
 
-            {/* Task description */}
+            {/* The brief, in full -- no longer competing with a clamped copy
+                in the header. */}
             <div>
               <div className="text-[10px] font-bold uppercase tracking-wide text-neutral-400 dark:text-neutral-500 mb-0.5">
                 {t('subAgents.task')}
               </div>
-              <div className="text-[11px] text-neutral-700 dark:text-neutral-300 leading-relaxed">
+              <div className="text-[12px] font-bold text-brutal-black dark:text-white leading-snug">
                 {task.description}
               </div>
             </div>
@@ -299,8 +310,9 @@ export const SubAgentView: React.FC<SubAgentViewProps> = ({ taskId, onClose }) =
                     <span
                       key={toolName}
                       className="text-[10px] px-1.5 py-0.5 bg-neutral-100 dark:bg-zinc-700 rounded-sm border border-neutral-200 dark:border-zinc-600 text-neutral-600 dark:text-neutral-300"
+                      title={toolName}
                     >
-                      {toolName}
+                      {toolLabel(toolName)}
                     </span>
                   ))}
                 </div>
@@ -381,10 +393,12 @@ export const SubAgentView: React.FC<SubAgentViewProps> = ({ taskId, onClose }) =
                     return (
                       <details key={i} className="text-[10px] group">
                         <summary
-                          className="flex items-center gap-1.5 cursor-pointer list-none select-none py-0.5 px-1 rounded-sm bg-neutral-50 dark:bg-zinc-800 hover:bg-neutral-100 dark:hover:bg-zinc-700"
+                          className="flex items-center gap-1.5 cursor-pointer list-none select-none py-0.5 px-1 rounded-sm bg-neutral-50 dark:bg-zinc-800 hover:bg-neutral-100 dark:hover:bg-zinc-700 min-w-0"
                           title={summary.title ?? undefined}
                         >
-                          <span className="font-bold uppercase tracking-wide text-neutral-700 dark:text-neutral-200 shrink-0">
+                          {/* The panel is narrow and these verbs are long; let
+                              it truncate rather than run off the edge. */}
+                          <span className="font-bold uppercase tracking-wide text-neutral-700 dark:text-neutral-200 truncate max-w-[60%]">
                             {summary.verb}
                           </span>
                           {summary.detail && (
@@ -450,15 +464,21 @@ export const SubAgentView: React.FC<SubAgentViewProps> = ({ taskId, onClose }) =
                 >
                   {subAgentOutcomeLabel(task.status, t)}
                 </div>
-                <pre
-                  className={`text-[11px] leading-relaxed whitespace-pre-wrap p-2 rounded-sm border-2 max-h-[300px] overflow-y-auto scrollbar-thin ${
-                    task.status === 'failed'
-                      ? 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-950 border-red-600'
-                      : 'text-neutral-700 dark:text-neutral-300 bg-neutral-50 dark:bg-zinc-800 border-neutral-200 dark:border-zinc-600'
-                  }`}
-                >
-                  {outcomeText}
-                </pre>
+                {/* A sub-agent writes its result in markdown -- headings,
+                    fences, lists -- and a <pre> printed the syntax instead of
+                    rendering it: literal ### and ``` on screen. A failure is
+                    different: a traceback or a raw stderr line is not markdown,
+                    and reflowing it would destroy the alignment that makes it
+                    readable, so that one keeps its <pre>. */}
+                {task.status === 'failed' ? (
+                  <pre className="text-[11px] leading-relaxed whitespace-pre-wrap p-2 rounded-sm border-2 max-h-[300px] overflow-y-auto scrollbar-thin text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-950 border-red-600">
+                    {outcomeText}
+                  </pre>
+                ) : (
+                  <div className="text-[11px] p-2 rounded-sm border-2 max-h-[300px] overflow-y-auto scrollbar-thin bg-neutral-50 dark:bg-zinc-800 border-neutral-200 dark:border-zinc-600 text-neutral-700 dark:text-neutral-300">
+                    <MarkdownRenderer content={outcomeText} compact />
+                  </div>
+                )}
               </div>
             )}
 

--- a/frontend/src/components/sidebar/WebActivitiesView.tsx
+++ b/frontend/src/components/sidebar/WebActivitiesView.tsx
@@ -4,6 +4,7 @@ import { BrowserView } from './BrowserView';
 import { WebSearchSidebarView } from './WebSearchSidebarView';
 import { WebPageReaderView } from './WebPageReaderView';
 import type { WebHistoryLog } from '../../hooks/useWebHistory';
+import { DisclosureChevron } from '../DisclosureChevron';
 
 interface WebActivitiesViewProps {
   history: WebHistoryLog[];
@@ -152,15 +153,10 @@ export const WebActivitiesView: React.FC<WebActivitiesViewProps> = ({
           <div className="text-[10px] uppercase tracking-widest opacity-80 mb-0.5">History</div>
           <div className="text-sm flex items-center gap-1">
             <span>{history.length}</span>
-            <svg
-              className={`w-3.5 h-3.5 transition-transform duration-200 ${isTimelineOpen ? 'rotate-180' : ''}`}
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={3}
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-            </svg>
+            <DisclosureChevron
+              expanded={isTimelineOpen}
+              className="w-3.5 h-3.5 transition-transform duration-200"
+            />
           </div>
         </button>
       </div>

--- a/frontend/src/components/sidebar/subAgentDisplay.tsx
+++ b/frontend/src/components/sidebar/subAgentDisplay.tsx
@@ -1,0 +1,44 @@
+/**
+ * Shared identity vocabulary for the sub-agent surfaces.
+ *
+ * The list and the detail panel should introduce an agent the same way, so the
+ * avatar and the tool label live here rather than being reinvented per view.
+ */
+import React from 'react';
+import { getProviderInitials, getProviderVisualForModel } from '../../lib/providerVisuals';
+import { isSubAgentActive } from '../chat/subAgentStatus';
+
+/**
+ * Identity tile. The provider's own colour with its initials -- deliberately
+ * not its logo: those are remote CDN URLs and the desktop app's CSP blocks
+ * off-origin images, so a logo here would render as a silent blank.
+ */
+export const AgentAvatar: React.FC<{
+  model?: string | null;
+  status?: string;
+  className?: string;
+}> = ({ model, status, className = 'w-7 h-7 text-[9px]' }) => {
+  const visual = getProviderVisualForModel(model ?? undefined);
+  const background = visual ? `#${visual.color}` : '#525252';
+  const initials = visual ? getProviderInitials(visual.label) : 'AI';
+  const active = isSubAgentActive(status);
+
+  return (
+    <div className="relative shrink-0">
+      <div
+        className={`flex items-center justify-center border-2 border-brutal-black dark:border-white rounded-sm font-bold tracking-tight text-white ${className}`}
+        style={{ backgroundColor: background }}
+        aria-hidden="true"
+      >
+        {initials}
+      </div>
+      {/* Presence, the way a roster shows it -- additive to the status badge,
+          which stays the shared vocabulary across every surface. */}
+      <span
+        className={`absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-white dark:border-zinc-800 ${
+          active ? 'bg-brutal-blue animate-pulse' : 'bg-neutral-300 dark:bg-zinc-600'
+        }`}
+      />
+    </div>
+  );
+};

--- a/frontend/src/components/sidebar/subAgentLabels.ts
+++ b/frontend/src/components/sidebar/subAgentLabels.ts
@@ -1,0 +1,8 @@
+/**
+ * Tools are registered under class-style names (`RunCommandTool`); the suffix
+ * is noise on a chip. Naming what an agent can actually do reads as capability,
+ * where a bare count only reads as a row in a ledger.
+ */
+export function toolLabel(name: string): string {
+  return name.replace(/Tool$/, '');
+}

--- a/frontend/src/components/sidebar/subAgentLabels.ts
+++ b/frontend/src/components/sidebar/subAgentLabels.ts
@@ -1,8 +1,0 @@
-/**
- * Tools are registered under class-style names (`RunCommandTool`); the suffix
- * is noise on a chip. Naming what an agent can actually do reads as capability,
- * where a bare count only reads as a row in a ledger.
- */
-export function toolLabel(name: string): string {
-  return name.replace(/Tool$/, '');
-}

--- a/frontend/src/hooks/useSubAgentStatus.ts
+++ b/frontend/src/hooks/useSubAgentStatus.ts
@@ -62,7 +62,14 @@ function notify() {
 }
 
 function _recordState(task: SubAgentSummary) {
-  _taskStates = { ..._taskStates, [task.task_id]: { ..._taskStates[task.task_id], ...task } };
+  const previous = _taskStates[task.task_id];
+  // A run does not un-finish. The stream and the poll below both write here,
+  // and either can arrive late or replay an older frame; whichever source saw
+  // the run end wins, so a settled task is never dragged back to 'running'.
+  if (previous && isSubAgentTerminal(previous.status) && !isSubAgentTerminal(task.status)) {
+    return;
+  }
+  _taskStates = { ..._taskStates, [task.task_id]: { ...previous, ...task } };
 }
 
 function _upsertTask(task: SubAgentSummary) {
@@ -82,6 +89,82 @@ function _applyTask(task: SubAgentSummary) {
   } else {
     _upsertTask(task);
   }
+}
+
+// ─── Shared fallback poll ────────────────────────────────────────────────────
+//
+// The stream is the fast path but not a complete one: it can end before a run
+// does, and it only carries tasks seen *this session* -- so a chat reopened on
+// a sub-agent that is still working learns nothing from it until something
+// changes. A poll covers that gap.
+//
+// One poll, not one per block. Each transcript block used to run its own 3s
+// timer, so a chat showing ten sub-agents made ten independent requests every
+// three seconds and stopped covering any of them the moment its block
+// unmounted. Blocks now register interest and this resolves them together.
+
+const SUBAGENT_POLL_INTERVAL_MS = 3000;
+const _watched = new Set<string>();
+let _pollTimer: ReturnType<typeof setInterval> | null = null;
+
+function _unresolvedIds(): string[] {
+  return [..._watched].filter((id) => !isSubAgentTerminal(_taskStates[id]?.status));
+}
+
+async function _pollUnresolved() {
+  const ids = _unresolvedIds();
+  if (ids.length === 0) {
+    _stopPolling();
+    return;
+  }
+
+  const results = await Promise.all(
+    ids.map(async (id) => {
+      try {
+        const res = await fetch(`${getApiBase()}/subagents/${id}`);
+        if (!res.ok) return null;
+        const task = (await res.json())?.task as SubAgentSummary | undefined;
+        return task?.task_id ? task : null;
+      } catch {
+        // Backend restarting or offline; the next tick retries.
+        return null;
+      }
+    })
+  );
+
+  const seen = results.filter((task): task is SubAgentSummary => task !== null);
+  if (seen.length === 0) return;
+  seen.forEach(_applyTask);
+  notify();
+}
+
+function _startPolling() {
+  if (_pollTimer || _unresolvedIds().length === 0) return;
+  _pollTimer = setInterval(() => {
+    void _pollUnresolved();
+  }, SUBAGENT_POLL_INTERVAL_MS);
+  void _pollUnresolved();
+}
+
+function _stopPolling() {
+  if (_pollTimer) {
+    clearInterval(_pollTimer);
+    _pollTimer = null;
+  }
+}
+
+/**
+ * Ask the shared poll to resolve `taskId` until it reaches a terminal state.
+ * Returns the unregister function. Safe to call for a task the stream already
+ * knows: it is dropped from the poll set as soon as its status settles.
+ */
+export function watchSubAgentTask(taskId: string): () => void {
+  _watched.add(taskId);
+  _startPolling();
+  return () => {
+    _watched.delete(taskId);
+    if (_watched.size === 0) _stopPolling();
+  };
 }
 
 function _openEventSource() {
@@ -121,6 +204,8 @@ function subscribe(fn: () => void) {
     _listeners.delete(fn);
     if (_listeners.size === 0) {
       _closeEventSource();
+      _stopPolling();
+      _watched.clear();
       _activeTasks = [];
       _taskStates = {};
     }

--- a/frontend/src/hooks/useSubAgentStatus.ts
+++ b/frontend/src/hooks/useSubAgentStatus.ts
@@ -61,15 +61,17 @@ function notify() {
   _listeners.forEach((fn) => fn());
 }
 
-function _recordState(task: SubAgentSummary) {
+/** @returns false when the update was rejected as stale. */
+function _recordState(task: SubAgentSummary): boolean {
   const previous = _taskStates[task.task_id];
   // A run does not un-finish. The stream and the poll below both write here,
   // and either can arrive late or replay an older frame; whichever source saw
   // the run end wins, so a settled task is never dragged back to 'running'.
   if (previous && isSubAgentTerminal(previous.status) && !isSubAgentTerminal(task.status)) {
-    return;
+    return false;
   }
   _taskStates = { ..._taskStates, [task.task_id]: { ...previous, ...task } };
+  return true;
 }
 
 function _upsertTask(task: SubAgentSummary) {
@@ -83,8 +85,13 @@ function _upsertTask(task: SubAgentSummary) {
 }
 
 function _applyTask(task: SubAgentSummary) {
-  _recordState(task);
-  if (isSubAgentTerminal(task.status)) {
+  const accepted = _recordState(task);
+  // Branch on what the store settled on, not on what arrived. A stale 'running'
+  // frame rejected above is still a finished run: adding it back to the active
+  // list would strand it there -- visible as live in the status bar and
+  // sidebar, yet skipped by the poll, which reads the (terminal) task state.
+  const settled = _taskStates[task.task_id]?.status ?? task.status;
+  if (!accepted || isSubAgentTerminal(settled)) {
     _activeTasks = _activeTasks.filter((a) => a.task_id !== task.task_id);
   } else {
     _upsertTask(task);

--- a/src/suzent/core/subagent_runner.py
+++ b/src/suzent/core/subagent_runner.py
@@ -13,6 +13,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+from collections import OrderedDict
 from typing import Dict, Optional
 
 from suzent.config import CONFIG
@@ -280,6 +281,35 @@ def _resolve_tool_names(tools_allowed: list[str]) -> tuple[list[str], list[str]]
 # ─── Public spawn API ─────────────────────────────────────────────────────────
 
 
+# ─── Tool-call → task lookup ─────────────────────────────────────────────────
+#
+# A blocking `agent` tool call can be cancelled by the streaming layer's tool
+# timeout while the sub-agent it started keeps running. The synthesized failure
+# is then the only trace the transcript will ever hold, so it has to carry the
+# task id -- otherwise the run is live but unreachable from the UI, with no way
+# to open it in the sidebar. Recorded when the task is created rather than when
+# the tool returns, because in blocking mode the tool may never return.
+
+_SPAWN_BY_TOOL_CALL: OrderedDict[str, str] = OrderedDict()
+_SPAWN_BY_TOOL_CALL_MAX = 256
+
+
+def _record_spawn_for_tool_call(tool_call_id: Optional[str], task_id: str) -> None:
+    if not tool_call_id:
+        return
+    _SPAWN_BY_TOOL_CALL[tool_call_id] = task_id
+    _SPAWN_BY_TOOL_CALL.move_to_end(tool_call_id)
+    while len(_SPAWN_BY_TOOL_CALL) > _SPAWN_BY_TOOL_CALL_MAX:
+        _SPAWN_BY_TOOL_CALL.popitem(last=False)
+
+
+def task_id_for_tool_call(tool_call_id: Optional[str]) -> Optional[str]:
+    """The sub-agent a given tool call spawned, if it is still remembered."""
+    if not tool_call_id:
+        return None
+    return _SPAWN_BY_TOOL_CALL.get(tool_call_id)
+
+
 async def spawn_subagent(
     parent_chat_id: str,
     description: str,
@@ -294,6 +324,7 @@ async def spawn_subagent(
     runtime: str = "native",
     acp_agent_id: Optional[str] = None,
     acp_session_id: Optional[str] = None,
+    tool_call_id: Optional[str] = None,
 ) -> SubAgentTask:
     """
     Create a SubAgentTask and launch it.
@@ -334,6 +365,8 @@ async def spawn_subagent(
         acp_agent_id=acp_agent_id,
         acp_session_id=acp_session_id,
     )
+
+    _record_spawn_for_tool_call(tool_call_id, task_id)
 
     async with _tasks_lock:
         _tasks[task_id] = task

--- a/src/suzent/streaming.py
+++ b/src/suzent/streaming.py
@@ -177,6 +177,28 @@ def _serialize_tool_output(output: Any) -> str:
     return str(output) if output else ""
 
 
+def _timed_out_agent_payload(task_id: str, timed_out_msg: str) -> str:
+    """Envelope for an `agent` call the tool timeout cancelled.
+
+    Carries a non-terminal status on purpose. Cancelling the call does not stop
+    the sub-agent, and the frontend infers 'completed' from the mere presence of
+    output when no status is given -- which would mark a run that may yet fail
+    as a success and, being terminal, exclude it from the poll that would have
+    found out. 'running' says "go and check", which is the truth here.
+    """
+    return json.dumps(
+        {
+            "success": False,
+            "message": (
+                f"{timed_out_msg} The sub-agent {task_id} it started "
+                "may still be running."
+            ),
+            "metadata": {"task_id": task_id, "status": "running"},
+        },
+        ensure_ascii=False,
+    )
+
+
 def _deferred_approval_status(result: Any) -> str:
     """Map deferred approval results without relying on object truthiness."""
     return "denied" if result is False or isinstance(result, ToolDenied) else "executed"
@@ -1200,17 +1222,8 @@ async def stream_agent_responses(
                             if _tname == "agent":
                                 _sub_task_id = _task_id_for_tool_call(_tcid)
                                 if _sub_task_id:
-                                    _msg = json.dumps(
-                                        {
-                                            "success": False,
-                                            "message": (
-                                                f"{timed_out_msg} The sub-agent "
-                                                f"{_sub_task_id} it started may "
-                                                "still be running."
-                                            ),
-                                            "metadata": {"task_id": _sub_task_id},
-                                        },
-                                        ensure_ascii=False,
+                                    _msg = _timed_out_agent_payload(
+                                        _sub_task_id, timed_out_msg
                                     )
                             # The model response must contain the ToolCallPart that
                             # each failed result answers, or the continuation is

--- a/src/suzent/streaming.py
+++ b/src/suzent/streaming.py
@@ -154,13 +154,26 @@ _DRAFT_PERSIST_INTERVAL_SECONDS = 0.75
 
 
 def _serialize_tool_output(output: Any) -> str:
+    """Render a tool result for persistence.
+
+    The frontend reads structured fields back out of this (a sub-agent block
+    recovers its task id and status from `metadata`), so every escape hatch
+    here has to stay valid JSON. Falling back to `str()` produced a Python
+    repr -- single-quoted, `True` rather than `true` -- which parses as
+    nothing and silently cost the caller those fields.
+    """
     if isinstance(output, dict):
-        return json.dumps(output, ensure_ascii=False)
+        return json.dumps(output, ensure_ascii=False, default=str)
     if hasattr(output, "model_dump"):
         try:
             return json.dumps(output.model_dump(mode="json"), ensure_ascii=False)
         except Exception:
-            return str(output)
+            # A value that JSON mode refuses; keep the shape and stringify the
+            # offending leaves rather than dropping the whole envelope.
+            try:
+                return json.dumps(output.model_dump(), ensure_ascii=False, default=str)
+            except Exception:
+                return json.dumps({"message": str(output)}, ensure_ascii=False)
     return str(output) if output else ""
 
 
@@ -1171,9 +1184,34 @@ async def stream_agent_responses(
                         _resp_call_ids = {
                             getattr(p, "tool_call_id", None) for p in _resp_parts
                         }
+                        from suzent.core.subagent_runner import (
+                            task_id_for_tool_call as _task_id_for_tool_call,
+                        )
+
                         _failed_returns: list = []
                         for _tcid, _call_part in _chk_inflight_calls.items():
                             _tname = getattr(_call_part, "tool_name", "") or ""
+                            # Cancelling the call does not stop what it started:
+                            # a sub-agent spawned by this call is still running,
+                            # and this synthesized result is the only record the
+                            # transcript will keep. Name the task so the block
+                            # can still be opened in the sidebar.
+                            _msg = timed_out_msg
+                            if _tname == "agent":
+                                _sub_task_id = _task_id_for_tool_call(_tcid)
+                                if _sub_task_id:
+                                    _msg = json.dumps(
+                                        {
+                                            "success": False,
+                                            "message": (
+                                                f"{timed_out_msg} The sub-agent "
+                                                f"{_sub_task_id} it started may "
+                                                "still be running."
+                                            ),
+                                            "metadata": {"task_id": _sub_task_id},
+                                        },
+                                        ensure_ascii=False,
+                                    )
                             # The model response must contain the ToolCallPart that
                             # each failed result answers, or the continuation is
                             # invalid. Add it if the part_end never arrived.
@@ -1183,7 +1221,7 @@ async def stream_agent_responses(
                             _failed_returns.append(
                                 _TRP(
                                     tool_name=_tname,
-                                    content=timed_out_msg,
+                                    content=_msg,
                                     tool_call_id=_tcid,
                                 )
                             )
@@ -1196,7 +1234,7 @@ async def stream_agent_responses(
                                         "tool_call_id": _tcid,
                                         "tool_name": _tname,
                                         "status": "error",
-                                        "output": timed_out_msg,
+                                        "output": _msg,
                                     },
                                 )
                             )

--- a/src/suzent/tools/agent_tool.py
+++ b/src/suzent/tools/agent_tool.py
@@ -374,6 +374,11 @@ class AgentTool(Tool):
             runtime=runtime,
             acp_agent_id=(acp_agent_id or "").strip() or None,
             acp_session_id=(acp_session_id or "").strip() or None,
+            # Blocking runs can outlive this tool call: the streaming layer
+            # cancels the call at its tool timeout while the sub-agent keeps
+            # going. Handing over the call id lets the synthesized failure name
+            # the task it started, so the run stays reachable from the UI.
+            tool_call_id=getattr(ctx, "tool_call_id", None),
         )
 
         tool_list = ", ".join(resolved) if resolved else "(none)"

--- a/tests/test_subagent_result_recovery.py
+++ b/tests/test_subagent_result_recovery.py
@@ -11,7 +11,7 @@ import json
 import pytest
 
 from suzent.core import subagent_runner
-from suzent.streaming import _serialize_tool_output
+from suzent.streaming import _serialize_tool_output, _timed_out_agent_payload
 
 
 class _Unserializable:
@@ -61,3 +61,17 @@ def test_tool_call_lookup_is_bounded() -> None:
     assert len(subagent_runner._SPAWN_BY_TOOL_CALL) <= limit
     # The oldest entries are the ones dropped; the newest must still resolve.
     assert subagent_runner.task_id_for_tool_call(f"bounded-{limit + 24}") is not None
+
+
+def test_timeout_envelope_names_the_task_and_stays_non_terminal() -> None:
+    payload = json.loads(_timed_out_agent_payload("sub_abc123", "Tool timed out."))
+    assert payload["metadata"]["task_id"] == "sub_abc123"
+    # Without a status the frontend infers 'completed' from the presence of
+    # output, marking a run that may yet fail as a success -- and terminal, so
+    # nothing polls it to find out otherwise.
+    assert payload["metadata"]["status"] == "running"
+
+
+def test_timeout_envelope_is_parseable_json() -> None:
+    raw = _timed_out_agent_payload("sub_abc123", "Tool timed out.")
+    assert json.loads(raw)["success"] is False

--- a/tests/test_subagent_result_recovery.py
+++ b/tests/test_subagent_result_recovery.py
@@ -1,0 +1,63 @@
+"""A cancelled `agent` tool call must still name the sub-agent it started.
+
+The streaming layer cancels a tool call at its timeout, but a sub-agent spawned
+by that call keeps running. The synthesized failure is the only record the
+transcript keeps, so losing the task id there leaves a live run with no way to
+reach it from the UI.
+"""
+
+import json
+
+import pytest
+
+from suzent.core import subagent_runner
+from suzent.streaming import _serialize_tool_output
+
+
+class _Unserializable:
+    def __repr__(self) -> str:
+        return "<unserializable>"
+
+
+class _JsonModeRejects:
+    """A result whose metadata json mode refuses but plain dump survives."""
+
+    def model_dump(self, mode=None):
+        if mode == "json":
+            raise ValueError("not json-serializable")
+        return {
+            "success": True,
+            "message": "Sub-agent sub_abc123 completed.",
+            "metadata": {"task_id": "sub_abc123", "extra": _Unserializable()},
+        }
+
+
+def test_serialize_tool_output_stays_json_when_json_mode_fails() -> None:
+    # Previously this fell back to str(), producing a Python repr that the
+    # frontend could not parse -- silently costing it task_id and status.
+    raw = _serialize_tool_output(_JsonModeRejects())
+    assert json.loads(raw)["metadata"]["task_id"] == "sub_abc123"
+
+
+def test_serialize_tool_output_survives_unserializable_dict_values() -> None:
+    raw = _serialize_tool_output({"task_id": "sub_abc123", "extra": _Unserializable()})
+    assert json.loads(raw)["task_id"] == "sub_abc123"
+
+
+def test_tool_call_lookup_returns_the_spawned_task() -> None:
+    subagent_runner._record_spawn_for_tool_call("call-1", "sub_deadbeef")
+    assert subagent_runner.task_id_for_tool_call("call-1") == "sub_deadbeef"
+
+
+@pytest.mark.parametrize("missing", [None, "", "never-seen"])
+def test_tool_call_lookup_is_quiet_about_unknown_calls(missing) -> None:
+    assert subagent_runner.task_id_for_tool_call(missing) is None
+
+
+def test_tool_call_lookup_is_bounded() -> None:
+    limit = subagent_runner._SPAWN_BY_TOOL_CALL_MAX
+    for i in range(limit + 25):
+        subagent_runner._record_spawn_for_tool_call(f"bounded-{i}", f"sub_{i:08x}")
+    assert len(subagent_runner._SPAWN_BY_TOOL_CALL) <= limit
+    # The oldest entries are the ones dropped; the newest must still resolve.
+    assert subagent_runner.task_id_for_tool_call(f"bounded-{limit + 24}") is not None


### PR DESCRIPTION
Follow-up to #147. Fixes the reported bug that a sub-agent's sidebar can't be opened after reloading a chat or restarting the app.

## The bug

The task id was recovered by regexing the tool's prose for `ID: sub_x` ([AssistantContent.tsx](../blob/main/frontend/src/components/chat/AssistantContent.tsx)), and the open-sidebar button is gated on having one. Measured against real persisted data — **it recovered 2 of 15 results**:

| persisted shape | count | old regex |
|---|---|---|
| `Sub-agent spawned (ID: sub_x)` | 2 | ✅ |
| `Sub-agent sub_x completed.` | 7 | ❌ id present, different wording |
| `Tool execution timed out after 60s` | 6 | ❌ no id recorded at all |

It only broke after a reload because a live run gets the id from the stream instead.

**The id was never missing.** The tool returns a JSON envelope whose `metadata` already carries `task_id`, `status`, `result_summary` and `error` — the frontend was pattern-matching the prose sitting right next to it.

## Frontend

- **Read `metadata` structurally**, with a widened prose scan retained for non-JSON payloads and the "completed" wording the old pattern missed
- **Seed status from `metadata.status`.** A background spawn returns `queued` while the run continues, so inferring `completed` from the presence of output froze the block as terminal and stopped anything from ever correcting it
- **One shared fallback poll** in `useSubAgentStatus` over unresolved tasks, replacing a 3s timer per block. Ten visible sub-agents meant ten independent requests every three seconds, and each stopped covering its task the moment its block unmounted — which #147's collapsed-rail change makes routine. `SubAgentCallBlock` is now presentation-only and just registers interest while its task is unfinished
- **Terminal states can't regress** in the shared store, so a late or replayed stream frame can't undo what the poll settled

The block looks and behaves exactly as before; this is plumbing.

## Backend

Two cases the frontend can't reach:

- **`_serialize_tool_output` fell back to `str()`** when json mode raised, emitting a Python repr (`{'success': True, …}`) that parses as nothing and silently cost the caller every structured field. Every path now emits valid JSON.
- **A blocking `agent` call cancelled by the tool timeout left no id anywhere**, even though the sub-agent it started keeps running — precisely when you'd want the sidebar link. `spawn_subagent` now records `tool_call_id -> task_id` when the task is created (registration has to happen there: in blocking mode the tool may never return), and the timeout path names the task in its synthesized result.

## The sidebar tab itself

Recovering the task id restored the open-sidebar button *inside* a transcript block, but the panel still could not be opened: `hasSubAgents` was read from `subAgentTasks`, which is live SSE state cleared on every chat switch. A chat with 15 finished sub-agents looked empty, so the Agents tab rendered with `disabled` — and `SubAgentList` behind it, which fetches its own history from `/subagents` and would have listed all 15, never got to run.

The tab now also opens on transcript history (any turn that called the `agent` tool). Kept as a separate `hasSubAgentHistory` prop rather than folded into `hasSubAgents`, because that flag also drives the pulsing activity dot and a finished history is not activity.

## Verification

Frontend **228 tests** (8 new, using the real payload shapes above including the Python-repr and timed-out cases) · backend **1496 tests** (7 new) · typecheck · build · prettier · ruff check + format · frontend lint diffed against baseline, **no new problems**.

Not exercised end-to-end against a live timing-out sub-agent — the timeout path is covered by unit tests on the lookup and serialization, not by a full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
