### PR TITLE
fix(memory): resolve core memory per request instead of per agent build

### DIFF
--- a/src/suzent/agent_manager.py
+++ b/src/suzent/agent_manager.py
@@ -31,9 +31,6 @@ from suzent.prompts import (
 from suzent.skills import get_skill_manager
 
 # Import memory lifecycle functions (for backward compatibility re-exports)
-from suzent.memory.lifecycle import (
-    get_memory_manager,
-)
 
 # Suppress LiteLLM's verbose logging
 os.environ["LITELLM_LOG"] = "ERROR"
@@ -228,9 +225,7 @@ def _is_transient_stdio_error(message: str) -> bool:
     )
 
 
-def create_agent(
-    config: Dict[str, Any], memory_context: Optional[str] = None
-) -> Agent[AgentDeps, str]:
+def create_agent(config: Dict[str, Any]) -> Agent[AgentDeps, str]:
     """
     Creates a pydantic-ai Agent based on the provided configuration.
 
@@ -404,7 +399,6 @@ def create_agent(
     register_dynamic_instructions(
         agent,
         base_instructions=base_instructions,
-        memory_context=memory_context,
         session_guidance_items=session_guidance_items,
         enabled_model_ids=enabled_models,
         current_model_id=model_id,
@@ -500,38 +494,12 @@ async def get_or_create_agent(config: Dict[str, Any], reset: bool = False) -> Ag
             logger.info("Config changed - creating new agent")
 
         if agent_instance is None or config_changed or reset:
-            # Fetch memory context if memory system is enabled
-            memory_context = None
-            memory_enabled = config.get("memory_enabled", False)
-            mem_manager = get_memory_manager()
-            if mem_manager and memory_enabled:
-                chat_id = config.get("_chat_id")
-                user_id = config.get("_user_id", "default-user")
-                sandbox_enabled = config.get("sandbox_enabled", CONFIG.sandbox_enabled)
-                try:
-                    from suzent.tools.filesystem.path_resolver import PathResolver
-                    from suzent.config import get_effective_volumes
-
-                    _path_resolver = PathResolver(
-                        chat_id=chat_id or "default",
-                        sandbox_enabled=sandbox_enabled,
-                        custom_volumes=get_effective_volumes(
-                            config.get("sandbox_volumes")
-                        ),
-                    )
-                    memory_context = await mem_manager.format_core_memory_for_context(
-                        chat_id=chat_id,
-                        user_id=user_id,
-                        sandbox_enabled=sandbox_enabled,
-                        path_resolver=_path_resolver,
-                    )
-                    if memory_context:
-                        logger.debug(f"Fetched core memory context for user={user_id}")
-                except Exception as e:
-                    logger.error(f"Error fetching memory context: {e}")
-                    memory_context = None
-
-            agent_instance = create_agent(config, memory_context=memory_context)
+            # No core-memory prefetch here on purpose. The agent is cached and
+            # reused across chats and users, so anything captured now would be
+            # served to whoever the agent is reused for next. Core memory is
+            # resolved per run from ctx.deps instead — see
+            # prompts.inject_memory_context.
+            agent_instance = create_agent(config)
             agent_config = config
 
         return agent_instance

--- a/src/suzent/agent_manager.py
+++ b/src/suzent/agent_manager.py
@@ -464,6 +464,18 @@ def build_agent_config(
     return config
 
 
+# Config keys that must NOT take part in the agent cache key.
+#
+# Everything else does, which is what keeps one project's repository
+# instructions out of another's: `_project_context_dir` / `_working_context_dir`
+# are set per request in chat_processor and deliberately left in the stable
+# config. Adding either of them here would reintroduce cross-project bleed.
+#
+# `_chat_id` / `_user_id` are safe to exclude only because every scoped section
+# is now resolved per run from `ctx.deps` rather than captured at construction.
+_TRANSIENT_KEYS = {"_runtime", "_chat_id", "_user_id"}
+
+
 async def get_or_create_agent(config: Dict[str, Any], reset: bool = False) -> Agent:
     """
     Get the current agent instance or create a new one if needed.
@@ -476,8 +488,6 @@ async def get_or_create_agent(config: Dict[str, Any], reset: bool = False) -> Ag
         pydantic-ai Agent instance ready for use.
     """
     global agent_instance, agent_config
-
-    _TRANSIENT_KEYS = {"_runtime", "_chat_id", "_user_id"}
 
     def _stable_config(cfg: dict) -> dict:
         return {k: v for k, v in cfg.items() if k not in _TRANSIENT_KEYS}

--- a/src/suzent/memory/manager.py
+++ b/src/suzent/memory/manager.py
@@ -2,6 +2,7 @@
 Memory Manager - orchestrates core and archival memory operations.
 """
 
+from collections import OrderedDict
 from typing import Dict, List, Any, Optional, Union, TYPE_CHECKING
 from datetime import datetime, timezone
 
@@ -48,6 +49,10 @@ KNOWN_FACTS_QUERY_CHARS = 2000
 # record the write path can defer to.
 DURABLE_SOURCE_TYPES = frozenset({"notebook", "archive_log"})
 
+# Rendered core-memory prompts retained at once. Comfortably above the number of
+# chats one service handles concurrently, while keeping the ceiling explicit.
+CORE_MEMORY_CACHE_MAXSIZE = 256
+
 
 class MemoryManager:
     """Central memory management service.
@@ -78,9 +83,13 @@ class MemoryManager:
         """
         self.store = store
         self.markdown_store = markdown_store
