### PR TITLE
fix(plan): charge goal budget on completed turns, not on prompt assembly

### DIFF
--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -837,13 +837,13 @@ class ChatProcessor:
             _is_user_turn if counts_toward_goal is None else counts_toward_goal
         )
 
-        from suzent.tools.plan_hooks import active_goal_id, advance_goal_turn
+        from suzent.tools.plan_hooks import active_goal_identity, advance_goal_turn
 
         # Pinned at turn start: a goal the agent creates mid-turn did not cost
         # this turn anything, and charging it can pause a max_turns=1 goal
         # before it runs a single step.
         _goal_at_start = (
-            active_goal_id(chat_id)
+            active_goal_identity(chat_id)
             if _counts_toward_goal and not is_heartbeat
             else None
         )
@@ -1265,7 +1265,7 @@ class ChatProcessor:
             # block: the judge could read the previous count, start one more
             # autonomous run, and take the goal past max_turns.
             if _counts_toward_goal and not stream_failed and _goal_at_start:
-                advance_goal_turn(chat_id, only_goal_id=_goal_at_start)
+                advance_goal_turn(chat_id, only_goal=_goal_at_start)
 
             # 10. Goal-mode continuation. After a normal turn, let the judge decide
             # whether to auto-continue toward a standing goal. Cheap no-op (one

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -444,6 +444,7 @@ class ChatProcessor:
         _message_history_override: list = None,
         system_reminders: list[str] = None,
         incoming_citation_sources: list[dict] = None,
+        counts_toward_goal: Optional[bool] = None,
     ) -> AsyncGenerator[str, None]:
         """
         Process a user message turn:
@@ -1204,7 +1205,11 @@ class ChatProcessor:
                     agent=agent,
                     postprocess_job_id=postprocess_job_id,
                     file_snapshot=file_snapshot_json,
-                    is_user_turn=bool(_turn_message),
+                    counts_toward_goal=(
+                        bool(_turn_message)
+                        if counts_toward_goal is None
+                        else counts_toward_goal
+                    ),
                 )
 
             task_id = f"post_process_{chat_id}_{postprocess_job_id}"
@@ -1277,7 +1282,7 @@ class ChatProcessor:
         agent: Any,
         postprocess_job_id: str,
         file_snapshot: list[dict],
-        is_user_turn: bool = False,
+        counts_toward_goal: bool = False,
     ) -> None:
         """Background post-processing for a completed turn.
 
@@ -1436,7 +1441,7 @@ class ChatProcessor:
                 # hook, which every prompt-assembling path calls — heartbeats,
                 # approval resumes, tool continuations and retries all spent
                 # budget on turns the user never took.
-                if is_user_turn and not stream_failed:
+                if counts_toward_goal and not stream_failed:
                     from suzent.tools.plan_hooks import advance_goal_turn
 
                     advance_goal_turn(chat_id)
@@ -1529,6 +1534,10 @@ class ChatProcessor:
             chat_id=chat_id,
             user_id=user_id,
             message_content=replay_message,
+            # The original turn already charged the goal, and the retry
+            # checkpoint restores chat state, messages and files but not the
+            # counter — so replaying would bill the same work twice.
+            counts_toward_goal=False,
             files=replay_files if replay_files else None,
             config_override=merged_config,
             is_social=is_social,
@@ -1722,6 +1731,7 @@ class ChatProcessor:
         is_heartbeat: bool = False,
         system_reminders: list[str] = None,
         incoming_citation_sources: list[dict] = None,
+        counts_toward_goal: Optional[bool] = None,
     ) -> str:
         """Run a chat turn with an SSE background stream so the frontend can watch it.
 
@@ -1744,6 +1754,7 @@ class ChatProcessor:
             _stream_queue=stream_queue,
             system_reminders=system_reminders,
             incoming_citation_sources=incoming_citation_sources,
+            counts_toward_goal=counts_toward_goal,
         )
 
     async def _process_upload_file(

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -837,6 +837,17 @@ class ChatProcessor:
             _is_user_turn if counts_toward_goal is None else counts_toward_goal
         )
 
+        from suzent.tools.plan_hooks import active_goal_id, advance_goal_turn
+
+        # Pinned at turn start: a goal the agent creates mid-turn did not cost
+        # this turn anything, and charging it can pause a max_turns=1 goal
+        # before it runs a single step.
+        _goal_at_start = (
+            active_goal_id(chat_id)
+            if _counts_toward_goal and not is_heartbeat
+            else None
+        )
+
         pending_trigger_rows: list[dict] = []
         # Shared with the streaming layer so the draft row this run writes can
         # be told apart from a previous turn's answer when placing the trigger.
@@ -1253,10 +1264,8 @@ class ChatProcessor:
             # budget. Doing it inside the background post-process raced this
             # block: the judge could read the previous count, start one more
             # autonomous run, and take the goal past max_turns.
-            if _counts_toward_goal and not stream_failed:
-                from suzent.tools.plan_hooks import advance_goal_turn
-
-                advance_goal_turn(chat_id)
+            if _counts_toward_goal and not stream_failed and _goal_at_start:
+                advance_goal_turn(chat_id, only_goal_id=_goal_at_start)
 
             # 10. Goal-mode continuation. After a normal turn, let the judge decide
             # whether to auto-continue toward a standing goal. Cheap no-op (one
@@ -1626,6 +1635,10 @@ class ChatProcessor:
             message_content="",
             config_override=config_override,
             _message_history_override=message_history,
+            # The steering text goes straight into history, so message_content is
+            # empty — but this is user-initiated work that can trigger another
+            # continuation, so it spends a slot like any other turn.
+            counts_toward_goal=True,
         ):
             yield chunk
 

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -1204,6 +1204,7 @@ class ChatProcessor:
                     agent=agent,
                     postprocess_job_id=postprocess_job_id,
                     file_snapshot=file_snapshot_json,
+                    is_user_turn=bool(_turn_message),
                 )
 
             task_id = f"post_process_{chat_id}_{postprocess_job_id}"
@@ -1276,6 +1277,7 @@ class ChatProcessor:
         agent: Any,
         postprocess_job_id: str,
         file_snapshot: list[dict],
+        is_user_turn: bool = False,
     ) -> None:
         """Background post-processing for a completed turn.
 
