### PR TITLE
fix(filesystem): honour the chat's working directory in every file tool

### DIFF
--- a/src/suzent/core/context_injection.py
+++ b/src/suzent/core/context_injection.py
@@ -72,6 +72,14 @@ def build_agent_deps(
     except Exception:
         _chat_perm = None
 
+    # A working directory the user authorized is a property of the chat, not of a
+    # single request. Clients don't re-send it every turn, so fall back to the
+    # persisted value — the same chain resolve_repository_context() uses. Without
+    # this the grant silently expired at a turn boundary and identical paths
+    # started failing mid-task.
+    if not cwd and _chat_obj is not None:
+        cwd = _chat_obj.working_directory or (_chat_obj.config or {}).get("cwd")
+
     # Merge layers: later layers win on conflict; command_rules are unioned by pattern
     def _merge_perm(base: dict, overlay: dict) -> dict:
         result = dict(base)
@@ -144,6 +152,7 @@ def build_agent_deps(
         sandbox_data_path=CONFIG.sandbox_data_path,
         custom_volumes=custom_volumes,
         workspace_root=workspace_root,
+        cwd=cwd,
     )
 
     # Memory manager — skip if explicitly disabled in config

--- a/src/suzent/core/subagent_runner.py
+++ b/src/suzent/core/subagent_runner.py
@@ -447,12 +447,56 @@ def inherited_working_directory(parent_chat) -> Optional[str]:
     return parent_chat.working_directory or (parent_chat.config or {}).get("cwd")
 
 
-def grants_cover(parent_chat, path: str) -> bool:
-    """True when the parent chat is already authorized for ``path``.
+def persistable_grants(base_config: dict, isolation: Optional[str]) -> dict:
+    """The grants worth storing on a sub-agent's chat for later turns.
+
+    process_turn_text carries the config for this turn, but a resumed or
+    follow-up turn rebuilds deps from the database — without persisting these
+    the sub-agent loses access to the folder it was spawned to work in.
+
+    A worktree cwd is the exception: _run_subagent tears the worktree down in
+    its finally block, so persisting it would point a resumed turn at a deleted
+    directory that the shell would helpfully recreate, empty.
+    """
+    grants = {
+        key: base_config[key]
+        for key in ("cwd", "sandbox_volumes")
+        if base_config.get(key)
+    }
+    if isolation == "worktree":
+        grants.pop("cwd", None)
+    return grants
+
+
+# Roots the agent addresses virtually; everything else absolute is a host path.
+_VIRTUAL_PREFIXES = ("/mnt", "/workspace", "/shared", "/persistence", "/uploads")
+
+
+def _is_virtual_address(path: str) -> bool:
+    """True when ``path`` is one the resolver maps rather than a host path."""
+    normalized = path.replace("\\", "/").strip()
+    is_windows_absolute = len(normalized) > 1 and normalized[1] == ":"
+    if is_windows_absolute:
+        return False
+    if not normalized.startswith("/"):
+        return True  # relative to the agent's cwd
+    return any(
+        normalized == prefix or normalized.startswith(f"{prefix}/")
+        for prefix in _VIRTUAL_PREFIXES
+    )
+
+
+def resolve_granted_cwd(parent_chat, path: str) -> Optional[str]:
+    """Resolve a sub-agent's requested cwd against the parent chat's grants.
 
     A sub-agent's cwd comes from the model, and it authorizes that directory for
-    the child's file tools. Bounding it by the parent's own grants keeps a spawn
-    from widening access the user never approved.
+    the child's file tools, so it is bounded by what the parent may already
+    reach. The value is resolved through the parent's PathResolver first: the
+    model addresses directories the way it sees them (``/mnt/data/sub``,
+    ``/workspace/pkg``), and those have to become host paths before either the
+    containment check or the child's own resolver can use them.
+
+    Returns the resolved host path, or None when the parent has no such grant.
     """
     from suzent.config import CONFIG, get_effective_volumes
     from suzent.tools.filesystem.path_resolver import PathResolver
@@ -466,7 +510,18 @@ def grants_cover(parent_chat, path: str) -> bool:
         workspace_root=config.get("workspace_root", CONFIG.workspace_root),
         cwd=inherited_working_directory(parent_chat),
     )
-    return resolver.allows(Path(path))
+    if _is_virtual_address(path):
+        try:
+            resolved = resolver.resolve(path)
+        except ValueError:
+            return None
+    else:
+        # A host path is a grant only when it genuinely sits inside one. Running
+        # it through resolve() would let sandbox mode's virtual mapping turn an
+        # unrecognized path into project_dir/<the whole path> — inside a grant,
+        # but not the directory anyone asked for.
+        resolved = Path(path).expanduser().resolve()
+    return str(resolved) if resolver.allows(resolved) else None
 
 
 async def _run_subagent(
@@ -581,12 +636,16 @@ async def _run_subagent(
             base_config["model"] = task.model_override
         if task.tools_allowed:
             base_config["tools"] = list(task.tools_allowed)
-        if task.cwd and not grants_cover(parent_chat, task.cwd):
-            raise RuntimeError(
-                f"cwd '{task.cwd}' is outside every directory this chat may access. "
-                "A sub-agent cannot be given access its parent does not have — ask "
-                "the user to mount that folder or set it as the working directory."
-            )
+        if task.cwd:
+            granted_cwd = resolve_granted_cwd(parent_chat, task.cwd)
+            if granted_cwd is None:
+                raise RuntimeError(
+                    f"cwd '{task.cwd}' is outside every directory this chat may "
+                    "access. A sub-agent cannot be given access its parent does "
+                    "not have — ask the user to mount that folder or set it as "
+                    "the working directory."
+                )
+            task.cwd = granted_cwd
         subagent_cwd = task.cwd or parent_cwd
         if subagent_cwd:
             base_config["cwd"] = subagent_cwd
@@ -619,15 +678,7 @@ async def _run_subagent(
                 (refreshed.config or {}).get("acp_session_id") if refreshed else None
             )
         else:
-            # Persist the grants (mounted volumes, working directory) on the child
-            # chat. process_turn_text carries them for this turn, but a resumed or
-            # follow-up turn rebuilds deps from the database — without this the
-            # sub-agent loses access to the folder it was spawned to work in.
-            grants = {
-                key: base_config[key]
-                for key in ("cwd", "sandbox_volumes")
-                if base_config.get(key)
-            }
+            grants = persistable_grants(base_config, task.isolation)
             if grants:
                 db.merge_chat_config(task.chat_id, grants)
             config_override = build_agent_config(base_config, require_social_tool=False)

--- a/src/suzent/core/subagent_runner.py
+++ b/src/suzent/core/subagent_runner.py
@@ -435,6 +435,40 @@ def _cancellation_reason(task: SubAgentTask) -> str:
     return "Stopped before it finished (the run was cancelled)"
 
 
+def inherited_working_directory(parent_chat) -> Optional[str]:
+    """The working directory a sub-agent inherits when it isn't pinned elsewhere.
+
+    A sub-agent that isn't given its own cwd works where its parent works.
+    Without this the child fell back to the project directory and every file
+    tool rejected the folder the parent had just been authorized for.
+    """
+    if parent_chat is None:
+        return None
+    return parent_chat.working_directory or (parent_chat.config or {}).get("cwd")
+
+
+def grants_cover(parent_chat, path: str) -> bool:
+    """True when the parent chat is already authorized for ``path``.
+
+    A sub-agent's cwd comes from the model, and it authorizes that directory for
+    the child's file tools. Bounding it by the parent's own grants keeps a spawn
+    from widening access the user never approved.
+    """
+    from suzent.config import CONFIG, get_effective_volumes
+    from suzent.tools.filesystem.path_resolver import PathResolver
+
+    config = (parent_chat.config or {}) if parent_chat else {}
+    resolver = PathResolver(
+        parent_chat.id if parent_chat else "",
+        config.get("sandbox_enabled", CONFIG.sandbox_enabled),
+        sandbox_data_path=CONFIG.sandbox_data_path,
+        custom_volumes=get_effective_volumes(config.get("sandbox_volumes")),
+        workspace_root=config.get("workspace_root", CONFIG.workspace_root),
+        cwd=inherited_working_directory(parent_chat),
+    )
+    return resolver.allows(Path(path))
+
+
 async def _run_subagent(
     task: SubAgentTask,
     wakeup_parent: bool = True,
@@ -524,12 +558,10 @@ async def _run_subagent(
         # Inherit parent chat's custom sandbox volumes so the subagent sees the
         # same custom mounts that were configured for the parent session.
         parent_chat = db.get_chat(task.parent_chat_id)
-        parent_sandbox_volumes = (
-            (parent_chat.config or {}).get("sandbox_volumes") if parent_chat else None
-        )
-        parent_permission_mode = (
-            (parent_chat.config or {}).get("permission_mode") if parent_chat else None
-        )
+        parent_config = (parent_chat.config or {}) if parent_chat else {}
+        parent_sandbox_volumes = parent_config.get("sandbox_volumes")
+        parent_cwd = inherited_working_directory(parent_chat)
+        parent_permission_mode = parent_config.get("permission_mode")
         subagent_permission_mode = (
             parent_permission_mode
             if parent_permission_mode in {"plan", "strict_readonly"}
@@ -549,8 +581,15 @@ async def _run_subagent(
             base_config["model"] = task.model_override
         if task.tools_allowed:
             base_config["tools"] = list(task.tools_allowed)
-        if task.cwd:
-            base_config["cwd"] = task.cwd
+        if task.cwd and not grants_cover(parent_chat, task.cwd):
+            raise RuntimeError(
+                f"cwd '{task.cwd}' is outside every directory this chat may access. "
+                "A sub-agent cannot be given access its parent does not have — ask "
+                "the user to mount that folder or set it as the working directory."
+            )
+        subagent_cwd = task.cwd or parent_cwd
+        if subagent_cwd:
+            base_config["cwd"] = subagent_cwd
 
         child_citation_sources: list[dict] = []
         if task.runtime == "acp":
@@ -561,7 +600,7 @@ async def _run_subagent(
                     "runtime": "acp",
                     "acp_agent_id": task.acp_agent_id,
                     "acp_session_id": task.acp_session_id,
-                    "acp_cwd": task.cwd
+                    "acp_cwd": subagent_cwd
                     or str(
                         Path(CONFIG.sandbox_data_path).resolve()
                         / "projects"
@@ -580,6 +619,17 @@ async def _run_subagent(
                 (refreshed.config or {}).get("acp_session_id") if refreshed else None
             )
         else:
+            # Persist the grants (mounted volumes, working directory) on the child
+            # chat. process_turn_text carries them for this turn, but a resumed or
+            # follow-up turn rebuilds deps from the database — without this the
+            # sub-agent loses access to the folder it was spawned to work in.
+            grants = {
+                key: base_config[key]
+                for key in ("cwd", "sandbox_volumes")
+                if base_config.get(key)
+            }
+            if grants:
+                db.merge_chat_config(task.chat_id, grants)
             config_override = build_agent_config(base_config, require_social_tool=False)
             result_text = await processor.process_turn_text(
                 chat_id=task.chat_id,

--- a/src/suzent/tools/agent_tool.py
+++ b/src/suzent/tools/agent_tool.py
@@ -16,8 +16,10 @@ Tool selection supports three mutually exclusive modes:
 AgentTool is always stripped from the sub-agent's tool set to prevent
 recursive spawning, regardless of which selection mode is used.
 
-The cwd parameter lets you pin the sub-agent's bash working directory to a
-specific path (e.g. a build folder or git worktree).
+The cwd parameter pins the sub-agent's working directory to a specific path
+(e.g. a build folder or git worktree). It governs both shell commands and the
+file tools, and it authorizes that directory for the sub-agent. Omit it and the
+sub-agent inherits the parent chat's working directory.
 """
 
 from typing import Annotated, Literal, Optional
@@ -138,7 +140,11 @@ class AgentTool(Tool):
             Optional[str],
             Field(
                 default=None,
-                description="Optional absolute working directory for bash commands inside the sub-agent.",
+                description=(
+                    "Optional absolute working directory for the sub-agent, governing "
+                    "both shell commands and file tools. Defaults to the parent "
+                    "chat's working directory."
+                ),
             ),
         ] = None,
         model_override: Annotated[
@@ -236,7 +242,7 @@ class AgentTool(Tool):
             tools_denied: Denylist — start from all tools, remove these. Mutually exclusive with tools_allowed.
             run_in_background: True (default) = fire-and-forget, auto-wakeup on completion.
                 False = blocking, result returned inline.
-            cwd: Working directory for bash commands inside the sub-agent.
+            cwd: Working directory for the sub-agent's shell and file tools.
             model_override: Optional enabled model ID for the sub-agent.
             inherit_context: If True, sub-agent receives a snapshot of current conversation history.
             isolation: 'none' (default) or 'worktree' (git-isolated branch).

--- a/src/suzent/tools/filesystem/file_tool_utils.py
+++ b/src/suzent/tools/filesystem/file_tool_utils.py
@@ -23,6 +23,7 @@ def get_or_create_path_resolver(deps: "AgentDeps"):
         sandbox_data_path=CONFIG.sandbox_data_path,
         custom_volumes=deps.custom_volumes,
         workspace_root=deps.workspace_root,
+        cwd=getattr(deps, "cwd", None),
     )
     deps.path_resolver = resolver
     return resolver