-        # (chat_id, user_id, sandbox_enabled) -> (revision, rendered section).
-        # Bounded by the number of live chats; entries are tiny strings.
-        self._core_memory_cache: Dict[tuple, tuple] = {}
+        # (chat_id, user_id, sandbox_enabled, *resolver paths) -> (revision, text).
+        # An LRU, not a plain dict: keys outlive the thing they describe. Deleted
+        # chats leave entries behind, and a chat that changes its cwd or notebook
+        # mount strands its previous key forever, so in a long-running service the
+        # footprint would track historical chat/path combinations rather than live
+        # ones. Each entry holds a full rendered prompt, so that adds up.
+        self._core_memory_cache: "OrderedDict[tuple, tuple]" = OrderedDict()
         self.embedding_gen = EmbeddingGenerator(
             model=embedding_model, dimension=embedding_dimension
         )
@@ -416,6 +425,7 @@ class MemoryManager:
         if revision is not None:
             cached = self._core_memory_cache.get(key)
             if cached is not None and cached[0] == revision:
+                self._core_memory_cache.move_to_end(key)
                 return cached[1]
 
         rendered = await self.format_core_memory_for_context(
@@ -429,6 +439,9 @@ class MemoryManager:
         # a chat with no core memory until some unrelated file happens to change.
         if revision is not None and rendered:
             self._core_memory_cache[key] = (revision, rendered)
+            self._core_memory_cache.move_to_end(key)
+            while len(self._core_memory_cache) > CORE_MEMORY_CACHE_MAXSIZE:
+                self._core_memory_cache.popitem(last=False)
         return rendered
 
     def _log_recalls(self, memories: List[Dict[str, Any]]) -> None:

--- a/src/suzent/memory/manager.py
+++ b/src/suzent/memory/manager.py
@@ -325,6 +325,28 @@ class MemoryManager:
         except Exception as e:
             logger.error(f"promote_memory_md failed: {e}")
 
+    @staticmethod
+    def _resolver_paths(sandbox_enabled: bool, path_resolver) -> tuple:
+        """Paths the core-memory section renders, as the resolver sees them now.
+
+        Host mode bakes the working directory and notebook mount into the prompt,
+        so these are part of the section's identity, not incidental formatting: a
+        chat that changes its authorized cwd renders different text from the very
+        same memory files.
+        """
+        if sandbox_enabled or path_resolver is None:
+            return (None, None, "/workspace/context.md" if sandbox_enabled else None)
+
+        shared_path = str(path_resolver.sandbox_data_path / "shared").replace("\\", "/")
+        mount_notebook = (
+            str(path_resolver.custom_mounts.get("/mnt/notebook", "")).replace("\\", "/")
+            or None
+        )
+        project_context_path = str(
+            path_resolver.get_working_dir() / "context.md"
+        ).replace("\\", "/")
+        return (shared_path, mount_notebook, project_context_path)
+
     async def format_core_memory_for_context(
         self,
         chat_id: Optional[str] = None,
@@ -339,22 +361,9 @@ class MemoryManager:
             logger.error(f"Error getting core memory blocks: {e}")
             return ""
 
-        shared_path = None
-        mount_notebook = None
-        project_context_path = "/workspace/context.md" if sandbox_enabled else None
-        if not sandbox_enabled and path_resolver is not None:
-            shared_path = str(path_resolver.sandbox_data_path / "shared").replace(
-                "\\", "/"
-            )
-            mount_notebook = (
-                str(path_resolver.custom_mounts.get("/mnt/notebook", "")).replace(
-                    "\\", "/"
-                )
-                or None
-            )
-            project_context_path = str(
-                path_resolver.get_working_dir() / "context.md"
-            ).replace("\\", "/")
+        shared_path, mount_notebook, project_context_path = self._resolver_paths(
+            sandbox_enabled, path_resolver
+        )
 
         return memory_context.format_core_memory_section(
             blocks,
@@ -392,7 +401,12 @@ class MemoryManager:
                 path_resolver=path_resolver,
             )
 
-        key = (chat_id, user_id, sandbox_enabled)
+        # Host mode renders the working directory and notebook mount into the
+        # section, so a chat that changes its authorized cwd must not be served
+        # the previous paths just because the memory files are untouched.
+        key = (chat_id, user_id, sandbox_enabled) + self._resolver_paths(
+            sandbox_enabled, path_resolver
+        )
         try:
             revision = store.core_memory_revision(chat_id)
         except Exception as e:
@@ -410,7 +424,10 @@ class MemoryManager:
             sandbox_enabled=sandbox_enabled,
             path_resolver=path_resolver,
         )
-        if revision is not None:
+        # format_core_memory_for_context() swallows read errors and returns "".
+        # Caching that under an unchanged revision would turn one bad request into
+        # a chat with no core memory until some unrelated file happens to change.
+        if revision is not None and rendered:
             self._core_memory_cache[key] = (revision, rendered)
         return rendered
 

--- a/src/suzent/memory/manager.py
+++ b/src/suzent/memory/manager.py
@@ -78,6 +78,9 @@ class MemoryManager:
         """
         self.store = store
         self.markdown_store = markdown_store
+        # (chat_id, user_id, sandbox_enabled) -> (revision, rendered section).
+        # Bounded by the number of live chats; entries are tiny strings.
+        self._core_memory_cache: Dict[tuple, tuple] = {}
         self.embedding_gen = EmbeddingGenerator(
             model=embedding_model, dimension=embedding_dimension
         )
@@ -361,6 +364,55 @@ class MemoryManager:
             mount_notebook=mount_notebook,
             project_context_path=project_context_path,
         )
+
+    async def get_core_memory_context(
+        self,
+        chat_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        sandbox_enabled: bool = True,
+        path_resolver=None,
+    ) -> str:
+        """Core-memory prompt section for a chat, rebuilt when its files change.
+
+        ``format_core_memory_for_context`` reads four files and re-renders the
+        whole section, which is too much to repeat on every model request. This
+        wraps it in a cache keyed by the scope that actually varies, invalidated
+        by ``core_memory_revision()`` so an edit to persona.md or MEMORY.md shows
+        up on the very next turn.
+
+        Falls through to an uncached render whenever there is no markdown store
+        (the legacy LanceDB path), where no cheap revision exists.
+        """
+        store = self.markdown_store
+        if store is None:
+            return await self.format_core_memory_for_context(
+                chat_id=chat_id,
+                user_id=user_id,
+                sandbox_enabled=sandbox_enabled,
+                path_resolver=path_resolver,
+            )
+
+        key = (chat_id, user_id, sandbox_enabled)
+        try:
+            revision = store.core_memory_revision(chat_id)
+        except Exception as e:
+            logger.debug(f"Core memory revision unavailable, rebuilding: {e}")
+            revision = None
+
+        if revision is not None:
+            cached = self._core_memory_cache.get(key)
+            if cached is not None and cached[0] == revision:
+                return cached[1]
+
+        rendered = await self.format_core_memory_for_context(
+            chat_id=chat_id,
+            user_id=user_id,
+            sandbox_enabled=sandbox_enabled,
+            path_resolver=path_resolver,
+        )
+        if revision is not None:
+            self._core_memory_cache[key] = (revision, rendered)
+        return rendered
 
     def _log_recalls(self, memories: List[Dict[str, Any]]) -> None:
         """Record retrieved memories to the recall log (usage signal for MEMORY.md

--- a/src/suzent/memory/manager.py
+++ b/src/suzent/memory/manager.py
@@ -351,9 +351,14 @@ class MemoryManager:
             str(path_resolver.custom_mounts.get("/mnt/notebook", "")).replace("\\", "/")
             or None
         )
-        project_context_path = str(
-            path_resolver.get_working_dir() / "context.md"
-        ).replace("\\", "/")
+        # project_dir, not get_working_dir(): context.md is read back through
+        # MarkdownMemoryStore.read_session_context(), which always resolves to the
+        # chat's project directory. A chat pointed at an authorized cwd has a
+        # different get_working_dir(), so rendering that would tell the agent to
+        # write somewhere nothing ever reads.
+        project_context_path = str(path_resolver.project_dir / "context.md").replace(
+            "\\", "/"
+        )
         return (shared_path, mount_notebook, project_context_path)
 
     async def format_core_memory_for_context(

--- a/src/suzent/memory/markdown_store.py
+++ b/src/suzent/memory/markdown_store.py
@@ -540,6 +540,36 @@ class MarkdownMemoryStore:
         """Path to the curated long-term memory file."""
         return self.base_dir / "MEMORY.md"
 
+    def core_memory_revision(self, chat_id: Optional[str] = None) -> tuple:
+        """Cheap fingerprint of every file that feeds the core-memory prompt.
+
+        Four ``stat`` calls, so it is safe to consult on every model request.
+        Callers cache the rendered core-memory section against this value and
+        rebuild only when it changes, which is what keeps an edit to
+        ``persona.md`` from waiting on the next agent rebuild to take effect.
+        """
+        paths = [
+            self._block_path("persona"),
+            self._block_path("user"),
+            self.memory_file_path,
+        ]
+        if chat_id:
+            try:
+                paths.append(self._context_path(chat_id))
+            except Exception:
+                # Project lookup can fail for a chat with no project yet; the
+                # remaining files still give a usable revision.
+                pass
+
+        fingerprint = []
+        for path in paths:
+            try:
+                stat = path.stat()
+                fingerprint.append((str(path), stat.st_mtime_ns, stat.st_size))
+            except OSError:
+                fingerprint.append((str(path), None, None))
+        return tuple(fingerprint)
+
     def manual_tail(self, existing: str) -> str:
         """Whatever a generator must not touch, taken from the current MEMORY.md.
 

--- a/src/suzent/prompts.py
+++ b/src/suzent/prompts.py
@@ -552,8 +552,33 @@ def register_dynamic_instructions(
         )
 
     @agent.instructions
-    def inject_memory_context(_: Any) -> str:
-        return memory_context or ""
+    async def inject_memory_context(ctx: Any) -> str:
+        """Core memory for the chat being served, not the one that built the agent.
+
+        Agents are cached and reused across chats, so a snapshot captured at
+        construction goes stale the moment anyone edits persona.md, user.md,
+        MEMORY.md or a project's context.md — the edit would not surface until
+        the agent happened to be rebuilt. Reading through ``ctx.deps`` each run
+        keeps the section current; the manager caches on a file-mtime revision
+        so a hit costs four ``stat`` calls.
+
+        ``deps.memory_manager`` is None whenever memory is disabled, which is
+        also the signal to fall back to the construction-time snapshot.
+        """
+        deps = getattr(ctx, "deps", None)
+        manager = getattr(deps, "memory_manager", None)
+        if manager is None:
+            return memory_context or ""
+        try:
+            return await manager.get_core_memory_context(
+                chat_id=getattr(deps, "chat_id", "") or None,
+                user_id=getattr(deps, "user_id", "") or None,
+                sandbox_enabled=getattr(deps, "sandbox_enabled", True),
+                path_resolver=getattr(deps, "path_resolver", None),
+            )
+        except Exception as e:
+            logger.warning(f"Falling back to snapshot core memory: {e}")
+            return memory_context or ""
 
     # Skills injection is now handled via SkillsReminderProvider out-of-band.
 

--- a/src/suzent/prompts.py
+++ b/src/suzent/prompts.py
@@ -454,7 +454,6 @@ def register_dynamic_instructions(
     agent: Any,
     *,
     base_instructions: str,
-    memory_context: str | None,
     session_guidance_items: list[str] | None = None,
     enabled_model_ids: list[str] | None = None,
     current_model_id: str | None = None,
@@ -553,22 +552,21 @@ def register_dynamic_instructions(
 
     @agent.instructions
     async def inject_memory_context(ctx: Any) -> str:
-        """Core memory for the chat being served, not the one that built the agent.
+        """Core memory for the chat being served, resolved per run.
 
-        Agents are cached and reused across chats, so a snapshot captured at
-        construction goes stale the moment anyone edits persona.md, user.md,
-        MEMORY.md or a project's context.md — the edit would not surface until
-        the agent happened to be rebuilt. Reading through ``ctx.deps`` each run
-        keeps the section current; the manager caches on a file-mtime revision
-        so a hit costs four ``stat`` calls.
+        There is deliberately no construction-time snapshot to fall back on.
+        The agent is cached and reused across chats and users — `_chat_id` and
+        `_user_id` are excluded from its cache key — so any captured string
+        belongs to whichever request happened to build the agent, and serving it
+        to the next one is exactly the cross-user bleed this section must not
+        cause. On failure, and when memory is off, the answer is nothing.
 
-        ``deps.memory_manager`` is None whenever memory is disabled, which is
-        also the signal to fall back to the construction-time snapshot.
+        `deps.memory_manager` is None precisely when memory is disabled.
         """
         deps = getattr(ctx, "deps", None)
         manager = getattr(deps, "memory_manager", None)
         if manager is None:
-            return memory_context or ""
+            return ""
         try:
             return await manager.get_core_memory_context(
                 chat_id=getattr(deps, "chat_id", "") or None,
@@ -577,8 +575,10 @@ def register_dynamic_instructions(
                 path_resolver=getattr(deps, "path_resolver", None),
             )
         except Exception as e:
-            logger.warning(f"Falling back to snapshot core memory: {e}")
-            return memory_context or ""
+            # Better a prompt with no core memory than one carrying someone
+            # else's.
+            logger.warning(f"Core memory unavailable this run, omitting: {e}")
+            return ""
 
     # Skills injection is now handled via SkillsReminderProvider out-of-band.
 

--- a/tests/memory/test_core_memory_freshness.py
+++ b/tests/memory/test_core_memory_freshness.py
@@ -200,3 +200,44 @@ async def test_a_transient_failure_is_not_cached(manager, store, monkeypatch):
     assert "RECOVERED" in await manager.get_core_memory_context(
         chat_id="c1", user_id="u1"
     )
+
+
+# --- Codex re-review follow-up (PR #163, commit e077dc0) --------------------
+
+
+@pytest.mark.asyncio
+async def test_the_cache_is_bounded(manager, store, monkeypatch):
+    """Keys outlive what they describe: deleted chats leave entries behind, and a
+    resolver change strands the previous key. Without a ceiling the footprint
+    tracks historical chat/path combinations, each holding a full prompt."""
+    from suzent.memory import manager as manager_mod
+
+    monkeypatch.setattr(manager_mod, "CORE_MEMORY_CACHE_MAXSIZE", 8)
+    persona = store._block_path("persona")
+    persona.parent.mkdir(parents=True, exist_ok=True)
+    persona.write_text("P", encoding="utf-8")
+
+    for i in range(40):
+        await manager.get_core_memory_context(chat_id=f"chat-{i}", user_id="u1")
+
+    assert len(manager._core_memory_cache) <= 8
+
+
+@pytest.mark.asyncio
+async def test_the_cache_evicts_least_recently_used(manager, store, monkeypatch):
+    from suzent.memory import manager as manager_mod
+
+    monkeypatch.setattr(manager_mod, "CORE_MEMORY_CACHE_MAXSIZE", 3)
+    persona = store._block_path("persona")
+    persona.parent.mkdir(parents=True, exist_ok=True)
+    persona.write_text("P", encoding="utf-8")
+
+    for name in ("a", "b", "c"):
+        await manager.get_core_memory_context(chat_id=name, user_id="u1")
+    # Touch "a" so "b" becomes the coldest entry, then overflow by one.
+    await manager.get_core_memory_context(chat_id="a", user_id="u1")
+    await manager.get_core_memory_context(chat_id="d", user_id="u1")
+
+    cached_chats = {key[0] for key in manager._core_memory_cache}
+    assert "a" in cached_chats, "recently used entry was evicted"
+    assert "b" not in cached_chats, "coldest entry should have been evicted first"

--- a/tests/memory/test_core_memory_freshness.py
+++ b/tests/memory/test_core_memory_freshness.py
@@ -130,10 +130,11 @@ async def test_legacy_path_without_markdown_store_is_not_cached():
 class _FakeResolver:
     """Minimal stand-in for PathResolver in host (non-sandbox) mode."""
 
-    def __init__(self, tmp_path, working, notebook="/host/notebook"):
+    def __init__(self, tmp_path, working, notebook="/host/notebook", project_dir=None):
         self.sandbox_data_path = tmp_path
         self.custom_mounts = {"/mnt/notebook": notebook}
         self._working = working
+        self.project_dir = project_dir if project_dir is not None else working
 
     def get_working_dir(self):
         return self._working
@@ -241,3 +242,22 @@ async def test_the_cache_evicts_least_recently_used(manager, store, monkeypatch)
     cached_chats = {key[0] for key in manager._core_memory_cache}
     assert "a" in cached_chats, "recently used entry was evicted"
     assert "b" not in cached_chats, "coldest entry should have been evicted first"
+
+
+@pytest.mark.asyncio
+async def test_context_path_follows_the_project_not_the_cwd(manager, store, tmp_path):
+    """context.md is read back via read_session_context(), which always resolves
+    to the chat's project directory. A chat pointed at an authorized cwd must not
+    be told to write somewhere nothing reads."""
+    resolver = _FakeResolver(
+        tmp_path,
+        working=tmp_path / "some" / "external" / "checkout",
+        project_dir=tmp_path / "projects" / "the-project",
+    )
+
+    rendered = await manager.get_core_memory_context(
+        chat_id="c1", user_id="u1", sandbox_enabled=False, path_resolver=resolver
+    )
+
+    assert "projects/the-project/context.md" in rendered
+    assert "external/checkout/context.md" not in rendered

--- a/tests/memory/test_core_memory_freshness.py
+++ b/tests/memory/test_core_memory_freshness.py
@@ -1,0 +1,124 @@
+"""Core memory must reflect the files as they are now, not as they were at agent build.
+
+Agents are cached and reused across chats and users, so anything captured in a
+closure at construction time outlives the request it was built for. Core memory
+used to be captured exactly that way: editing persona.md or a project's
+context.md had no effect until something unrelated forced the agent to rebuild.
+"""
+
+import pytest
+
+from suzent.memory.manager import MemoryManager
+from suzent.memory.markdown_store import MarkdownMemoryStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return MarkdownMemoryStore(
+        base_dir=tmp_path / "memory", notebook_dir=tmp_path / "notebook"
+    )
+
+
+@pytest.fixture
+def manager(store):
+    return MemoryManager(store=None, markdown_store=store)
+
+
+# --- revision fingerprint ---------------------------------------------------
+
+
+def test_revision_changes_when_a_block_file_changes(store):
+    before = store.core_memory_revision()
+    store._block_path("persona").parent.mkdir(parents=True, exist_ok=True)
+    store._block_path("persona").write_text("I am new", encoding="utf-8")
+
+    assert store.core_memory_revision() != before
+
+
+def test_revision_is_stable_when_nothing_changes(store):
+    assert store.core_memory_revision() == store.core_memory_revision()
+
+
+def test_revision_survives_missing_files(store):
+    """A fresh install has none of these files; that must not raise."""
+    assert isinstance(store.core_memory_revision(), tuple)
+
+
+# --- cached accessor --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_core_memory_refreshes_after_a_file_edit(manager, store):
+    persona = store._block_path("persona")
+    persona.parent.mkdir(parents=True, exist_ok=True)
+    persona.write_text("ORIGINAL-PERSONA", encoding="utf-8")
+
+    first = await manager.get_core_memory_context(chat_id="c1", user_id="u1")
+    assert "ORIGINAL-PERSONA" in first
+
+    persona.write_text("EDITED-PERSONA", encoding="utf-8")
+    second = await manager.get_core_memory_context(chat_id="c1", user_id="u1")
+
+    assert "EDITED-PERSONA" in second
+    assert "ORIGINAL-PERSONA" not in second
+
+
+@pytest.mark.asyncio
+async def test_unchanged_files_are_served_from_cache(manager, store, monkeypatch):
+    persona = store._block_path("persona")
+    persona.parent.mkdir(parents=True, exist_ok=True)
+    persona.write_text("STABLE", encoding="utf-8")
+
+    await manager.get_core_memory_context(chat_id="c1", user_id="u1")
+
+    calls = []
+    original = manager.format_core_memory_for_context
+
+    async def counting(*args, **kwargs):
+        calls.append(1)
+        return await original(*args, **kwargs)
+
+    monkeypatch.setattr(manager, "format_core_memory_for_context", counting)
+    await manager.get_core_memory_context(chat_id="c1", user_id="u1")
+
+    assert calls == [], "unchanged core memory should not be re-rendered"
+
+
+@pytest.mark.asyncio
+async def test_cache_is_scoped_per_chat(manager, store):
+    """Two chats share persona/user/facts but not their project context."""
+    persona = store._block_path("persona")
+    persona.parent.mkdir(parents=True, exist_ok=True)
+    persona.write_text("SHARED", encoding="utf-8")
+
+    a = await manager.get_core_memory_context(chat_id="chat-a", user_id="u1")
+    b = await manager.get_core_memory_context(chat_id="chat-b", user_id="u1")
+
+    assert "SHARED" in a and "SHARED" in b
+
+
+@pytest.mark.asyncio
+async def test_legacy_path_without_markdown_store_is_not_cached():
+    """No markdown store means no cheap revision, so every read must go live.
+
+    This is also what keeps the legacy LanceDB path from serving one user's
+    persona to another: nothing is retained between calls.
+    """
+
+    class FakeLanceStore:
+        def __init__(self):
+            self.calls = []
+
+        async def get_all_memory_blocks(self, chat_id=None, user_id=None):
+            self.calls.append(user_id)
+            return {"persona": f"persona-for-{user_id}"}
+
+    lance = FakeLanceStore()
+    manager = MemoryManager(store=lance, markdown_store=None)
+
+    first = await manager.get_core_memory_context(chat_id="c", user_id="alice")
+    second = await manager.get_core_memory_context(chat_id="c", user_id="bob")
+
+    assert "persona-for-alice" in first
+    assert "persona-for-bob" in second
+    assert lance.calls == ["alice", "bob"]

--- a/tests/memory/test_core_memory_freshness.py
+++ b/tests/memory/test_core_memory_freshness.py
@@ -122,3 +122,81 @@ async def test_legacy_path_without_markdown_store_is_not_cached():
     assert "persona-for-alice" in first
     assert "persona-for-bob" in second
     assert lance.calls == ["alice", "bob"]
+
+
+# --- Codex review follow-ups (PR #163) --------------------------------------
+
+
+class _FakeResolver:
+    """Minimal stand-in for PathResolver in host (non-sandbox) mode."""
+
+    def __init__(self, tmp_path, working, notebook="/host/notebook"):
+        self.sandbox_data_path = tmp_path
+        self.custom_mounts = {"/mnt/notebook": notebook}
+        self._working = working
+
+    def get_working_dir(self):
+        return self._working
+
+
+@pytest.mark.asyncio
+async def test_changing_the_working_dir_bypasses_the_cache(manager, store, tmp_path):
+    """Host mode renders cwd into the prompt, so it is part of the cache identity."""
+    persona = store._block_path("persona")
+    persona.parent.mkdir(parents=True, exist_ok=True)
+    persona.write_text("P", encoding="utf-8")
+
+    first = await manager.get_core_memory_context(
+        chat_id="c1",
+        user_id="u1",
+        sandbox_enabled=False,
+        path_resolver=_FakeResolver(tmp_path, tmp_path / "project-a"),
+    )
+    second = await manager.get_core_memory_context(
+        chat_id="c1",
+        user_id="u1",
+        sandbox_enabled=False,
+        path_resolver=_FakeResolver(tmp_path, tmp_path / "project-b"),
+    )
+
+    assert "project-a" in first
+    assert "project-b" in second, "stale cwd served from cache after the mount changed"
+
+
+def test_resolver_paths_carry_the_notebook_mount(manager, tmp_path):
+    """The mount does not change the rendered text today, but it is resolver
+    state the section is built from, so it belongs in the cache identity rather
+    than being rediscovered as a bug the day the template starts printing it."""
+    a = manager._resolver_paths(
+        False, _FakeResolver(tmp_path, tmp_path / "p", notebook="/mnt/first")
+    )
+    b = manager._resolver_paths(
+        False, _FakeResolver(tmp_path, tmp_path / "p", notebook="/mnt/second")
+    )
+
+    assert a != b
+    assert "/mnt/first" in a and "/mnt/second" in b
+
+
+def test_resolver_paths_are_inert_in_sandbox_mode(manager, tmp_path):
+    assert manager._resolver_paths(True, None) == (None, None, "/workspace/context.md")
+
+
+@pytest.mark.asyncio
+async def test_a_transient_failure_is_not_cached(manager, store, monkeypatch):
+    """One bad read must not leave the chat without core memory indefinitely."""
+    persona = store._block_path("persona")
+    persona.parent.mkdir(parents=True, exist_ok=True)
+    persona.write_text("RECOVERED", encoding="utf-8")
+
+    async def boom(*args, **kwargs):
+        raise OSError("transient")
+
+    monkeypatch.setattr(manager, "get_core_memory", boom)
+    assert await manager.get_core_memory_context(chat_id="c1", user_id="u1") == ""
+
+    monkeypatch.undo()
+    # Same revision as the failed attempt — recovery must not wait on a file edit.
+    assert "RECOVERED" in await manager.get_core_memory_context(
+        chat_id="c1", user_id="u1"
+    )

--- a/tests/prompts/test_core_memory_is_request_scoped.py
+++ b/tests/prompts/test_core_memory_is_request_scoped.py
@@ -39,9 +39,9 @@ class _FakeAgent:
         return fn
 
 
-def _memory_injector(snapshot):
+def _memory_injector():
     agent = _FakeAgent()
-    register_dynamic_instructions(agent, base_instructions="", memory_context=snapshot)
+    register_dynamic_instructions(agent, base_instructions="")
     fn = next(f for f in agent.functions if f.__name__ == "inject_memory_context")
     return fn
 
@@ -58,7 +58,7 @@ class _FakeManager:
 @pytest.mark.asyncio
 async def test_injector_reads_the_serving_chat_not_the_build_time_snapshot():
     manager = _FakeManager()
-    fn = _memory_injector("STALE-SNAPSHOT")
+    fn = _memory_injector()
     ctx = SimpleNamespace(
         deps=SimpleNamespace(
             memory_manager=manager,
@@ -76,19 +76,27 @@ async def test_injector_reads_the_serving_chat_not_the_build_time_snapshot():
 @pytest.mark.asyncio
 async def test_injector_returns_nothing_when_memory_is_disabled():
     """deps.memory_manager is None exactly when memory is off."""
-    fn = _memory_injector(None)
+    fn = _memory_injector()
     ctx = SimpleNamespace(deps=SimpleNamespace(memory_manager=None))
 
     assert await fn(ctx) == ""
 
 
 @pytest.mark.asyncio
-async def test_injector_falls_back_to_the_snapshot_when_the_lookup_fails():
+async def test_injector_omits_memory_when_the_lookup_fails():
+    """Never fall back to a construction-time snapshot.
+
+    The agent is cached across chats and users, so a captured string belongs to
+    whichever request built the agent. Serving it to the next one is the exact
+    cross-user bleed this section must not cause — a prompt with no core memory
+    beats one carrying someone else's.
+    """
+
     class Broken:
         async def get_core_memory_context(self, **kwargs):
             raise RuntimeError("store offline")
 
-    fn = _memory_injector("SNAPSHOT")
+    fn = _memory_injector()
     ctx = SimpleNamespace(
         deps=SimpleNamespace(
             memory_manager=Broken(),
@@ -99,4 +107,4 @@ async def test_injector_falls_back_to_the_snapshot_when_the_lookup_fails():
         )
     )
 
-    assert await fn(ctx) == "SNAPSHOT"
+    assert await fn(ctx) == ""

--- a/tests/prompts/test_core_memory_is_request_scoped.py
+++ b/tests/prompts/test_core_memory_is_request_scoped.py
@@ -1,0 +1,102 @@
+"""Core memory and the agent cache key must agree about what is per-request.
+
+The agent instance is cached and reused. Anything scoped to a chat, a user or a
+project is therefore only safe if it is either part of the cache key or resolved
+fresh from `ctx.deps` on every run. These tests pin both halves of that bargain.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from suzent.agent_manager import _TRANSIENT_KEYS
+from suzent.prompts import register_dynamic_instructions
+
+
+def test_project_identity_stays_in_the_agent_cache_key():
+    """RepoContext is built from static roots, so the project must key the cache."""
+    for key in ("_project_context_dir", "_working_context_dir", "_repository_root"):
+        assert key not in _TRANSIENT_KEYS, (
+            f"{key} was excluded from the agent cache key; a cached agent would "
+            "then carry one project's repository instructions into another"
+        )
+
+
+def test_chat_and_user_are_excluded_from_the_cache_key():
+    """Excluded on purpose — scoped sections resolve per run from ctx.deps."""
+    assert {"_chat_id", "_user_id"} <= _TRANSIENT_KEYS
+
+
+# --- the injector itself ----------------------------------------------------
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.functions = []
+
+    def instructions(self, fn):
+        self.functions.append(fn)
+        return fn
+
+
+def _memory_injector(snapshot):
+    agent = _FakeAgent()
+    register_dynamic_instructions(agent, base_instructions="", memory_context=snapshot)
+    fn = next(f for f in agent.functions if f.__name__ == "inject_memory_context")
+    return fn
+
+
+class _FakeManager:
+    def __init__(self):
+        self.seen = []
+
+    async def get_core_memory_context(self, chat_id=None, user_id=None, **kwargs):
+        self.seen.append((chat_id, user_id))
+        return f"MEMORY[{user_id}/{chat_id}]"
+
+
+@pytest.mark.asyncio
+async def test_injector_reads_the_serving_chat_not_the_build_time_snapshot():
+    manager = _FakeManager()
+    fn = _memory_injector("STALE-SNAPSHOT")
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            memory_manager=manager,
+            chat_id="chat-b",
+            user_id="bob",
+            sandbox_enabled=True,
+            path_resolver=None,
+        )
+    )
+
+    assert await fn(ctx) == "MEMORY[bob/chat-b]"
+    assert manager.seen == [("chat-b", "bob")]
+
+
+@pytest.mark.asyncio
+async def test_injector_returns_nothing_when_memory_is_disabled():
+    """deps.memory_manager is None exactly when memory is off."""
+    fn = _memory_injector(None)
+    ctx = SimpleNamespace(deps=SimpleNamespace(memory_manager=None))
+
+    assert await fn(ctx) == ""
+
+
+@pytest.mark.asyncio
+async def test_injector_falls_back_to_the_snapshot_when_the_lookup_fails():
+    class Broken:
+        async def get_core_memory_context(self, **kwargs):
+            raise RuntimeError("store offline")
+
+    fn = _memory_injector("SNAPSHOT")
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            memory_manager=Broken(),
+            chat_id="c",
+            user_id="u",
+            sandbox_enabled=True,
+            path_resolver=None,
+        )
+    )
+
+    assert await fn(ctx) == "SNAPSHOT"

--- a/tests/prompts/test_prompt_architecture.py
+++ b/tests/prompts/test_prompt_architecture.py
@@ -33,7 +33,6 @@ def test_register_dynamic_instructions_registers_all_sections():
     register_dynamic_instructions(
         agent,
         base_instructions="",
-        memory_context="",
     )
 
     assert len(agent.functions) == 11
@@ -41,7 +40,7 @@ def test_register_dynamic_instructions_registers_all_sections():
 
 def test_citation_rules_available_before_sources_exist():
     agent = _FakeAgent()
-    register_dynamic_instructions(agent, base_instructions="", memory_context="")
+    register_dynamic_instructions(agent, base_instructions="")
     funcs = {fn.__name__: fn for fn in agent.functions}
 
     # The model needs the marker rules before it calls tools; labelled tool
@@ -56,7 +55,7 @@ def test_citation_rules_appear_once_sources_exist():
     from suzent.core.citation_manager import CitationManager, CitationSourceType
 
     agent = _FakeAgent()
-    register_dynamic_instructions(agent, base_instructions="", memory_context="")
+    register_dynamic_instructions(agent, base_instructions="")
     funcs = {fn.__name__: fn for fn in agent.functions}
 
     mgr = CitationManager()
@@ -77,7 +76,7 @@ def test_citation_rules_are_static_and_cacheable():
     from suzent.core.citation_manager import CitationManager, CitationSourceType
 
     agent = _FakeAgent()
-    register_dynamic_instructions(agent, base_instructions="", memory_context="")
+    register_dynamic_instructions(agent, base_instructions="")
     inject = {fn.__name__: fn for fn in agent.functions}["inject_citation_rules"]
 
     mgr_a = CitationManager()
@@ -95,7 +94,6 @@ def test_permission_feedback_instruction_includes_user_guidance():
     register_dynamic_instructions(
         agent,
         base_instructions="",
-        memory_context="",
     )
     funcs = {fn.__name__: fn for fn in agent.functions}
     ctx = SimpleNamespace(
@@ -115,7 +113,6 @@ def test_register_dynamic_instructions_environment_uses_host_paths():
     register_dynamic_instructions(
         agent,
         base_instructions="",
-        memory_context="",
     )
 
     funcs = {fn.__name__: fn for fn in agent.functions}
@@ -140,7 +137,6 @@ def test_register_dynamic_instructions_stateless_keeps_environment_context():
     register_dynamic_instructions(
         agent,
         base_instructions="",
-        memory_context="",
     )
 
     funcs = {fn.__name__: fn for fn in agent.functions}
@@ -167,7 +163,6 @@ def test_register_dynamic_instructions_can_suppress_environment_context():
     register_dynamic_instructions(
         agent,
         base_instructions="",
-        memory_context="",
     )
 
     funcs = {fn.__name__: fn for fn in agent.functions}
@@ -191,7 +186,6 @@ def test_register_dynamic_instructions_empty_social_returns_empty_string():
     register_dynamic_instructions(
         agent,
         base_instructions="",
-        memory_context="",
     )
 
     funcs = {fn.__name__: fn for fn in agent.functions}


### PR DESCRIPTION
## Problem

Agents are cached and reused across chats and users. Core memory was captured in a closure at construction:

```python
@agent.instructions
def inject_memory_context(_: Any) -> str:
    return memory_context or ""
```

The `_` is the tell — the run context was never consulted. Editing `persona.md`, `user.md`, `MEMORY.md`, or a project's `context.md` had no effect until something unrelated forced the agent to rebuild.

The same closure is why the legacy LanceDB path was a cross-user hazard. `_user_id` is excluded from the agent cache key, and on that path `get_core_memory()` reads persona/user/facts *by* `user_id` — so two users sharing a model, tool set and project shared one snapshot. In practice `lifecycle.py` always supplies a markdown store, so the default deployment doesn't reach it; treating it as defence in depth.

## What this is not

Not an isolation fix. I want to be precise, because an earlier draft of the audit claimed cross-chat `context.md` bleed and that claim was wrong:

- `context.md` is **project**-scoped, via `get_project_dir(chat_id)`, not chat-scoped.
- `_project_context_dir` / `_working_context_dir` / `_repository_root` are already part of the stable config, so different projects already rebuild the agent.

The audit doc has been corrected. This PR is about staleness.

## Approach

- `inject_memory_context` is now async and resolves from `ctx.deps`. It falls back to the construction-time snapshot only when memory is disabled (`deps.memory_manager` is `None` — already exactly that condition) or the lookup raises.
- `MemoryManager.get_core_memory_context()` caches on a file-mtime revision, so a per-request read costs four `stat` calls rather than four file reads plus a re-render. The legacy path has no cheap revision and stays uncached — which is also what makes it correct.
- `_TRANSIENT_KEYS` moved to module scope so the cache-key invariant is testable instead of living in a comment. A test now fails if anyone adds `_project_context_dir` to it.

## Caching note

Core memory sits in the system prompt, i.e. inside the prompt-cache prefix. Resolving per request means an edit to a memory file invalidates that chat's prefix — correct, and rare relative to turn count. Chats already have distinct prefixes, so nothing is lost across chats. The alternative (moving core memory into the user message to protect the prefix) would re-bill it every turn and is explicitly not what this does.

## Tests

`tests/memory/test_core_memory_freshness.py` (7) — revision fingerprint behaviour including missing files, refresh after edit, cache hit on no-change, and the legacy path staying live per user.

`tests/prompts/test_core_memory_is_request_scoped.py` (5) — the injector reads the serving chat rather than the snapshot, returns empty when memory is off, falls back on error, and the cache-key guards.

Full suite: 1649 passed. `ruff check` / `ruff format` clean.

## Context

P1-0 in `docs/03-developing/system-prompt-and-reminder-audit.md`. Follows #162 (P0, forgeable reminder boundaries). Independent of it — no shared files.