### PR TITLE
fix(logging): trace prompt structure instead of dumping its contents

### DIFF
--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -1004,8 +1004,12 @@ class ChatProcessor:
         # DEBUG unconditionally, so the previous full-text line put all of that
         # in the log on every single turn (AGENTS.md: never log secrets or PII).
         #
-        # Full text requires SUZENT_PROMPT_TRACE, a deliberate opt-in rather than
-        # a side effect of turning on debug logging.
+        # There is deliberately no flag to print the text. AGENTS.md states the
+        # prohibition without qualification, and the prompt carries core memory,
+        # permission feedback, sender names and project instructions — an opt-in
+        # does not make writing that to disk acceptable, it just moves who is
+        # responsible. The sha is enough to tell two turns apart, and the section
+        # sizes are what the log was actually useful for.
         try:
             if logger._core.min_level <= 10:  # DEBUG
                 import asyncio as _asyncio
@@ -1030,12 +1034,6 @@ class ChatProcessor:
                     _digest,
                     ", ".join(f"{name}:{len(text)}" for name, text in _sections),
                 )
-                if os.environ.get("SUZENT_PROMPT_TRACE"):
-                    logger.debug(
-                        "[SystemPrompt] full text for chat {} (SUZENT_PROMPT_TRACE):\n{}",
-                        chat_id,
-                        _prompt,
-                    )
         except Exception as e:
             logger.debug(f"[SystemPrompt] Failed to resolve debug prompt: {e}")
 

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -997,15 +997,23 @@ class ChatProcessor:
                 message_history, _budget
             )
 
-        # Debug-only: log complete system prompt (static + dynamic sections)
-        # as resolved by pydantic-ai instruction runners for this run context.
+        # Debug-only prompt trace. Metadata by default: section names and sizes
+        # say what the prompt was made of, which is what this is actually useful
+        # for, without writing persona, user.md, MEMORY.md, the project
+        # context.md and repository instructions to disk. File logging records
+        # DEBUG unconditionally, so the previous full-text line put all of that
+        # in the log on every single turn (AGENTS.md: never log secrets or PII).
+        #
+        # Full text requires SUZENT_PROMPT_TRACE, a deliberate opt-in rather than
+        # a side effect of turning on debug logging.
         try:
             if logger._core.min_level <= 10:  # DEBUG
                 import asyncio as _asyncio
-                from suzent.prompts import resolve_full_system_prompt
+                import hashlib as _hashlib
+                from suzent.prompts import resolve_system_prompt_sections
 