--- a/src/suzent/tools/filesystem/glob_tool.py
+++ b/src/suzent/tools/filesystem/glob_tool.py
@@ -11,6 +11,7 @@ from suzent.core.agent_deps import AgentDeps
 from suzent.tools.base import Tool, ToolErrorCode, ToolGroup, ToolResult
 
 from suzent.logger import get_logger
+from suzent.tools.filesystem.file_tool_utils import get_or_create_path_resolver
 from suzent.tools.filesystem.path_resolver import PathResolver
 
 logger = get_logger(__name__)
@@ -59,20 +60,7 @@ class GlobTool(Tool):
             List of matching file paths, or a message if no matches found.
         """
         deps = ctx.deps
-        if deps.path_resolver:
-            self._resolver = deps.path_resolver
-        else:
-            from suzent.tools.filesystem.path_resolver import PathResolver
-            from suzent.config import CONFIG
-
-            self._resolver = PathResolver(
-                deps.chat_id,
-                deps.sandbox_enabled,
-                sandbox_data_path=CONFIG.sandbox_data_path,
-                custom_volumes=deps.custom_volumes,
-                workspace_root=deps.workspace_root,
-            )
-            deps.path_resolver = self._resolver
+        self._resolver = get_or_create_path_resolver(deps)
 
         try:
             # Use unified finder from resolver

--- a/src/suzent/tools/filesystem/grep_tool.py
+++ b/src/suzent/tools/filesystem/grep_tool.py
@@ -16,6 +16,7 @@ from suzent.core.agent_deps import AgentDeps
 from suzent.tools.base import Tool, ToolErrorCode, ToolGroup, ToolResult
 
 from suzent.logger import get_logger
+from suzent.tools.filesystem.file_tool_utils import get_or_create_path_resolver
 from suzent.tools.filesystem.path_resolver import DEFAULT_PRUNED_DIRS, PathResolver
 
 logger = get_logger(__name__)
@@ -101,20 +102,7 @@ class GrepTool(Tool):
             Matching lines grouped by file, or a message if no matches found.
         """
         deps = ctx.deps
