### PR TITLE
refactor(memory): move notebook procedure into the notebook skill

### DIFF
--- a/skills/notebook/SKILL.md
+++ b/skills/notebook/SKILL.md
@@ -55,6 +55,9 @@ writes.
 
 When filing is authorized:
 
-1. Follow `schema.md` for the destination and page structure.
-2. Update `index.md` only when required by the schema.
-3. Append a `query-filed` entry to `log.md` when the log convention requires it.
+1. Check what already exists first — read `index.md`, and Glob the vault for the
+   topic. A page written without looking is a duplicate or an orphan. Update or
+   link the existing page instead of creating a second one.
+2. Follow `schema.md` for the destination and page structure.
+3. Update `index.md` only when required by the schema.
+4. Append a `query-filed` entry to `log.md` when the log convention requires it.

--- a/skills/notebook/SKILL.md
+++ b/skills/notebook/SKILL.md
@@ -36,6 +36,17 @@ Use the schema's link style. Prefer full vault-relative paths when links could b
 Read the selected procedure completely before acting. Treat referenced binary assets as
 immutable unless the user explicitly asks to replace them.
 
+## Answering from the notebook
+
+1. Read `index.md` first to identify candidate pages.
+2. Read those pages and synthesize with citations back to them.
+3. File the result only under the rules below — answering a question is not
+   itself a reason to write a page.
+
+Durable outputs are comparisons, analyses, syntheses, and decision breakdowns:
+material someone would want to find again. A direct answer to a direct question
+is not one.
+
 ## Filing conversation results
 
 File a result only when the user explicitly requests it or the vault/session has an

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -500,13 +500,24 @@ class ChatProcessor:
         # the stable config, enabling a skill updates persistence but reuses a
         # cached agent that has no SkillTool — and the prompt would then point
         # at a tool the run does not actually have.
+        #
+        # Read through the same per-chat manager build_agent_deps uses, not the
+        # global singleton: toggle_skill persists through a per-chat manager and
+        # never reloads the singleton, so the singleton's answer can be stale
+        # for the life of the process.
         try:
-            from suzent.skills.manager import SkillManager
+            from suzent.skills.manager import get_skill_manager_for_chat
 
             config["_skills_enabled"] = bool(
-                SkillManager.get_instance().has_enabled_skills()
+                get_skill_manager_for_chat(
+                    chat_id,
+                    config.get("cwd"),
+                    custom_volumes=config.get("sandbox_volumes"),
+                    sandbox_enabled=config.get("sandbox_enabled", True),
+                ).has_enabled_skills()
             )
-        except Exception:
+        except Exception as e:
+            logger.debug(f"Could not read skill enablement for {chat_id}: {e}")
             config["_skills_enabled"] = False
 
         config["_has_discovered_skills"] = bool(

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -496,6 +496,19 @@ class ChatProcessor:
             if repository_context.repository_root is not None
             else None
         )
+        # SkillTool equipment is decided once, in create_agent. Without this in
+        # the stable config, enabling a skill updates persistence but reuses a
+        # cached agent that has no SkillTool — and the prompt would then point
+        # at a tool the run does not actually have.
+        try:
+            from suzent.skills.manager import SkillManager
+
+            config["_skills_enabled"] = bool(
+                SkillManager.get_instance().has_enabled_skills()
+            )
+        except Exception:
+            config["_skills_enabled"] = False
+
         config["_has_discovered_skills"] = bool(
             discover_skill_roots(repository_context)
         )

--- a/src/suzent/memory/manager.py
+++ b/src/suzent/memory/manager.py
@@ -54,6 +54,23 @@ DURABLE_SOURCE_TYPES = frozenset({"notebook", "archive_log"})
 CORE_MEMORY_CACHE_MAXSIZE = 256
 
 
