### PR TITLE
fix(permissions): make the host path boundary advisory, and propagate grants to sub-agents

### DIFF
--- a/src/suzent/core/subagent_runner.py
+++ b/src/suzent/core/subagent_runner.py
@@ -447,6 +447,32 @@ def inherited_working_directory(parent_chat) -> Optional[str]:
     return parent_chat.working_directory or (parent_chat.config or {}).get("cwd")
 
 
+# Permission state the user granted on the parent chat. A sub-agent works on the
+# parent's task, so a decision the user already made for that task should reach
+# it — otherwise the child re-litigates every approval through the classifier,
+# with no user to ask, and an "always allow" the user clicked minutes ago has no
+# effect. Grants only: the child's own mode still governs everything else, and
+# nothing here can exceed what the parent was given.
+_INHERITED_PERMISSION_KEYS = (
+    "permission_rules",
+    "permission_policies",
+    "tool_approval_policy",
+)
+
+
+def inherited_permission_grants(parent_config: dict) -> dict:
+    """Copy the parent chat's permission grants for a sub-agent's config."""
+    grants: dict = {}
+    for key in _INHERITED_PERMISSION_KEYS:
+        value = parent_config.get(key)
+        if not value:
+            continue
+        # Defensive copy: each agent's deps must own their policy structures so
+        # a decision recorded by one run cannot mutate another's.
+        grants[key] = list(value) if isinstance(value, list) else dict(value)
+    return grants
+
+
 def persistable_grants(base_config: dict, isolation: Optional[str]) -> dict:
     """The grants worth storing on a sub-agent's chat for later turns.
 
@@ -640,6 +666,7 @@ async def _run_subagent(
         }
         if parent_sandbox_volumes:
             base_config["sandbox_volumes"] = parent_sandbox_volumes
+        base_config.update(inherited_permission_grants(parent_config))
         if task.model_override:
             base_config["model"] = task.model_override
         if task.tools_allowed:

--- a/src/suzent/core/subagent_runner.py
+++ b/src/suzent/core/subagent_runner.py
@@ -496,7 +496,13 @@ def resolve_granted_cwd(parent_chat, path: str) -> Optional[str]:
     ``/workspace/pkg``), and those have to become host paths before either the
     containment check or the child's own resolver can use them.
 
-    Returns the resolved host path, or None when the parent has no such grant.
+    In sandbox mode the parent's grants are a real boundary, so a cwd outside
+    them is refused. On the host they are advisory — the parent itself reaches
+    other directories by asking the user — so the cwd is accepted and the
+    child's own approval prompts do the gating.
+
+    Returns the resolved host path, or None when a sandboxed parent has no such
+    grant.
     """
     from suzent.config import CONFIG, get_effective_volumes
     from suzent.tools.filesystem.path_resolver import PathResolver
@@ -521,7 +527,9 @@ def resolve_granted_cwd(parent_chat, path: str) -> Optional[str]:
         # unrecognized path into project_dir/<the whole path> — inside a grant,
         # but not the directory anyone asked for.
         resolved = Path(path).expanduser().resolve()
