### PR TITLE
fix(display): commit the trigger row inside the snapshot transaction

### DIFF
--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -823,6 +823,9 @@ class ChatProcessor:
             else None
         )
         pending_trigger_rows: list[dict] = []
+        # Shared with the streaming layer so the draft row this run writes can
+        # be told apart from a previous turn's answer when placing the trigger.
+        stream_run_id = str(uuid.uuid4())
         display_trigger = None
         if system_reminders and not (message_content and message_content.strip()):
             display_trigger = "\n\n---\n\n".join(
@@ -1060,6 +1063,7 @@ class ChatProcessor:
                 deferred_tool_results=deferred_tool_results,
                 permission_resolutions=permission_resolutions,
                 is_heartbeat=is_heartbeat,
+                run_id=stream_run_id,
             ):
                 try:
                     if chunk.startswith("data: "):
@@ -1172,6 +1176,7 @@ class ChatProcessor:
                         model_id=getattr(agent, "_model_id", None),
                         tool_names=getattr(agent, "_tool_names", []),
                         append_display_messages=pending_trigger_rows,
+                        draft_run_id=stream_run_id,
                     )
             except Exception as e:
                 logger.warning(
@@ -1965,6 +1970,7 @@ class ChatProcessor:
         model_id: Optional[str],
         tool_names: List[str],
         append_display_messages: Optional[List[Dict[str, Any]]] = None,
+        draft_run_id: Optional[str] = None,
     ) -> Optional[int]:
         """Persist only agent_state for fast-follow turn recovery.
 
@@ -1981,7 +1987,10 @@ class ChatProcessor:
                 messages, model_id=model_id, tool_names=tool_names
             )
             revision = db.commit_snapshot_state(
-                chat_id, agent_state, append_display_messages=append_display_messages
+                chat_id,
+                agent_state,
+                append_display_messages=append_display_messages,
+                draft_run_id=draft_run_id,
             )
             if revision is None:
                 db.update_chat(chat_id, agent_state=agent_state)

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -2689,10 +2689,18 @@ def trigger_rows_for_snapshot(
     """
     if not display_trigger or is_heartbeat:
         return []
+
+    from suzent.core.system_reminder import sanitize_untrusted_text
+
+    # Same treatment wrap_in_system_reminder gives it. Scheduled prompts and
+    # subagent results are user-influenced, and _preserve_display_triggers
+    # prefers this stored content over the placeholder rebuilt from history — so
+    # storing the raw value would put delimiters back into the visible transcript
+    # permanently, undoing the sanitizing on the path that does it.
     stamp = getattr(part, "timestamp", None)
     row: dict = {
         "role": "system_triggered",
-        "content": display_trigger,
+        "content": sanitize_untrusted_text(display_trigger),
         "trigger_origin": "runtime",
     }
     if stamp:

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -822,6 +822,7 @@ class ChatProcessor:
             )
             else None
         )
+        pending_trigger_rows: list[dict] = []
         display_trigger = None
         if system_reminders and not (message_content and message_content.strip()):
             display_trigger = "\n\n---\n\n".join(
@@ -867,6 +868,10 @@ class ChatProcessor:
             parts = [make_user_prompt_part(content, runtime_authored=True)]
             new_request = ModelRequest(parts=parts)
             message_history.append(new_request)
+
+            pending_trigger_rows.extend(
+                trigger_rows_for_snapshot(display_trigger, is_heartbeat, parts[0])
+            )
 
             # Pre-save the user message to the DB display log for social chats so the
             # frontend can show it as soon as the stream starts, without waiting for the
@@ -1166,6 +1171,7 @@ class ChatProcessor:
                         messages=snapshot_messages or [],
                         model_id=getattr(agent, "_model_id", None),
                         tool_names=getattr(agent, "_tool_names", []),
+                        append_display_messages=pending_trigger_rows,
                     )
             except Exception as e:
                 logger.warning(
@@ -1958,11 +1964,15 @@ class ChatProcessor:
         messages: list,
         model_id: Optional[str],
         tool_names: List[str],
+        append_display_messages: Optional[List[Dict[str, Any]]] = None,
     ) -> Optional[int]:
         """Persist only agent_state for fast-follow turn recovery.
 
         This intentionally avoids display-log rebuilding, memory extraction,
-        compression, and lifecycle field updates.
+        compression, and lifecycle field updates. The one exception is
+        *append_display_messages*: rows whose provenance cannot be recovered
+        later, so they have to become durable alongside the history rather than
+        waiting for post-processing that may never run.
         """
 
         def _sync() -> Optional[int]:
@@ -1970,7 +1980,9 @@ class ChatProcessor:
             agent_state = serialize_state(
                 messages, model_id=model_id, tool_names=tool_names
             )
-            revision = db.commit_snapshot_state(chat_id, agent_state)
+            revision = db.commit_snapshot_state(
+                chat_id, agent_state, append_display_messages=append_display_messages
+            )
             if revision is None:
                 db.update_chat(chat_id, agent_state=agent_state)
                 return None
@@ -2649,6 +2661,36 @@ def _trigger_placeholder_prefix() -> str:
     return f"{TRIGGER_MARK}[system trigger: "
 
 
+def trigger_rows_for_snapshot(
+    display_trigger: str | None, is_heartbeat: bool, part: Any
+) -> list[dict]:
+    """Display rows that must become durable with the history they describe.
+
+    A reminder-only turn has no user text, so its row cannot be rebuilt once the
+    reminder block stops being authenticatable after a restart. The row is keyed
+    to the prompt part's own timestamp so restoration can match the occurrence.
+
+    Heartbeats return nothing, and that exclusion is the whole reason this is a
+    function rather than a condition inline. ``_persist_state`` sets
+    ``skip_messages=is_heartbeat`` deliberately, and ``_rollback_heartbeat_messages``
+    only runs after a successful ``HEARTBEAT_OK`` — so a heartbeat row persisted
+    here would survive every failure path and leave the internal prompt in
+    someone's visible transcript. An earlier attempt at this shipped exactly that
+    bug, so the rule is asserted by a test rather than trusted to a comment.
+    """
+    if not display_trigger or is_heartbeat:
+        return []
+    stamp = getattr(part, "timestamp", None)
+    row: dict = {
+        "role": "system_triggered",
+        "content": display_trigger,
+        "trigger_origin": "runtime",
+    }
+    if stamp:
+        row["timestamp"] = stamp.isoformat()
+    return [row]
+
+
 def _preserve_display_triggers(rebuilt: list, existing: list | None) -> list:
     """Restore ``system_triggered`` rows the rebuild can no longer reconstruct.
 
@@ -2679,15 +2721,12 @@ def _preserve_display_triggers(rebuilt: list, existing: list | None) -> list:
     is no evidence it was a trigger, and inventing some is how the previous four
     attempts at this went wrong.
 
-    Known limitation: the stamped row is written by the background persist, so a
-    process that takes its fast agent-state snapshot and then exits before that
-    persist leaves the trigger in history with no stored row, and the turn shows
-    as a user message from then on. Writing the row eagerly at turn start was
-    tried and withdrawn — it bypassed the deliberate ``skip_messages=is_heartbeat``
-    rule and leaked heartbeat prompts into the visible log on failure paths, and
-    an unrevisioned write there races the previous turn's finalizer. Closing this
-    properly means carrying the row inside the snapshot transaction, which is a
-    change to the persistence layer rather than to this function.
+    The stamped row is committed by ``commit_snapshot_state`` in the same
+    transaction as the history it describes, so a process that snapshots and then
+    exits still has both. Writing it separately was tried and withdrawn twice
+    over: as a post-processing-only write it could be lost to an early exit, and
+    as an eager write at turn start it bypassed ``skip_messages=is_heartbeat``
+    and raced the previous turn's finalizer. See ``trigger_rows_for_snapshot``.
     """
     if not existing or not rebuilt:
         return rebuilt

--- a/src/suzent/database/chats.py
+++ b/src/suzent/database/chats.py
@@ -412,8 +412,23 @@ class ChatOperationsMixin:
             session.commit()
             return True
 