@@ -1428,6 +1430,16 @@ class ChatProcessor:
                 db.update_job_step_status(
                     job_id, PostProcessStep.DISPLAY, StepStatus.SUCCESS
                 )
+
+                # Charge the goal budget once, here, for a turn that actually
+                # ran and persisted. It used to be charged inside the reminder
+                # hook, which every prompt-assembling path calls — heartbeats,
+                # approval resumes, tool continuations and retries all spent
+                # budget on turns the user never took.
+                if is_user_turn and not stream_failed:
+                    from suzent.tools.plan_hooks import advance_goal_turn
+
+                    advance_goal_turn(chat_id)
             except Exception as e:
                 logger.error(f"State persistence failed: {e}")
                 db.update_job_step_status(

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -823,6 +823,20 @@ class ChatProcessor:
             )
             else None
         )
+        # Chargeable-turn test, kept separate from _turn_message. That value
+        # answers "should per-turn retrieval hooks run", which needs query text;
+        # this answers "did the user ask for work", which a file alone does. An
+        # attachment-only prompt runs the agent and can trigger continuation, so
+        # it has to spend a slot.
+        _is_user_turn = bool(
+            ((message_content and message_content.strip()) or files)
+            and not is_heartbeat
+            and not resume_approvals
+        )
+        _counts_toward_goal = (
+            _is_user_turn if counts_toward_goal is None else counts_toward_goal
+        )
+
         pending_trigger_rows: list[dict] = []
         # Shared with the streaming layer so the draft row this run writes can
         # be told apart from a previous turn's answer when placing the trigger.
@@ -1205,11 +1219,6 @@ class ChatProcessor:
                     agent=agent,
                     postprocess_job_id=postprocess_job_id,
                     file_snapshot=file_snapshot_json,
-                    counts_toward_goal=(
-                        bool(_turn_message)
-                        if counts_toward_goal is None
-                        else counts_toward_goal
-                    ),
                 )
 
             task_id = f"post_process_{chat_id}_{postprocess_job_id}"
@@ -1239,6 +1248,15 @@ class ChatProcessor:
                     # Last-resort fallback. This path should be rare because overflow
                     # registration bypasses max_concurrent but still respects shutdown.
                     asyncio.create_task(_make_post_process_coro())
+
+            # Charge the goal before continuation is allowed to look at the
+            # budget. Doing it inside the background post-process raced this
+            # block: the judge could read the previous count, start one more
+            # autonomous run, and take the goal past max_turns.
+            if _counts_toward_goal and not stream_failed:
+                from suzent.tools.plan_hooks import advance_goal_turn
+
+                advance_goal_turn(chat_id)
 
             # 10. Goal-mode continuation. After a normal turn, let the judge decide
             # whether to auto-continue toward a standing goal. Cheap no-op (one
@@ -1282,7 +1300,6 @@ class ChatProcessor:
         agent: Any,
         postprocess_job_id: str,
         file_snapshot: list[dict],
-        counts_toward_goal: bool = False,
     ) -> None:
         """Background post-processing for a completed turn.
 
@@ -1436,15 +1453,6 @@ class ChatProcessor:
                     job_id, PostProcessStep.DISPLAY, StepStatus.SUCCESS
                 )
 
-                # Charge the goal budget once, here, for a turn that actually
-                # ran and persisted. It used to be charged inside the reminder
-                # hook, which every prompt-assembling path calls — heartbeats,
-                # approval resumes, tool continuations and retries all spent
-                # budget on turns the user never took.
-                if counts_toward_goal and not stream_failed:
-                    from suzent.tools.plan_hooks import advance_goal_turn
-
-                    advance_goal_turn(chat_id)
             except Exception as e:
                 logger.error(f"State persistence failed: {e}")
                 db.update_job_step_status(

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -1534,10 +1534,14 @@ class ChatProcessor:
             chat_id=chat_id,
             user_id=user_id,
             message_content=replay_message,
-            # The original turn already charged the goal, and the retry
-            # checkpoint restores chat state, messages and files but not the
-            # counter — so replaying would bill the same work twice.
-            counts_toward_goal=False,
+            # Charged like any other turn. A retry is a second attempt that
+            # does real work, and the checkpoint is written at turn start —
+            # before the outcome is known — so there is no record of whether
+            # the first attempt was charged. Forcing False meant a retry of a
+            # *failed* turn went entirely uncounted, and a goal could then run
+            # past max_turns. For a budget whose job is to stop runaway work,
+            # over-charging pauses early and is recoverable with /goal resume;
+            # under-charging removes the stop condition and is not.
             files=replay_files if replay_files else None,
             config_override=merged_config,
             is_social=is_social,
@@ -1675,6 +1679,7 @@ class ChatProcessor:
         system_reminders: list[str] = None,
         incoming_citation_sources: list[dict] = None,
         citation_sources_out: list[dict] = None,
+        counts_toward_goal: Optional[bool] = None,
     ) -> str:
         """Run a conversation turn and return only the final response text.
 
