### PR TITLE
feat(reminders): time out, parallelise, dedupe and cap reminder providers

### DIFF
--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -843,6 +843,62 @@ def clear_per_turn_hooks() -> None:
 # ---------------------------------------------------------------------------
 
 
+#: How long any one reminder provider may take before it is dropped for the turn.
+HOOK_TIMEOUT_SECONDS = 2.0
+
+#: Ceiling on the assembled reminder body, in characters.
+#:
+#: Measured on the text that actually gets sent, not on per-provider
+#: declarations. Providers that describe their own size drift from what they
+#: emit; the assembled string cannot.
+REMINDER_BUDGET_CHARS = 6000
+
+
+def _dedupe_fragments(parts: list[str]) -> list[str]:
+    """Drop fragments identical to one already present, keeping the first.
+
+    Two providers can produce the same text — a task list surfaced by both the
+    plan hook and an ad-hoc caller, say — and paying for it twice buys nothing.
+    """
+    seen: set[str] = set()
+    unique = []
+    for part in parts:
+        if part in seen:
+            continue
+        seen.add(part)
+        unique.append(part)
+    return unique
+
+
+def _apply_budget(parts: list[str], chat_id: str) -> list[str]:
+    """Keep the assembled body under REMINDER_BUDGET_CHARS.
+
+    Whole fragments are dropped from the end rather than characters from the
+    middle: half a plan snapshot is worse than no plan snapshot, because the
+    model cannot tell it is reading a fragment. Registration order is priority
+    order, so the last-registered providers yield first.
+
+    The first fragment is always kept, even alone over budget. A reminder that
+    truncates to nothing is indistinguishable from a provider that produced
+    nothing, and the caller has no way to notice.
+    """
+    separator_cost = len(FRAGMENT_SEPARATOR)
+    kept: list[str] = []
+    used = 0
+    for index, part in enumerate(parts):
+        cost = len(part) + (separator_cost if kept else 0)
+        if kept and used + cost > REMINDER_BUDGET_CHARS:
+            dropped = len(parts) - index
+            logger.warning(
+                f"[system-reminder] chat={chat_id} over budget: dropped {dropped} "
+                f"of {len(parts)} fragment(s) at {used}/{REMINDER_BUDGET_CHARS} chars"
+            )
+            break
+        kept.append(part)
+        used += cost
+    return kept
+
+
 async def build_combined_reminder(
     chat_id: str,
     deps: Any,
@@ -865,42 +921,42 @@ async def build_combined_reminder(
     """
     parts: list[str] = []
 
-    # 1. Global hooks (always-on)
-    for hook in _global_hooks:
+    async def _run(hook, *args) -> Optional[str]:
+        """Run one provider under a timeout, never letting it fail the turn."""
         try:
-            content = await hook(chat_id, deps)
-            if content:
-                parts.append(content.strip())
+            return await asyncio.wait_for(hook(*args), timeout=HOOK_TIMEOUT_SECONDS)
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Reminder hook {hook.__name__} timed out after "
+                f"{HOOK_TIMEOUT_SECONDS}s — skipped"
+            )
         except Exception as e:
-            logger.warning(f"System Reminder global hook {hook.__name__} failed: {e}")
+            logger.warning(f"Reminder hook {hook.__name__} failed: {e}")
+        return None
 
-    # 2. Per-turn hooks (only when there is a real user message)
-    # Each hook runs with a timeout so a slow embedding/search call never
-    # stalls the message pipeline. Timed-out hooks are skipped silently.
-    _PER_TURN_TIMEOUT = 2.0  # seconds
+    # Providers are independent, so they run together. Serially, a slow one
+    # delayed every one after it — and global hooks had no timeout at all, so a
+    # single hung provider stalled the whole message pipeline indefinitely.
+    scheduled = [(hook, _run(hook, chat_id, deps)) for hook in _global_hooks]
     if user_message and user_message.strip():
-        for hook in _per_turn_hooks:
-            try:
-                content = await asyncio.wait_for(
-                    hook(chat_id, deps, user_message),
-                    timeout=_PER_TURN_TIMEOUT,
-                )
-                if content:
-                    parts.append(content.strip())
-            except asyncio.TimeoutError:
-                logger.debug(
-                    f"Per-turn hook {hook.__name__} timed out after {_PER_TURN_TIMEOUT}s — skipped"
-                )
-            except Exception as e:
-                logger.warning(
-                    f"System Reminder per-turn hook {hook.__name__} failed: {e}"
-                )
+        scheduled += [
+            (hook, _run(hook, chat_id, deps, user_message)) for hook in _per_turn_hooks
+        ]
 
-    # 3. Caller-supplied adhoc reminders
+    if scheduled:
+        # Registration order is the priority order, and gather preserves it, so
+        # what a caller registered first is what survives truncation.
+        for content in await asyncio.gather(*(coro for _, coro in scheduled)):
+            if content and content.strip():
+                parts.append(content.strip())
+
     if adhoc_reminders:
         for r in adhoc_reminders:
             if r and r.strip():
                 parts.append(r.strip())
+
+    parts = _dedupe_fragments(parts)
+    parts = _apply_budget(parts, chat_id)
 
     if not parts:
         logger.debug(f"[system-reminder] chat={chat_id} — no content, skipping")

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -870,21 +870,28 @@ def _dedupe_fragments(parts: list[str]) -> list[str]:
     return unique
 
 
-def _apply_budget(parts: list[str], chat_id: str) -> list[str]:
+def _apply_budget(parts: list[str], chat_id: str, reserved: int = 0) -> list[str]:
     """Keep the assembled body under REMINDER_BUDGET_CHARS.
 
-    Whole fragments are dropped from the end rather than characters from the
-    middle: half a plan snapshot is worse than no plan snapshot, because the
-    model cannot tell it is reading a fragment. Registration order is priority
-    order, so the last-registered providers yield first.
+    Fragments arrive already sanitized, because that is what gets sent.
+    Measuring the raw text was wrong by a wide margin: sanitizing expands each
+    one-character PUA delimiter into ``[reminder-delimiter]``, and goal, task
+    and retrieved-memory text is user-influenced, so a body that measured under
+    the cap could arrive many times over it.
 
-    The first fragment is always kept, even alone over budget. A reminder that
-    truncates to nothing is indistinguishable from a provider that produced
-    nothing, and the caller has no way to notice.
+    *reserved* accounts for text prepended inside the block that is not a
+    fragment — the display trigger — so the cap covers everything the model
+    reads rather than only the part this function happens to hold.
+
+    Whole fragments are dropped from the end rather than characters from the
+    middle: half a plan snapshot is worse than none, because the model cannot
+    tell it is reading a fragment. The first fragment is always kept, even alone
+    over budget — truncating to nothing is indistinguishable from a provider
+    that produced nothing, and the caller cannot tell the difference.
     """
     separator_cost = len(FRAGMENT_SEPARATOR)
     kept: list[str] = []
-    used = 0
+    used = reserved
     for index, part in enumerate(parts):
         cost = len(part) + (separator_cost if kept else 0)
         if kept and used + cost > REMINDER_BUDGET_CHARS:
@@ -950,13 +957,25 @@ async def build_combined_reminder(
             if content and content.strip():
                 parts.append(content.strip())
 
-    if adhoc_reminders:
-        for r in adhoc_reminders:
-            if r and r.strip():
-                parts.append(r.strip())
+    # Caller-supplied directives go first, so they survive truncation. They are
+    # specific to this turn — a peer's attribution, the analyze_image directive
+    # for a non-vision model — while hook output is ambient and reproducible on
+    # the next turn. Appending them last meant ambient content could crowd out
+    # the one instruction the turn actually depended on.
+    direct = [r.strip() for r in (adhoc_reminders or []) if r and r.strip()]
+    parts = direct + parts
 
+    # Sanitize before measuring: this is the text that gets sent. wrap_in_system
+    # _reminder sanitizes again, which is a no-op on already-clean text.
+    parts = [sanitize_untrusted_text(part) for part in parts]
     parts = _dedupe_fragments(parts)
-    parts = _apply_budget(parts, chat_id)
+
+    # The trigger is prepended inside the block, so it spends from the same
+    # budget; without this the cap covered only part of what the model reads.
+    trigger_cost = (
+        len(sanitize_untrusted_text(display_trigger)) if display_trigger else 0
+    )
+    parts = _apply_budget(parts, chat_id, reserved=trigger_cost)
 
     if not parts:
         logger.debug(f"[system-reminder] chat={chat_id} — no content, skipping")

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -616,9 +616,12 @@ async def startup():
     except Exception as e:
         logger.warning(f"Failed to start genai-prices updater: {e}")
 
+    # Registration order is priority order under the reminder budget, so the
+    # goal objective goes first: a large skill catalog crowding it out leaves
+    # the agent working on a goal it can no longer see.
+    register_global_hook(plan_reminder_hook)
     register_global_hook(skills_reminder_hook)
     register_global_hook(repository_agents_reminder_hook)
-    register_global_hook(plan_reminder_hook)
     register_per_turn_hook(_memory_rag_hook)
 
     from suzent.tools.browsing_tool import BrowserSessionManager

--- a/src/suzent/tools/plan_hooks.py
+++ b/src/suzent/tools/plan_hooks.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Optional
 
 from suzent.database import get_database
@@ -62,10 +63,20 @@ def advance_goal_turn(chat_id: str, only_goal_id: Optional[str] = None) -> None:
 async def plan_reminder_hook(chat_id: str, deps: Any) -> Optional[str]:
     """Inject the active project Goal and open Tasks into the system reminder.
 
-    Pure read. Reminder providers run on every path that assembles a prompt, so
-    anything that mutates here is charged to turns the user never took — see
-    advance_goal_turn.
+    Pure read, and deliberately so: reminder providers run on every path that
+    assembles a prompt, so anything mutating here is charged to turns the user
+    never took — see advance_goal_turn.
+
+    The body is synchronous database access, which is why it runs on a worker
+    thread. A provider that blocks the event loop cannot be timed out, because
+    cancelling needs the loop to run, so a stalled database would otherwise hold
+    the turn open past the provider deadline. Being read-only is what makes that
+    safe: a thread that outlives its cancelled await changes nothing.
     """
+    return await asyncio.to_thread(_build_plan_reminder, chat_id)
+
+
+def _build_plan_reminder(chat_id: str) -> Optional[str]:
     db = get_database()
     project_id = db.get_chat_project_id(chat_id)
     if not project_id:

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -92,7 +92,9 @@ async def test_combined_reminder_merges_global_and_adhoc():
     clear_global_hooks()
 
     assert result is not None
-    assert "global\n\n---\n\nadhoc" in result
+    # Caller directives come first: they are specific to this turn and must
+    # survive truncation, while hook output is ambient and returns next turn.
+    assert "adhoc\n\n---\n\nglobal" in result
 
 
 def test_rebuild_strips_reminder_from_display_messages():
@@ -1616,3 +1618,65 @@ async def test_one_oversized_fragment_is_still_delivered(clean_hooks, monkeypatc
     sr.register_global_hook(huge)
 
     assert "IMPORTANT" in await sr.build_combined_reminder("c", None)
+
+
+@pytest.mark.asyncio
+async def test_budget_measures_the_sanitized_text(clean_hooks, monkeypatch):
+    """Sanitizing expands each one-character PUA delimiter into
+    `[reminder-delimiter]`, so a raw body under the cap could arrive many times
+    over it. Goal, task and memory text is user-influenced, so this is reachable."""
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 1000)
+
+    async def delimiters(chat_id, deps):
+        return PUA_START * 300  # 300 raw chars -> ~6000 after sanitizing
+
+    async def later(chat_id, deps):
+        return "SHOULD_BE_DROPPED"
+
+    sr.register_global_hook(delimiters)
+    sr.register_global_hook(later)
+
+    body = extract_system_reminder_content(await sr.build_combined_reminder("c", None))
+
+    assert "SHOULD_BE_DROPPED" not in body, "measured the raw text, not what is sent"
+
+
+@pytest.mark.asyncio
+async def test_the_display_trigger_spends_from_the_same_budget(
+    clean_hooks, monkeypatch
+):
+    """It is prepended inside the block, so a cap that ignores it covers only
+    part of what the model reads."""
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 400)
+    sr.register_global_hook(_sized_hook("KEEP", 100))
+    sr.register_global_hook(_sized_hook("DROP", 100))
+
+    body = extract_system_reminder_content(
+        await sr.build_combined_reminder("c", None, display_trigger="T" * 350)
+    )
+
+    assert "KEEP" in body
+    assert "DROP" not in body
+
+
+@pytest.mark.asyncio
+async def test_caller_directives_outrank_ambient_hooks(clean_hooks, monkeypatch):
+    """A peer's attribution or the analyze_image directive is specific to this
+    turn; skill and plan content is ambient and returns next turn."""
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 100)
+    sr.register_global_hook(_sized_hook("AMBIENT", 250))
+
+    body = extract_system_reminder_content(
+        await sr.build_combined_reminder(
+            "c", None, adhoc_reminders=["DIRECTIVE: inspect the image"]
+        )
+    )
+
+    assert "DIRECTIVE" in body
+    assert "AMBIENT" not in body

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -1680,3 +1680,57 @@ async def test_caller_directives_outrank_ambient_hooks(clean_hooks, monkeypatch)
 
     assert "DIRECTIVE" in body
     assert "AMBIENT" not in body
+
+
+@pytest.mark.asyncio
+async def test_a_blocking_provider_cannot_hold_the_turn_open(clean_hooks, monkeypatch):
+    """asyncio.wait_for needs the loop running to cancel anything, so a provider
+    that blocks it cannot be timed out. Providers doing synchronous work must
+    hand it to a thread — plan_reminder_hook wraps its database access this way."""
+    import asyncio as _asyncio
+    import time
+
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "HOOK_TIMEOUT_SECONDS", 0.05)
+
+    async def blocking_but_threaded(chat_id, deps):
+        await _asyncio.to_thread(time.sleep, 1.0)
+        return "slow"
+
+    async def quick(chat_id, deps):
+        return "quick"
+
+    sr.register_global_hook(blocking_but_threaded)
+    sr.register_global_hook(quick)
+
+    started = time.monotonic()
+    result = await sr.build_combined_reminder("c", None)
+    elapsed = time.monotonic() - started
+
+    assert "quick" in result
+    assert elapsed < 0.5, f"deadline could not fire: {elapsed:.2f}s"
+
+
+def test_the_plan_hook_does_its_database_work_off_the_loop():
+    import inspect
+
+    from suzent.tools import plan_hooks
+
+    source = inspect.getsource(plan_hooks.plan_reminder_hook)
+
+    assert "to_thread" in source
+
+
+def test_the_goal_fragment_outranks_ambient_catalogues():
+    """Registration order is priority order under the budget, so a large skill
+    catalog must not be able to hide the objective the agent is working on."""
+    import inspect
+
+    from suzent import server
+
+    source = inspect.getsource(server)
+    plan = source.index("register_global_hook(plan_reminder_hook)")
+    skills = source.index("register_global_hook(skills_reminder_hook)")
+
+    assert plan < skills

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -1447,3 +1447,172 @@ def test_every_registered_history_processor_takes_a_run_context():
         make_compaction_history_processor,
     ):
         assert takes_run_context(factory()), factory.__name__
+
+
+# ---------------------------------------------------------------------------
+# Provider budget, isolation and concurrency
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clean_hooks():
+    from suzent.core.system_reminder import clear_global_hooks, clear_per_turn_hooks
+
+    clear_global_hooks()
+    clear_per_turn_hooks()
+    yield
+    clear_global_hooks()
+    clear_per_turn_hooks()
+
+
+@pytest.mark.asyncio
+async def test_a_hung_global_hook_cannot_stall_the_turn(clean_hooks, monkeypatch):
+    """Global hooks previously had no timeout at all, so one hung provider
+    blocked every message indefinitely."""
+    import asyncio as _asyncio
+
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "HOOK_TIMEOUT_SECONDS", 0.05)
+
+    async def hangs(chat_id, deps):
+        await _asyncio.sleep(30)
+        return "never"
+
+    async def works(chat_id, deps):
+        return "delivered"
+
+    sr.register_global_hook(hangs)
+    sr.register_global_hook(works)
+
+    result = await _asyncio.wait_for(sr.build_combined_reminder("c", None), timeout=5)
+
+    assert "delivered" in result
+    assert "never" not in result
+
+
+@pytest.mark.asyncio
+async def test_a_failing_provider_does_not_lose_the_others(clean_hooks):
+    from suzent.core import system_reminder as sr
+
+    async def broken(chat_id, deps):
+        raise RuntimeError("provider exploded")
+
+    async def works(chat_id, deps):
+        return "delivered"
+
+    sr.register_global_hook(broken)
+    sr.register_global_hook(works)
+
+    assert "delivered" in await sr.build_combined_reminder("c", None)
+
+
+def _slow_hook(label: str, delay: float = 0.1):
+    """A distinct coroutine per call — registration de-duplicates by identity."""
+
+    async def hook(chat_id, deps):
+        import asyncio as _asyncio
+
+        await _asyncio.sleep(delay)
+        return label
+
+    hook.__name__ = f"slow_{label}"
+    return hook
+
+
+def _sized_hook(label: str, size: int):
+    async def hook(chat_id, deps):
+        return label + "x" * size
+
+    hook.__name__ = f"sized_{label}"
+    return hook
+
+
+@pytest.mark.asyncio
+async def test_providers_run_concurrently(clean_hooks):
+    """Serially these take 0.3s; together, about 0.1s."""
+    import time
+
+    from suzent.core import system_reminder as sr
+
+    for label in ("a", "b", "c"):
+        sr.register_global_hook(_slow_hook(label))
+
+    started = time.monotonic()
+    await sr.build_combined_reminder("c", None)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.25, f"looks serial: {elapsed:.2f}s"
+
+
+@pytest.mark.asyncio
+async def test_identical_fragments_are_not_paid_for_twice(clean_hooks):
+    from suzent.core import system_reminder as sr
+
+    async def one(chat_id, deps):
+        return "[ACTIVE TASKS] #1 ship it"
+
+    async def two(chat_id, deps):
+        return "[ACTIVE TASKS] #1 ship it"
+
+    sr.register_global_hook(one)
+    sr.register_global_hook(two)
+
+    result = await sr.build_combined_reminder("c", None)
+
+    assert result.count("[ACTIVE TASKS] #1 ship it") == 1
+
+
+@pytest.mark.asyncio
+async def test_the_body_stays_within_budget(clean_hooks, monkeypatch):
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 500)
+
+    for i in range(6):
+        sr.register_global_hook(_sized_hook(f"F{i}", 200))
+
+    result = await sr.build_combined_reminder("c", None)
+    body = extract_system_reminder_content(result)
+
+    assert len(body) <= 500 + len(sr.FRAGMENT_SEPARATOR)
+
+
+@pytest.mark.asyncio
+async def test_truncation_drops_whole_fragments_from_the_end(clean_hooks, monkeypatch):
+    """Registration order is priority order, and half a fragment is worse than
+    none because the model cannot tell it is reading one."""
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 300)
+
+    async def first(chat_id, deps):
+        return "FIRST" + "a" * 200
+
+    async def later(chat_id, deps):
+        return "LATER" + "b" * 200
+
+    sr.register_global_hook(first)
+    sr.register_global_hook(later)
+
+    body = extract_system_reminder_content(await sr.build_combined_reminder("c", None))
+
+    assert "FIRST" in body
+    assert "LATER" not in body
+    assert body.endswith("a" * 200), "the kept fragment must be intact"
+
+
+@pytest.mark.asyncio
+async def test_one_oversized_fragment_is_still_delivered(clean_hooks, monkeypatch):
+    """Truncating to nothing is indistinguishable from a provider that produced
+    nothing, and the caller cannot tell the difference."""
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 50)
+
+    async def huge(chat_id, deps):
+        return "IMPORTANT" + "x" * 500
+
+    sr.register_global_hook(huge)
+
+    assert "IMPORTANT" in await sr.build_combined_reminder("c", None)


### PR DESCRIPTION
P1-2 from the prompt/reminder audit.

## What was wrong

Four gaps in how providers are combined:

| Gap | Effect |
|---|---|
| Global hooks had **no timeout** (only per-turn hooks did) | one hung provider stalled every message indefinitely |
| Providers ran **serially** | each slow one delayed all those after it |
| **No dedupe** | two providers emitting the same text paid for it twice |
| **No ceiling** on the assembled body | unbounded growth into the prompt |

## What I did not do, and why

The audit proposed a structured `ReminderFragment` with `priority`, `max_chars`, `dedupe_key` and `trust` fields. I did not build that.

Declaring per-provider sizes is the same mistake that cost the most review rounds elsewhere in this work: the payload walker enumerated known types and leaked three times; the skill revision fingerprinted selected inputs and missed a path change. **A declaration drifts from what is actually emitted; the assembled string cannot.** So the budget is measured on the final body, and dedupe compares actual text.

Priority is already expressed by registration order, and `gather` preserves it — so that is now the documented, tested contract rather than a new field to keep in sync.

## Truncation choices

**Whole fragments, dropped from the end.** Half a plan snapshot is worse than none, because the model cannot tell it is reading a fragment.

**One oversized fragment is still delivered**, even alone over budget. Truncating to nothing is indistinguishable from a provider that produced nothing, and the caller has no way to notice the difference.

Budget is 6000 characters, the figure the audit suggested. It should be re-derived from real prompt traces — #167 already emits per-section sizes, so the data is there.

## Tests

7 cases: a hung global hook cannot stall the turn, a failing provider does not lose the others, providers run concurrently (0.3s serial vs ~0.1s), identical fragments appear once, the body stays within budget, truncation keeps the earlier fragment intact and drops the later one whole, and a single oversized fragment still arrives.

Six of the seven fail against the previous code — verified by stashing `src/`.

Suite 1850 passed, ruff clean.