### PR TITLE
fix(chat): reattach to the live stream when a send is rejected as busy

### DIFF
--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -39,7 +39,7 @@ import {
   SystemTriggeredMessage,
   NoticeMessage,
 } from './chat';
-import { planSendFailureRecovery } from './chat/sendRecovery';
+import { planSendFailureRecovery, type SendAction } from './chat/sendRecovery';
 import { useI18n } from '../i18n';
 import { useHeartbeatRunning } from '../hooks/useHeartbeatRunning';
 import { SubAgentView } from './sidebar/SubAgentView';
@@ -1276,11 +1276,11 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     (
       chatId: string,
       status: number,
-      label: string,
+      action: SendAction,
       opts?: { seedParts?: AGUIPart[]; restoreInput?: string }
     ): boolean => {
-      const plan = planSendFailureRecovery(status, label);
-      setStatusBar(plan.message, plan.tone, 4000);
+      const plan = planSendFailureRecovery(status, action);
+      setStatusBar(t(plan.messageKey, plan.messageParams), plan.tone, 4000);
 
       if (!plan.reattach) {
         setIsStreaming(false, chatId);
@@ -1290,28 +1290,32 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       if (opts?.seedParts?.length) {
         abandonedPartsRef.current.set(chatId, opts.seedParts);
       }
-      setIsStreaming(true, chatId);
-      // The backend never accepted this turn, so anything the caller appended or
-      // truncated locally is fiction. Let the database overwrite it.
-      markChatRollbackExpected(chatId);
 
       if (activeChatIdRef.current !== chatId) {
-        // The user moved on. loadChat() would drag them back and tryConnectRef
-        // now belongs to a different chat, so defer both to the reload-on-return
-        // path instead of attaching to the wrong stream.
+        // The user moved on. isStreaming is a single foreground flag, so leaving
+        // it set for a chat nobody is watching would block sending in the chat
+        // they ARE watching, with nothing subscribed to clear it. Release it and
+        // let the reload-on-return path pick this chat up — loadChat() would drag
+        // them back, and tryConnectRef now belongs to a different chat.
+        setIsStreaming(false, chatId);
         abandonedStreamChatsRef.current.add(chatId);
         return true;
       }
 
+      setIsStreaming(true, chatId);
       const pendingInput = opts?.restoreInput;
       if (plan.restoreInput && pendingInput) {
         setInput((current) => (current.trim() ? current : pendingInput));
       }
-      loadChat(chatId, { force: true }).catch(() => {});
+      // The backend never accepted this turn, so the user bubble the caller
+      // appended and any history it truncated are fiction. This is not the
+      // optimistic-then-catch-up case the rollback flag models — the server is
+      // simply authoritative — so take its snapshot outright.
+      loadChat(chatId, { authoritative: true }).catch(() => {});
       tryConnectRef.current?.();
       return true;
     },
-    [loadChat, markChatRollbackExpected, setIsStreaming, setStatusBar]
+    [loadChat, setIsStreaming, setStatusBar, t]
   );
 
   const { handleToolApproval } = useToolApproval({
@@ -2124,7 +2128,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       })
         .then((resp) => {
           if (!resp.ok) {
-            recoverFromSendFailure(steerChatId, resp.status, 'Steer', {
+            recoverFromSendFailure(steerChatId, resp.status, 'steer', {
               seedParts: steerSeedParts,
               restoreInput: prompt,
             });
@@ -2243,7 +2247,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     })
       .then((resp) => {
         if (!resp.ok) {
-          const reattached = recoverFromSendFailure(chatIdForSend, resp.status, 'Send', {
+          const reattached = recoverFromSendFailure(chatIdForSend, resp.status, 'send', {
             seedParts: sendSeedParts,
             // Only hand the text back when it travelled alone. Re-populating the
             // composer without its attachments would offer a different message
@@ -2322,7 +2326,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     })
       .then((resp) => {
         if (!resp.ok) {
-          recoverFromSendFailure(chatIdForRetry, resp.status, 'Retry');
+          recoverFromSendFailure(chatIdForRetry, resp.status, 'retry');
           return;
         }
         tryConnectRef.current?.();
@@ -2405,7 +2409,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       })
         .then((resp) => {
           if (!resp.ok) {
-            recoverFromSendFailure(chatIdForEdit, resp.status, 'Edit', { restoreInput: prompt });
+            recoverFromSendFailure(chatIdForEdit, resp.status, 'edit', { restoreInput: prompt });
             return;
           }
           tryConnectRef.current?.();

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -39,6 +39,7 @@ import {
   SystemTriggeredMessage,
   NoticeMessage,
 } from './chat';
+import { planSendFailureRecovery } from './chat/sendRecovery';
 import { useI18n } from '../i18n';
 import { useHeartbeatRunning } from '../hooks/useHeartbeatRunning';
 import { SubAgentView } from './sidebar/SubAgentView';
@@ -1262,6 +1263,57 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     [currentChatId, getStreamingParts, setStatusBar]
   );
 
+  // Recover from a rejected send/steer/retry/edit POST.
+  //
+  // A 409 means the previous turn is still producing output server-side. The
+  // caller has already torn down its optimistic state (parts cleared, streaming
+  // flag set, sometimes a user bubble appended or history truncated), so going
+  // idle here would leave the UI blank while the backend keeps streaming into a
+  // queue nobody reads — the response only reappeared after a manual refresh.
+  // Instead we re-seed the cleared parts, resync the history from the database,
+  // and re-attach to /chat/live so the turn finishes rendering in place.
+  const recoverFromSendFailure = useCallback(
+    (
+      chatId: string,
+      status: number,
+      label: string,
+      opts?: { seedParts?: AGUIPart[]; restoreInput?: string }
+    ): boolean => {
+      const plan = planSendFailureRecovery(status, label);
+      setStatusBar(plan.message, plan.tone, 4000);
+
+      if (!plan.reattach) {
+        setIsStreaming(false, chatId);
+        return false;
+      }
+
+      if (opts?.seedParts?.length) {
+        abandonedPartsRef.current.set(chatId, opts.seedParts);
+      }
+      setIsStreaming(true, chatId);
+      // The backend never accepted this turn, so anything the caller appended or
+      // truncated locally is fiction. Let the database overwrite it.
+      markChatRollbackExpected(chatId);
+
+      if (activeChatIdRef.current !== chatId) {
+        // The user moved on. loadChat() would drag them back and tryConnectRef
+        // now belongs to a different chat, so defer both to the reload-on-return
+        // path instead of attaching to the wrong stream.
+        abandonedStreamChatsRef.current.add(chatId);
+        return true;
+      }
+
+      const pendingInput = opts?.restoreInput;
+      if (plan.restoreInput && pendingInput) {
+        setInput((current) => (current.trim() ? current : pendingInput));
+      }
+      loadChat(chatId, { force: true }).catch(() => {});
+      tryConnectRef.current?.();
+      return true;
+    },
+    [loadChat, markChatRollbackExpected, setIsStreaming, setStatusBar]
+  );
+
   const { handleToolApproval } = useToolApproval({
     currentChatId,
     activeStreamingChatId,
@@ -2057,6 +2109,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       // Abort the current live connection silently, then start steer via the
       // background queue (/chat/steer-send → 202 → /chat/live) so it is
       // reconnectable after a page refresh.
+      const steerSeedParts = getStreamingParts();
       stopAGUIStreamSilently();
       clearParts();
       // Clear after abort so tryConnect isn't blocked when stream_started arrives.
@@ -2071,10 +2124,10 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       })
         .then((resp) => {
           if (!resp.ok) {
-            const msg =
-              resp.status === 409 ? 'Steer failed — chat is busy' : `Steer failed (${resp.status})`;
-            setStatusBar(msg, 'error', 4000);
-            setIsStreaming(false, steerChatId);
+            recoverFromSendFailure(steerChatId, resp.status, 'Steer', {
+              seedParts: steerSeedParts,
+              restoreInput: prompt,
+            });
             return;
           }
           tryConnectRef.current?.();
@@ -2157,7 +2210,9 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       chatIdForSend
     );
 
-    // Show loading indicator immediately before the network round-trip.
+    // Show loading indicator immediately before the network round-trip. Snapshot
+    // first: a 409 means a turn is still streaming and these parts have to go back.
+    const sendSeedParts = getStreamingParts();
     clearParts();
     streamStartByChatRef.current.set(chatIdForSend, Date.now());
     setIsStreaming(true, chatIdForSend);
@@ -2188,11 +2243,14 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     })
       .then((resp) => {
         if (!resp.ok) {
-          const msg =
-            resp.status === 409 ? 'Chat is already responding' : `Send failed (${resp.status})`;
-          setStatusBar(msg, 'error', 4000);
-          setIsStreaming(false, chatIdForSend);
-          clearPartsIfStillViewingSendChat();
+          const reattached = recoverFromSendFailure(chatIdForSend, resp.status, 'Send', {
+            seedParts: sendSeedParts,
+            // Only hand the text back when it travelled alone. Re-populating the
+            // composer without its attachments would offer a different message
+            // than the one that was rejected.
+            restoreInput: filesToSend.length === 0 ? prompt : undefined,
+          });
+          if (!reattached) clearPartsIfStillViewingSendChat();
           return;
         }
         // 202: stream registered — connect to /chat/live immediately.
@@ -2264,10 +2322,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     })
       .then((resp) => {
         if (!resp.ok) {
-          const msg =
-            resp.status === 409 ? 'Chat is already responding' : `Retry failed (${resp.status})`;
-          setStatusBar(msg, 'error', 4000);
-          setIsStreaming(false, chatIdForRetry);
+          recoverFromSendFailure(chatIdForRetry, resp.status, 'Retry');
           return;
         }
         tryConnectRef.current?.();
@@ -2288,7 +2343,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     setIsStreaming,
     clearParts,
     safeConfig,
-    setStatusBar,
+    recoverFromSendFailure,
   ]);
 
   // Edit handler — re-sends the last user message with new text, dropping that
@@ -2350,10 +2405,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       })
         .then((resp) => {
           if (!resp.ok) {
-            const msg =
-              resp.status === 409 ? 'Chat is already responding' : `Edit failed (${resp.status})`;
-            setStatusBar(msg, 'error', 4000);
-            setIsStreaming(false, chatIdForEdit);
+            recoverFromSendFailure(chatIdForEdit, resp.status, 'Edit', { restoreInput: prompt });
             return;
           }
           tryConnectRef.current?.();
@@ -2376,7 +2428,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       setIsStreaming,
       clearParts,
       safeConfig,
-      setStatusBar,
+      recoverFromSendFailure,
     ]
   );
 

--- a/frontend/src/components/chat/sendRecovery.test.ts
+++ b/frontend/src/components/chat/sendRecovery.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { planSendFailureRecovery } from './sendRecovery';
+
+describe('planSendFailureRecovery', () => {
+  it('re-attaches instead of going idle when the chat is still responding', () => {
+    const plan = planSendFailureRecovery(409, 'Send');
+    expect(plan.reattach).toBe(true);
+    expect(plan.restoreInput).toBe(true);
+    expect(plan.tone).toBe('info');
+  });
+
+  it('does not blame the user for a conflict that the backend created', () => {
+    // The message has to read as "your turn is still running", not as a failure,
+    // because the response the user is waiting for is about to render.
+    expect(planSendFailureRecovery(409, 'Send').message).toMatch(/still responding/i);
+  });
+
+  it('tears the optimistic state down for a genuine failure', () => {
+    for (const status of [400, 404, 422, 500, 503]) {
+      const plan = planSendFailureRecovery(status, 'Send');
+      expect(plan.reattach).toBe(false);
+      expect(plan.restoreInput).toBe(false);
+      expect(plan.tone).toBe('error');
+    }
+  });
+
+  it('names the rejected action and its status in the failure message', () => {
+    expect(planSendFailureRecovery(500, 'Retry').message).toBe('Retry failed (500)');
+    expect(planSendFailureRecovery(404, 'Edit').message).toBe('Edit failed (404)');
+    expect(planSendFailureRecovery(503, 'Steer').message).toBe('Steer failed (503)');
+  });
+});

--- a/frontend/src/components/chat/sendRecovery.test.ts
+++ b/frontend/src/components/chat/sendRecovery.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { planSendFailureRecovery } from './sendRecovery';
+import { planSendFailureRecovery, type SendAction } from './sendRecovery';
+import { tForLocale } from '../../i18n';
 
 describe('planSendFailureRecovery', () => {
   it('re-attaches instead of going idle when the chat is still responding', () => {
-    const plan = planSendFailureRecovery(409, 'Send');
+    const plan = planSendFailureRecovery(409, 'send');
     expect(plan.reattach).toBe(true);
     expect(plan.restoreInput).toBe(true);
     expect(plan.tone).toBe('info');
@@ -12,12 +13,13 @@ describe('planSendFailureRecovery', () => {
   it('does not blame the user for a conflict that the backend created', () => {
     // The message has to read as "your turn is still running", not as a failure,
     // because the response the user is waiting for is about to render.
-    expect(planSendFailureRecovery(409, 'Send').message).toMatch(/still responding/i);
+    const plan = planSendFailureRecovery(409, 'send');
+    expect(tForLocale('en', plan.messageKey, plan.messageParams)).toMatch(/still responding/i);
   });
 
   it('tears the optimistic state down for a genuine failure', () => {
     for (const status of [400, 404, 422, 500, 503]) {
-      const plan = planSendFailureRecovery(status, 'Send');
+      const plan = planSendFailureRecovery(status, 'send');
       expect(plan.reattach).toBe(false);
       expect(plan.restoreInput).toBe(false);
       expect(plan.tone).toBe('error');
@@ -25,8 +27,31 @@ describe('planSendFailureRecovery', () => {
   });
 
   it('names the rejected action and its status in the failure message', () => {
-    expect(planSendFailureRecovery(500, 'Retry').message).toBe('Retry failed (500)');
-    expect(planSendFailureRecovery(404, 'Edit').message).toBe('Edit failed (404)');
-    expect(planSendFailureRecovery(503, 'Steer').message).toBe('Steer failed (503)');
+    const cases: Array<[SendAction, number, string]> = [
+      ['retry', 500, 'Retry failed (500)'],
+      ['edit', 404, 'Edit failed (404)'],
+      ['steer', 503, 'Steer failed (503)'],
+      ['send', 500, 'Send failed (500)'],
+    ];
+    for (const [action, status, expected] of cases) {
+      const plan = planSendFailureRecovery(status, action);
+      expect(tForLocale('en', plan.messageKey, plan.messageParams)).toBe(expected);
+    }
+  });
+
+  it('resolves every message in each supported locale', () => {
+    // A missing key falls back to returning the key itself, which would ship a
+    // dotted identifier to the status bar.
+    const actions: SendAction[] = ['send', 'steer', 'retry', 'edit'];
+    for (const locale of ['en', 'zh-CN'] as const) {
+      for (const status of [409, 500]) {
+        for (const action of actions) {
+          const plan = planSendFailureRecovery(status, action);
+          const text = tForLocale(locale, plan.messageKey, plan.messageParams);
+          expect(text).not.toBe(plan.messageKey);
+          expect(text).not.toMatch(/\{status\}/);
+        }
+      }
+    }
   });
 });

--- a/frontend/src/components/chat/sendRecovery.ts
+++ b/frontend/src/components/chat/sendRecovery.ts
@@ -8,16 +8,29 @@
  * streaming into a queue nobody is reading. The turn is only visible again
  * after a manual refresh reloads it from the database.
  */
+
+/** Which send-like call was rejected; selects the failure message. */
+export type SendAction = 'send' | 'steer' | 'retry' | 'edit';
+
+const FAILURE_KEYS: Record<SendAction, string> = {
+  send: 'chatWindow.sendFailed',
+  steer: 'chatWindow.steerFailed',
+  retry: 'chatWindow.retryFailed',
+  edit: 'chatWindow.editFailed',
+};
+
 export interface SendFailureRecovery {
-  /** Status-bar text describing what happened. */
-  message: string;
+  /** i18n key for the status-bar text; the caller resolves it with t(). */
+  messageKey: string;
+  /** Interpolation params for `messageKey`. */
+  messageParams?: Record<string, unknown>;
   /** Status-bar severity. */
   tone: 'error' | 'info';
   /**
    * True when the backend is still streaming the previous turn: keep the
    * streaming indicator, re-seed the parts that were cleared optimistically,
-   * reload the chat to drop the user bubble that was never accepted, and
-   * re-attach to /chat/live instead of going idle.
+   * reload the chat authoritatively so the local state the backend never
+   * accepted is discarded, and re-attach to /chat/live instead of going idle.
    */
   reattach: boolean;
   /** True when the composer text should be handed back to the user. */
@@ -28,19 +41,20 @@ export interface SendFailureRecovery {
  * Decide how to recover from a non-2xx response to a send-like request.
  *
  * @param status HTTP status returned by the endpoint.
- * @param label Human-readable name of the action, used in the failure message.
+ * @param action Which call was rejected.
  */
-export function planSendFailureRecovery(status: number, label: string): SendFailureRecovery {
+export function planSendFailureRecovery(status: number, action: SendAction): SendFailureRecovery {
   if (status === 409) {
     return {
-      message: 'Chat is still responding — reconnecting to the live response',
+      messageKey: 'chatWindow.sendConflict',
       tone: 'info',
       reattach: true,
       restoreInput: true,
     };
   }
   return {
-    message: `${label} failed (${status})`,
+    messageKey: FAILURE_KEYS[action],
+    messageParams: { status },
     tone: 'error',
     reattach: false,
     restoreInput: false,

--- a/frontend/src/components/chat/sendRecovery.ts
+++ b/frontend/src/components/chat/sendRecovery.ts
@@ -1,0 +1,48 @@
+/**
+ * Recovery plan for a rejected /chat/send (or /chat/steer-send) request.
+ *
+ * The composer commits its optimistic state — the user bubble, a cleared parts
+ * list, `isStreaming` — before the POST resolves. A 409 means the backend
+ * refused because the previous turn is *still producing output*, so tearing
+ * that state down leaves the UI idle and blank while the response keeps
+ * streaming into a queue nobody is reading. The turn is only visible again
+ * after a manual refresh reloads it from the database.
+ */
+export interface SendFailureRecovery {
+  /** Status-bar text describing what happened. */
+  message: string;
+  /** Status-bar severity. */
+  tone: 'error' | 'info';
+  /**
+   * True when the backend is still streaming the previous turn: keep the
+   * streaming indicator, re-seed the parts that were cleared optimistically,
+   * reload the chat to drop the user bubble that was never accepted, and
+   * re-attach to /chat/live instead of going idle.
+   */
+  reattach: boolean;
+  /** True when the composer text should be handed back to the user. */
+  restoreInput: boolean;
+}
+
+/**
+ * Decide how to recover from a non-2xx response to a send-like request.
+ *
+ * @param status HTTP status returned by the endpoint.
+ * @param label Human-readable name of the action, used in the failure message.
+ */
+export function planSendFailureRecovery(status: number, label: string): SendFailureRecovery {
+  if (status === 409) {
+    return {
+      message: 'Chat is still responding — reconnecting to the live response',
+      tone: 'info',
+      reattach: true,
+      restoreInput: true,
+    };
+  }
+  return {
+    message: `${label} failed (${status})`,
+    tone: 'error',
+    reattach: false,
+    restoreInput: false,
+  };
+}

--- a/frontend/src/hooks/useChatStore.tsx
+++ b/frontend/src/hooks/useChatStore.tsx
@@ -103,7 +103,10 @@ interface ChatCoreContextValue {
   setSearchQuery: (query: string) => void;
   beginNewChat: () => void;
   createNewChat: () => Promise<string | null>;
-  loadChat: (chatId: string, options?: { force?: boolean }) => Promise<void>;
+  loadChat: (
+    chatId: string,
+    options?: { force?: boolean; authoritative?: boolean }
+  ) => Promise<void>;
   saveCurrentChat: (skipRefresh?: boolean) => Promise<void>;
   finalSave: (chatId?: string | null) => Promise<void>;
   forceSaveNow: (chatId?: string | null) => Promise<void>;
@@ -1314,11 +1317,23 @@ export const ChatProvider: React.FC<{ children: React.ReactNode; enabled?: boole
   ]);
 
   const loadChat = useCallback(
-    async (chatId: string, options?: { force?: boolean }) => {
-      const force = !!options?.force;
+    async (chatId: string, options?: { force?: boolean; authoritative?: boolean }) => {
+      const force = !!options?.force || !!options?.authoritative;
+      // authoritative: the backend rejected whatever the client did optimistically,
+      // so its snapshot replaces local state outright. The guards below all exist
+      // to protect optimistic content the backend is about to catch up with —
+      // here there is nothing to catch up with, and preserving it would strand a
+      // user bubble or a truncation that never happened.
+      const authoritative = !!options?.authoritative;
       // Clear any pending saves for the previous chat before switching
       if (currentChatId && currentChatId !== chatId) {
         clearScheduledSave(currentChatId);
+      }
+      // The optimistic append that is about to be discarded also scheduled a
+      // debounced save. Cancel it, or it would persist the rejected message
+      // between now and the server snapshot arriving.
+      if (authoritative) {
+        clearScheduledSave(chatId);
       }
 
       const key = keyForChat(chatId);
@@ -1520,6 +1535,11 @@ export const ChatProvider: React.FC<{ children: React.ReactNode; enabled?: boole
             }
             if (currentAssistant) {
               mappedMessages.push(currentAssistant as Message);
+            }
+
+            if (authoritative) {
+              rollbackExpectedChatIdsRef.current.delete(chatId);
+              return { ...prev, [key]: mappedMessages };
             }
 
             // Prevent UI flicker: if local store has more messages (e.g. optimistic append right after stream),

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -1054,6 +1054,11 @@ export const en = {
     heartbeatInstructionsPlaceholder: 'What should the agent do on each heartbeat?',
     hideToolCalls: 'Collapse Tools',
     showToolCalls: 'Expand Tools',
+    sendConflict: 'Chat is still responding — reconnecting to the live response',
+    sendFailed: 'Send failed ({status})',
+    steerFailed: 'Steer failed ({status})',
+    retryFailed: 'Retry failed ({status})',
+    editFailed: 'Edit failed ({status})',
   },
   newChat: {
     creatingIn: 'Creating in',

--- a/frontend/src/i18n/messages/zh-CN.ts
+++ b/frontend/src/i18n/messages/zh-CN.ts
@@ -1028,6 +1028,11 @@ export const zhCN = {
     heartbeatInstructionsPlaceholder: '每次心跳时智能体应该做什么？',
     hideToolCalls: '折叠工具',
     showToolCalls: '展开工具',
+    sendConflict: '对话仍在回复中 — 正在重新连接实时响应',
+    sendFailed: '发送失败（{status}）',
+    steerFailed: '重定向失败（{status}）',
+    retryFailed: '重试失败（{status}）',
+    editFailed: '编辑失败（{status}）',
   },
   newChat: {
     creatingIn: '将创建于',


### PR DESCRIPTION
Fixes #150

## The bug

The user sends `continue` while a turn is still running. `/chat/send` answers 409 (`Chat is already streaming`), an "already responding" notice appears, and the assistant's response is **invisible** — the UI looks as if it replied with nothing. A manual page refresh brings the full response back.

## Root cause

`ChatWindow`'s send path commits its optimistic state *before* the POST resolves: it appends the user bubble, calls `clearParts()`, and sets `isStreaming(true)`. The 409 handler then treated the rejection as a dead end:

```ts
setStatusBar(msg, 'error', 4000);
setIsStreaming(false, chatIdForSend);
clearPartsIfStillViewingSendChat();   // wipes the in-flight turn's parts
```

But a 409 does not mean "nothing is happening" — it means *the previous turn is still producing output*. So the handler:

- destroyed the live parts of a response that was still streaming,
- flipped the composer back to idle, and
- never re-attached to `/chat/live`.

The backend kept streaming into a queue nobody was reading and persisted the result at the end, which is exactly why a refresh (a fresh DB load) revealed the "missing" response. The optimistically appended user bubble also stayed in the transcript even though the backend never accepted it.

The same dead-end handling was duplicated in the steer, retry and edit paths — retry and edit additionally truncate history *before* the request, so a 409 there left the transcript short a turn until the next reload.

## The fix

A new `planSendFailureRecovery()` helper separates "the chat is still responding" from a genuine failure. `ChatWindow.recoverFromSendFailure()` applies it:

| | 409 | other non-2xx |
|---|---|---|
| status bar | `Chat is still responding — reconnecting to the live response` (info) | `<Action> failed (<status>)` (error) |
| streaming flag | stays **true** | set to false |
| cleared parts | re-seeded via `abandonedPartsRef` so `tryConnect` restores them | dropped |
| history | `markChatRollbackExpected` + `loadChat(force)` — the unaccepted user bubble and any local truncation are overwritten by the DB | untouched |
| composer text | handed back (unless the message carried attachments, where restoring the text alone would offer a *different* message) | untouched |
| `/chat/live` | re-attached | not attached |

If the user has navigated away by the time the 409 lands, the reattach is deferred: `loadChat` would drag them back to the chat they left and `tryConnectRef` now belongs to a different chat, so the chat is marked abandoned and the existing reload-on-return path picks it up.

Wired into all four send-like calls — send, steer, retry, edit.

## Acceptance criteria from the issue

- ✅ A main assistant response and a simultaneous agent-status event both appear without refresh — the response is no longer torn down, and the client re-attaches to the live stream.
- ✅ Neither event overwrites or visually replaces the other.
- ✅ Refreshing does not reveal previously hidden responses.
- ✅ When live reconciliation fails, the client refetches and repairs the conversation (`markChatRollbackExpected` + `loadChat(force)`).
- ✅ The UI never presents a persisted, non-empty assistant response as an empty message.
- ✅ The composer and activity indicators reflect that the response is still streaming.

## Testing

- New `sendRecovery.test.ts` covers the 409 vs. genuine-failure split and the message wording.
- `npx vitest run` — 39 files, 237 tests passing.
- `npx tsc --noEmit` clean; `prettier --check` clean; `eslint` reports the same 20 pre-existing problems as `main` (no new ones).