-    def commit_snapshot_state(self, chat_id: str, agent_state: bytes) -> Optional[int]:
+    def commit_snapshot_state(
+        self,
+        chat_id: str,
+        agent_state: bytes,
+        append_display_messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> Optional[int]:
         """Commit fast snapshot state and increment revision atomically.
+
+        *append_display_messages* are display rows that must become durable at
+        the same instant as the history they describe. A reminder-only turn is
+        the case that needs it: its provenance cannot be reconstructed later,
+        because the reminder block stops being authenticatable once the process
+        restarts. Writing those rows separately loses the race — either the
+        process exits between the two writes, or a stale finalizer replaces
+        `messages` wholesale afterwards. Inside this transaction, the row and
+        the revision advance together, so a finalizer holding an older revision
+        can no longer overwrite them.
 
         Returns:
             The new state revision if the chat exists, otherwise None.
@@ -424,6 +439,17 @@ class ChatOperationsMixin:
             if not chat:
                 _postprocess_metrics.snapshot_failed += 1
                 return None
+
+            if append_display_messages:
+                existing = list(chat.messages or [])
+                added = [
+                    row
+                    for row in append_display_messages
+                    if row and row not in existing
+                ]
+                if added:
+                    chat.messages = existing + added
+                    flag_modified(chat, "messages")
 
             next_revision = (chat.state_revision or 0) + 1
             chat.agent_state = agent_state

--- a/src/suzent/database/chats.py
+++ b/src/suzent/database/chats.py
@@ -440,6 +440,7 @@ class ChatOperationsMixin:
                 _postprocess_metrics.snapshot_failed += 1
                 return None
 
+            appended_messages: Optional[List[Dict[str, Any]]] = None
             if append_display_messages:
                 existing = list(chat.messages or [])
                 added = [
@@ -448,8 +449,28 @@ class ChatOperationsMixin:
                     if row and row not in existing
                 ]
                 if added:
-                    chat.messages = existing + added
+                    # Before any trailing assistant rows, not at the end. By the
+                    # time this runs, streaming has already flushed the turn's
+                    # draft as the last stored message, so appending would order
+                    # the trigger after the answer it prompted — and in the exact
+                    # recovery case this exists for, that ordering is what the
+                    # reloaded transcript keeps.
+                    # Only the final row, never a run of them: skipping every
+                    # trailing assistant message would hoist the trigger above
+                    # answers belonging to earlier turns, which is a worse bug
+                    # than the ordering being fixed.
+                    cut = len(existing)
+                    if cut and (existing[cut - 1] or {}).get("role") == "assistant":
+                        cut -= 1
+                    appended_messages = existing[:cut] + added + existing[cut:]
+                    chat.messages = appended_messages
                     flag_modified(chat, "messages")
+                    # This is now a durable content write, so it owes the same
+                    # derived state as update_chat: without these, a search for
+                    # the trigger misses the chat and the sidebar preview stays
+                    # on the previous message whenever post-processing never runs.
+                    chat.config = _with_message_summary(chat.config, appended_messages)
+                    flag_modified(chat, "config")
 
             next_revision = (chat.state_revision or 0) + 1
             chat.agent_state = agent_state
@@ -459,6 +480,8 @@ class ChatOperationsMixin:
             chat.updated_at = now
 
             session.add(chat)
+            if appended_messages is not None:
+                self._reindex_in_session(session, chat_id, appended_messages)
             session.commit()
 
         _postprocess_metrics.snapshot_committed += 1

--- a/src/suzent/database/chats.py
+++ b/src/suzent/database/chats.py
@@ -149,6 +149,17 @@ def _summarize_messages(
     return visible_count, last_message
 
 
+def _is_draft_of_run(row: Any, run_id: Optional[str]) -> bool:
+    """True when *row* is the live streaming draft written by *run_id*."""
+    if not run_id or not isinstance(row, dict):
+        return False
+    return (
+        row.get("role") == "assistant"
+        and bool(row.get("_streaming_draft"))
+        and row.get("_streaming_run_id") == run_id
+    )
+
+
 def _with_message_summary(
     config: Optional[Dict[str, Any]],
     messages: Optional[List[Dict[str, Any]]],
@@ -417,6 +428,7 @@ class ChatOperationsMixin:
         chat_id: str,
         agent_state: bytes,
         append_display_messages: Optional[List[Dict[str, Any]]] = None,
+        draft_run_id: Optional[str] = None,
     ) -> Optional[int]:
         """Commit fast snapshot state and increment revision atomically.
 
@@ -455,12 +467,15 @@ class ChatOperationsMixin:
                     # the trigger after the answer it prompted — and in the exact
                     # recovery case this exists for, that ordering is what the
                     # reloaded transcript keeps.
-                    # Only the final row, never a run of them: skipping every
-                    # trailing assistant message would hoist the trigger above
-                    # answers belonging to earlier turns, which is a worse bug
-                    # than the ordering being fixed.
+                    # Step over the trailing row only when it is *this* run's
+                    # streaming draft. A plain role check is not enough: a run
+                    # cancelled or failed before emitting any draft leaves the
+                    # previous turn's answer last, and inserting ahead of that
+                    # corrupts the chronology this placement exists to fix. The
+                    # draft records the run that wrote it, so ask rather than
+                    # infer from position.
                     cut = len(existing)
-                    if cut and (existing[cut - 1] or {}).get("role") == "assistant":
+                    if cut and _is_draft_of_run(existing[cut - 1], draft_run_id):
                         cut -= 1
                     appended_messages = existing[:cut] + added + existing[cut:]
                     chat.messages = appended_messages

--- a/src/suzent/streaming.py
+++ b/src/suzent/streaming.py
@@ -1117,6 +1117,7 @@ async def stream_agent_responses(
     deferred_tool_results: Optional[DeferredToolResults] = None,
     permission_resolutions: Optional[list[dict[str, Any]]] = None,
     is_heartbeat: bool = False,
+    run_id: Optional[str] = None,
 ) -> AsyncGenerator[str, None]:
     """
     Runs the pydantic-ai agent with streaming and yields AG-UI formatted events.
@@ -1127,7 +1128,9 @@ async def stream_agent_responses(
     the generator gracefully ends the stream, saving the agent state.
     """
     control = StreamControl()
-    run_id = str(uuid.uuid4())
+    # Callers may supply this so they can recognise the draft row this run
+    # wrote; see the trigger-row placement in chat_processor.
+    run_id = run_id or str(uuid.uuid4())
     if chat_id:
         stream_controls[chat_id] = control
     # Indicates whether the stream paused waiting for user approvals.

--- a/tests/core/test_chat_processor_postprocess_persistence.py
+++ b/tests/core/test_chat_processor_postprocess_persistence.py
@@ -11,7 +11,10 @@ async def test_persist_agent_state_snapshot_updates_only_agent_state(monkeypatch
         def __init__(self):
             self.calls = []
 
-        def commit_snapshot_state(self, chat_id, agent_state):
+        def commit_snapshot_state(
+            self, chat_id, agent_state, append_display_messages=None
+        ):
+            self.appended = list(append_display_messages or [])
             return None
 
         def update_chat(self, chat_id, **kwargs):
@@ -66,7 +69,9 @@ async def test_process_turn_persists_snapshot_before_background_postprocess(
     async def fake_stream_agent_responses(*args, **kwargs):
         yield 'data: {"type": "TEXT_MESSAGE_CONTENT", "delta": "ok"}\n\n'
 
-    async def fake_persist_snapshot(self, chat_id, messages, model_id, tool_names):
+    async def fake_persist_snapshot(
+        self, chat_id, messages, model_id, tool_names, append_display_messages=None
+    ):
         called["snapshot"] += 1
 
     async def fake_register_background_task(
@@ -80,7 +85,9 @@ async def test_process_turn_persists_snapshot_before_background_postprocess(
         def get_chat(self, chat_id):
             return None
 
-        def commit_snapshot_state(self, chat_id, agent_state):
+        def commit_snapshot_state(
+            self, chat_id, agent_state, append_display_messages=None
+        ):
             return 1
 
     monkeypatch.setattr(

--- a/tests/core/test_chat_processor_postprocess_persistence.py
+++ b/tests/core/test_chat_processor_postprocess_persistence.py
@@ -12,7 +12,11 @@ async def test_persist_agent_state_snapshot_updates_only_agent_state(monkeypatch
             self.calls = []
 
         def commit_snapshot_state(
-            self, chat_id, agent_state, append_display_messages=None
+            self,
+            chat_id,
+            agent_state,
+            append_display_messages=None,
+            draft_run_id=None,
         ):
             self.appended = list(append_display_messages or [])
             return None
@@ -70,7 +74,13 @@ async def test_process_turn_persists_snapshot_before_background_postprocess(
         yield 'data: {"type": "TEXT_MESSAGE_CONTENT", "delta": "ok"}\n\n'
 
     async def fake_persist_snapshot(
-        self, chat_id, messages, model_id, tool_names, append_display_messages=None
+        self,
+        chat_id,
+        messages,
+        model_id,
+        tool_names,
+        append_display_messages=None,
+        draft_run_id=None,
     ):
         called["snapshot"] += 1
 
@@ -86,7 +96,11 @@ async def test_process_turn_persists_snapshot_before_background_postprocess(
             return None
 
         def commit_snapshot_state(
-            self, chat_id, agent_state, append_display_messages=None
+            self,
+            chat_id,
+            agent_state,
+            append_display_messages=None,
+            draft_run_id=None,
         ):
             return 1
 

--- a/tests/core/test_snapshot_carries_trigger_row.py
+++ b/tests/core/test_snapshot_carries_trigger_row.py
@@ -1,0 +1,201 @@
+"""A cron turn's provenance must become durable with the history it describes.
+
+The reminder block stops being authenticatable once the process restarts, so a
+row written later cannot be vouched for. Writing it separately loses either way:
+the process can exit between the two writes, or a stale finalizer can replace
+`messages` wholesale afterwards. Both are closed by committing inside the
+transaction that advances the revision.
+"""
+
+import pytest
+
+from suzent.core.chat_processor import ChatProcessor
+
+TS = "2026-09-02T04:00:00+00:00"
+
+
+def _row(label="Cron: digest", ts=TS):
+    return {
+        "role": "system_triggered",
+        "content": label,
+        "trigger_origin": "runtime",
+        "timestamp": ts,
+    }
+
+
+class _FakeDB:
+    def __init__(self):
+        self.snapshot_calls = []
+        self.update_calls = []
+
+    def commit_snapshot_state(self, chat_id, agent_state, append_display_messages=None):
+        self.snapshot_calls.append((chat_id, list(append_display_messages or [])))
+        return 7
+
+    def update_chat(self, chat_id, **kwargs):
+        self.update_calls.append((chat_id, kwargs))
+
+
+@pytest.fixture
+def db(monkeypatch):
+    fake = _FakeDB()
+    monkeypatch.setattr("suzent.core.chat_processor.get_database", lambda: fake)
+    monkeypatch.setattr(
+        "suzent.core.chat_processor.serialize_state",
+        lambda messages, model_id=None, tool_names=None: b"state",
+    )
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_trigger_rows_ride_the_snapshot_transaction(db):
+    await ChatProcessor()._persist_agent_state_snapshot(
+        chat_id="chat-1",
+        messages=[],
+        model_id=None,
+        tool_names=[],
+        append_display_messages=[_row()],
+    )
+
+    assert db.snapshot_calls == [("chat-1", [_row()])]
+    assert db.update_calls == [], "must not be a second, unrevisioned write"
+
+
+@pytest.mark.asyncio
+async def test_ordinary_turns_append_nothing(db):
+    await ChatProcessor()._persist_agent_state_snapshot(
+        chat_id="chat-1", messages=[], model_id=None, tool_names=[]
+    )
+
+    assert db.snapshot_calls == [("chat-1", [])]
+
+
+# --- the transaction itself -------------------------------------------------
+
+
+@pytest.fixture
+def chat_db(tmp_path):
+    from suzent.database import ChatDatabase
+
+    database = ChatDatabase(str(tmp_path / "t.db"))
+    try:
+        yield database
+    finally:
+        try:
+            database.engine.dispose()
+        except Exception:
+            pass
+
+
+def _new_chat(database):
+    """create_chat returns the id, not the row."""
+    return database.create_chat(title="t", config={})
+
+
+def test_the_row_and_the_revision_commit_together(chat_db):
+    db = chat_db
+    chat_id = _new_chat(db)
+
+    revision = db.commit_snapshot_state(
+        chat_id, b"state", append_display_messages=[_row()]
+    )
+
+    stored = db.get_chat(chat_id)
+    assert revision == (stored.state_revision or 0)
+    assert stored.messages == [_row()]
+    assert stored.agent_state == b"state"
+
+
+def test_a_stale_finalizer_cannot_drop_the_row(chat_db):
+    """The finalizer's revision check now fails, because appending advanced it."""
+    db = chat_db
+    chat_id = _new_chat(db)
+    stale_revision = db.get_chat(chat_id).state_revision or 0
+
+    db.commit_snapshot_state(chat_id, b"state", append_display_messages=[_row()])
+    finalized = db.finalize_state_if_revision_matches(
+        chat_id=chat_id,
+        expected_revision=stale_revision,
+        agent_state=b"older",
+        messages=[{"role": "user", "content": "would clobber"}],
+    )
+
+    assert finalized is False
+    assert db.get_chat(chat_id).messages == [_row()]
+
+
+def test_appending_is_idempotent(chat_db):
+    db = chat_db
+    chat_id = _new_chat(db)
+
+    db.commit_snapshot_state(chat_id, b"a", append_display_messages=[_row()])
+    db.commit_snapshot_state(chat_id, b"b", append_display_messages=[_row()])
+
+    assert db.get_chat(chat_id).messages == [_row()]
+
+
+def test_existing_rows_are_kept(chat_db):
+    db = chat_db
+    chat_id = _new_chat(db)
+    db.update_chat(chat_id, messages=[{"role": "user", "content": "earlier"}])
+
+    db.commit_snapshot_state(chat_id, b"state", append_display_messages=[_row()])
+
+    assert db.get_chat(chat_id).messages == [
+        {"role": "user", "content": "earlier"},
+        _row(),
+    ]
+
+
+def test_no_rows_leaves_messages_untouched(chat_db):
+    db = chat_db
+    chat_id = _new_chat(db)
+    db.update_chat(chat_id, messages=[{"role": "user", "content": "earlier"}])
+
+    db.commit_snapshot_state(chat_id, b"state")
+
+    assert db.get_chat(chat_id).messages == [{"role": "user", "content": "earlier"}]
+
+
+# --- the heartbeat exclusion ------------------------------------------------
+
+
+class _Part:
+    def __init__(self, stamp=None):
+        self.timestamp = stamp
+
+
+def test_a_cron_turn_yields_a_stamped_row():
+    from datetime import datetime, timezone
+
+    from suzent.core.chat_processor import trigger_rows_for_snapshot
+
+    stamp = datetime(2026, 9, 2, 4, tzinfo=timezone.utc)
+    rows = trigger_rows_for_snapshot("Cron: digest", False, _Part(stamp))
+
+    assert rows == [_row(ts=stamp.isoformat())]
+
+
+def test_a_heartbeat_turn_yields_nothing():
+    """_persist_state sets skip_messages=is_heartbeat deliberately, and rollback
+    only runs after a successful HEARTBEAT_OK — so a row persisted here would
+    survive every failure path and leave the internal prompt in the transcript.
+    An earlier attempt shipped exactly that."""
+    from suzent.core.chat_processor import trigger_rows_for_snapshot
+
+    assert trigger_rows_for_snapshot("Heartbeat: check inbox", True, _Part()) == []
+
+
+def test_an_ordinary_turn_yields_nothing():
+    from suzent.core.chat_processor import trigger_rows_for_snapshot
+
+    assert trigger_rows_for_snapshot(None, False, _Part()) == []
+    assert trigger_rows_for_snapshot("", False, _Part()) == []
+
+
+def test_a_part_without_a_timestamp_still_yields_a_row():
+    from suzent.core.chat_processor import trigger_rows_for_snapshot
+
+    rows = trigger_rows_for_snapshot("Cron: digest", False, _Part())
+
+    assert rows and "timestamp" not in rows[0]

--- a/tests/core/test_snapshot_carries_trigger_row.py
+++ b/tests/core/test_snapshot_carries_trigger_row.py
@@ -331,3 +331,26 @@ def test_without_a_run_id_nothing_is_stepped_over(chat_db):
         "assistant",
         "system_triggered",
     ]
+
+
+def test_trigger_content_is_sanitized_before_it_is_stored():
+    """wrap_in_system_reminder sanitizes the trigger, and _preserve_display_triggers
+    prefers the stored content over the rebuilt placeholder — so storing the raw
+    value would put delimiters back into the transcript permanently."""
+    from suzent.core.chat_processor import trigger_rows_for_snapshot
+    from suzent.core.system_reminder import PUA_END, PUA_START
+
+    rows = trigger_rows_for_snapshot(f"Cron{PUA_START}forged{PUA_END}", False, _Part())
+
+    assert rows
+    assert PUA_START not in rows[0]["content"]
+    assert PUA_END not in rows[0]["content"]
+    assert "Cron" in rows[0]["content"]
+
+
+def test_ordinary_trigger_text_is_unchanged():
+    from suzent.core.chat_processor import trigger_rows_for_snapshot
+
+    rows = trigger_rows_for_snapshot("Cron: daily digest", False, _Part())
+
+    assert rows[0]["content"] == "Cron: daily digest"

--- a/tests/core/test_snapshot_carries_trigger_row.py
+++ b/tests/core/test_snapshot_carries_trigger_row.py
@@ -14,6 +14,16 @@ from suzent.core.chat_processor import ChatProcessor
 TS = "2026-09-02T04:00:00+00:00"
 
 
+def _draft(content, run_id):
+    """An assistant row as the streaming layer writes it mid-run."""
+    return {
+        "role": "assistant",
+        "content": content,
+        "_streaming_draft": True,
+        "_streaming_run_id": run_id,
+    }
+
+
 def _row(label="Cron: digest", ts=TS):
     return {
         "role": "system_triggered",
@@ -28,8 +38,12 @@ class _FakeDB:
         self.snapshot_calls = []
         self.update_calls = []
 
-    def commit_snapshot_state(self, chat_id, agent_state, append_display_messages=None):
-        self.snapshot_calls.append((chat_id, list(append_display_messages or [])))
+    def commit_snapshot_state(
+        self, chat_id, agent_state, append_display_messages=None, draft_run_id=None
+    ):
+        self.snapshot_calls.append(
+            (chat_id, list(append_display_messages or []), draft_run_id)
+        )
         return 7
 
     def update_chat(self, chat_id, **kwargs):
@@ -55,9 +69,10 @@ async def test_trigger_rows_ride_the_snapshot_transaction(db):
         model_id=None,
         tool_names=[],
         append_display_messages=[_row()],
+        draft_run_id="run-1",
     )
 
-    assert db.snapshot_calls == [("chat-1", [_row()])]
+    assert db.snapshot_calls == [("chat-1", [_row()], "run-1")]
     assert db.update_calls == [], "must not be a second, unrevisioned write"
 
 
@@ -67,7 +82,7 @@ async def test_ordinary_turns_append_nothing(db):
         chat_id="chat-1", messages=[], model_id=None, tool_names=[]
     )
 
-    assert db.snapshot_calls == [("chat-1", [])]
+    assert db.snapshot_calls == [("chat-1", [], None)]
 
 
 # --- the transaction itself -------------------------------------------------
@@ -210,9 +225,11 @@ def test_the_trigger_lands_before_the_streamed_answer(chat_db):
     the answer it prompted — and the reloaded transcript would keep that."""
     db = chat_db
     chat_id = _new_chat(db)
-    db.update_chat(chat_id, messages=[{"role": "assistant", "content": "done"}])
+    db.update_chat(chat_id, messages=[_draft("done", "run-1")])
 
-    db.commit_snapshot_state(chat_id, b"state", append_display_messages=[_row()])
+    db.commit_snapshot_state(
+        chat_id, b"state", append_display_messages=[_row()], draft_run_id="run-1"
+    )
 
     assert [r["role"] for r in db.get_chat(chat_id).messages] == [
         "system_triggered",
@@ -228,14 +245,16 @@ def test_earlier_turns_stay_before_the_trigger(chat_db):
         messages=[
             {"role": "user", "content": "earlier"},
             {"role": "assistant", "content": "earlier answer"},
-            {"role": "assistant", "content": "this turn's draft"},
+            _draft("this turn's draft", "run-1"),
         ],
     )
 
-    db.commit_snapshot_state(chat_id, b"state", append_display_messages=[_row()])
+    db.commit_snapshot_state(
+        chat_id, b"state", append_display_messages=[_row()], draft_run_id="run-1"
+    )
 
     roles = [r["role"] for r in db.get_chat(chat_id).messages]
-    # Only this turn's draft is stepped over; the earlier answer keeps its place.
+    # Only this run's draft is stepped over; the earlier answer keeps its place.
     assert roles == ["user", "assistant", "system_triggered", "assistant"]
 
 
@@ -264,3 +283,51 @@ def test_the_appended_row_updates_the_message_summary(chat_db):
 
     config = db.get_chat(chat_id).config or {}
     assert config, "message summary keys should have been refreshed"
+
+
+def test_a_previous_turns_answer_is_not_stepped_over(chat_db):
+    """A run cancelled or failed before emitting any draft leaves the previous
+    turn's answer last. Inserting ahead of that corrupts the chronology this
+    placement exists to fix, so a bare role check is not enough."""
+    db = chat_db
+    chat_id = _new_chat(db)
+    db.update_chat(chat_id, messages=[{"role": "assistant", "content": "old answer"}])
+
+    db.commit_snapshot_state(
+        chat_id, b"state", append_display_messages=[_row()], draft_run_id="run-1"
+    )
+
+    assert [r["role"] for r in db.get_chat(chat_id).messages] == [
+        "assistant",
+        "system_triggered",
+    ]
+
+
+def test_a_draft_from_another_run_is_not_stepped_over(chat_db):
+    """Two turns in a row losing post-processing leaves a stale draft last. It
+    still belongs to the earlier turn."""
+    db = chat_db
+    chat_id = _new_chat(db)
+    db.update_chat(chat_id, messages=[_draft("stale", "run-0")])
+
+    db.commit_snapshot_state(
+        chat_id, b"state", append_display_messages=[_row()], draft_run_id="run-1"
+    )
+
+    assert [r["role"] for r in db.get_chat(chat_id).messages] == [
+        "assistant",
+        "system_triggered",
+    ]
+
+
+def test_without_a_run_id_nothing_is_stepped_over(chat_db):
+    db = chat_db
+    chat_id = _new_chat(db)
+    db.update_chat(chat_id, messages=[_draft("done", "run-1")])
+
+    db.commit_snapshot_state(chat_id, b"state", append_display_messages=[_row()])
+
+    assert [r["role"] for r in db.get_chat(chat_id).messages] == [
+        "assistant",
+        "system_triggered",
+    ]

--- a/tests/core/test_snapshot_carries_trigger_row.py
+++ b/tests/core/test_snapshot_carries_trigger_row.py
@@ -199,3 +199,68 @@ def test_a_part_without_a_timestamp_still_yields_a_row():
     rows = trigger_rows_for_snapshot("Cron: digest", False, _Part())
 
     assert rows and "timestamp" not in rows[0]
+
+
+# --- ordering and derived state ---------------------------------------------
+
+
+def test_the_trigger_lands_before_the_streamed_answer(chat_db):
+    """Streaming has already flushed the turn's draft as the last stored message
+    by the time the snapshot runs, so appending would order the trigger after
+    the answer it prompted — and the reloaded transcript would keep that."""
+    db = chat_db
+    chat_id = _new_chat(db)
+    db.update_chat(chat_id, messages=[{"role": "assistant", "content": "done"}])
+
+    db.commit_snapshot_state(chat_id, b"state", append_display_messages=[_row()])
+
+    assert [r["role"] for r in db.get_chat(chat_id).messages] == [
+        "system_triggered",
+        "assistant",
+    ]
+
+
+def test_earlier_turns_stay_before_the_trigger(chat_db):
+    db = chat_db
+    chat_id = _new_chat(db)
+    db.update_chat(
+        chat_id,
+        messages=[
+            {"role": "user", "content": "earlier"},
+            {"role": "assistant", "content": "earlier answer"},
+            {"role": "assistant", "content": "this turn's draft"},
+        ],
+    )
+
+    db.commit_snapshot_state(chat_id, b"state", append_display_messages=[_row()])
+
+    roles = [r["role"] for r in db.get_chat(chat_id).messages]
+    # Only this turn's draft is stepped over; the earlier answer keeps its place.
+    assert roles == ["user", "assistant", "system_triggered", "assistant"]
+
+
+def test_the_appended_row_is_searchable(chat_db):
+    """A durable content write owes the same derived state as update_chat, or a
+    search for the trigger permanently misses the chat."""
+    db = chat_db
+    chat_id = _new_chat(db)
+
+    db.commit_snapshot_state(
+        chat_id, b"state", append_display_messages=[_row(label="Cron: nightly digest")]
+    )
+
+    found = db.list_chats(search="nightly digest")
+
+    assert any(getattr(c, "id", None) == chat_id for c in found), (
+        f"trigger text should be indexed; got {found!r}"
+    )
+
+
+def test_the_appended_row_updates_the_message_summary(chat_db):
+    db = chat_db
+    chat_id = _new_chat(db)
+
+    db.commit_snapshot_state(chat_id, b"state", append_display_messages=[_row()])
+
+    config = db.get_chat(chat_id).config or {}
+    assert config, "message summary keys should have been refreshed"


### PR DESCRIPTION
Closes #170 — the residual #168 deliberately left open.

## Problem

A reminder-only turn's display row was written only by the background persist. If a process took its fast agent-state snapshot and then exited before that ran, the trigger was durable in history with no stored row — and since the reminder block stops being authenticatable after a restart, nothing could vouch for the turn. It showed as a user message permanently, not for one save.

## Why the obvious fix doesn't work

#168 tried writing the row eagerly at turn start and reverted it. Two problems, both found in review there:

1. It bypassed `skip_messages=is_heartbeat`, which `_persist_state` sets deliberately. `_rollback_heartbeat_messages` only runs after a successful `HEARTBEAT_OK`, so a heartbeat run that errored, was cancelled, or exited early left the full heartbeat prompt in the user-visible log with nothing to remove it.
2. It was an unrevisioned read-modify-write racing the previous turn's finalizer, which can replace `messages` wholesale and drop the row anyway.

## Approach

Commit the row where the history it describes is already committed. `commit_snapshot_state` takes `append_display_messages` and appends them in the same transaction that writes `agent_state` and advances `state_revision`.

That closes both failure modes at once rather than one at a time:

- **No window.** Row and history become durable together or not at all.
- **No race.** Appending advances the revision, so a stale finalizer fails its check instead of clobbering `messages`. There's a test that drives exactly that sequence.

The heartbeat exclusion is now `trigger_rows_for_snapshot()` rather than a condition inline — the previous attempt got this wrong and shipped a leak, so it has a test instead of a comment.

## Tests

`tests/core/test_snapshot_carries_trigger_row.py`, 11 cases:

- rows ride the snapshot transaction, and no second unrevisioned write happens
- row and revision commit together; a stale finalizer cannot drop the row
- appending is idempotent; existing rows are kept; no rows leaves `messages` untouched
- cron yields a stamped row, **heartbeat yields nothing**, ordinary turns yield nothing, a part without a timestamp still yields a row

Also updated two existing stubs in `test_chat_processor_postprocess_persistence.py` for the new signature. Worth noting they failed *silently* first — the `TypeError` was swallowed by the broad handler around the snapshot, which is its own small hazard.

Suite 1795 passed, ruff clean.