+def _notebook_skill_available() -> bool:
+    """Whether the model could actually load the notebook skill this session.
+
+    Skills default to disabled, in which case SkillTool is not equipped at all,
+    so the core-memory section must not send the model after a tool it does not
+    have. Unknown states resolve to False: pointing at the vault directly always
+    works, whereas pointing at an absent tool does not.
+    """
+    try:
+        from suzent.skills.manager import SkillManager
+
+        manager = SkillManager.get_instance()
+        return bool(manager.is_skill_enabled("notebook"))
+    except Exception:
+        return False
+
+
 class MemoryManager:
     """Central memory management service.
 
@@ -386,6 +403,7 @@ class MemoryManager:
             shared_path=shared_path,
             mount_notebook=mount_notebook,
             project_context_path=project_context_path,
+            notebook_skill_available=_notebook_skill_available(),
         )
 
     async def get_core_memory_context(

--- a/src/suzent/memory/manager.py
+++ b/src/suzent/memory/manager.py
@@ -54,23 +54,6 @@ DURABLE_SOURCE_TYPES = frozenset({"notebook", "archive_log"})
 CORE_MEMORY_CACHE_MAXSIZE = 256
 
 
-def _notebook_skill_available() -> bool:
-    """Whether the model could actually load the notebook skill this session.
-
-    Skills default to disabled, in which case SkillTool is not equipped at all,
-    so the core-memory section must not send the model after a tool it does not
-    have. Unknown states resolve to False: pointing at the vault directly always
-    works, whereas pointing at an absent tool does not.
-    """
-    try:
-        from suzent.skills.manager import SkillManager
-
-        manager = SkillManager.get_instance()
-        return bool(manager.is_skill_enabled("notebook"))
-    except Exception:
-        return False
-
-
 class MemoryManager:
     """Central memory management service.
 
@@ -384,6 +367,7 @@ class MemoryManager:
         user_id: Optional[str] = None,
         sandbox_enabled: bool = True,
         path_resolver=None,
+        notebook_skill_available: bool = False,
     ) -> str:
         """Format core memory as text for prompt injection."""
         try:
@@ -403,7 +387,7 @@ class MemoryManager:
             shared_path=shared_path,
             mount_notebook=mount_notebook,
             project_context_path=project_context_path,
-            notebook_skill_available=_notebook_skill_available(),
+            notebook_skill_available=notebook_skill_available,
         )
 
     async def get_core_memory_context(
@@ -412,6 +396,7 @@ class MemoryManager:
         user_id: Optional[str] = None,
         sandbox_enabled: bool = True,
         path_resolver=None,
+        notebook_skill_available: bool = False,
     ) -> str:
         """Core-memory prompt section for a chat, rebuilt when its files change.
 
@@ -431,14 +416,21 @@ class MemoryManager:
                 user_id=user_id,
                 sandbox_enabled=sandbox_enabled,
                 path_resolver=path_resolver,
+                notebook_skill_available=notebook_skill_available,
             )
 
         # Host mode renders the working directory and notebook mount into the
         # section, so a chat that changes its authorized cwd must not be served
         # the previous paths just because the memory files are untouched.
-        key = (chat_id, user_id, sandbox_enabled) + self._resolver_paths(
-            sandbox_enabled, path_resolver
-        )
+        # notebook_skill_available changes the rendered text, so it is part of
+        # the identity. Keying only on memory-file revisions meant toggling the
+        # skill left every existing chat on the previous wording indefinitely.
+        key = (
+            chat_id,
+            user_id,
+            sandbox_enabled,
+            notebook_skill_available,
+        ) + self._resolver_paths(sandbox_enabled, path_resolver)
         try:
             revision = store.core_memory_revision(chat_id)
         except Exception as e:
@@ -456,6 +448,7 @@ class MemoryManager:
             user_id=user_id,
             sandbox_enabled=sandbox_enabled,
             path_resolver=path_resolver,
+            notebook_skill_available=notebook_skill_available,
         )
         # format_core_memory_for_context() swallows read errors and returns "".
         # Caching that under an unchanged revision would turn one bad request into

--- a/src/suzent/memory/memory_context.py
+++ b/src/suzent/memory/memory_context.py
@@ -30,7 +30,8 @@ def _notebook_hint(title: str, root: str, skill_available: bool) -> str:
         )
     return (
         f"{title}\n"
-        f"Read `{root}/schema.md` before any vault work — it is the authority on "
+        f"To answer from it, start at `{root}/index.md` and cite the pages you use. "
+        f"Before changing it, read `{root}/schema.md` — it is the authority on "
         "structure, naming, indexes and cross-links. Check for an existing page "
         "before creating one, and file a result only when asked to."
     )

--- a/src/suzent/memory/memory_context.py
+++ b/src/suzent/memory/memory_context.py
@@ -12,6 +12,30 @@ from suzent.memory.markdown_store import MEMORY_GENERATED_END
 # ===== Core Memory Context Prompts =====
 
 
+def _notebook_hint(title: str, root: str, skill_available: bool) -> str:
+    """Point at wherever the vault conventions can actually be reached.
+
+    Skills are disabled by default, so `SkillTool` is often not equipped. Naming
+    a skill the model cannot load would be worse than saying nothing — it looks
+    like a route out of the problem and is not one. In that case point at the
+    vault's own `schema.md`, which the skill itself treats as the sole authority
+    anyway, so the fallback is the same source without the tool in between.
+    """
+    if skill_available:
+        return (
+            f"{title}\n"
+            "Load the `notebook` skill before any vault work. It owns the vault "
+            "conventions, the ingest and lint runbooks, and the rules for when a "
+            "result may be filed."
+        )
+    return (
+        f"{title}\n"
+        f"Read `{root}/schema.md` before any vault work — it is the authority on "
+        "structure, naming, indexes and cross-links. Check for an existing page "
+        "before creating one, and file a result only when asked to."
+    )
+
+
 def format_core_memory_section(
     blocks: Dict[str, str],
     sandbox_enabled: bool = True,
@@ -20,6 +44,7 @@ def format_core_memory_section(
     mount_skills: Optional[str] = None,
     mount_notebook: Optional[str] = None,
     project_context_path: Optional[str] = None,
+    notebook_skill_available: bool = True,
 ) -> str:
     """
     Format core memory blocks for agent context injection.
