### PR TITLE
fix(subagents): stop a rejected spawn from rendering as done

### DIFF
--- a/frontend/src/components/chat/subAgentResult.test.ts
+++ b/frontend/src/components/chat/subAgentResult.test.ts
@@ -115,3 +115,61 @@ describe('parseSubAgentResult — agent identity', () => {
     });
   });
 });
+
+describe('a call that never spawned anything', () => {
+  it('reads a rejected spawn as failed, not done', () => {
+    // The caller treats any output as success, so without this an `agent` call
+    // rejected for a bad subagent_type rendered DONE beside the real ones.
+    const info = parseSubAgentResult(
+      JSON.stringify({
+        success: false,
+        message: "Unknown subagent_type 'general'. Available: explore, plan, verify, web, write",
+        error_code: 'invalid_argument',
+        metadata: {},
+      })
+    );
+
+    expect(info.status).toBe('failed');
+    expect(info.error).toContain("Unknown subagent_type 'general'");
+    expect(info.taskId).toBeUndefined();
+  });
+
+  it('carries the reason through for an unrecognized tool list', () => {
+    const info = parseSubAgentResult(
+      JSON.stringify({
+        success: false,
+        message: 'None of the provided tool names were recognized.',
+        metadata: { unrecognized_tools: ['NopeTool'] },
+      })
+    );
+
+    expect(info.status).toBe('failed');
+    expect(info.error).toBe('None of the provided tool names were recognized.');
+  });
+
+  it('leaves a timed-out call reporting running, since its child may still be', () => {
+    const info = parseSubAgentResult(
+      JSON.stringify({
+        success: false,
+        message: 'Tool execution timed out after 60s.',
+        metadata: { task_id: 'sub_abc123', status: 'running' },
+      })
+    );
+
+    expect(info.status).toBe('running');
+    expect(info.taskId).toBe('sub_abc123');
+  });
+
+  it('leaves a successful spawn alone', () => {
+    const info = parseSubAgentResult(
+      JSON.stringify({
+        success: true,
+        message: 'Sub-agent spawned (ID: sub_abc123).',
+        metadata: { task_id: 'sub_abc123', status: 'queued' },
+      })
+    );
+
+    expect(info.status).toBe('queued');
+    expect(info.error).toBeUndefined();
+  });
+});

--- a/frontend/src/components/chat/subAgentResult.ts
+++ b/frontend/src/components/chat/subAgentResult.ts
@@ -36,15 +36,25 @@ export function parseSubAgentResult(output: string | undefined): SubAgentResultI
 
   if (trimmed.startsWith('{')) {
     try {
-      const metadata = JSON.parse(trimmed)?.metadata;
+      const envelope = JSON.parse(trimmed);
+      const metadata = envelope?.metadata;
       if (metadata && typeof metadata === 'object') {
         const status = metadata.status;
+        // A call that never spawned anything — an unknown subagent_type, an
+        // unrecognized tool list — comes back as a failure envelope with an
+        // empty metadata object. Reading metadata alone found no status, and
+        // the caller's fallback treats any output at all as success, so a
+        // rejected call rendered as DONE beside the ones that really ran.
+        // `metadata.status` still wins where it exists: a timed-out call
+        // deliberately reports 'running', because its sub-agent may well be.
+        const failed = envelope?.success === false;
+        const message = typeof envelope?.message === 'string' ? envelope.message : undefined;
         return {
           taskId: typeof metadata.task_id === 'string' ? metadata.task_id : undefined,
-          status: SUB_AGENT_STATUSES.has(status) ? status : undefined,
+          status: SUB_AGENT_STATUSES.has(status) ? status : failed ? 'failed' : undefined,
           resultSummary:
             typeof metadata.result_summary === 'string' ? metadata.result_summary : undefined,
-          error: typeof metadata.error === 'string' ? metadata.error : undefined,
+          error: typeof metadata.error === 'string' ? metadata.error : failed ? message : undefined,
           model: typeof metadata.model_override === 'string' ? metadata.model_override : undefined,
           subagentType:
             typeof metadata.subagent_type === 'string' ? metadata.subagent_type : undefined,


### PR DESCRIPTION
An `agent` call that never spawned anything showed **DONE** in the transcript, beside the calls that really ran.

Observed: a turn where the model tried `subagent_type: 'general'`, was rejected twice, retried without it, and succeeded once. The transcript showed three delegated tasks, all marked DONE — reading as three sub-agents having completed when one had.

## Cause

A rejected call returns a failure envelope with an **empty** metadata object:

```json
{"success": false, "message": "Unknown subagent_type 'general'. Available: …", "metadata": {}}
```

`parseSubAgentResult` read `metadata` alone. An empty object is still an object, so it took that branch and returned every field as `undefined` — including `status`. The caller then falls back to `persisted.status ?? (b.content ? 'completed' : 'running')`, and a rejection *is* output, so it resolved to `completed`.

## Fix

Read `success` from the envelope as well, and carry `message` through as the error.

`metadata.status` still takes precedence where it exists — deliberately, so the tool-timeout envelope keeps reporting `running`. That envelope is `success: false` but its sub-agent may well still be going, which is the entire reason it carries a non-terminal status.

## Testing

4 new cases: a rejected subagent_type, an unrecognized tool list, the timed-out envelope keeping `running`, and a successful spawn unaffected. 309 frontend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)