### PR TITLE
fix(frontend): stop hover-tinted rows re-rasterising their text

### DIFF
--- a/frontend/src/components/chat/ToolCallBlock.tsx
+++ b/frontend/src/components/chat/ToolCallBlock.tsx
@@ -505,7 +505,7 @@ const ToolCallBlockComponent: React.FC<ToolCallBlockProps> = ({
   });
 
   const headerClassName = [
-    'group/tool-header inline-flex items-center gap-1.5 px-2.5 py-1 text-[11px] font-mono font-bold uppercase tracking-wide rounded-sm transition-colors select-none',
+    'group/tool-header hover-tint-text inline-flex items-center gap-1.5 px-2.5 py-1 text-[11px] font-mono font-bold uppercase tracking-wide rounded-sm transition-colors select-none',
     hasDetails ? 'cursor-pointer hover:bg-neutral-100 dark:hover:bg-zinc-700' : 'cursor-default',
     expanded
       ? 'bg-neutral-100 dark:bg-zinc-700 text-brutal-black dark:text-white'

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -17,6 +17,23 @@
     @apply shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-[1px] hover:shadow-[4px_4px_0_0_#000] active:translate-x-[1px] active:translate-y-[1px] active:shadow-none transition-all;
   }
 
+  /*
+   * Text whose backdrop only appears on hover.
+   *
+   * These rows sit on `bg-transparent` at rest and take an opaque tint on
+   * hover. WebKit rasterises text differently depending on what is behind it
+   * -- subpixel antialiasing over an opaque backdrop, grayscale over a
+   * transparent one -- so the glyphs are re-rendered at the moment the tint
+   * arrives and visibly shift by a fraction of a pixel. Nothing moves in
+   * layout terms, which is why it reads as the text itself squirming.
+   *
+   * Pinning the smoothing keeps the rasterisation identical in both states.
+   */
+  .hover-tint-text {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
   /* Skips layout/paint for off-screen message rows, keeping long histories
      cheap to scroll. The placeholder size is per row type: `auto` remembers a
      row's real height once it has been rendered, so these estimates only have
@@ -385,6 +402,8 @@ code {
 /* Tool Sequence Grouping */
 .tool-group-summary {
   @apply inline-flex items-center gap-2 px-3 py-1.5 bg-transparent rounded-sm hover:bg-neutral-100 dark:hover:bg-zinc-700 transition-all cursor-pointer select-none mb-1 border border-transparent;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 .tool-group-summary.active-approval {
@@ -420,6 +439,8 @@ code {
 }
 
 .activity-rail-header {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -513,6 +534,8 @@ code {
 }
 
 .tool-call-header-pending {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   color: #111;
   border: 2px solid transparent;
   background: transparent;


### PR DESCRIPTION
Reported: hovering a tool block makes its text — and nearby rows — shift very slightly.

## Why three probes found nothing

There is no layout shift. Text moving without geometry moving is text being **re-rasterized**.

These rows sit on `bg-transparent` at rest and take an opaque tint on hover ([ToolCallBlock.tsx:509](../blob/main/frontend/src/components/chat/ToolCallBlock.tsx), [styles.css:387](../blob/main/frontend/src/styles.css), and the pending header). WebKit renders text differently depending on what is behind it: **subpixel antialiasing over an opaque backdrop, grayscale over a transparent one**. The tint arriving re-renders every glyph in the row under the other mode, and they land a fraction of a pixel off.

`getBoundingClientRect` is identical throughout — which is exactly why it reads as the text itself squirming rather than as anything moving, and why three rounds of geometry instrumentation came back empty. I was measuring the wrong quantity.

## Fix

Pin font smoothing on the four hover-tinted rows — tool header, tool-group summary, activity rail header, pending header — so the rasterisation is the same in both states.

## Caveats

**Not verified in this environment.** The effect is subpixel and WebKit-specific; it needs looking at on the machine that shows it. Merging at the author's request with that stated.

`-webkit-font-smoothing: antialiased` renders text very slightly thinner. On these small uppercase mono labels it should be imperceptible, but it is a real change to how they draw.

If the shift persists, the alternative is to give the rows an opaque background at rest matching their surroundings, so the backdrop never changes at all.

## Verification

typecheck · 233 tests · build · prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)