@@ -1700,6 +1705,7 @@ class ChatProcessor:
                 is_heartbeat=is_heartbeat,
                 system_reminders=system_reminders,
                 incoming_citation_sources=incoming_citation_sources,
+                counts_toward_goal=counts_toward_goal,
             ):
                 if _stream_queue is not None:
                     await _stream_queue.put(chunk)

--- a/src/suzent/core/goals.py
+++ b/src/suzent/core/goals.py
@@ -239,6 +239,10 @@ async def run_goal_step(chat_id: str, user_id: str) -> None:
             message_content="",
             config_override=_goal_config_override(),
             system_reminders=[CONTINUATION_PROMPT],
+            # No user message, but this is a turn of work on the goal and has to
+            # be charged — otherwise max_turns can never stop a goal whose judge
+            # keeps asking for more.
+            counts_toward_goal=True,
         )
     except Exception as e:
         logger.error(f"[goal] step execution failed for {chat_id}: {e}")

--- a/src/suzent/database/migrations.py
+++ b/src/suzent/database/migrations.py
@@ -42,6 +42,19 @@ class DatabaseMigrationMixin:
                     conn.execute(text("ALTER TABLE cron_jobs DROP COLUMN is_heartbeat"))
                 conn.commit()
 
+        # Migration: goals gain a generation counter so a replacement can be
+        # told apart from the goal it replaced (same row id, possibly same text).
+        if "goals" in inspector.get_table_names():
+            columns = [col["name"] for col in inspector.get_columns("goals")]
+            if "generation" not in columns:
+                with self.engine.connect() as conn:
+                    conn.execute(
+                        text(
+                            "ALTER TABLE goals ADD COLUMN generation INTEGER DEFAULT 0"
+                        )
+                    )
+                    conn.commit()
+
         # Migration: Add session lifecycle columns to 'chats' table
         if "chats" in inspector.get_table_names():
             columns = [col["name"] for col in inspector.get_columns("chats")]

--- a/src/suzent/database/models.py
+++ b/src/suzent/database/models.py
@@ -175,6 +175,10 @@ class GoalModel(SQLModel, table=True):
     subgoals: list = Field(default_factory=list, sa_column=Column(JSON))
     max_turns: Optional[int] = None
     turns_elapsed: int = Field(default=0)
+    # Bumped whenever `set` replaces this goal in place. The row id survives a
+    # replacement and the objective may be re-set unchanged, so neither
+    # identifies *which* goal a turn was working on; this does.
+    generation: int = Field(default=0)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: Optional[datetime] = None

--- a/src/suzent/tools/goal_tool.py
+++ b/src/suzent/tools/goal_tool.py
@@ -102,12 +102,16 @@ class GoalTool(Tool):
         goal = db.get_goal(project_id, chat_id=chat_id)
         effective_turns = max_turns or DEFAULT_MAX_TURNS
         if goal:
+            # A replacement reuses the row and resets the count, so bump the
+            # generation: anything holding the old identity must not treat this
+            # as the goal it was watching.
             db.update_goal(
                 goal.id,
                 objective=objective,
                 status="active",
                 turns_elapsed=0,
                 max_turns=effective_turns,
+                generation=(goal.generation or 0) + 1,
             )
         else:
             db.create_goal(

--- a/src/suzent/tools/plan_hooks.py
+++ b/src/suzent/tools/plan_hooks.py
@@ -6,8 +6,37 @@ from suzent.logger import get_logger
 logger = get_logger(__name__)
 
 
+def advance_goal_turn(chat_id: str) -> None:
+    """Charge one turn against the active goal's budget.
+
+    Called once per completed user turn from the chat lifecycle, not from the
+    reminder hook. Building a prompt is a read, and this used to run inside it —
+    so the budget was charged by every path that assembled a reminder, including
+    heartbeats, approval resumes and tool continuations, none of which are a turn
+    the user took. Retries charged again for work already paid for.
+
+    Best-effort: a goal that misses one increment is better than a turn that
+    fails because its bookkeeping did.
+    """
+    try:
+        db = get_database()
+        project_id = db.get_chat_project_id(chat_id)
+        if not project_id:
+            return
+        goal = db.get_goal(project_id, chat_id=chat_id)
+        if goal and goal.status == "active":
+            db.update_goal(goal.id, turns_elapsed=goal.turns_elapsed + 1)
+    except Exception as e:
+        logger.warning(f"Could not advance goal turn count for chat {chat_id}: {e}")
+
+
 async def plan_reminder_hook(chat_id: str, deps: Any) -> Optional[str]:
-    """Inject the active project Goal and open Tasks into the system reminder each turn."""
+    """Inject the active project Goal and open Tasks into the system reminder.
+
+    Pure read. Reminder providers run on every path that assembles a prompt, so
+    anything that mutates here is charged to turns the user never took — see
+    advance_goal_turn.
+    """
     db = get_database()
     project_id = db.get_chat_project_id(chat_id)
     if not project_id:
@@ -35,7 +64,6 @@ async def plan_reminder_hook(chat_id: str, deps: Any) -> Optional[str]:
             parts.append(
                 "Evaluate: if the goal is achieved call manage_goal(action='clear'). Otherwise keep working."
             )
-        db.update_goal(goal.id, turns_elapsed=goal.turns_elapsed + 1)
 
     active_tasks = db.list_tasks(
         project_id=project_id,

--- a/src/suzent/tools/plan_hooks.py
+++ b/src/suzent/tools/plan_hooks.py
@@ -6,7 +6,27 @@ from suzent.logger import get_logger
 logger = get_logger(__name__)
 
 
-def advance_goal_turn(chat_id: str) -> None:
+def active_goal_id(chat_id: str) -> Optional[str]:
+    """Id of the goal active for *chat_id* right now, if any.
+
+    Read at turn start so the charge can be pinned to it. Without that, a goal
+    the agent creates during the turn is billed for its own setup — and with
+    max_turns=1 it pauses before running a single autonomous step.
+    """
+    try:
+        db = get_database()
+        project_id = db.get_chat_project_id(chat_id)
+        if not project_id:
+            return None
+        goal = db.get_goal(project_id, chat_id=chat_id)
+        if goal and goal.status == "active":
+            return goal.id
+    except Exception as e:
+        logger.debug(f"Could not read active goal for chat {chat_id}: {e}")
+    return None
+
+
+def advance_goal_turn(chat_id: str, only_goal_id: Optional[str] = None) -> None:
     """Charge one turn against the active goal's budget.
 
     Called once per completed user turn from the chat lifecycle, not from the
@@ -24,8 +44,17 @@ def advance_goal_turn(chat_id: str) -> None:
         if not project_id:
             return
         goal = db.get_goal(project_id, chat_id=chat_id)
-        if goal and goal.status == "active":
-            db.update_goal(goal.id, turns_elapsed=goal.turns_elapsed + 1)
+        if not goal or goal.status != "active":
+            return
+        # Only the goal that was already running when the turn began. A goal
+        # created during the turn did not cost it anything.
+        if only_goal_id is not None and goal.id != only_goal_id:
+            logger.debug(
+                f"Not charging chat {chat_id}: goal {goal.id} was not active at "
+                "turn start"
+            )
+            return
+        db.update_goal(goal.id, turns_elapsed=goal.turns_elapsed + 1)
     except Exception as e:
         logger.warning(f"Could not advance goal turn count for chat {chat_id}: {e}")
 

--- a/src/suzent/tools/plan_hooks.py
+++ b/src/suzent/tools/plan_hooks.py
@@ -6,17 +6,18 @@ from suzent.logger import get_logger
 logger = get_logger(__name__)
 
 
-def active_goal_identity(chat_id: str) -> Optional[tuple[str, str]]:
-    """Identity of the goal active for *chat_id* right now, as (id, objective).
+def active_goal_identity(chat_id: str) -> Optional[tuple[int, int]]:
+    """Identity of the goal active for *chat_id* right now, as (id, generation).
 
     Read at turn start so the charge can be pinned to it. Without that, a goal
     created during the turn is billed for its own setup, and at max_turns=1 it
     pauses before running a single autonomous step.
 
-    The objective is part of the identity because replacing a goal reuses the
-    row: manage_goal(action='set') updates in place and resets turns_elapsed,
-    keeping the same id. Matching on id alone would charge the replacement for
-    work done under the objective it replaced.
+    Generation rather than objective text. Replacing a goal reuses the row and
+    resets turns_elapsed, so the id is unchanged — and the objective can be
+    re-set to the same string, for instance to change only max_turns, so that
+    does not distinguish them either. The counter is bumped on replacement and
+    nothing else, which is the property actually needed.
     """
     try:
         db = get_database()
@@ -25,14 +26,14 @@ def active_goal_identity(chat_id: str) -> Optional[tuple[str, str]]:
             return None
         goal = db.get_goal(project_id, chat_id=chat_id)
         if goal and goal.status == "active":
-            return (goal.id, goal.objective)
+            return (goal.id, goal.generation or 0)
     except Exception as e:
         logger.debug(f"Could not read active goal for chat {chat_id}: {e}")
     return None
 
 
 def advance_goal_turn(
-    chat_id: str, only_goal: Optional[tuple[str, str]] = None
+    chat_id: str, only_goal: Optional[tuple[int, int]] = None
 ) -> None:
     """Charge one turn against the active goal's budget.
 
@@ -55,7 +56,7 @@ def advance_goal_turn(
             return
         # Only the goal that was already running when the turn began. One
         # created — or replaced — during the turn did not cost it anything.
-        if only_goal is not None and (goal.id, goal.objective) != only_goal:
+        if only_goal is not None and (goal.id, goal.generation or 0) != only_goal:
             logger.debug(
                 f"Not charging chat {chat_id}: the active goal changed during the turn"
             )

--- a/src/suzent/tools/plan_hooks.py
+++ b/src/suzent/tools/plan_hooks.py
@@ -6,12 +6,17 @@ from suzent.logger import get_logger
 logger = get_logger(__name__)
 
 
-def active_goal_id(chat_id: str) -> Optional[str]:
-    """Id of the goal active for *chat_id* right now, if any.
+def active_goal_identity(chat_id: str) -> Optional[tuple[str, str]]:
+    """Identity of the goal active for *chat_id* right now, as (id, objective).
 
     Read at turn start so the charge can be pinned to it. Without that, a goal
-    the agent creates during the turn is billed for its own setup — and with
-    max_turns=1 it pauses before running a single autonomous step.
+    created during the turn is billed for its own setup, and at max_turns=1 it
+    pauses before running a single autonomous step.
+
+    The objective is part of the identity because replacing a goal reuses the
+    row: manage_goal(action='set') updates in place and resets turns_elapsed,
+    keeping the same id. Matching on id alone would charge the replacement for
+    work done under the objective it replaced.
     """
     try:
         db = get_database()
@@ -20,13 +25,15 @@ def active_goal_id(chat_id: str) -> Optional[str]:
             return None
         goal = db.get_goal(project_id, chat_id=chat_id)
         if goal and goal.status == "active":
-            return goal.id
+            return (goal.id, goal.objective)
     except Exception as e:
         logger.debug(f"Could not read active goal for chat {chat_id}: {e}")
     return None
 
 
-def advance_goal_turn(chat_id: str, only_goal_id: Optional[str] = None) -> None:
+def advance_goal_turn(
+    chat_id: str, only_goal: Optional[tuple[str, str]] = None
+) -> None:
     """Charge one turn against the active goal's budget.
 
     Called once per completed user turn from the chat lifecycle, not from the
@@ -46,12 +53,11 @@ def advance_goal_turn(chat_id: str, only_goal_id: Optional[str] = None) -> None:
         goal = db.get_goal(project_id, chat_id=chat_id)
         if not goal or goal.status != "active":
             return
-        # Only the goal that was already running when the turn began. A goal
-        # created during the turn did not cost it anything.
-        if only_goal_id is not None and goal.id != only_goal_id:
+        # Only the goal that was already running when the turn began. One
+        # created — or replaced — during the turn did not cost it anything.
+        if only_goal is not None and (goal.id, goal.objective) != only_goal:
             logger.debug(
-                f"Not charging chat {chat_id}: goal {goal.id} was not active at "
-                "turn start"
+                f"Not charging chat {chat_id}: the active goal changed during the turn"
             )
             return
         db.update_goal(goal.id, turns_elapsed=goal.turns_elapsed + 1)

--- a/tests/core/test_goal_turn_counting.py
+++ b/tests/core/test_goal_turn_counting.py
@@ -162,16 +162,32 @@ def test_an_autonomous_goal_step_is_chargeable() -> None:
     assert "counts_toward_goal=True" in source
 
 
-def test_a_replayed_retry_is_not_chargeable() -> None:
-    """The original turn already charged, and apply_retry_checkpoint restores
-    chat state, messages and files but not the counter."""
+def test_a_retry_is_charged_like_any_other_turn() -> None:
+    """A retry does real work, and the checkpoint is written at turn start —
+    before the outcome is known — so nothing records whether the first attempt
+    was charged. Forcing it uncharged let a retry of a *failed* turn go
+    uncounted and a goal run past max_turns. For a budget whose job is to stop
+    runaway work, pausing early is recoverable and failing to stop is not."""
     import inspect
 
     from suzent.core import chat_processor
 
     source = inspect.getsource(chat_processor.ChatProcessor._handle_retry_command)
 
-    assert "counts_toward_goal=False" in source
+    assert "counts_toward_goal=False" not in source
+
+
+def test_the_flag_reaches_process_turn_through_every_entry_point() -> None:
+    """run_goal_step goes through process_background_turn -> process_turn_text
+    -> process_turn. A gap anywhere raises TypeError, which run_goal_step
+    catches and only logs — so autonomous steps would stop silently."""
+    import inspect
+
+    from suzent.core.chat_processor import ChatProcessor
+
+    for method in ("process_turn", "process_turn_text", "process_background_turn"):
+        params = inspect.signature(getattr(ChatProcessor, method)).parameters
+        assert "counts_toward_goal" in params, method
 
 
 def test_an_explicit_answer_overrides_the_inference() -> None:

--- a/tests/core/test_goal_turn_counting.py
+++ b/tests/core/test_goal_turn_counting.py
@@ -136,18 +136,47 @@ def test_a_database_failure_does_not_break_the_turn(monkeypatch):
 # --- which turns qualify ----------------------------------------------------
 
 
-def test_a_plain_user_turn_is_chargeable_by_default() -> None:
-    """process_turn computes `_turn_message` as non-empty only for a real user
-    message that is not a heartbeat and not an approval resume; with no explicit
-    answer, that is what decides."""
+def test_chargeability_is_its_own_predicate_not_the_hook_one() -> None:
+    """`_turn_message` answers 'should retrieval hooks run', which needs query
+    text. Chargeability answers 'did the user ask for work', which a file alone
+    does — an attachment-only prompt runs the agent and can trigger
+    continuation, so it must spend a slot. Reusing the first for the second let
+    those turns run free."""
     import inspect
 
     from suzent.core import chat_processor
 
     source = inspect.getsource(chat_processor.ChatProcessor.process_turn)
 
-    assert "bool(_turn_message)" in source
+    assert "_is_user_turn = bool(" in source
+    assert "or files" in source
     assert "if counts_toward_goal is None" in source
+
+
+def test_the_budget_is_charged_before_continuation_is_scheduled() -> None:
+    """Charging inside the background post-process raced the continuation
+    scheduler: the judge could read the previous count, start one more
+    autonomous run, and take the goal past max_turns."""
+    import inspect
+
+    from suzent.core import chat_processor
+
+    source = inspect.getsource(chat_processor.ChatProcessor.process_turn)
+    charge = source.index("advance_goal_turn(chat_id)")
+    schedule = source.index("maybe_continue_goal")
+
+    assert charge < schedule, "the increment must land before the judge looks"
+
+
+def test_post_processing_no_longer_charges() -> None:
+    """One place only, or the two can disagree."""
+    import inspect
+
+    from suzent.core import chat_processor
+
+    source = inspect.getsource(chat_processor.ChatProcessor._post_process_turn)
+
+    assert "advance_goal_turn" not in source
 
 
 def test_an_autonomous_goal_step_is_chargeable() -> None:

--- a/tests/core/test_goal_turn_counting.py
+++ b/tests/core/test_goal_turn_counting.py
@@ -1,0 +1,149 @@
+"""Goal budget is charged by turns the user took, not by prompt assembly.
+
+The increment used to live inside `plan_reminder_hook`, which runs on every path
+that assembles a reminder. Heartbeats, approval resumes, tool continuations and
+retries all consumed budget, so `turns_elapsed` measured how often a prompt was
+built rather than how much work the user asked for.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from suzent.tools.plan_hooks import advance_goal_turn, plan_reminder_hook
+
+
+class _Goal:
+    def __init__(
+        self, status: str = "active", turns: int = 0, max_turns: int | None = 10
+    ):
+        self.id = "goal-1"
+        self.status = status
+        self.turns_elapsed = turns
+        self.max_turns = max_turns
+        self.objective = "Ship it"
+        self.subgoals: list[str] = []
+
+
+class _DB:
+    def __init__(self, goal: _Goal | None = None, project_id: str | None = "proj-1"):
+        self.goal = goal
+        self._project_id = project_id
+        self.updates: list[tuple[str, int]] = []
+
+    def get_chat_project_id(self, chat_id: str):
+        return self._project_id
+
+    def get_goal(self, project_id: str, chat_id: str | None = None):
+        return self.goal
+
+    def update_goal(self, goal_id: str, turns_elapsed: int):
+        self.updates.append((goal_id, turns_elapsed))
+        if self.goal:
+            self.goal.turns_elapsed = turns_elapsed
+
+    def list_tasks(self, **kwargs):
+        return []
+
+
+@pytest.fixture
+def db(monkeypatch):
+    instance = _DB(_Goal())
+    monkeypatch.setattr("suzent.tools.plan_hooks.get_database", lambda: instance)
+    return instance
+
+
+# --- the reminder is a pure read --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_building_the_reminder_does_not_spend_budget(db):
+    await plan_reminder_hook("chat-1", SimpleNamespace())
+
+    assert db.updates == [], "assembling a prompt is a read"
+
+
+@pytest.mark.asyncio
+async def test_repeated_reminders_never_accumulate(db):
+    """A heartbeat, an approval resume and a retry each build a reminder."""
+    for _ in range(5):
+        await plan_reminder_hook("chat-1", SimpleNamespace())
+
+    assert db.goal.turns_elapsed == 0
+
+
+@pytest.mark.asyncio
+async def test_the_reminder_still_reports_the_budget(db):
+    db.goal.turns_elapsed = 3
+    text = await plan_reminder_hook("chat-1", SimpleNamespace())
+
+    assert "3/10 turns used" in text
+
+
+# --- the lifecycle event is what charges ------------------------------------
+
+
+def test_a_completed_turn_charges_one(db):
+    advance_goal_turn("chat-1")
+
+    assert db.updates == [("goal-1", 1)]
+
+
+def test_charging_is_one_per_call(db):
+    advance_goal_turn("chat-1")
+    advance_goal_turn("chat-1")
+
+    assert db.goal.turns_elapsed == 2
+
+
+def test_a_paused_goal_is_not_charged(db):
+    db.goal.status = "paused"
+
+    advance_goal_turn("chat-1")
+
+    assert db.updates == []
+
+
+def test_no_goal_is_harmless(monkeypatch):
+    instance = _DB(goal=None)
+    monkeypatch.setattr("suzent.tools.plan_hooks.get_database", lambda: instance)
+
+    advance_goal_turn("chat-1")
+
+    assert instance.updates == []
+
+
+def test_no_project_is_harmless(monkeypatch):
+    instance = _DB(_Goal(), project_id=None)
+    monkeypatch.setattr("suzent.tools.plan_hooks.get_database", lambda: instance)
+
+    advance_goal_turn("chat-1")
+
+    assert instance.updates == []
+
+
+def test_a_database_failure_does_not_break_the_turn(monkeypatch):
+    """Bookkeeping must not be able to fail a turn that already succeeded."""
+
+    def boom():
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr("suzent.tools.plan_hooks.get_database", boom)
+
+    advance_goal_turn("chat-1")  # must not raise
+
+
+# --- which turns qualify ----------------------------------------------------
+
+
+def test_only_real_user_turns_are_passed_through_as_chargeable():
+    """process_turn computes `_turn_message` as non-empty only for a real user
+    message that is not a heartbeat and not an approval resume; that same value
+    decides whether the turn is charged."""
+    import inspect
+
+    from suzent.core import chat_processor
+
+    source = inspect.getsource(chat_processor.ChatProcessor.process_turn)
+
+    assert "is_user_turn=bool(_turn_message)" in source

--- a/tests/core/test_goal_turn_counting.py
+++ b/tests/core/test_goal_turn_counting.py
@@ -162,7 +162,7 @@ def test_the_budget_is_charged_before_continuation_is_scheduled() -> None:
     from suzent.core import chat_processor
 
     source = inspect.getsource(chat_processor.ChatProcessor.process_turn)
-    charge = source.index("advance_goal_turn(chat_id)")
+    charge = source.index("advance_goal_turn(chat_id, only_goal_id=")
     schedule = source.index("maybe_continue_goal")
 
     assert charge < schedule, "the increment must land before the judge looks"
@@ -228,3 +228,42 @@ def test_an_explicit_answer_overrides_the_inference() -> None:
     signature = inspect.signature(chat_processor.ChatProcessor.process_turn)
 
     assert signature.parameters["counts_toward_goal"].default is None
+
+
+def test_a_goal_created_during_the_turn_is_not_charged(db):
+    """The turn that sets a goal did not cost that goal anything. Charging it
+    pauses a max_turns=1 goal before it runs a single autonomous step."""
+    created_mid_turn = _Goal()
+    created_mid_turn.id = "goal-new"
+    db.goal = created_mid_turn
+
+    advance_goal_turn("chat-1", only_goal_id="goal-that-was-running")
+
+    assert db.updates == []
+
+
+def test_the_goal_running_at_turn_start_is_charged(db):
+    advance_goal_turn("chat-1", only_goal_id="goal-1")
+
+    assert db.updates == [("goal-1", 1)]
+
+
+def test_active_goal_id_reads_the_current_goal(db):
+    from suzent.tools.plan_hooks import active_goal_id
+
+    assert active_goal_id("chat-1") == "goal-1"
+
+    db.goal.status = "paused"
+    assert active_goal_id("chat-1") is None
+
+
+def test_steering_is_charged() -> None:
+    """process_steer puts its text straight into history, so message_content is
+    empty — but it is user-initiated work that can trigger continuation."""
+    import inspect
+
+    from suzent.core import chat_processor
+
+    source = inspect.getsource(chat_processor.ChatProcessor.process_steer)
+
+    assert "counts_toward_goal=True" in source

--- a/tests/core/test_goal_turn_counting.py
+++ b/tests/core/test_goal_turn_counting.py
@@ -136,14 +136,50 @@ def test_a_database_failure_does_not_break_the_turn(monkeypatch):
 # --- which turns qualify ----------------------------------------------------
 
 
-def test_only_real_user_turns_are_passed_through_as_chargeable():
+def test_a_plain_user_turn_is_chargeable_by_default() -> None:
     """process_turn computes `_turn_message` as non-empty only for a real user
-    message that is not a heartbeat and not an approval resume; that same value
-    decides whether the turn is charged."""
+    message that is not a heartbeat and not an approval resume; with no explicit
+    answer, that is what decides."""
     import inspect
 
     from suzent.core import chat_processor
 
     source = inspect.getsource(chat_processor.ChatProcessor.process_turn)
 
-    assert "is_user_turn=bool(_turn_message)" in source
+    assert "bool(_turn_message)" in source
+    assert "if counts_toward_goal is None" in source
+
+
+def test_an_autonomous_goal_step_is_chargeable() -> None:
+    """It has no user message, but it is a turn of work on the goal. Without
+    this, max_turns can never stop a goal whose judge keeps asking for more."""
+    import inspect
+
+    from suzent.core import goals
+
+    source = inspect.getsource(goals.run_goal_step)
+
+    assert "counts_toward_goal=True" in source
+
+
+def test_a_replayed_retry_is_not_chargeable() -> None:
+    """The original turn already charged, and apply_retry_checkpoint restores
+    chat state, messages and files but not the counter."""
+    import inspect
+
+    from suzent.core import chat_processor
+
+    source = inspect.getsource(chat_processor.ChatProcessor._handle_retry_command)
+
+    assert "counts_toward_goal=False" in source
+
+
+def test_an_explicit_answer_overrides_the_inference() -> None:
+    """The two callers that know better must be able to say so."""
+    import inspect
+
+    from suzent.core import chat_processor
+
+    signature = inspect.signature(chat_processor.ChatProcessor.process_turn)
+
+    assert signature.parameters["counts_toward_goal"].default is None

--- a/tests/core/test_goal_turn_counting.py
+++ b/tests/core/test_goal_turn_counting.py
@@ -17,7 +17,8 @@ class _Goal:
     def __init__(
         self, status: str = "active", turns: int = 0, max_turns: int | None = 10
     ):
-        self.id = "goal-1"
+        self.id = 1
+        self.generation = 0
         self.status = status
         self.turns_elapsed = turns
         self.max_turns = max_turns
@@ -86,7 +87,7 @@ async def test_the_reminder_still_reports_the_budget(db):
 def test_a_completed_turn_charges_one(db):
     advance_goal_turn("chat-1")
 
-    assert db.updates == [("goal-1", 1)]
+    assert db.updates == [(1, 1)]
 
 
 def test_charging_is_one_per_call(db):
@@ -234,36 +235,45 @@ def test_a_goal_created_during_the_turn_is_not_charged(db):
     """The turn that sets a goal did not cost that goal anything. Charging it
     pauses a max_turns=1 goal before it runs a single autonomous step."""
     created_mid_turn = _Goal()
-    created_mid_turn.id = "goal-new"
+    created_mid_turn.id = 2
     db.goal = created_mid_turn
 
-    advance_goal_turn("chat-1", only_goal=("goal-that-was-running", "Ship it"))
+    advance_goal_turn("chat-1", only_goal=(99, 0))
 
     assert db.updates == []
 
 
 def test_the_goal_running_at_turn_start_is_charged(db):
-    advance_goal_turn("chat-1", only_goal=("goal-1", "Ship it"))
+    advance_goal_turn("chat-1", only_goal=(1, 0))
 
-    assert db.updates == [("goal-1", 1)]
+    assert db.updates == [(1, 1)]
 
 
 def test_active_goal_identity_reads_the_current_goal(db):
     from suzent.tools.plan_hooks import active_goal_identity
 
-    assert active_goal_identity("chat-1") == ("goal-1", "Ship it")
+    assert active_goal_identity("chat-1") == (1, 0)
 
     db.goal.status = "paused"
     assert active_goal_identity("chat-1") is None
 
 
 def test_a_goal_replaced_during_the_turn_is_not_charged(db):
-    """manage_goal(action='set') updates the row in place and resets
-    turns_elapsed, so the id is unchanged — matching on it alone charged the
-    replacement for work done under the objective it replaced."""
-    db.goal.objective = "A completely different objective"
+    """manage_goal(action='set') reuses the row and resets turns_elapsed, so the
+    id is unchanged. It bumps generation, which is what distinguishes them."""
+    db.goal.generation = 1
 
-    advance_goal_turn("chat-1", only_goal=("goal-1", "Ship it"))
+    advance_goal_turn("chat-1", only_goal=(1, 0))
+
+    assert db.updates == []
+
+
+def test_a_replacement_with_identical_text_is_still_detected(db):
+    """Re-setting a goal to change only max_turns leaves the objective byte
+    identical, so text could never have distinguished them."""
+    db.goal.generation = 1  # objective deliberately unchanged
+
+    advance_goal_turn("chat-1", only_goal=(1, 0))
 
     assert db.updates == []
 

--- a/tests/core/test_goal_turn_counting.py
+++ b/tests/core/test_goal_turn_counting.py
@@ -162,7 +162,7 @@ def test_the_budget_is_charged_before_continuation_is_scheduled() -> None:
     from suzent.core import chat_processor
 
     source = inspect.getsource(chat_processor.ChatProcessor.process_turn)
-    charge = source.index("advance_goal_turn(chat_id, only_goal_id=")
+    charge = source.index("advance_goal_turn(chat_id, only_goal=")
     schedule = source.index("maybe_continue_goal")
 
     assert charge < schedule, "the increment must land before the judge looks"
@@ -237,24 +237,35 @@ def test_a_goal_created_during_the_turn_is_not_charged(db):
     created_mid_turn.id = "goal-new"
     db.goal = created_mid_turn
 
-    advance_goal_turn("chat-1", only_goal_id="goal-that-was-running")
+    advance_goal_turn("chat-1", only_goal=("goal-that-was-running", "Ship it"))
 
     assert db.updates == []
 
 
 def test_the_goal_running_at_turn_start_is_charged(db):
-    advance_goal_turn("chat-1", only_goal_id="goal-1")
+    advance_goal_turn("chat-1", only_goal=("goal-1", "Ship it"))
 
     assert db.updates == [("goal-1", 1)]
 
 
-def test_active_goal_id_reads_the_current_goal(db):
-    from suzent.tools.plan_hooks import active_goal_id
+def test_active_goal_identity_reads_the_current_goal(db):
+    from suzent.tools.plan_hooks import active_goal_identity
 
-    assert active_goal_id("chat-1") == "goal-1"
+    assert active_goal_identity("chat-1") == ("goal-1", "Ship it")
 
     db.goal.status = "paused"
-    assert active_goal_id("chat-1") is None
+    assert active_goal_identity("chat-1") is None
+
+
+def test_a_goal_replaced_during_the_turn_is_not_charged(db):
+    """manage_goal(action='set') updates the row in place and resets
+    turns_elapsed, so the id is unchanged — matching on it alone charged the
+    replacement for work done under the objective it replaced."""
+    db.goal.objective = "A completely different objective"
+
+    advance_goal_turn("chat-1", only_goal=("goal-1", "Ship it"))
+
+    assert db.updates == []
 
 
 def test_steering_is_charged() -> None:


### PR DESCRIPTION
P1-3 from the prompt/reminder audit.

## Problem

`plan_reminder_hook` incremented `turns_elapsed` while *building* the reminder:

```python
parts.append("Evaluate: if the goal is achieved call manage_goal(action='clear')...")
db.update_goal(goal.id, turns_elapsed=goal.turns_elapsed + 1)   # inside a read
```

Reminder providers run on every path that assembles a prompt. So the budget was charged by heartbeats, approval resumes, tool continuations and retries — none of which is a turn the user took. `turns_elapsed` measured how often a prompt got built, and goals hit "turn budget exhausted" early for reasons nobody could see.

## What "a turn" means now

A real user message. `process_turn` already computes exactly that when deciding whether to run per-turn hooks — non-empty content, not a heartbeat, not an approval resume — so `is_user_turn=bool(_turn_message)` reuses it rather than introducing a second definition that can drift from the first.

The count advances once, after the turn has run and persisted. A failed stream is not charged. `advance_goal_turn` is best-effort: bookkeeping must not fail a turn that already succeeded.

## Migration: none, deliberately

Existing goals keep their inflated counts. There is no way to tell retroactively which increments were real turns, so resetting would hand back budget that may genuinely have been spent. Counting is accurate from here, and the visible effect is that active goals stop consuming budget when nothing is happening.

If you would rather reset counts on deploy, that is a one-line migration — but it needs to be your call, since it changes when live goals pause.

## Tests

10 cases in `tests/core/test_goal_turn_counting.py`: building the reminder spends nothing, five reminders in a row still spend nothing, the reminder still *reports* the budget, a completed turn charges exactly one, paused goals and missing goals/projects are no-ops, a database failure cannot break the turn, and the chargeable-turn definition is the one `process_turn` already uses.

Suite 1853 passed, ruff clean.