-        if deps.path_resolver:
-            self._resolver = deps.path_resolver
-        else:
-            from suzent.tools.filesystem.path_resolver import PathResolver
-            from suzent.config import CONFIG
-
-            self._resolver = PathResolver(
-                deps.chat_id,
-                deps.sandbox_enabled,
-                sandbox_data_path=CONFIG.sandbox_data_path,
-                custom_volumes=deps.custom_volumes,
-                workspace_root=deps.workspace_root,
-            )
-            deps.path_resolver = self._resolver
+        self._resolver = get_or_create_path_resolver(deps)
 
         try:
             # Compile regex

--- a/src/suzent/tools/filesystem/path_resolver.py
+++ b/src/suzent/tools/filesystem/path_resolver.py
@@ -65,6 +65,7 @@ class PathResolver:
         uploads_path: Optional[str] = None,
         custom_volumes: Optional[List[str]] = None,
         workspace_root: Optional[str] = None,
+        cwd: Optional[str] = None,
     ):
         """
         Initialize the path resolver.
@@ -78,6 +79,9 @@ class PathResolver:
             uploads_path: Deprecated; uploads live under the project workspace
             custom_volumes: List of "host:container" volume mapping strings
             workspace_root: Root directory for host mode execution (default: from CONFIG)
+            cwd: The chat's authorized working directory. When set it becomes the
+                agent's cwd and an allowed root, so every file tool reaches the
+                same directory the shell already runs in.
         """
         from suzent.config import CONFIG
 
@@ -90,6 +94,7 @@ class PathResolver:
             uploads_path or CONFIG.sandbox_data_path
         ).resolve()  # Use sandbox path for consistency
         self.workspace_root = Path(workspace_root or CONFIG.workspace_root).resolve()
+        self.cwd = Path(cwd).expanduser().resolve() if cwd else None
         self.custom_mounts: Dict[str, Path] = {}  # container_path -> host_path
 
         # Resolve project slug if not supplied
@@ -219,8 +224,12 @@ class PathResolver:
             logger.warning(f"Could not create directories: {e}")
 
     def get_working_dir(self) -> Path:
-        """Project directory — the agent's cwd, shared across all chats in the project."""
-        return self.project_dir
+        """The agent's cwd: the authorized working directory, else the project directory.
+
+        The project directory is shared across all chats in the project; a chat
+        that was pointed at a specific folder works there instead.
+        """
+        return self.cwd or self.project_dir
 
     def resolve(self, virtual_path: str) -> Path:
         """
@@ -312,7 +321,7 @@ class PathResolver:
           /uploads/*    → project_dir/uploads/* (legacy alias)
           /persistence/* → project_dir/* (legacy alias)
           /mnt/*        → custom mount (must be registered)
-          other paths   → resolved relative to project_dir
+          other paths   → resolved relative to the agent's cwd (get_working_dir)
         """
         if (
             path.startswith("/workspace/")
@@ -352,12 +361,53 @@ class PathResolver:
             rel_path = path.lstrip("/")
             return (self.project_dir / rel_path).resolve()
 
-        # Relative paths are relative to project_dir (the agent's cwd)
-        return (self.project_dir / path).resolve()
+        # Relative paths are relative to the agent's cwd — the chat's working
+        # directory when one is authorized, otherwise the project dir. This is
+        # the same directory the shell tool runs commands in.
+        return (self.get_working_dir() / path).resolve()
+
+    def granted_roots(self, include_workspace: bool = False) -> List[Tuple[str, Path]]:
+        """Every directory this chat is allowed to touch, as (label, path) pairs.
+
+        One list backs both validators and the error messages, so a grant can
+        never apply to some file tools but not others.
+        """
+        roots: List[Tuple[str, Path]] = []
+        if include_workspace:
+            roots.append(("workspace", self.workspace_root))
+        roots.append(("project", self.project_dir))
+        roots.append(("shared", (self.sandbox_data_path / "shared").resolve()))
+        if self.cwd is not None:
+            roots.append(("working directory", self.cwd))
+        for mount_point, host_path in self.custom_mounts.items():
+            roots.append((f"volume {mount_point}", host_path.resolve()))
+        return roots
+
+    @staticmethod
+    def _is_within(resolved: Path, root: Path) -> bool:
+        try:
+            resolved.relative_to(root)
+            return True
+        except ValueError:
+            return False
+
+    def _access_denied_error(self, resolved: Path, summary: str) -> ValueError:
+        """Build a denial that names every grant the chat has and how to add one."""
+        grants = "\n".join(
+            f"  - {label}: {path}"
+            for label, path in self.granted_roots(include_workspace=True)
+        )
+        return ValueError(
+            f"{summary}: '{resolved}'.\n"
+            f"Directories this chat may access:\n{grants}\n"
+            "To work outside them, mount the folder as a custom volume "
+            "(host:/mnt/<name>) or set it as the chat's working directory. "
+            "Neither can be granted by the agent — ask the user to authorize it."
+        )
 
     def _validate_within_workspace(self, resolved: Path) -> Path:
         """
-        Ensure resolved path is within workspace, sandbox-data, or custom volumes.
+        Ensure resolved path is within workspace, sandbox-data, cwd, or custom volumes.
 
         Used for validating absolute host paths in host mode.
 
@@ -370,56 +420,30 @@ class PathResolver:
         Raises:
             ValueError: If path is outside all allowed directories
         """
-        # Check if within workspace
-        try:
-            resolved.relative_to(self.workspace_root)
-            return resolved
-        except ValueError:
-            pass
-
-        # Check if within sandbox data directories (same validation as sandbox mode)
-        allowed_sandbox_roots = [
-            self.project_dir,
-            self.sandbox_data_path / "shared",
-        ]
-        for root in allowed_sandbox_roots:
-            try:
-                resolved.relative_to(root.resolve())
+        for _label, root in self.granted_roots(include_workspace=True):
+            if self._is_within(resolved, root):
                 return resolved
-            except ValueError:
-                continue
 
-        # Check if within any custom volume host path
-        for host_path in self.custom_mounts.values():
-            try:
-                resolved.relative_to(host_path.resolve())
-                return resolved  # Within custom volume
-            except ValueError:
-                continue
-
-        raise ValueError(
-            f"Path '{resolved}' is outside workspace, sandbox-data, and custom volumes. "
-            f"Workspace: {self.workspace_root}, Sandbox: {self.sandbox_data_path}"
+        raise self._access_denied_error(
+            resolved, "Path is outside every directory this chat may access"
         )
 
     def _validate_path(self, resolved: Path) -> None:
-        """Validate that path is within allowed directories."""
-        # Allowed roots: project_dir (covers /workspace and legacy /uploads), shared, custom mounts
-        allowed_roots = [
-            self.project_dir,
-            self.sandbox_data_path / "shared",
-        ]
-        allowed_roots.extend(self.custom_mounts.values())
+        """Validate that a resolved virtual path stayed inside an allowed root."""
+        for _label, root in self.granted_roots():
+            if self._is_within(resolved, root):
+                return
 
-        for root in allowed_roots:
-            try:
-                resolved.relative_to(root.resolve())
-                return  # Path is valid
-            except ValueError:
-                continue
+        raise self._access_denied_error(
+            resolved, "Path traversal detected — resolved outside allowed directories"
+        )
 
-        raise ValueError(
-            f"Path traversal detected: {resolved} is outside allowed directories"
+    def allows(self, path: Path) -> bool:
+        """True when ``path`` falls inside any directory this chat may access."""
+        resolved = Path(path).expanduser().resolve()
+        return any(
+            self._is_within(resolved, root)
+            for _label, root in self.granted_roots(include_workspace=True)
         )
 
     def is_path_allowed(self, path: Path) -> bool:
@@ -586,7 +610,13 @@ class PathResolver:
         # Determine roots to search
         search_roots = []
 
-        if search_path == "/" or (search_path is None and pattern.startswith("/")):
+        if search_path is None and not pattern.startswith("/"):
+            # No root and a relative pattern means "search the working directory",
+            # which is what the glob/grep tools document. Resolving "/" here made
+            # every such search fail in host mode, because the filesystem root is
+            # outside every grant.
+            search_roots = [(None, self.get_working_dir())]
+        elif search_path == "/" or (search_path is None and pattern.startswith("/")):
             # Search all virtual roots
             search_roots = self.get_virtual_roots()
         else:

--- a/src/suzent/tools/filesystem/path_resolver.py
+++ b/src/suzent/tools/filesystem/path_resolver.py
@@ -286,23 +286,30 @@ class PathResolver:
                     f"Path traversal detected in custom volume: {resolved}"
                 )
 
-        # 2. Branch based on sandbox mode for absolute host paths
-        if not self.sandbox_enabled:
-            # HOST MODE: check for absolute host paths first
-            is_windows_absolute = len(virtual_path) > 1 and virtual_path[1] == ":"
-            is_unix_absolute = virtual_path.startswith("/") and not any(
-                virtual_path.startswith(prefix)
-                for prefix in [
-                    "/shared",
-                    "/uploads",
-                    "/mnt",
-                    "/workspace",
-                    "/persistence",
-                ]
-            )
-            if is_windows_absolute or is_unix_absolute:
-                resolved = Path(virtual_path).resolve()
+        # 2. Absolute host paths, i.e. everything that isn't a virtual root.
+        is_windows_absolute = len(virtual_path) > 1 and virtual_path[1] == ":"
+        is_unix_absolute = virtual_path.startswith("/") and not any(
+            virtual_path.startswith(prefix)
+            for prefix in [
+                "/shared",
+                "/uploads",
+                "/mnt",
+                "/workspace",
+                "/persistence",
+            ]
+        )
+        if is_windows_absolute or is_unix_absolute:
+            resolved = Path(virtual_path).resolve()
+            if not self.sandbox_enabled:
                 return self._validate_within_workspace(resolved)
+            # Sandbox mode maps virtual roots, but a directory that was explicitly
+            # granted is addressable by its host path too. Without this the same
+            # folder resolved correctly for a relative path and was silently
+            # rewritten to project_dir/<the whole absolute path> for an absolute
+            # one — a wrong file, with no error. Ungranted host paths still fall
+            # through to the virtual mapping below, so nothing new is reachable.
+            if self.allows(resolved):
+                return resolved
 
         # 3. Resolve virtual paths (same logic for both sandbox and host modes)
         resolved = self._resolve_virtual_path(virtual_path)

--- a/tests/core/test_working_directory_grant.py
+++ b/tests/core/test_working_directory_grant.py
@@ -9,7 +9,11 @@ from types import SimpleNamespace
 
 import pytest
 
-from suzent.core.subagent_runner import grants_cover, inherited_working_directory
+from suzent.core.subagent_runner import (
+    inherited_working_directory,
+    persistable_grants,
+    resolve_granted_cwd,
+)
 
 
 def _build_deps(
@@ -117,15 +121,82 @@ def test_subagent_inherits_the_parent_working_directory(chat, expected):
     assert inherited_working_directory(chat) == expected
 
 
+def _parent_chat(temp_db, tmp_path, target_folder, volumes=None):
+    parent_id = temp_db.create_chat(
+        "parent",
+        config={
+            "sandbox_enabled": False,
+            "workspace_root": str(tmp_path / "workspace"),
+            "sandbox_volumes": volumes or [],
+        },
+    )
+    temp_db.update_chat(parent_id, working_directory=str(target_folder))
+    return temp_db.get_chat(parent_id)
+
+
 def test_a_subagent_cannot_be_pointed_outside_the_parent_grants(
     monkeypatch, temp_db, tmp_path, target_folder
 ):
     # cwd on the spawn tool is model-chosen, so it must not widen access.
     monkeypatch.setattr("suzent.database.get_database", lambda: temp_db)
+    parent = _parent_chat(temp_db, tmp_path, target_folder)
+
+    assert resolve_granted_cwd(parent, str(target_folder / "captions")) == str(
+        (target_folder / "captions").resolve()
+    )
+    assert (
+        resolve_granted_cwd(parent, str(tmp_path / "Documents" / "elsewhere")) is None
+    )
+
+
+def test_a_subagent_may_be_pinned_by_the_virtual_path_it_can_see(
+    monkeypatch, temp_db, tmp_path, target_folder
+):
+    # The model addresses directories as it sees them, so a mounted volume's
+    # virtual path has to resolve to its host path rather than be rejected.
+    monkeypatch.setattr("suzent.database.get_database", lambda: temp_db)
+    volume_root = tmp_path / "Documents" / "library"
+    (volume_root / "pkg").mkdir(parents=True)
+    parent = _parent_chat(
+        temp_db, tmp_path, target_folder, volumes=[f"{volume_root}:/mnt/library"]
+    )
+
+    assert resolve_granted_cwd(parent, "/mnt/library/pkg") == str(
+        (volume_root / "pkg").resolve()
+    )
+    assert resolve_granted_cwd(parent, "/mnt/nothing-mounted") is None
+
+
+def test_grants_are_persisted_so_a_later_turn_keeps_the_folder():
+    config = {"cwd": "/authorized", "sandbox_volumes": ["/host:/mnt/data"]}
+
+    assert persistable_grants(config, None) == config
+
+
+def test_a_disposable_worktree_cwd_is_not_persisted():
+    # The worktree is removed in _run_subagent's finally block, so a resumed turn
+    # would otherwise point at a deleted directory.
+    config = {
+        "cwd": "/repo/.git/worktrees-tmp/subagent-1",
+        "sandbox_volumes": ["/host:/mnt/data"],
+    }
+
+    assert persistable_grants(config, "worktree") == {
+        "sandbox_volumes": ["/host:/mnt/data"]
+    }
+
+
+def test_an_unrecognized_host_path_is_not_laundered_by_virtual_mapping(
+    monkeypatch, temp_db, tmp_path, target_folder
+):
+    # In sandbox mode an unmatched absolute path falls through to
+    # project_dir/<the whole path>, which is inside a grant but is not the
+    # directory that was asked for. It must not count as an authorization.
+    monkeypatch.setattr("suzent.database.get_database", lambda: temp_db)
     parent_id = temp_db.create_chat(
         "parent",
         config={
-            "sandbox_enabled": False,
+            "sandbox_enabled": True,
             "workspace_root": str(tmp_path / "workspace"),
             "sandbox_volumes": [],
         },
@@ -133,5 +204,7 @@ def test_a_subagent_cannot_be_pointed_outside_the_parent_grants(
     temp_db.update_chat(parent_id, working_directory=str(target_folder))
     parent = temp_db.get_chat(parent_id)
 
-    assert grants_cover(parent, str(target_folder / "captions")) is True
-    assert grants_cover(parent, str(tmp_path / "Documents" / "elsewhere")) is False
+    assert resolve_granted_cwd(parent, "/etc") is None
+    assert resolve_granted_cwd(parent, str(target_folder)) == str(
+        target_folder.resolve()
+    )

--- a/tests/core/test_working_directory_grant.py
+++ b/tests/core/test_working_directory_grant.py
@@ -1,0 +1,137 @@
+"""A folder the user authorized stays authorized across turns and sub-agents.
+
+The working directory used to be read only from the request config, so it
+vanished at the next turn boundary, and sub-agents fell back to the project
+directory even when the parent was pinned to the user's folder.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from suzent.core.subagent_runner import grants_cover, inherited_working_directory
+
+
+def _build_deps(
+    monkeypatch,
+    temp_db,
+    tmp_path,
+    *,
+    working_directory=None,
+    chat_config=None,
+    config=None,
+):
+    """Build AgentDeps for a chat persisted with the given grant."""
+    monkeypatch.setattr("suzent.database.get_database", lambda: temp_db)
+    chat_id = temp_db.create_chat("grant test", config=chat_config or {})
+    if working_directory is not None:
+        temp_db.update_chat(chat_id, working_directory=working_directory)
+
+    from suzent.core.context_injection import build_agent_deps
+
+    base = {
+        "sandbox_enabled": False,
+        "workspace_root": str(tmp_path / "workspace"),
+        "sandbox_data_path": str(tmp_path / "sandbox"),
+        "memory_enabled": False,
+    }
+    return build_agent_deps(
+        chat_id=chat_id, user_id="user-1", config={**base, **(config or {})}
+    )
+
+
+@pytest.fixture
+def target_folder(tmp_path):
+    folder = tmp_path / "Documents" / "project" / "assets"
+    (folder / "captions").mkdir(parents=True)
+    return folder
+
+
+def test_working_directory_survives_a_turn_that_omits_it(
+    monkeypatch, temp_db, tmp_path, target_folder
+):
+    deps = _build_deps(
+        monkeypatch, temp_db, tmp_path, working_directory=str(target_folder)
+    )
+
+    assert deps.cwd == str(target_folder)
+    assert deps.path_resolver.get_working_dir() == target_folder.resolve()
+    assert deps.path_resolver.resolve(str(target_folder)) == target_folder.resolve()
+
+
+def test_persisted_chat_config_also_carries_the_grant(
+    monkeypatch, temp_db, tmp_path, target_folder
+):
+    deps = _build_deps(
+        monkeypatch, temp_db, tmp_path, chat_config={"cwd": str(target_folder)}
+    )
+
+    assert deps.path_resolver.get_working_dir() == target_folder.resolve()
+
+
+def test_request_config_still_wins_over_the_persisted_value(
+    monkeypatch, temp_db, tmp_path, target_folder
+):
+    other = tmp_path / "Documents" / "other"
+    other.mkdir(parents=True)
+
+    deps = _build_deps(
+        monkeypatch,
+        temp_db,
+        tmp_path,
+        working_directory=str(other),
+        config={"cwd": str(target_folder)},
+    )
+
+    assert deps.path_resolver.get_working_dir() == target_folder.resolve()
+
+
+def test_no_grant_leaves_the_resolver_on_the_project_dir(
+    monkeypatch, temp_db, tmp_path
+):
+    deps = _build_deps(monkeypatch, temp_db, tmp_path)
+
+    assert deps.cwd is None
+    assert deps.path_resolver.get_working_dir() == deps.path_resolver.project_dir
+
+
+@pytest.mark.parametrize(
+    "chat, expected",
+    [
+        (None, None),
+        (SimpleNamespace(config={}, working_directory=None), None),
+        (SimpleNamespace(config={}, working_directory="/authorized"), "/authorized"),
+        (
+            SimpleNamespace(config={"cwd": "/from-config"}, working_directory=None),
+            "/from-config",
+        ),
+        (
+            SimpleNamespace(
+                config={"cwd": "/from-config"}, working_directory="/column"
+            ),
+            "/column",
+        ),
+    ],
+)
+def test_subagent_inherits_the_parent_working_directory(chat, expected):
+    assert inherited_working_directory(chat) == expected
+
+
+def test_a_subagent_cannot_be_pointed_outside_the_parent_grants(
+    monkeypatch, temp_db, tmp_path, target_folder
+):
+    # cwd on the spawn tool is model-chosen, so it must not widen access.
+    monkeypatch.setattr("suzent.database.get_database", lambda: temp_db)
+    parent_id = temp_db.create_chat(
+        "parent",
+        config={
+            "sandbox_enabled": False,
+            "workspace_root": str(tmp_path / "workspace"),
+            "sandbox_volumes": [],
+        },
+    )
+    temp_db.update_chat(parent_id, working_directory=str(target_folder))
+    parent = temp_db.get_chat(parent_id)
+
+    assert grants_cover(parent, str(target_folder / "captions")) is True
+    assert grants_cover(parent, str(tmp_path / "Documents" / "elsewhere")) is False

--- a/tests/tools/test_path_resolver_working_directory.py
+++ b/tests/tools/test_path_resolver_working_directory.py
@@ -1,0 +1,132 @@
+"""A chat's authorized working directory must reach every file tool.
+
+The shell tool has always executed in ``deps.cwd``; the path resolver did not
+know about it, so the same folder was writable from bash and rejected by read,
+edit, glob and grep.
+"""
+
+import pytest
+
+from suzent.tools.filesystem.path_resolver import PathResolver
+
+
+@pytest.fixture
+def target_folder(tmp_path):
+    folder = tmp_path / "Documents" / "project" / "assets"
+    (folder / "captions").mkdir(parents=True)
+    (folder / "notes.txt").write_text("top level")
+    (folder / "captions" / "a.txt").write_text("nested")
+    return folder
+
+
+def make_resolver(tmp_path, cwd=None, custom_volumes=None):
+    return PathResolver(
+        chat_id="test-chat",
+        sandbox_enabled=False,
+        project_slug="default",
+        sandbox_data_path=str(tmp_path / "sandbox"),
+        workspace_root=str(tmp_path / "workspace"),
+        custom_volumes=custom_volumes,
+        cwd=str(cwd) if cwd else None,
+    )
+
+
+def test_working_directory_is_the_agent_cwd(tmp_path, target_folder):
+    resolver = make_resolver(tmp_path, cwd=target_folder)
+
+    assert resolver.get_working_dir() == target_folder.resolve()
+
+
+def test_project_dir_remains_the_cwd_when_no_folder_is_authorized(tmp_path):
+    resolver = make_resolver(tmp_path)
+
+    assert resolver.get_working_dir() == resolver.project_dir
+
+
+def test_absolute_paths_inside_the_working_directory_resolve(tmp_path, target_folder):
+    resolver = make_resolver(tmp_path, cwd=target_folder)
+
+    assert resolver.resolve(str(target_folder)) == target_folder.resolve()
+    assert (
+        resolver.resolve(str(target_folder / "captions" / "a.txt"))
+        == (target_folder / "captions" / "a.txt").resolve()
+    )
+
+
+def test_relative_paths_resolve_against_the_working_directory(tmp_path, target_folder):
+    resolver = make_resolver(tmp_path, cwd=target_folder)
+
+    assert resolver.resolve("notes.txt") == (target_folder / "notes.txt").resolve()
+
+
+def test_glob_enumerates_the_working_directory_without_an_explicit_root(
+    tmp_path, target_folder
+):
+    resolver = make_resolver(tmp_path, cwd=target_folder)
+
+    found = {host for host, _virtual in resolver.find_files("**/*.txt", None)}
+
+    assert found == {
+        (target_folder / "notes.txt").resolve(),
+        (target_folder / "captions" / "a.txt").resolve(),
+    }
+
+
+def test_glob_enumerates_the_working_directory_by_absolute_root(
+    tmp_path, target_folder
+):
+    resolver = make_resolver(tmp_path, cwd=target_folder)
+
+    found = {
+        host for host, _virtual in resolver.find_files("**/*.txt", str(target_folder))
+    }
+
+    assert len(found) == 2
+
+
+def test_rootless_glob_falls_back_to_the_project_dir_in_host_mode(tmp_path):
+    # Previously this resolved "/" and was denied outright, so a bare
+    # glob_search("**/*.py") failed on the host with an outside-workspace error.
+    resolver = make_resolver(tmp_path)
+    (resolver.project_dir / "module.py").write_text("x = 1")
+
+    found = [host for host, _virtual in resolver.find_files("**/*.py", None)]
+
+    assert found == [(resolver.project_dir / "module.py").resolve()]
+
+
+def test_paths_outside_every_grant_are_still_rejected(tmp_path, target_folder):
+    resolver = make_resolver(tmp_path, cwd=target_folder)
+    sibling = target_folder.parent / "secrets.txt"
+    sibling.write_text("nope")
+
+    with pytest.raises(ValueError):
+        resolver.resolve(str(sibling))
+
+
+def test_denial_names_every_grant_and_a_recovery_action(tmp_path, target_folder):
+    resolver = make_resolver(
+        tmp_path,
+        cwd=target_folder,
+        custom_volumes=[f"{tmp_path / 'shared-notes'}:/mnt/notes"],
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        resolver.resolve(str(tmp_path / "elsewhere" / "file.txt"))
+
+    message = str(excinfo.value)
+    assert str(target_folder.resolve()) in message
+    assert "/mnt/notes" in message
+    assert "custom volume" in message
+
+
+def test_granted_roots_are_shared_by_both_validators(tmp_path, target_folder):
+    resolver = make_resolver(tmp_path, cwd=target_folder)
+    labels = {label for label, _path in resolver.granted_roots()}
+
+    assert "working directory" in labels
+    # The workspace root is only a grant for absolute host paths, so it is opt-in.
+    assert "workspace" not in labels
+    assert "workspace" in {
+        label for label, _path in resolver.granted_roots(include_workspace=True)
+    }

--- a/tests/tools/test_path_resolver_working_directory.py
+++ b/tests/tools/test_path_resolver_working_directory.py
@@ -130,3 +130,41 @@ def test_granted_roots_are_shared_by_both_validators(tmp_path, target_folder):
     assert "workspace" in {
         label for label, _path in resolver.granted_roots(include_workspace=True)
     }
+
+
+def test_sandbox_mode_reaches_granted_directories_by_host_path(tmp_path, target_folder):
+    # Sandbox mode maps virtual roots, but a granted directory must resolve the
+    # same way whichever address is used. Previously an absolute host path was
+    # silently rewritten to project_dir/<the whole path> — a different file, and
+    # no error, because the rewritten path passed validation.
+    resolver = PathResolver(
+        chat_id="test-chat",
+        sandbox_enabled=True,
+        project_slug="default",
+        sandbox_data_path=str(tmp_path / "sandbox"),
+        workspace_root=str(tmp_path / "workspace"),
+        custom_volumes=[f"{target_folder}:/mnt/assets"],
+        cwd=str(target_folder),
+    )
+
+    expected = (target_folder / "notes.txt").resolve()
+    assert resolver.resolve("notes.txt") == expected
+    assert resolver.resolve(str(target_folder / "notes.txt")) == expected
+    assert resolver.resolve("/mnt/assets/notes.txt") == expected
+
+
+def test_sandbox_mode_still_maps_ungranted_absolute_paths_virtually(tmp_path):
+    # Nothing new becomes reachable: an ungranted host path keeps falling
+    # through to the virtual mapping instead of escaping the sandbox roots.
+    resolver = PathResolver(
+        chat_id="test-chat",
+        sandbox_enabled=True,
+        project_slug="default",
+        sandbox_data_path=str(tmp_path / "sandbox"),
+        workspace_root=str(tmp_path / "workspace"),
+    )
+
+    resolved = resolver.resolve("/etc/passwd")
+
+    assert resolved == (resolver.project_dir / "etc" / "passwd").resolve()
+    assert resolver.allows(resolved)


### PR DESCRIPTION
Fixes #149

## The bug

A folder the user authorized behaves differently depending on which tool touches it and which turn you are in: glob enumerates it once, reads work for a while, then the identical absolute path comes back as `is outside workspace, sandbox-data, and custom volumes`. Sub-agents spawned with that folder as `cwd` report the same denial.

## Root causes

**1. The working directory was never a grant.** The shell tool has always resolved its working directory from `deps.cwd` ([`bash_tool.py:712`](src/suzent/tools/shell/bash_tool.py:712)), but `PathResolver` did not know `cwd` existed. Its allowed roots were workspace / project / shared / custom mounts only. So the agent's own cwd was rejected by `read`, `edit`, `write`, `glob` and `grep` — and by bash's *own* path policy, which validates through the same resolver. Relative paths compounded it: they resolved against the project directory while the shell ran commands somewhere else entirely.

**2. The grant expired at a turn boundary.** `build_agent_deps()` read `cwd` only from the request config. `resolve_repository_context()` — resolving the *same* concept — also fell back to `chat.working_directory` and `chat.config["cwd"]`. Clients don't re-send `cwd` every turn, so repository discovery kept finding the folder while the tools silently lost it. That is the "succeeds and fails within one task" in the report.

**3. Sub-agents inherited nothing.** `subagent_runner` set `base_config["cwd"]` for bash and stopped there; the child's file tools stayed pinned to the project directory. A child with no explicit `cwd` didn't inherit the parent's at all, and nothing was persisted on the child chat, so a resumed turn lost it again.

**4. A rootless glob was denied outright in host mode.** `find_files(pattern, None)` fell through to `resolve("/")`. In sandbox mode that maps to the project dir; on the host the filesystem root is outside every grant, so a bare `glob_search("**/*.py")` failed with an outside-workspace error while `glob_search("**/*.py", path="<abs>")` also failed — but with a different message. Rephrasing the call changed the outcome, which is exactly the inconsistency the report describes.

## The fix

`PathResolver` takes a `cwd`. When set it is the agent's working directory (`get_working_dir()`), the base for relative paths, and an allowed root.

`granted_roots()` is now the single list behind `_validate_within_workspace`, `_validate_path` and the error text, so a grant cannot apply to some file tools and not others. Denials name every directory the chat may access and the two concrete ways to add one:

```
Path is outside every directory this chat may access: '/Users/x/Documents/other.txt'.
Directories this chat may access:
  - workspace: /Users/x/.suzent
  - project: /Users/x/.suzent/sandbox/projects/default
  - shared: /Users/x/.suzent/sandbox/shared
  - working directory: /Users/x/Documents/project/assets
To work outside them, mount the folder as a custom volume (host:/mnt/<name>) or
set it as the chat's working directory. Neither can be granted by the agent —
ask the user to authorize it.
```

`build_agent_deps()` falls back to `chat.working_directory` then `chat.config["cwd"]`, matching `resolve_repository_context()` — the grant now outlives the request that created it.

`subagent_runner` inherits the parent's working directory when the task isn't pinned elsewhere, and persists the grants (`cwd`, `sandbox_volumes`) onto the child chat so a resumed turn keeps them. `glob_tool` and `grep_tool` drop their duplicated resolver construction in favour of the shared `get_or_create_path_resolver`, which is how they silently missed `cwd` in the first place.

`find_files(pattern, None)` searches the working directory instead of resolving `/`.

### On the security boundary

`cwd` on `AgentTool` is model-chosen, and it now authorizes a directory rather than only pointing bash at it. So a spawn is bounded by `grants_cover()`: a sub-agent cwd outside the parent's own grants fails the spawn with the message above rather than silently widening access the user never approved. Worktree isolation is unaffected — a worktree lives under its repository, which the parent is already granted.

## Acceptance criteria from the issue

- ✅ Authorize a folder once — `glob`, `read`, `grep`, `edit` and `write` all reach it.
- ✅ Access no longer disappears at a turn boundary.
- ✅ A spawned write agent inherits the folder without a manual copy.
- ✅ Permission failures name the exact missing grant and a concrete recovery action.

Two items from the issue's wish list are deliberately **not** in this PR, as they are UX work rather than this defect: surfacing read-only vs. read-write authorization in the UI, and a one-click "import folder into the workspace / export changes back" flow.

## Testing

- `tests/tools/test_path_resolver_working_directory.py` — 10 tests: cwd as working dir and allowed root, relative resolution, glob with and without an explicit root, the rootless-glob host-mode regression, escapes still rejected, and the denial naming its grants.
- `tests/core/test_working_directory_grant.py` — 10 tests: the turn-boundary fallback (column and config), request config winning, no-grant behaviour unchanged, sub-agent inheritance, and the escalation guard.
- `uv run pytest -m "not sandbox and not integration"` — 1516 passed.
- `ruff check` / `ruff format --check` clean.