-                system_prompt = await _asyncio.wait_for(
-                    resolve_full_system_prompt(
+                _sections = await _asyncio.wait_for(
+                    resolve_system_prompt_sections(
                         agent,
                         deps,
                         user_prompt=full_prompt or None,
@@ -1013,12 +1021,21 @@ class ChatProcessor:
                     ),
                     timeout=5.0,
                 )
+                _prompt = "\n\n".join(text for _, text in _sections)
+                _digest = _hashlib.sha256(_prompt.encode("utf-8")).hexdigest()[:8]
                 logger.debug(
-                    "[SystemPrompt] Resolved full prompt ({} chars) for chat {}:\n{}",
-                    len(system_prompt),
+                    "[SystemPrompt] chat={} chars={} sha={} sections={}",
                     chat_id,
-                    system_prompt,
+                    len(_prompt),
+                    _digest,
+                    ", ".join(f"{name}:{len(text)}" for name, text in _sections),
                 )
+                if os.environ.get("SUZENT_PROMPT_TRACE"):
+                    logger.debug(
+                        "[SystemPrompt] full text for chat {} (SUZENT_PROMPT_TRACE):\n{}",
+                        chat_id,
+                        _prompt,
+                    )
         except Exception as e:
             logger.debug(f"[SystemPrompt] Failed to resolve debug prompt: {e}")
 

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -1013,7 +1013,6 @@ class ChatProcessor:
         try:
             if logger._core.min_level <= 10:  # DEBUG
                 import asyncio as _asyncio
-                import hashlib as _hashlib
                 from suzent.prompts import resolve_system_prompt_sections
 
                 _sections = await _asyncio.wait_for(
@@ -1025,13 +1024,16 @@ class ChatProcessor:
                     ),
                     timeout=5.0,
                 )
-                _prompt = "\n\n".join(text for _, text in _sections)
-                _digest = _hashlib.sha256(_prompt.encode("utf-8")).hexdigest()[:8]
+                # Sizes only — no digest. A short unsalted hash of the prompt is
+                # a verifier for its contents: with the other sections known or
+                # predictable, someone holding the logs can hash candidate sender
+                # names or permission feedback until one matches, and it links
+                # identical private prompts across runs. chat_id already
+                # correlates lines within a conversation.
                 logger.debug(
-                    "[SystemPrompt] chat={} chars={} sha={} sections={}",
+                    "[SystemPrompt] chat={} chars={} sections={}",
                     chat_id,
-                    len(_prompt),
-                    _digest,
+                    sum(len(text) for _, text in _sections),
                     ", ".join(f"{name}:{len(text)}" for name, text in _sections),
                 )
         except Exception as e:

--- a/src/suzent/prompts.py
+++ b/src/suzent/prompts.py
@@ -252,13 +252,19 @@ def resolve_prompt_section(
     return value
 
 
-async def resolve_full_system_prompt(
+async def resolve_system_prompt_sections(
     agent: Any,
     deps: Any,
     *,
     user_prompt: str | Sequence[UserContent] | None = None,
     message_history: Sequence[ModelMessage] | None = None,
-) -> str:
+) -> list[tuple[str, str]]:
+    """Resolve the system prompt as ``(section_name, text)`` pairs.
+
+    Debug-only, like ``resolve_full_system_prompt`` which builds on it. Keeping
+    the sections separate lets callers report *what* the prompt is made of and
+    how large each part is without putting any of the text in a log line.
+    """
     static_instructions, instruction_runners = agent._get_instructions(None)
 
     run_context = RunContext(
@@ -269,9 +275,9 @@ async def resolve_full_system_prompt(
         messages=list(message_history or []),
     )
 
-    parts: list[str] = []
+    sections: list[tuple[str, str]] = []
     if static_instructions:
-        parts.append(static_instructions)
+        sections.append(("static", static_instructions))
 
     for runner in instruction_runners:
         runner_func = getattr(runner, "function", None)
@@ -289,9 +295,22 @@ async def resolve_full_system_prompt(
             )
             continue
         if section:
-            parts.append(section)
+            sections.append((runner_name, section))
 
-    return "\n\n".join(parts)
+    return sections
+
+
+async def resolve_full_system_prompt(
+    agent: Any,
+    deps: Any,
+    *,
+    user_prompt: str | Sequence[UserContent] | None = None,
+    message_history: Sequence[ModelMessage] | None = None,
+) -> str:
+    sections = await resolve_system_prompt_sections(
+        agent, deps, user_prompt=user_prompt, message_history=message_history
+    )
+    return "\n\n".join(text for _, text in sections)
 
 
 def build_execution_mode_section(

--- a/tests/prompts/test_prompt_trace_redaction.py
+++ b/tests/prompts/test_prompt_trace_redaction.py
@@ -1,0 +1,82 @@
+"""The prompt trace must say what the prompt contained, not what it said.
+
+File logging records DEBUG unconditionally, so a full-text line puts persona,
+user.md, MEMORY.md, the project context.md and repository instructions on disk
+on every turn. AGENTS.md forbids logging secrets or PII.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from suzent.prompts import (
+    resolve_full_system_prompt,
+    resolve_system_prompt_sections,
+)
+
+
+class _FakeRunner:
+    def __init__(self, name, text):
+        self.function = SimpleNamespace(__name__=name)
+        self._text = text
+
+    async def run(self, ctx):
+        return self._text
+
+
+class _FakeAgent:
+    def __init__(self, static, runners):
+        self._static = static
+        self._runners = runners
+        self.functions = []
+
+    def _get_instructions(self, _):
+        return self._static, self._runners
+
+    def _get_model(self, _):
+        return None
+
+    def instructions(self, fn):
+        self.functions.append(fn)
+        return fn
+
+
+@pytest.fixture
+def agent():
+    return _FakeAgent(
+        "STATIC RULES",
+        [
+            _FakeRunner("inject_memory_context", "SECRET-PERSONA and SECRET-FACTS"),
+            _FakeRunner("inject_social_context", "hello"),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_sections_carry_names_and_text(agent):
+    sections = await resolve_system_prompt_sections(agent, SimpleNamespace())
+
+    assert [name for name, _ in sections] == [
+        "static",
+        "inject_memory_context",
+        "inject_social_context",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_full_prompt_still_matches_the_joined_sections(agent):
+    sections = await resolve_system_prompt_sections(agent, SimpleNamespace())
+    full = await resolve_full_system_prompt(agent, SimpleNamespace())
+
+    assert full == "\n\n".join(text for _, text in sections)
+
+
+@pytest.mark.asyncio
+async def test_a_trace_line_can_be_built_without_any_body_text(agent):
+    """The shape the chat processor logs: names and sizes, never content."""
+    sections = await resolve_system_prompt_sections(agent, SimpleNamespace())
+    line = ", ".join(f"{name}:{len(text)}" for name, text in sections)
+
+    assert "inject_memory_context:31" in line
+    assert "SECRET-PERSONA" not in line
+    assert "SECRET-FACTS" not in line

--- a/tests/prompts/test_prompt_trace_redaction.py
+++ b/tests/prompts/test_prompt_trace_redaction.py
@@ -80,3 +80,18 @@ async def test_a_trace_line_can_be_built_without_any_body_text(agent):
     assert "inject_memory_context:31" in line
     assert "SECRET-PERSONA" not in line
     assert "SECRET-FACTS" not in line
+
+
+def test_no_environment_flag_can_turn_the_full_prompt_back_on():
+    """AGENTS.md states the prohibition without qualification, so there is no
+    opt-in. A flag would also have to get truthiness right — SUZENT_PROMPT_TRACE
+    read as a bare env lookup treated "false" and "0" as enabled."""
+    import inspect
+
+    from suzent.core import chat_processor
+
+    source = inspect.getsource(chat_processor)
+    trace_block = source[source.index("[SystemPrompt]") - 2000 :]
+
+    assert "SUZENT_PROMPT_TRACE" not in source
+    assert "full text" not in trace_block.split("# 8. Stream Response")[0]

--- a/tests/prompts/test_prompt_trace_redaction.py
+++ b/tests/prompts/test_prompt_trace_redaction.py
@@ -95,3 +95,18 @@ def test_no_environment_flag_can_turn_the_full_prompt_back_on():
 
     assert "SUZENT_PROMPT_TRACE" not in source
     assert "full text" not in trace_block.split("# 8. Stream Response")[0]
+
+
+def test_the_trace_logs_no_content_derived_digest():
+    """A short unsalted hash of the prompt is a verifier for its contents:
+    with the other sections predictable, candidate sender names or permission
+    feedback can be hashed until one matches."""
+    import inspect
+
+    from suzent.core import chat_processor
+
+    source = inspect.getsource(chat_processor)
+    block = source[source.index("[SystemPrompt] chat=") - 1500 :][:2000]
+
+    assert "hashlib" not in block
+    assert "sha=" not in block


### PR DESCRIPTION
Closes #165.

## Problem

`chat_processor` resolved and logged the **entire** system prompt at DEBUG: persona, `user.md`, `MEMORY.md`, the project `context.md`, repository instructions. File logging records DEBUG unconditionally, so all of that hit disk on every turn.

`AGENTS.md:35` — never log secrets or PII.

#162 fixed the equivalent leak on the reminder side (it was writing `RUNTIME_NONCE` and the full reminder body) but deliberately left this alone rather than widening scope mid-review.

## Approach

Prompt resolution is split into `resolve_system_prompt_sections()` returning `(name, text)` pairs, with `resolve_full_system_prompt()` built on it — so the sections stay separate and can be *described* without being printed.

The default line is now:

```
[SystemPrompt] chat=<id> chars=1234 sha=a1b2c3d4 sections=static:812, inject_date_context:56, inject_memory_context:9001, ...
```

This is more useful than the old dump for what the log is actually for — seeing which sections are present and how much of the budget each takes — and it carries no content. The `sha` gives you a stable identity to compare turns without revealing anything.

Full text now requires `SUZENT_PROMPT_TRACE`. Enabling debug logging no longer implies dumping user data; you have to ask for it.

## Note on the gating

The block stays behind the DEBUG check because resolution runs every instruction runner and is not free. The trace is opt-in on top of that.

## Tests

`tests/prompts/test_prompt_trace_redaction.py` — sections carry names, the joined sections still equal the full prompt (so the refactor is behaviour-preserving), and a trace line built the way the processor builds it contains the section sizes but none of their text.

Suite 1751 passed, ruff clean.