@@ -54,11 +79,8 @@ def format_core_memory_section(
             f"- `{_context_path}` — **this project's** shared scratchpad and task state\n"
             "- `/shared/memory/archive/YYYY-MM-DD.md` — daily knowledge logs (auto-written, append-only)"
         )
-        notebook_hint = (
-            "## Notebook (/mnt/notebook/)\n"
-            "Load the `notebook` skill before any vault work. It owns the vault "
-            "conventions, the ingest and lint runbooks, and the rules for when a "
-            "result may be filed."
+        notebook_hint = _notebook_hint(
+            "## Notebook (/mnt/notebook/)", "/mnt/notebook", notebook_skill_available
         )
         curated_memory_hint = "- Read `/shared/memory/MEMORY.md` for a curated summary of everything you know about the user"
     else:
@@ -73,11 +95,8 @@ def format_core_memory_section(
             f"- `{_context_path}` — **this project's** shared scratchpad and task state\n"
             f"- `{_shared}/memory/archive/YYYY-MM-DD.md` — daily knowledge logs (auto-written, append-only)"
         )
-        notebook_hint = (
-            "## Notebook (Host-Mounted Paths)\n"
-            "Load the `notebook` skill before any vault work. It owns the vault "
-            "conventions, the ingest and lint runbooks, and the rules for when a "
-            "result may be filed."
+        notebook_hint = _notebook_hint(
+            "## Notebook (Host-Mounted Paths)", _notebook, notebook_skill_available
         )
         if not _notebook:
             notebook_hint = (

--- a/src/suzent/memory/memory_context.py
+++ b/src/suzent/memory/memory_context.py
@@ -54,10 +54,11 @@ def format_core_memory_section(
             f"- `{_context_path}` — **this project's** shared scratchpad and task state\n"
             "- `/shared/memory/archive/YYYY-MM-DD.md` — daily knowledge logs (auto-written, append-only)"
         )
-        notebook_title = "## Notebook (/mnt/notebook/)"
-        notebook_runbook = (
-            "Load the `notebook` skill, then follow its advertised `ingest.md` "
-            "or `lint.md` runbook."
+        notebook_hint = (
+            "## Notebook (/mnt/notebook/)\n"
+            "Load the `notebook` skill before any vault work. It owns the vault "
+            "conventions, the ingest and lint runbooks, and the rules for when a "
+            "result may be filed."
         )
         curated_memory_hint = "- Read `/shared/memory/MEMORY.md` for a curated summary of everything you know about the user"
     else:
@@ -72,13 +73,17 @@ def format_core_memory_section(
             f"- `{_context_path}` — **this project's** shared scratchpad and task state\n"
             f"- `{_shared}/memory/archive/YYYY-MM-DD.md` — daily knowledge logs (auto-written, append-only)"
         )
-        notebook_title = "## Notebook (Host-Mounted Paths)"
-        notebook_runbook = (
-            "Load the `notebook` skill, then follow its advertised `ingest.md` "
-            "or `lint.md` runbook."
+        notebook_hint = (
+            "## Notebook (Host-Mounted Paths)\n"
+            "Load the `notebook` skill before any vault work. It owns the vault "
+            "conventions, the ingest and lint runbooks, and the rules for when a "
+            "result may be filed."
         )
         if not _notebook:
-            notebook_runbook += " If notebook is not configured in this session, skip notebook operations."
+            notebook_hint = (
+                "## Notebook\n"
+                "No notebook is configured in this session; skip notebook operations."
+            )
         curated_memory_hint = f"- Read `{_shared}/memory/MEMORY.md` for a curated summary of everything you know about the user"
 
     return f"""# Memory System
@@ -103,29 +108,7 @@ Your memory lives in plain markdown files you can read and write directly:
   above that line is not yours and will not survive the next pass
 - Do **not** append duplicate or ephemeral information; keep files concise and scannable
 
-{notebook_title}
-Your notebook IS the wiki. Pages live directly in the vault alongside your other notes —
-no separate subfolder. You own this layer: create pages, update them, maintain cross-references,
-and respect the existing vault structure.
-
-Navigation:
-- `index.md` - catalog of synthesized pages by category (at notebook root)
-- `log.md` - append-only record of ingests, query filings, and lint passes (at notebook root)
-
-**Before creating any page:** explore the vault with GlobTool to check whether a folder or
-file already exists for that topic. If it does, link to it — do not duplicate it.
-
-Query workflow:
-1) Read `index.md` first to identify candidate pages
-2) Read relevant pages and synthesize with citations
-3) File the result only when the user explicitly requests it or an enabled capture policy requires it
-
-Durable outputs include comparisons, analyses, syntheses, and decision breakdowns.
-When filing an authorized durable output:
-- Write a page in the appropriate vault location (not necessarily the root)
-- Follow the vault's `schema.md` for index and log updates
-
-{notebook_runbook}
+{notebook_hint}
 
 **Memory Guidelines:**
 - Search archival memory before asking the user for information they may have already shared

--- a/src/suzent/memory/memory_context.py
+++ b/src/suzent/memory/memory_context.py
@@ -33,7 +33,8 @@ def _notebook_hint(title: str, root: str, skill_available: bool) -> str:
         f"To answer from it, start at `{root}/index.md` and cite the pages you use. "
         f"Before changing it, read `{root}/schema.md` — it is the authority on "
         "structure, naming, indexes and cross-links. Check for an existing page "
-        "before creating one, and file a result only when asked to."
+        "before creating one. File a result only when you are asked to or an "
+        "enabled capture policy requires it."
     )
 
 

--- a/src/suzent/prompts.py
+++ b/src/suzent/prompts.py
@@ -469,6 +469,27 @@ def build_citation_section(deps: Any) -> str:
     return CITATION_RULES_SECTION
 
 
+def _notebook_skill_available(deps: Any) -> bool:
+    """Whether *this run* could load the notebook skill.
+
+    Reads the run's own skill manager off deps rather than the global
+    singleton. A repository-provided skill is discovered into a per-chat manager
+    whose skills are enabled by default, so the singleton can say "disabled"
+    while the run can load it perfectly well — and runtime toggles land on the
+    per-chat manager too.
+
+    Unknown resolves to False: pointing at the vault always works, pointing at
+    an absent tool does not.
+    """
+    manager = getattr(deps, "skill_manager", None)
+    if manager is None:
+        return False
+    try:
+        return bool(manager.is_skill_enabled("notebook"))
+    except Exception:
+        return False
+
+
 def register_dynamic_instructions(
     agent: Any,
     *,
@@ -592,6 +613,7 @@ def register_dynamic_instructions(
                 user_id=getattr(deps, "user_id", "") or None,
                 sandbox_enabled=getattr(deps, "sandbox_enabled", True),
                 path_resolver=getattr(deps, "path_resolver", None),
+                notebook_skill_available=_notebook_skill_available(deps),
             )
         except Exception as e:
             # Better a prompt with no core memory than one carrying someone

--- a/tests/memory/test_core_memory_scope.py
+++ b/tests/memory/test_core_memory_scope.py
@@ -75,3 +75,60 @@ def test_the_memory_file_safety_rule_survives(sandbox: bool) -> None:
 def test_core_memory_stays_within_budget(sandbox: bool) -> None:
     """A ceiling so procedure cannot drift back in. Was 3264 chars."""
     assert len(_section(sandbox)) < 2600, len(_section(sandbox))
+
+
+# --- the pointer has to be reachable ----------------------------------------
+
+
+@pytest.mark.parametrize("sandbox", [True, False])
+def test_without_the_skill_it_points_at_the_vault_instead(sandbox: bool) -> None:
+    """Skills are disabled by default, so SkillTool is often not equipped.
+    Naming a skill the model cannot load is worse than saying nothing — it looks
+    like a route out of the problem and is not one."""
+    section = format_core_memory_section(
+        BLOCKS,
+        sandbox_enabled=sandbox,
+        shared_path="/host/shared",
+        mount_notebook="/host/nb",
+        notebook_skill_available=False,
+    )
+
+    assert "`notebook` skill" not in section
+    assert "schema.md" in section
+    assert "existing page" in section
+
+
+@pytest.mark.parametrize("sandbox", [True, False])
+def test_the_fallback_stays_short(sandbox: bool) -> None:
+    """It is a pointer to the vault's own authority, not the runbook again."""
+    section = format_core_memory_section(
+        BLOCKS,
+        sandbox_enabled=sandbox,
+        shared_path="/host/shared",
+        mount_notebook="/host/nb",
+        notebook_skill_available=False,
+    )
+
+    for procedure in ("ingest.md", "lint.md", "log.md", "query workflow"):
+        assert procedure not in section.lower()
+    assert len(section) < 2600, len(section)
+
+
+def test_availability_defaults_to_false_when_it_cannot_be_determined() -> None:
+    """Pointing at the vault always works; pointing at an absent tool does not."""
+    from suzent.memory.manager import _notebook_skill_available
+
+    assert _notebook_skill_available() in (True, False)
+
+
+def test_unknown_skill_state_is_treated_as_unavailable(monkeypatch) -> None:
+    import suzent.memory.manager as manager_mod
+
+    def boom():
+        raise RuntimeError("no skill manager")
+
+    monkeypatch.setattr(
+        "suzent.skills.manager.SkillManager.get_instance", staticmethod(boom)
+    )
+
+    assert manager_mod._notebook_skill_available() is False

--- a/tests/memory/test_core_memory_scope.py
+++ b/tests/memory/test_core_memory_scope.py
@@ -62,6 +62,10 @@ def test_the_fallback_covers_answering_as_well_as_writing(sandbox: bool) -> None
 
     assert "index.md" in section and "cite" in section
     assert "schema.md" in section
+    # The capture-policy exception matters here specifically: with no skill,
+    # this text is the only thing authorising an automatic capture, and "only
+    # when asked" silently disabled them.
+    assert "capture policy" in section
 
 
 @pytest.mark.parametrize("sandbox", [True, False])

--- a/tests/memory/test_core_memory_scope.py
+++ b/tests/memory/test_core_memory_scope.py
@@ -114,21 +114,66 @@ def test_the_fallback_stays_short(sandbox: bool) -> None:
     assert len(section) < 2600, len(section)
 
 
-def test_availability_defaults_to_false_when_it_cannot_be_determined() -> None:
-    """Pointing at the vault always works; pointing at an absent tool does not."""
-    from suzent.memory.manager import _notebook_skill_available
+def test_availability_reads_the_runs_own_skill_manager() -> None:
+    """A repository-provided skill is discovered into a per-chat manager whose
+    skills are enabled by default, so the global singleton can say 'disabled'
+    while this run can load it fine."""
+    from types import SimpleNamespace
 
-    assert _notebook_skill_available() in (True, False)
+    from suzent.prompts import _notebook_skill_available
 
-
-def test_unknown_skill_state_is_treated_as_unavailable(monkeypatch) -> None:
-    import suzent.memory.manager as manager_mod
-
-    def boom():
-        raise RuntimeError("no skill manager")
-
-    monkeypatch.setattr(
-        "suzent.skills.manager.SkillManager.get_instance", staticmethod(boom)
+    enabled = SimpleNamespace(
+        skill_manager=SimpleNamespace(is_skill_enabled=lambda n: True)
+    )
+    disabled = SimpleNamespace(
+        skill_manager=SimpleNamespace(is_skill_enabled=lambda n: False)
     )
 
-    assert manager_mod._notebook_skill_available() is False
+    assert _notebook_skill_available(enabled) is True
+    assert _notebook_skill_available(disabled) is False
+
+
+def test_no_skill_manager_is_treated_as_unavailable() -> None:
+    from types import SimpleNamespace
+
+    from suzent.prompts import _notebook_skill_available
+
+    assert _notebook_skill_available(SimpleNamespace()) is False
+    assert _notebook_skill_available(SimpleNamespace(skill_manager=None)) is False
+
+
+def test_a_broken_skill_manager_is_treated_as_unavailable() -> None:
+    """Pointing at the vault always works; pointing at an absent tool does not."""
+    from types import SimpleNamespace
+
+    from suzent.prompts import _notebook_skill_available
+
+    def boom(name: str) -> bool:
+        raise RuntimeError("skill state unreadable")
+
+    deps = SimpleNamespace(skill_manager=SimpleNamespace(is_skill_enabled=boom))
+
+    assert _notebook_skill_available(deps) is False
+
+
+@pytest.mark.asyncio
+async def test_toggling_the_skill_invalidates_the_cached_section(tmp_path) -> None:
+    """The section is cached on memory-file revisions, so without this in the
+    key an existing chat would keep the old wording forever after a toggle."""
+    from suzent.memory.manager import MemoryManager
+    from suzent.memory.markdown_store import MarkdownMemoryStore
+
+    store = MarkdownMemoryStore(
+        base_dir=tmp_path / "memory", notebook_dir=tmp_path / "notebook"
+    )
+    manager = MemoryManager(store=None, markdown_store=store)
+
+    without = await manager.get_core_memory_context(
+        chat_id="c1", user_id="u1", notebook_skill_available=False
+    )
+    with_skill = await manager.get_core_memory_context(
+        chat_id="c1", user_id="u1", notebook_skill_available=True
+    )
+
+    assert "schema.md" in without
+    assert "`notebook` skill" in with_skill

--- a/tests/memory/test_core_memory_scope.py
+++ b/tests/memory/test_core_memory_scope.py
@@ -1,0 +1,77 @@
+"""Core memory carries state, not procedure.
+
+It is injected on every turn a chat has memory enabled, so anything in it is
+paid for continuously. Notebook conventions, ingest and lint runbooks, and
+filing policy are procedure — they belong to the `notebook` skill, which is
+loaded only when the work actually calls for it.
+"""
+
+import pytest
+
+from suzent.memory.memory_context import format_core_memory_section
+
+BLOCKS = {"persona": "p", "user": "u", "facts": "f", "context": "c"}
+
+
+def _section(sandbox: bool = True, notebook: str | None = "/host/nb") -> str:
+    return format_core_memory_section(
+        BLOCKS,
+        sandbox_enabled=sandbox,
+        shared_path="/host/shared",
+        mount_notebook=notebook,
+    )
+
+
+@pytest.mark.parametrize("sandbox", [True, False])
+def test_core_memory_still_carries_the_blocks(sandbox: bool) -> None:
+    """The state itself is the reason this section exists."""
+    section = _section(sandbox)
+
+    for value in BLOCKS.values():
+        assert value in section
+
+
+@pytest.mark.parametrize("sandbox", [True, False])
+def test_notebook_procedure_is_not_in_the_always_on_prompt(sandbox: bool) -> None:
+    section = _section(sandbox).lower()
+
+    for procedure in (
+        "index.md",
+        "log.md",
+        "schema.md",
+        "ingest.md",
+        "lint.md",
+        "globtool",
+        "query workflow",
+        "durable output",
+    ):
+        assert procedure not in section, f"{procedure!r} belongs to the notebook skill"
+
+
+@pytest.mark.parametrize("sandbox", [True, False])
+def test_it_still_points_at_the_skill(sandbox: bool) -> None:
+    """Removing the procedure must not remove the pointer to where it lives."""
+    assert "`notebook` skill" in _section(sandbox)
+
+
+def test_an_unconfigured_notebook_says_so_and_nothing_more() -> None:
+    section = _section(sandbox=False, notebook=None)
+
+    assert "No notebook is configured" in section
+    assert "`notebook` skill" not in section
+
+
+@pytest.mark.parametrize("sandbox", [True, False])
+def test_the_memory_file_safety_rule_survives(sandbox: bool) -> None:
+    """MEMORY.md's generated zone is overwritten by consolidation; losing that
+    warning would cost the user real text."""
+    section = _section(sandbox)
+
+    assert "MEMORY.md" in section
+    assert "below" in section
+
+
+@pytest.mark.parametrize("sandbox", [True, False])
+def test_core_memory_stays_within_budget(sandbox: bool) -> None:
+    """A ceiling so procedure cannot drift back in. Was 3264 chars."""
+    assert len(_section(sandbox)) < 2600, len(_section(sandbox))

--- a/tests/memory/test_core_memory_scope.py
+++ b/tests/memory/test_core_memory_scope.py
@@ -201,3 +201,23 @@ async def test_toggling_the_skill_invalidates_the_cached_section(tmp_path) -> No
 
     assert "schema.md" in without
     assert "`notebook` skill" in with_skill
+
+
+def test_enabling_a_skill_rebuilds_the_agent() -> None:
+    """SkillTool equipment is fixed in create_agent, so skill state has to be
+    part of the agent cache key. Otherwise a toggle updates persistence, the
+    per-request manager reports the skill as enabled, and the prompt points at
+    a tool the cached agent never equipped."""
+    from suzent.agent_manager import _TRANSIENT_KEYS
+
+    assert "_skills_enabled" not in _TRANSIENT_KEYS
+
+
+def test_skill_state_is_recorded_in_the_agent_config() -> None:
+    import inspect
+
+    from suzent.core import chat_processor
+
+    source = inspect.getsource(chat_processor.ChatProcessor.process_turn)
+
+    assert "_skills_enabled" in source

--- a/tests/memory/test_core_memory_scope.py
+++ b/tests/memory/test_core_memory_scope.py
@@ -49,6 +49,22 @@ def test_notebook_procedure_is_not_in_the_always_on_prompt(sandbox: bool) -> Non
 
 
 @pytest.mark.parametrize("sandbox", [True, False])
+def test_the_fallback_covers_answering_as_well_as_writing(sandbox: bool) -> None:
+    """Two different things can go wrong in a vault: a bad answer and a bad
+    write. The fallback guarded only the second."""
+    section = format_core_memory_section(
+        BLOCKS,
+        sandbox_enabled=sandbox,
+        shared_path="/host/shared",
+        mount_notebook="/host/nb",
+        notebook_skill_available=False,
+    )
+
+    assert "index.md" in section and "cite" in section
+    assert "schema.md" in section
+
+
+@pytest.mark.parametrize("sandbox", [True, False])
 def test_it_still_points_at_the_skill(sandbox: bool) -> None:
     """Removing the procedure must not remove the pointer to where it lives."""
     assert "`notebook` skill" in _section(sandbox)
@@ -96,6 +112,10 @@ def test_without_the_skill_it_points_at_the_vault_instead(sandbox: bool) -> None
     assert "`notebook` skill" not in section
     assert "schema.md" in section
     assert "existing page" in section
+    # Answering, not just writing. On a fresh install this is the only notebook
+    # guidance the model gets, so omitting retrieval loses the query path
+    # entirely rather than merely degrading it.
+    assert "index.md" in section
 
 
 @pytest.mark.parametrize("sandbox", [True, False])

--- a/tests/memory/test_core_memory_scope.py
+++ b/tests/memory/test_core_memory_scope.py
@@ -221,3 +221,8 @@ def test_skill_state_is_recorded_in_the_agent_config() -> None:
     source = inspect.getsource(chat_processor.ChatProcessor.process_turn)
 
     assert "_skills_enabled" in source
+    # Through the per-chat manager, not the singleton: toggle_skill persists via
+    # a per-chat manager and never reloads the singleton, so the singleton can
+    # answer with pre-toggle state for the life of the process.
+    assert "get_skill_manager_for_chat(" in source
+    assert "SkillManager.get_instance()" not in source

--- a/tests/prompts/test_prompt_path_modes.py
+++ b/tests/prompts/test_prompt_path_modes.py
@@ -21,8 +21,19 @@ def test_memory_context_host_mode_avoids_virtual_paths():
     assert "/mnt/notebook" not in text
     assert "/shared/memory/" not in text
     assert "${SHARED_PATH}/memory/MEMORY.md" in text
-    assert "Load the `notebook` skill" in text
+    # No notebook mount was supplied, so the section says so rather than
+    # pointing at a skill for a resource this session does not have.
+    assert "No notebook is configured" in text
     assert "MOUNT_SKILLS" not in text
+
+
+def test_memory_context_host_mode_points_at_the_skill_when_mounted():
+    text = format_core_memory_section(
+        _sample_blocks(), sandbox_enabled=False, mount_notebook="/host/vault"
+    )
+
+    assert "Load the `notebook` skill" in text
+    assert "/mnt/notebook" not in text
 
 
 def test_memory_context_sandbox_mode_keeps_virtual_paths():


### PR DESCRIPTION
P1-6 from the prompt/reminder audit.

## Problem

The core-memory section is injected on **every turn** a chat has memory enabled. Roughly a third of it was notebook procedure:

- vault structure and "your notebook IS the wiki"
- `index.md` / `log.md` navigation
- the pre-creation GlobTool duplicate check
- the query workflow
- what counts as a durable output
- pointers to the `ingest.md` / `lint.md` runbooks

None of it applies unless someone is working in the vault, and all of it competed for attention on ordinary coding and chat turns.

## What moved where

The `notebook` skill already owned nearly all of it — schema authority, `index.md`/`log.md` rules, ingest and lint procedures, filing policy, and the Glob check (`ingest.md:53`). So this is mostly deleting a second copy.

Only two things were unique to the prompt, and those moved into `SKILL.md` rather than being dropped: the query workflow (read index → synthesize with citations → file only when authorized) and the definition of a durable output.

**Core memory keeps state and the rules that protect it:** the blocks, where the files live, and the warning that consolidation rewrites everything above `MEMORY.md`'s generated marker — losing that one would cost the user real text.

## Behaviour change worth noting

In host mode with no notebook mount, the section previously said "Load the `notebook` skill … If notebook is not configured, skip notebook operations." It now just says no notebook is configured. Naming a skill for a resource the session does not have is noise, and the skill itself already handles the unconfigured case. `test_memory_context_host_mode_avoids_virtual_paths` was asserting the old string; updated, and a new case covers the mounted-host path so pointer coverage is not lost.

## Result

**3264 → 2261 characters**, every turn.

`tests/memory/test_core_memory_scope.py` asserts the blocks survive, procedure is gone, the pointer remains, the unconfigured case is clean, the `MEMORY.md` safety rule survives, and the section stays under 2600 chars. Five of them fail against the previous version — verified by stashing `src/`.

Suite 1855 passed, ruff clean.