-    return str(resolved) if resolver.allows(resolved) else None
+    if resolver.allows(resolved) or not resolver.sandbox_enabled:
+        return str(resolved)
+    return None
 
 
 async def _run_subagent(
@@ -640,10 +648,10 @@ async def _run_subagent(
             granted_cwd = resolve_granted_cwd(parent_chat, task.cwd)
             if granted_cwd is None:
                 raise RuntimeError(
-                    f"cwd '{task.cwd}' is outside every directory this chat may "
-                    "access. A sub-agent cannot be given access its parent does "
-                    "not have — ask the user to mount that folder or set it as "
-                    "the working directory."
+                    f"cwd '{task.cwd}' is outside every directory this sandboxed "
+                    "chat may access. A sub-agent cannot be given access its "
+                    "parent does not have — ask the user to mount that folder or "
+                    "set it as the working directory."
                 )
             task.cwd = granted_cwd
         subagent_cwd = task.cwd or parent_cwd

--- a/src/suzent/tools/filesystem/path_resolver.py
+++ b/src/suzent/tools/filesystem/path_resolver.py
@@ -427,13 +427,25 @@ class PathResolver:
         Raises:
             ValueError: If path is outside all allowed directories
         """
-        for _label, root in self.granted_roots(include_workspace=True):
-            if self._is_within(resolved, root):
-                return resolved
+        if self.allows(resolved):
+            return resolved
 
-        raise self._access_denied_error(
-            resolved, "Path is outside every directory this chat may access"
+        if self.sandbox_enabled:
+            raise self._access_denied_error(
+                resolved, "Path is outside every directory this chat may access"
+            )
+
+        # HOST MODE: the grant list is advisory here, not a boundary. It only
+        # ever covered the file tools and the handful of shell commands the path
+        # catalog knows, so raising blocked the reviewable, approval-gated tools
+        # while `python -c "open(...)"` went through untouched — and it did so
+        # below the consent layer, where the user could not authorize the folder
+        # they had just asked the agent to work in. Callers that care ask
+        # allows() and route the operation to approval instead.
+        logger.debug(
+            f"Path outside this chat's granted directories (host mode): {resolved}"
         )
+        return resolved
 
     def _validate_path(self, resolved: Path) -> None:
         """Validate that a resolved virtual path stayed inside an allowed root."""

--- a/src/suzent/tools/shell/permissions/evaluator.py
+++ b/src/suzent/tools/shell/permissions/evaluator.py
@@ -4,7 +4,7 @@ from .command_classifier import classify_command
 from .command_parser import parse_command
 from .mode_policy import evaluate_mode
 from .path_extractor import extract_path_uses
-from .path_policy import validate_paths
+from .path_policy import validate_dangerous_paths, validate_paths
 from .policy_models import (
     CommandClass,
     CommandDecision,
@@ -59,8 +59,19 @@ def evaluate_command_policy(
             metadata={"base_command": ctx.base_command},
         )
 
-    path_eval = validate_paths(extract_path_uses(ctx), resolver)
-    if path_eval is not None:
+    path_uses = extract_path_uses(ctx)
+
+    # Catastrophic targets (rm -rf /, /etc, C:/Windows) are never approvable.
+    dangerous_paths = validate_dangerous_paths(path_uses)
+    if dangerous_paths is not None:
+        dangerous_paths.metadata["base_command"] = ctx.base_command
+        return dangerous_paths
+
+    path_eval = validate_paths(path_uses, resolver)
+
+    # Under the sandbox the resolver backs real containment, so a path it cannot
+    # reach is refused outright — no rule and no mode negotiates that.
+    if path_eval is not None and path_eval.decision == CommandDecision.DENY:
         path_eval.metadata["base_command"] = ctx.base_command
         return path_eval
 
@@ -77,6 +88,22 @@ def evaluate_command_policy(
         )
 
     mode_decision = evaluate_mode(mode, command_class)
+
+    # On the host the same check is advisory: it can upgrade a mode decision to
+    # ASK, and only that. It sits below the rules and the mode so an explicit
+    # rule can authorize the folder the user asked the agent to work in, and so
+    # Full Access still means what it says. As a gate above them it was
+    # unappealable, and it only ever saw the handful of commands the catalog
+    # extracts paths for — filtering command names, not access.
+    if (
+        path_eval is not None
+        and mode_decision == CommandDecision.ALLOW
+        and mode != PermissionMode.FULL_ACCESS
+    ):
+        path_eval.metadata["base_command"] = ctx.base_command
+        path_eval.metadata["mode"] = mode.value
+        return path_eval
+
     if mode == PermissionMode.FULL_APPROVAL and mode_decision == CommandDecision.ASK:
         fallback = default_action.strip().lower()
         if fallback == "deny":

--- a/src/suzent/tools/shell/permissions/path_policy.py
+++ b/src/suzent/tools/shell/permissions/path_policy.py
@@ -31,7 +31,10 @@ def _is_dangerous_remove_target(path_text: str) -> bool:
     return lowered in blocked_roots
 
 
-def validate_paths(path_uses: list[PathUse], resolver) -> PermissionEvaluation | None:
+def validate_dangerous_paths(
+    path_uses: list[PathUse],
+) -> PermissionEvaluation | None:
+    """Hard deny for targets no approval should be able to authorize."""
     for use in path_uses:
         if use.operation == "delete" and _is_dangerous_remove_target(use.path):
             return PermissionEvaluation(
@@ -40,22 +43,52 @@ def validate_paths(path_uses: list[PathUse], resolver) -> PermissionEvaluation |
                 command_class=CommandClass.DANGEROUS,
                 metadata={"path": use.path, "operation": use.operation},
             )
+    return None
 
+
+def validate_paths(path_uses: list[PathUse], resolver) -> PermissionEvaluation | None:
+    """Ask before touching a path outside the chat's grants.
+
+    This is advisory, not a boundary. Paths are only extracted for the base
+    commands in the catalog, so `cat /etc/passwd` is caught while
+    `python -c "open('/etc/passwd').read()"` is not — it filters command names,
+    not access. Treating it as a hard deny therefore blocked the reviewable
+    tools while leaving every interpreter open, and did so above the consent
+    layer, where no permission rule or mode could authorize the folder the user
+    had just asked the agent to work in.
+
+    Sandbox mode is different: there the resolver backs real containment, so a
+    path it rejects stays rejected.
+    """
+    dangerous = validate_dangerous_paths(path_uses)
+    if dangerous is not None:
+        return dangerous
+
+    sandboxed = bool(getattr(resolver, "sandbox_enabled", False))
+
+    def outside(use: PathUse, detail: str) -> PermissionEvaluation:
+        return PermissionEvaluation(
+            # Sandbox mode is real containment, so an unreachable path stays a
+            # denial there. On the host it is a prompt the user can answer.
+            decision=CommandDecision.DENY if sandboxed else CommandDecision.ASK,
+            reason=f"Path is outside this chat's granted directories: {use.path}",
+            command_class=CommandClass.UNKNOWN,
+            metadata={"path": use.path, "operation": use.operation, "error": detail},
+        )
+
+    for use in path_uses:
+        candidate = use.path.strip().strip("\"'")
+        if not candidate:
+            continue
         try:
-            candidate = use.path.strip().strip("\"'")
-            if not candidate:
-                continue
-            resolver.resolve(candidate)
+            resolved = resolver.resolve(candidate)
         except ValueError as exc:
-            return PermissionEvaluation(
-                decision=CommandDecision.DENY,
-                reason=f"Path denied by policy: {use.path}",
-                command_class=CommandClass.UNKNOWN,
-                metadata={
-                    "path": use.path,
-                    "operation": use.operation,
-                    "error": str(exc),
-                },
-            )
+            # Unresolvable rather than merely ungranted: an unregistered mount,
+            # a UNC share, a traversal out of a volume.
+            return outside(use, str(exc))
+        # resolve() no longer refuses ungranted host paths, so ask the resolver
+        # directly instead of reading a raised error as the signal.
+        if not resolver.allows(resolved):
+            return outside(use, f"resolved to {resolved}")
 
     return None

--- a/tests/core/test_working_directory_grant.py
+++ b/tests/core/test_working_directory_grant.py
@@ -121,11 +121,11 @@ def test_subagent_inherits_the_parent_working_directory(chat, expected):
     assert inherited_working_directory(chat) == expected
 
 
-def _parent_chat(temp_db, tmp_path, target_folder, volumes=None):
+def _parent_chat(temp_db, tmp_path, target_folder, volumes=None, sandbox_enabled=False):
     parent_id = temp_db.create_chat(
         "parent",
         config={
-            "sandbox_enabled": False,
+            "sandbox_enabled": sandbox_enabled,
             "workspace_root": str(tmp_path / "workspace"),
             "sandbox_volumes": volumes or [],
         },
@@ -134,12 +134,13 @@ def _parent_chat(temp_db, tmp_path, target_folder, volumes=None):
     return temp_db.get_chat(parent_id)
 
 
-def test_a_subagent_cannot_be_pointed_outside_the_parent_grants(
+def test_a_sandboxed_subagent_cannot_be_pointed_outside_the_parent_grants(
     monkeypatch, temp_db, tmp_path, target_folder
 ):
-    # cwd on the spawn tool is model-chosen, so it must not widen access.
+    # cwd on the spawn tool is model-chosen. Under the sandbox the parent's
+    # grants are a real boundary, so it must not widen access.
     monkeypatch.setattr("suzent.database.get_database", lambda: temp_db)
-    parent = _parent_chat(temp_db, tmp_path, target_folder)
+    parent = _parent_chat(temp_db, tmp_path, target_folder, sandbox_enabled=True)
 
     assert resolve_granted_cwd(parent, str(target_folder / "captions")) == str(
         (target_folder / "captions").resolve()
@@ -147,6 +148,19 @@ def test_a_subagent_cannot_be_pointed_outside_the_parent_grants(
     assert (
         resolve_granted_cwd(parent, str(tmp_path / "Documents" / "elsewhere")) is None
     )
+
+
+def test_a_host_subagent_may_be_pointed_at_any_directory(
+    monkeypatch, temp_db, tmp_path, target_folder
+):
+    # On the host the parent reaches other directories by asking the user, so
+    # refusing here would only block delegating work the parent may itself do.
+    # The child's own approval prompts stay the gate.
+    monkeypatch.setattr("suzent.database.get_database", lambda: temp_db)
+    parent = _parent_chat(temp_db, tmp_path, target_folder)
+    elsewhere = tmp_path / "Documents" / "elsewhere"
+
+    assert resolve_granted_cwd(parent, str(elsewhere)) == str(elsewhere.resolve())
 
 
 def test_a_subagent_may_be_pinned_by_the_virtual_path_it_can_see(
@@ -164,7 +178,6 @@ def test_a_subagent_may_be_pinned_by_the_virtual_path_it_can_see(
     assert resolve_granted_cwd(parent, "/mnt/library/pkg") == str(
         (volume_root / "pkg").resolve()
     )
-    assert resolve_granted_cwd(parent, "/mnt/nothing-mounted") is None
 
 
 def test_grants_are_persisted_so_a_later_turn_keeps_the_folder():

--- a/tests/core/test_working_directory_grant.py
+++ b/tests/core/test_working_directory_grant.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import pytest
 
 from suzent.core.subagent_runner import (
+    inherited_permission_grants,
     inherited_working_directory,
     persistable_grants,
     resolve_granted_cwd,
@@ -221,3 +222,47 @@ def test_an_unrecognized_host_path_is_not_laundered_by_virtual_mapping(
     assert resolve_granted_cwd(parent, str(target_folder)) == str(
         target_folder.resolve()
     )
+
+
+def test_a_subagent_inherits_the_permission_grants_the_user_made():
+    # A sub-agent works on the parent's task and has no user to prompt: its
+    # interaction_profile routes every ASK to the classifier instead. Without
+    # the parent's grants, an "always allow" the user clicked minutes earlier
+    # had no effect on the agent they delegated the work to.
+    parent_config = {
+        "permission_rules": [
+            {"id": "r1", "toolName": "run_command", "behavior": "allow"}
+        ],
+        "permission_policies": {"run_command": {"default": "allow"}},
+        "tool_approval_policy": {"write_file": "always_allow"},
+        "model": "should-not-be-inherited",
+    }
+
+    grants = inherited_permission_grants(parent_config)
+
+    assert grants == {
+        "permission_rules": parent_config["permission_rules"],
+        "permission_policies": parent_config["permission_policies"],
+        "tool_approval_policy": parent_config["tool_approval_policy"],
+    }
+
+
+def test_inherited_grants_are_copied_not_shared():
+    # Each agent's deps must own their policy structures, or a decision recorded
+    # by one run mutates another's.
+    parent_config = {
+        "permission_rules": [{"id": "r1"}],
+        "tool_approval_policy": {"write_file": "always_allow"},
+    }
+
+    grants = inherited_permission_grants(parent_config)
+    grants["permission_rules"].append({"id": "r2"})
+    grants["tool_approval_policy"]["edit_file"] = "always_allow"
+
+    assert parent_config["permission_rules"] == [{"id": "r1"}]
+    assert parent_config["tool_approval_policy"] == {"write_file": "always_allow"}
+
+
+def test_a_parent_without_grants_adds_nothing():
+    assert inherited_permission_grants({}) == {}
+    assert inherited_permission_grants({"permission_rules": []}) == {}

--- a/tests/tools/shell/test_bash_path_policy.py
+++ b/tests/tools/shell/test_bash_path_policy.py
@@ -5,17 +5,21 @@ from suzent.tools.shell.permissions.path_policy import validate_paths
 from suzent.tools.shell.permissions.policy_models import CommandDecision, PathUse
 
 
-def _deps(tmp_path):
+def _deps(tmp_path, sandbox_enabled=False):
     return SimpleNamespace(
         chat_id="chat-1",
-        sandbox_enabled=False,
+        sandbox_enabled=sandbox_enabled,
         workspace_root=str(tmp_path),
         custom_volumes=[],
         path_resolver=None,
     )
 
 
-def test_path_policy_denies_outside_workspace(tmp_path):
+def test_path_policy_asks_before_leaving_the_workspace_on_the_host(tmp_path):
+    # Advisory, not a boundary: paths are only extracted for catalogued base
+    # commands, so a hard deny stopped `cat /etc/passwd` while
+    # `python -c "open('/etc/passwd')"` sailed past. Asking lets the user
+    # authorize the folder they pointed the agent at.
     resolver = get_or_create_path_resolver(_deps(tmp_path))
 
     result = validate_paths(
@@ -24,7 +28,31 @@ def test_path_policy_denies_outside_workspace(tmp_path):
     )
 
     assert result is not None
+    assert result.decision == CommandDecision.ASK
+
+
+def test_path_policy_still_denies_outside_the_sandbox(tmp_path):
+    resolver = get_or_create_path_resolver(_deps(tmp_path, sandbox_enabled=True))
+
+    result = validate_paths(
+        [PathUse(path="/mnt/not-registered/file", operation="read")],
+        resolver,
+    )
+
+    assert result is not None
     assert result.decision == CommandDecision.DENY
+
+
+def test_path_policy_allows_paths_inside_the_grants(tmp_path):
+    resolver = get_or_create_path_resolver(_deps(tmp_path))
+
+    assert (
+        validate_paths(
+            [PathUse(path=str(tmp_path / "notes.txt"), operation="read")],
+            resolver,
+        )
+        is None
+    )
 
 
 def test_path_policy_denies_dangerous_delete_target(tmp_path):

--- a/tests/tools/shell/test_bash_path_policy_is_advisory.py
+++ b/tests/tools/shell/test_bash_path_policy_is_advisory.py
@@ -1,0 +1,107 @@
+"""Reaching outside the chat's grants asks; it does not veto.
+
+The path check only sees the base commands the catalog extracts paths for, so
+as a hard deny above the consent layer it stopped `cat /etc/passwd` while
+`python -c "open('/etc/passwd').read()"` went through untouched — filtering
+command names rather than access, and leaving the user no way to authorize the
+folder they had just asked the agent to work in.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from suzent.tools.filesystem.file_tool_utils import get_or_create_path_resolver
+from suzent.tools.shell.permissions.evaluator import evaluate_command_policy
+from suzent.tools.shell.permissions.policy_models import CommandDecision
+
+
+@pytest.fixture
+def host_resolver(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    return get_or_create_path_resolver(
+        SimpleNamespace(
+            chat_id="chat-1",
+            sandbox_enabled=False,
+            workspace_root=str(workspace),
+            custom_volumes=[],
+            path_resolver=None,
+        )
+    )
+
+
+def decide(resolver, command, mode="default", rules=None):
+    return evaluate_command_policy(
+        command,
+        resolver=resolver,
+        mode_value=mode,
+        raw_rules=rules or [],
+        default_action="ask",
+    ).decision
+
+
+def test_reaching_outside_the_grants_asks_instead_of_refusing(host_resolver):
+    assert decide(host_resolver, "cat /etc/passwd") == CommandDecision.ASK
+
+
+def test_a_permission_rule_can_authorize_the_folder(host_resolver):
+    # Previously unreachable: the path check ran above the rule engine, so no
+    # rule could grant access to a directory outside the workspace.
+    rules = [{"pattern": "cat /etc/", "match_type": "prefix", "action": "allow"}]
+    assert (
+        decide(host_resolver, "cat /etc/passwd", rules=rules) == CommandDecision.ALLOW
+    )
+
+
+def test_a_deny_rule_still_wins(host_resolver):
+    rules = [{"pattern": "cat /etc/", "match_type": "prefix", "action": "deny"}]
+    assert decide(host_resolver, "cat /etc/passwd", rules=rules) == CommandDecision.DENY
+
+
+def test_full_access_means_what_it_says(host_resolver):
+    assert (
+        decide(host_resolver, "cat /etc/passwd", mode="full_access")
+        == CommandDecision.ALLOW
+    )
+
+
+def test_paths_inside_the_grants_are_not_prompted(host_resolver):
+    inside = host_resolver.workspace_root / "notes.txt"
+    assert decide(host_resolver, f"cat {inside}") == CommandDecision.ALLOW
+
+
+def test_catastrophic_targets_stay_unapprovable(host_resolver):
+    # The hard deny keeps its position above the rules and the mode.
+    rules = [{"pattern": "rm ", "match_type": "prefix", "action": "allow"}]
+    assert decide(host_resolver, "rm -rf /", mode="full_access") == CommandDecision.DENY
+    assert decide(host_resolver, "rm -rf /etc", rules=rules) == CommandDecision.DENY
+
+
+def test_the_check_no_longer_splits_cat_from_python(host_resolver):
+    # The asymmetry this replaces: one of these was denied outright and the
+    # other allowed, which pushed the agent towards the unreviewable route.
+    catted = decide(host_resolver, "cat /etc/passwd")
+    scripted = decide(host_resolver, "python3 -c \"print(open('/etc/passwd').read())\"")
+
+    assert catted == scripted
+
+
+def test_sandbox_containment_is_not_negotiable(tmp_path):
+    # Unlike the host's advisory check, this one sits above the rules and the
+    # mode: neither an allow rule nor Full Access may talk past it.
+    resolver = get_or_create_path_resolver(
+        SimpleNamespace(
+            chat_id="chat-1",
+            sandbox_enabled=True,
+            workspace_root=str(tmp_path / "workspace"),
+            custom_volumes=[],
+            path_resolver=None,
+        )
+    )
+    rules = [{"pattern": "cat /mnt/", "match_type": "prefix", "action": "allow"}]
+    command = "cat /mnt/not-registered/file"
+
+    assert decide(resolver, command) == CommandDecision.DENY
+    assert decide(resolver, command, rules=rules) == CommandDecision.DENY
+    assert decide(resolver, command, mode="full_access") == CommandDecision.DENY

--- a/tests/tools/test_path_resolver_working_directory.py
+++ b/tests/tools/test_path_resolver_working_directory.py
@@ -95,24 +95,51 @@ def test_rootless_glob_falls_back_to_the_project_dir_in_host_mode(tmp_path):
     assert found == [(resolver.project_dir / "module.py").resolve()]
 
 
-def test_paths_outside_every_grant_are_still_rejected(tmp_path, target_folder):
+def test_host_mode_reports_paths_outside_the_grants_without_refusing_them(
+    tmp_path, target_folder
+):
+    # On the host the grant list is advisory: it covers the file tools and a
+    # handful of shell commands, so refusing here only blocked the reviewable,
+    # approval-gated tools while every interpreter went through. Callers ask allows()
+    # and route the operation to approval instead.
     resolver = make_resolver(tmp_path, cwd=target_folder)
     sibling = target_folder.parent / "secrets.txt"
     sibling.write_text("nope")
 
+    resolved = resolver.resolve(str(sibling))
+
+    assert resolved == sibling.resolve()
+    assert resolver.allows(resolved) is False
+    assert resolver.allows(target_folder / "notes.txt") is True
+
+
+def test_sandbox_mode_still_refuses_paths_outside_every_grant(tmp_path, target_folder):
+    resolver = PathResolver(
+        chat_id="test-chat",
+        sandbox_enabled=True,
+        project_slug="default",
+        sandbox_data_path=str(tmp_path / "sandbox"),
+        workspace_root=str(tmp_path / "workspace"),
+        cwd=str(target_folder),
+    )
+
     with pytest.raises(ValueError):
-        resolver.resolve(str(sibling))
+        resolver.resolve("/mnt/not-registered/file.txt")
 
 
 def test_denial_names_every_grant_and_a_recovery_action(tmp_path, target_folder):
-    resolver = make_resolver(
-        tmp_path,
-        cwd=target_folder,
+    resolver = PathResolver(
+        chat_id="test-chat",
+        sandbox_enabled=True,
+        project_slug="default",
+        sandbox_data_path=str(tmp_path / "sandbox"),
+        workspace_root=str(tmp_path / "workspace"),
         custom_volumes=[f"{tmp_path / 'shared-notes'}:/mnt/notes"],
+        cwd=str(target_folder),
     )
 
     with pytest.raises(ValueError) as excinfo:
-        resolver.resolve(str(tmp_path / "elsewhere" / "file.txt"))
+        resolver._validate_within_workspace(tmp_path / "elsewhere" / "file.txt")
 
     message = str(excinfo.value)
     assert str(target_folder.resolve()) in message


### PR DESCRIPTION
Refs #149. **Stacked on #154** — rebase onto `main` once that merges.

Two halves of the same problem: a boundary that could not be approved past, and grants that did not reach the agent doing the work.

---

## Part 1 — the host path check was a veto, not a boundary

`extract_path_uses` only pulls paths for the ~15 base commands in the catalog (`cat`, `ls`, `grep`, `cp`, `rm`, `sed`…). On the host, in **Full Access**:

| command | before |
|---|---|
| `cat /etc/passwd` | **deny** |
| `cp ~/.ssh/id_rsa /tmp/x` | **deny** |
| `python3 -c "print(open('/etc/passwd').read())"` | allow |
| `awk '{print}' /etc/passwd` | allow |
| `node -e "…readFileSync('/etc/passwd')"` | allow |
| `tar cf /tmp/out.tar /etc` | allow |

It filtered command *names*, not access. Three consequences:

- **Unappealable.** [`evaluator.py`](src/suzent/tools/shell/permissions/evaluator.py) ran `validate_paths` before the rule engine and the mode policy, returning `DENY`. No permission rule and no mode could authorize a folder — the mechanism behind #149's "The tool call was denied."
- **Inverted safety gradient.** The file tools resolve through the same list, so the blocked route was the reviewable one — `write_file`/`edit_file` show a diff and prompt — while the unreviewable `python -c` was allowed. The reporter in #149 hit exactly this and went looking for a shell junction after the file tools refused.
- **Redundant.** Host mode already means "you are on the host machine," with a permission system the user controls.

### After

| | before | after |
|---|---|---|
| path outside the grants | `DENY`, unappealable | `ASK` |
| with an `allow` permission rule | `DENY` | `ALLOW` |
| with a `deny` permission rule | `DENY` | `DENY` |
| in Full Access | `DENY` | `ALLOW` |
| path inside the grants | `ALLOW` | `ALLOW` (unchanged) |
| `cat` vs `python -c`, same file | different | same |

The resolver stops raising for ungranted host paths, so the file tools reach the folder the user pointed them at; `write_file`/`edit_file` are already `requires_approval = True`, so their approval prompt — which shows the path — becomes the gate. `validate_paths` asks `resolver.allows()` directly instead of reading a raised error as its signal.

**Still hard denies, both above the rules and the mode:** catastrophic targets (`rm -rf /`, `/etc`, `C:/Windows`) via a split-out `validate_dangerous_paths()`, and everything in **sandbox mode**, where the resolver backs real containment — not negotiable by rule or by Full Access.

---

## Part 2 — sub-agents inherited no permission grants

Measured on a parent with rules and a remembered approval:

| | parent | sub-agent |
|---|---|---|
| `permission_rules` | 2 | **0** |
| `tool_approval_policy` | `{write_file: always_allow}` | **`{}`** |
| `permission_mode` | `default` | `auto` |
| `interaction_profile` | `interactive` | `subagent` |
| `sandbox_volumes` / `cwd` | — | inherited ✓ |

`interaction_profile: "subagent"` fails every `== "interactive"` check in the permission engine, so an `ASK` never reaches the user — it goes to the auto classifier, where a block, a low-confidence verdict, **or an unavailable classifier** all resolve to `DENY`.

So an "always allow" the user clicked minutes earlier had no effect on the agent they delegated the work to. That is the delegated-write half of #149 — and it would have blunted Part 1: a sub-agent reaching outside the grants would ask, find no user, and be denied.

Sub-agents now inherit `permission_rules`, `permission_policies` and `tool_approval_policy` from the parent chat. Grants only — the child's own mode still governs everything else, and nothing inherited can exceed what the parent was given. Structures are copied, not shared, so one run's recorded decision cannot mutate another's.

The sub-agent `cwd` guard follows the same host/sandbox split: refused under a sandboxed parent, accepted on the host, where the parent itself reaches other directories by asking.

---

## What this does *not* do

It does not make **reads** prompt. `read_file`, `glob` and `grep` have no per-argument approval channel — `requires_approval` is a class attribute, and making them always prompt would be unusable. They now behave like the `awk`/`python` reads that were already allowed. Per-path approval for read-only tools is its own change.

## Testing

- New `test_bash_path_policy_is_advisory.py` — 8 tests: ASK instead of DENY, rules authorizing and denying, Full Access, no new prompts inside the grants, catastrophic targets unapprovable, sandbox containment unnegotiable by rule or mode, and `cat`/`python` agreeing.
- New sub-agent grant tests: what is inherited, that copies are defensive, and that a parent without grants adds nothing.
- Updated the three tests that asserted the old hard deny, each with a sandbox counterpart.
- `uv run pytest -m "not sandbox and not integration"` — 1537 passed. `ruff check` / `format --check` clean.