### PR TITLE
feat(reminders): time out, parallelise, dedupe and cap reminder providers

### DIFF
--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -14,7 +14,7 @@ import shutil
 import time
 import uuid
 from pathlib import Path
-from typing import AsyncGenerator, List, Dict, Any, Optional
+from typing import AsyncGenerator, List, Dict, Any, Optional, Sequence
 
 from ag_ui.core import (
     CustomEvent,
@@ -798,7 +798,6 @@ class ChatProcessor:
 
         # --- System Reminder Injection (includes per-turn RAG hook when memory enabled) ---
         from suzent.core.system_reminder import (
-            TRIGGER_SEPARATOR,
             build_combined_reminder,
             make_user_prompt_part,
             sanitize_untrusted_text,
@@ -855,9 +854,10 @@ class ChatProcessor:
         stream_run_id = str(uuid.uuid4())
         display_trigger = None
         if system_reminders and not (message_content and message_content.strip()):
-            display_trigger = TRIGGER_SEPARATOR.join(
-                r.strip() for r in system_reminders if r and r.strip()
-            )
+            # The constituents, not a join. build_combined_reminder has to match
+            # these against the same strings arriving as fragments, and a join
+            # cannot be taken back apart once a reminder contains the separator.
+            display_trigger = [r.strip() for r in system_reminders if r and r.strip()]
         # Stateless chats (dream, sub-agents) run a fixed, self-contained prompt and
         # must not receive skill-discovery / plan / RAG reminders — that ambient
         # chatter (e.g. the suzent-automation skill hint) is what made the dream agent
@@ -2722,7 +2722,7 @@ def _trigger_placeholder_prefix() -> str:
 
 
 def trigger_rows_for_snapshot(
-    display_trigger: str | None, is_heartbeat: bool, part: Any
+    display_trigger: str | Sequence[str] | None, is_heartbeat: bool, part: Any
 ) -> list[dict]:
     """Display rows that must become durable with the history they describe.
 
@@ -2741,7 +2741,16 @@ def trigger_rows_for_snapshot(
     if not display_trigger or is_heartbeat:
         return []
 
-    from suzent.core.system_reminder import sanitize_untrusted_text
+    from suzent.core.system_reminder import TRIGGER_SEPARATOR, sanitize_untrusted_text
+
+    # Joined the one way the reminder joins it, so the visible row says what the
+    # model was actually shown.
+    if not isinstance(display_trigger, str):
+        display_trigger = TRIGGER_SEPARATOR.join(
+            r.strip() for r in display_trigger if r and r.strip()
+        )
+        if not display_trigger:
+            return []
 
     # Same treatment wrap_in_system_reminder gives it. Scheduled prompts and
     # subagent results are user-influenced, and _preserve_display_triggers

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -2741,26 +2741,26 @@ def trigger_rows_for_snapshot(
     if not display_trigger or is_heartbeat:
         return []
 
-    from suzent.core.system_reminder import TRIGGER_SEPARATOR, sanitize_untrusted_text
+    from suzent.core.system_reminder import canonical_display_trigger
 
-    # Joined the one way the reminder joins it, so the visible row says what the
-    # model was actually shown.
-    if not isinstance(display_trigger, str):
-        display_trigger = TRIGGER_SEPARATOR.join(
-            r.strip() for r in display_trigger if r and r.strip()
-        )
-        if not display_trigger:
-            return []
+    # The same function the block uses, so the row says what the model was
+    # actually shown. Rendering it independently here is how the two came to
+    # disagree: the block deduplicated repeated reminders and the transcript
+    # kept showing them twice.
+    display_trigger = canonical_display_trigger(display_trigger)
+    if not display_trigger:
+        return []
 
-    # Same treatment wrap_in_system_reminder gives it. Scheduled prompts and
-    # subagent results are user-influenced, and _preserve_display_triggers
-    # prefers this stored content over the placeholder rebuilt from history — so
-    # storing the raw value would put delimiters back into the visible transcript
-    # permanently, undoing the sanitizing on the path that does it.
     stamp = getattr(part, "timestamp", None)
     row: dict = {
         "role": "system_triggered",
-        "content": sanitize_untrusted_text(display_trigger),
+        # Already sanitized by canonical_display_trigger, which is the same
+        # treatment wrap_in_system_reminder gives it. Scheduled prompts and
+        # subagent results are user-influenced, and _preserve_display_triggers
+        # prefers this stored content over the placeholder rebuilt from history
+        # — so an unsanitized value would put delimiters back into the visible
+        # transcript permanently.
+        "content": display_trigger,
         "trigger_origin": "runtime",
     }
     if stamp:

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -14,7 +14,7 @@ import shutil
 import time
 import uuid
 from pathlib import Path
-from typing import AsyncGenerator, List, Dict, Any, Optional, Sequence
+from typing import AsyncGenerator, List, Dict, Any, Optional
 
 from ag_ui.core import (
     CustomEvent,
@@ -900,7 +900,7 @@ class ChatProcessor:
             message_history.append(new_request)
 
             pending_trigger_rows.extend(
-                trigger_rows_for_snapshot(display_trigger, is_heartbeat, parts[0])
+                trigger_rows_for_snapshot(full_prompt, is_heartbeat, parts[0])
             )
 
             # Pre-save the user message to the DB display log for social chats so the
@@ -2722,9 +2722,13 @@ def _trigger_placeholder_prefix() -> str:
 
 
 def trigger_rows_for_snapshot(
-    display_trigger: str | Sequence[str] | None, is_heartbeat: bool, part: Any
+    rendered_prompt: str | None, is_heartbeat: bool, part: Any
 ) -> list[dict]:
     """Display rows that must become durable with the history they describe.
+
+    Takes the rendered prompt, not the reminders that went into it: the row has
+    to say what the model was shown, and the only thing that knows that is the
+    text that was sent.
 
     A reminder-only turn has no user text, so its row cannot be rebuilt once the
     reminder block stops being authenticatable after a restart. The row is keyed
@@ -2738,16 +2742,20 @@ def trigger_rows_for_snapshot(
     someone's visible transcript. An earlier attempt at this shipped exactly that
     bug, so the rule is asserted by a test rather than trusted to a comment.
     """
-    if not display_trigger or is_heartbeat:
+    if not rendered_prompt or is_heartbeat:
         return []
 
-    from suzent.core.system_reminder import canonical_display_trigger
+    from suzent.core.system_reminder import extract_system_reminder_display_trigger
 
-    # The same function the block uses, so the row says what the model was
-    # actually shown. Rendering it independently here is how the two came to
-    # disagree: the block deduplicated repeated reminders and the transcript
-    # kept showing them twice.
-    display_trigger = canonical_display_trigger(display_trigger)
+    # Read back out of the block that was just built, rather than derived from
+    # the same inputs a second time. Every rule the builder applies — joining,
+    # sanitizing, deduplicating, budgeting — is already baked into that text,
+    # and each time this path recomputed one of them it reproduced some and
+    # missed others: the transcript showed reminders twice after the model
+    # stopped seeing them twice, then recorded reminders dropped by the budget
+    # that the model never received at all. There is nothing here left to keep
+    # in step.
+    display_trigger = extract_system_reminder_display_trigger(rendered_prompt)
     if not display_trigger:
         return []
 

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -798,6 +798,7 @@ class ChatProcessor:
 
         # --- System Reminder Injection (includes per-turn RAG hook when memory enabled) ---
         from suzent.core.system_reminder import (
+            TRIGGER_SEPARATOR,
             build_combined_reminder,
             make_user_prompt_part,
             sanitize_untrusted_text,
@@ -854,7 +855,7 @@ class ChatProcessor:
         stream_run_id = str(uuid.uuid4())
         display_trigger = None
         if system_reminders and not (message_content and message_content.strip()):
-            display_trigger = "\n\n---\n\n".join(
+            display_trigger = TRIGGER_SEPARATOR.join(
                 r.strip() for r in system_reminders if r and r.strip()
             )
         # Stateless chats (dream, sub-agents) run a fixed, self-contained prompt and

--- a/src/suzent/core/repository_context.py
+++ b/src/suzent/core/repository_context.py
@@ -329,13 +329,24 @@ async def repository_agents_reminder_hook(chat_id: str, deps: object) -> str | N
         return None
 
     sandbox_enabled = bool(getattr(deps, "sandbox_enabled", True))
-    lines: list[str] = []
-    for agent_file in agent_files:
-        path = agent_file.path.resolve()
-        location = str(path)
-        if sandbox_enabled:
-            location = deps.path_resolver.to_virtual_path(path) or str(path)
-        lines.append(f"- {path.stem} ({agent_file.source}): {location}")
+    resolver = getattr(deps, "path_resolver", None)
+
+    def _render() -> list[str]:
+        # Path.resolve() touches the filesystem, so this runs off the event
+        # loop: blocking before the first await makes the provider deadline
+        # unenforceable, and an unreachable network mount would stall the turn.
+        rendered: list[str] = []
+        for agent_file in agent_files:
+            path = agent_file.path.resolve()
+            location = str(path)
+            if sandbox_enabled and resolver is not None:
+                location = resolver.to_virtual_path(path) or str(path)
+            rendered.append(f"- {path.stem} ({agent_file.source}): {location}")
+        return rendered
+
+    from suzent.core.system_reminder import run_provider_blocking
+
+    lines = await run_provider_blocking(_render)
     return (
         "Repository agent definitions are available. Read the matching definition "
         "before delegating work that fits it:\n" + "\n".join(lines)

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -954,6 +954,11 @@ async def run_provider_blocking(fn: Callable[..., Any], *args: Any) -> Any:
 #: emit; the assembled string cannot.
 REMINDER_BUDGET_CHARS = 6000
 
+#: Appended to content the cap had to cut, so the model can tell a clipped
+#: reminder from a complete one. Silently trimmed text is worse than either the
+#: cut or the overshoot: it reads as authoritative and is not.
+TRUNCATION_MARKER = "\n\n[truncated: over the system-reminder budget]"
+
 
 def _dedupe_fragments(parts: list[str]) -> list[str]:
     """Drop fragments identical to one already present, keeping the first.
@@ -976,7 +981,7 @@ def _apply_budget(
     chat_id: str,
     reserved: int = 0,
     separator: str = FRAGMENT_SEPARATOR,
-    exempt_first: Optional[bool] = None,
+    truncate_first: Optional[bool] = None,
 ) -> list[str]:
     """Keep the assembled body under REMINDER_BUDGET_CHARS.
 
@@ -994,25 +999,42 @@ def _apply_budget(
     middle: half a plan snapshot is worse than none, because the model cannot
     tell it is reading a fragment.
 
-    One item may exceed the cap on its own, and only one: an empty body is
-    indistinguishable from a provider that produced nothing, so something has to
-    survive. *exempt_first* says whether this call is the one that may spend
-    that allowance; it defaults to "only if nothing has been delivered yet".
+    Nothing is exempt. An item too large to fit is truncated to what is left
+    and marked, rather than admitted whole or dropped: the cap is then a real
+    ceiling on what is sent, with no case in which it is quietly exceeded.
 
-    It is a parameter rather than an inference because the two are not the same
-    question. Reserving space for an envelope is not delivering content, and
-    inferring the exemption from ``reserved`` meant reserving 71 characters for
-    the trigger's tags silently withdrew the exemption and dropped a single
-    oversized reminder — the whole turn — on the floor.
+    The alternative to truncating is not "send it all" — that was five separate
+    ways of exceeding the cap, each one an item that had claimed to be the
+    single thing that could not be helped. Nor is it "drop it": on a
+    reminder-only turn the reminder is the entire turn, and an empty body cannot
+    be told apart from a provider that had nothing to say, so dropping loses the
+    delivery silently. Truncating loses the tail and says so, which is the only
+    one of the three the model can react to.
+
+    *truncate_first* says whether this call is the one that may spend the last
+    resort; it defaults to "only if nothing has been delivered yet". Whole
+    fragments are still dropped from the end rather than trimmed — half a plan
+    snapshot is worse than none — so only the first item, and only when nothing
+    else will survive, is ever cut.
     """
     separator_cost = len(separator)
     kept: list[str] = []
     used = reserved
+    may_truncate = truncate_first if truncate_first is not None else reserved == 0
     for index, part in enumerate(parts):
         cost = len(part) + (separator_cost if kept else 0)
-        may_exempt = exempt_first if exempt_first is not None else reserved == 0
-        protected = not kept and may_exempt
-        if not protected and used + cost > REMINDER_BUDGET_CHARS:
+        if used + cost > REMINDER_BUDGET_CHARS:
+            if not kept and may_truncate:
+                room = REMINDER_BUDGET_CHARS - used - len(TRUNCATION_MARKER)
+                if room > 0:
+                    logger.warning(
+                        f"[system-reminder] chat={chat_id} over budget: truncated "
+                        f"{len(part)} chars to {room} at "
+                        f"{used}/{REMINDER_BUDGET_CHARS}"
+                    )
+                    kept.append(part[:room] + TRUNCATION_MARKER)
+                    used = REMINDER_BUDGET_CHARS
+                    continue
             dropped = len(parts) - index
             logger.warning(
                 f"[system-reminder] chat={chat_id} over budget: dropped {dropped} "
@@ -1150,9 +1172,9 @@ async def build_combined_reminder(
         chat_id,
         reserved=len(render_trigger_block("")) if _constituents else 0,
         separator=TRIGGER_SEPARATOR,
-        # The trigger goes out first, so this is the pass that may keep one
-        # oversized item. The envelope it reserves for is not content.
-        exempt_first=True,
+        # The trigger goes out first, so this is the pass that may spend the
+        # last resort. The envelope it reserves for is not content.
+        truncate_first=True,
     )
     display_trigger = TRIGGER_SEPARATOR.join(_constituents) or None
 

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -843,6 +843,62 @@ def clear_per_turn_hooks() -> None:
 # ---------------------------------------------------------------------------
 
 
+#: How long any one reminder provider may take before it is dropped for the turn.
+HOOK_TIMEOUT_SECONDS = 2.0
+
+#: Ceiling on the assembled reminder body, in characters.
+#:
+#: Measured on the text that actually gets sent, not on per-provider
+#: declarations. Providers that describe their own size drift from what they
+#: emit; the assembled string cannot.
+REMINDER_BUDGET_CHARS = 6000
+
+
+def _dedupe_fragments(parts: list[str]) -> list[str]:
+    """Drop fragments identical to one already present, keeping the first.
+
+    Two providers can produce the same text — a task list surfaced by both the
+    plan hook and an ad-hoc caller, say — and paying for it twice buys nothing.
+    """
+    seen: set[str] = set()
+    unique = []
+    for part in parts:
+        if part in seen:
+            continue
+        seen.add(part)
+        unique.append(part)
+    return unique
+
+
+def _apply_budget(parts: list[str], chat_id: str) -> list[str]:
+    """Keep the assembled body under REMINDER_BUDGET_CHARS.
+
+    Whole fragments are dropped from the end rather than characters from the
+    middle: half a plan snapshot is worse than no plan snapshot, because the
+    model cannot tell it is reading a fragment. Registration order is priority
+    order, so the last-registered providers yield first.
+
+    The first fragment is always kept, even alone over budget. A reminder that
+    truncates to nothing is indistinguishable from a provider that produced
+    nothing, and the caller has no way to notice.
+    """
+    separator_cost = len(FRAGMENT_SEPARATOR)
+    kept: list[str] = []
+    used = 0
+    for index, part in enumerate(parts):
+        cost = len(part) + (separator_cost if kept else 0)
+        if kept and used + cost > REMINDER_BUDGET_CHARS:
+            dropped = len(parts) - index
+            logger.warning(
+                f"[system-reminder] chat={chat_id} over budget: dropped {dropped} "
+                f"of {len(parts)} fragment(s) at {used}/{REMINDER_BUDGET_CHARS} chars"
+            )
+            break
+        kept.append(part)
+        used += cost
+    return kept
+
+
 async def build_combined_reminder(
     chat_id: str,
     deps: Any,
@@ -865,42 +921,42 @@ async def build_combined_reminder(
     """
     parts: list[str] = []
 
-    # 1. Global hooks (always-on)
-    for hook in _global_hooks:
+    async def _run(hook, *args) -> Optional[str]:
+        """Run one provider under a timeout, never letting it fail the turn."""
         try:
-            content = await hook(chat_id, deps)
-            if content:
-                parts.append(content.strip())
+            return await asyncio.wait_for(hook(*args), timeout=HOOK_TIMEOUT_SECONDS)
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Reminder hook {hook.__name__} timed out after "
+                f"{HOOK_TIMEOUT_SECONDS}s — skipped"
+            )
         except Exception as e:
-            logger.warning(f"System Reminder global hook {hook.__name__} failed: {e}")
+            logger.warning(f"Reminder hook {hook.__name__} failed: {e}")
+        return None
 
-    # 2. Per-turn hooks (only when there is a real user message)
-    # Each hook runs with a timeout so a slow embedding/search call never
-    # stalls the message pipeline. Timed-out hooks are skipped silently.
-    _PER_TURN_TIMEOUT = 2.0  # seconds
+    # Providers are independent, so they run together. Serially, a slow one
+    # delayed every one after it — and global hooks had no timeout at all, so a
+    # single hung provider stalled the whole message pipeline indefinitely.
+    scheduled = [(hook, _run(hook, chat_id, deps)) for hook in _global_hooks]
     if user_message and user_message.strip():
-        for hook in _per_turn_hooks:
-            try:
-                content = await asyncio.wait_for(
-                    hook(chat_id, deps, user_message),
-                    timeout=_PER_TURN_TIMEOUT,
-                )
-                if content:
-                    parts.append(content.strip())
-            except asyncio.TimeoutError:
-                logger.debug(
-                    f"Per-turn hook {hook.__name__} timed out after {_PER_TURN_TIMEOUT}s — skipped"
-                )
-            except Exception as e:
-                logger.warning(
-                    f"System Reminder per-turn hook {hook.__name__} failed: {e}"
-                )
+        scheduled += [
+            (hook, _run(hook, chat_id, deps, user_message)) for hook in _per_turn_hooks
+        ]
 
-    # 3. Caller-supplied adhoc reminders
+    if scheduled:
+        # Registration order is the priority order, and gather preserves it, so
+        # what a caller registered first is what survives truncation.
+        for content in await asyncio.gather(*(coro for _, coro in scheduled)):
+            if content and content.strip():
+                parts.append(content.strip())
+
     if adhoc_reminders:
         for r in adhoc_reminders:
             if r and r.strip():
                 parts.append(r.strip())
+
+    parts = _dedupe_fragments(parts)
+    parts = _apply_budget(parts, chat_id)
 
     if not parts:
         logger.debug(f"[system-reminder] chat={chat_id} — no content, skipping")

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -855,11 +855,21 @@ HOOK_TIMEOUT_SECONDS = 2.0
 #: long after the turn itself returned. Daemon threads let the process leave.
 #:
 #: The bound matters for the same reason the pool did: a stuck thread cannot be
-#: killed, so without a ceiling they accumulate. At saturation a provider is
-#: skipped rather than queued, because queueing behind wedged work is how a
-#: transient stall becomes a permanent one.
+#: killed, so without a ceiling they accumulate. At saturation a caller waits
+#: for a slot rather than being dropped — the bound exists to contain wedged
+#: threads, and ordinary concurrency is not wedged: a handful of turns running
+#: at once routinely needs more than four reads, and skipping them would
+#: silently drop context from a perfectly healthy request.
+#:
+#: The wait is what keeps that safe. It is bounded by the caller's own deadline,
+#: so a genuinely wedged provider still stops at HOOK_TIMEOUT_SECONDS instead of
+#: queueing behind the block forever.
 _PROVIDER_THREADS = 4
 _provider_slots = threading.Semaphore(_PROVIDER_THREADS)
+
+#: How often a waiting provider retries the slot. Short enough to be invisible
+#: next to the deadline, long enough not to spin.
+_SLOT_POLL_SECONDS = 0.01
 
 
 async def run_provider_blocking(fn: Callable[..., Any], *args: Any) -> Any:
@@ -874,9 +884,12 @@ async def run_provider_blocking(fn: Callable[..., Any], *args: Any) -> Any:
     times out, the work carries on to completion, so anything it writes lands
     after the provider was abandoned.
     """
-    if not _provider_slots.acquire(blocking=False):
-        logger.warning("Reminder provider threads are saturated; skipping provider")
-        return None
+    # Await a slot rather than taking it or giving up. Blocking the acquire
+    # would block the loop — the exact failure this function exists to prevent —
+    # so the wait yields, and the caller's timeout cancels it if the pool never
+    # frees up. Sleeping here is not a stall: nothing else can start the work.
+    while not _provider_slots.acquire(blocking=False):
+        await asyncio.sleep(_SLOT_POLL_SECONDS)
 
     loop = asyncio.get_running_loop()
     future: asyncio.Future = loop.create_future()

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+from concurrent.futures import ThreadPoolExecutor
 import os
 import re
 import secrets
@@ -845,6 +846,42 @@ def clear_per_turn_hooks() -> None:
 
 #: How long any one reminder provider may take before it is dropped for the turn.
 HOOK_TIMEOUT_SECONDS = 2.0
+
+#: Threads available to reminder providers doing blocking work.
+#:
+#: Deliberately separate from asyncio's default executor. Cancelling the await
+#: on a timed-out provider does not stop the thread — Python cannot kill one —
+#: so a wedged filesystem or database leaves workers occupied. On the shared
+#: executor those stragglers would eventually starve every other to_thread
+#: caller in the process; here the damage is bounded to this pool, and the turn
+#: itself is unaffected because the await still times out.
+_PROVIDER_THREADS = 4
+_provider_executor: Optional[ThreadPoolExecutor] = None
+
+
+def _get_provider_executor() -> ThreadPoolExecutor:
+    global _provider_executor
+    if _provider_executor is None:
+        _provider_executor = ThreadPoolExecutor(
+            max_workers=_PROVIDER_THREADS, thread_name_prefix="reminder-provider"
+        )
+    return _provider_executor
+
+
+async def run_provider_blocking(fn: Callable[..., Any], *args: Any) -> Any:
+    """Run a reminder provider's blocking work off the event loop.
+
+    Providers that do synchronous I/O must call this. A provider that blocks
+    before its first await cannot be timed out at all, because cancelling needs
+    the loop to run — so an unreachable network mount or a wedged database stalls
+    every turn regardless of HOOK_TIMEOUT_SECONDS.
+
+    Only safe for read-only work: a thread that outlives its cancelled await
+    keeps going, so anything it writes lands after the provider was abandoned.
+    """
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_get_provider_executor(), fn, *args)
+
 
 #: Ceiling on the assembled reminder body, in characters.
 #:

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -21,7 +21,7 @@ import threading
 import os
 import re
 import secrets
-from typing import Any, Callable, Awaitable, Optional, List
+from typing import Any, Callable, Awaitable, Optional, List, Sequence, Union
 
 from pydantic_ai.tools import RunContext
 
@@ -1017,7 +1017,7 @@ async def build_combined_reminder(
     deps: Any,
     adhoc_reminders: Optional[List[str]] = None,
     user_message: Optional[str] = None,
-    display_trigger: Optional[str] = None,
+    display_trigger: Union[str, Sequence[str], None] = None,
 ) -> Optional[str]:
     """Merge all reminder sources into a single wrapped ``<system-reminder>`` block.
 
@@ -1027,6 +1027,13 @@ async def build_combined_reminder(
         adhoc_reminders: Caller-supplied one-off strings for this turn.
         user_message: Current user message text.  When non-empty, per-turn
             hooks are also invoked (e.g. dynamic RAG memory retrieval).
+        display_trigger: The reminder(s) this turn exists to deliver, shown in
+            the transcript. Pass the constituents, not a joined string: they are
+            also handed in as fragments, and recovering the boundaries by
+            splitting the join cannot work — a reminder whose own text contains
+            the separator, such as a Markdown rule, splits into pieces that
+            match nothing and is then sent twice. Joining is this module's job
+            because deduplicating is too.
 
     Returns:
         A fully wrapped ``<system-reminder>`` string, or ``None`` if nothing
@@ -1080,25 +1087,31 @@ async def build_combined_reminder(
     # ad-hoc fragment, and the trigger is prepended inside the block — so the
     # model saw it twice and it was charged twice. Dropping the fragment keeps
     # the content (the trigger envelope carries it) and halves the cost.
-    if display_trigger:
-        # Every constituent, not just the whole. A reminder-only turn passes the
-        # joined trigger here and the same strings individually as fragments, so
-        # matching only the join left each piece duplicated whenever there was
-        # more than one — and the model paid for all of it twice.
-        _trigger = sanitize_untrusted_text(display_trigger).strip()
-        charged = {_trigger}
-        charged.update(
-            piece.strip()
-            for piece in _trigger.split(TRIGGER_SEPARATOR)
-            if piece.strip()
-        )
+    # A string is one constituent, not a join to be taken apart. Every earlier
+    # version of this recovered the boundaries by splitting the rendered
+    # trigger, which is unrecoverable in general and wrong whenever a reminder
+    # contains the separator itself.
+    _constituents = (
+        [display_trigger]
+        if isinstance(display_trigger, str)
+        else list(display_trigger or [])
+    )
+    _constituents = [c.strip() for c in _constituents if c and c.strip()]
+    display_trigger = TRIGGER_SEPARATOR.join(_constituents) or None
+
+    if _constituents:
+        # The same strings arrive as fragments, and the trigger is prepended
+        # inside the block, so without this the model reads and pays for each
+        # one twice.
+        charged = {sanitize_untrusted_text(c).strip() for c in _constituents}
+        charged.add(sanitize_untrusted_text(display_trigger).strip())
         parts = [part for part in parts if part not in charged]
 
     # The trigger is prepended inside the block, so it spends from the same
     # budget; without this the cap covered only part of what the model reads.
     trigger_cost = (
         len(render_trigger_block(sanitize_untrusted_text(display_trigger)))
-        if display_trigger and display_trigger.strip()
+        if display_trigger
         else 0
     )
     parts = _apply_budget(parts, chat_id, reserved=trigger_cost)

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -870,21 +870,28 @@ def _dedupe_fragments(parts: list[str]) -> list[str]:
     return unique
 
 
-def _apply_budget(parts: list[str], chat_id: str) -> list[str]:
+def _apply_budget(parts: list[str], chat_id: str, reserved: int = 0) -> list[str]:
     """Keep the assembled body under REMINDER_BUDGET_CHARS.
 
-    Whole fragments are dropped from the end rather than characters from the
-    middle: half a plan snapshot is worse than no plan snapshot, because the
-    model cannot tell it is reading a fragment. Registration order is priority
-    order, so the last-registered providers yield first.
+    Fragments arrive already sanitized, because that is what gets sent.
+    Measuring the raw text was wrong by a wide margin: sanitizing expands each
+    one-character PUA delimiter into ``[reminder-delimiter]``, and goal, task
+    and retrieved-memory text is user-influenced, so a body that measured under
+    the cap could arrive many times over it.
 
-    The first fragment is always kept, even alone over budget. A reminder that
-    truncates to nothing is indistinguishable from a provider that produced
-    nothing, and the caller has no way to notice.
+    *reserved* accounts for text prepended inside the block that is not a
+    fragment — the display trigger — so the cap covers everything the model
+    reads rather than only the part this function happens to hold.
+
+    Whole fragments are dropped from the end rather than characters from the
+    middle: half a plan snapshot is worse than none, because the model cannot
+    tell it is reading a fragment. The first fragment is always kept, even alone
+    over budget — truncating to nothing is indistinguishable from a provider
+    that produced nothing, and the caller cannot tell the difference.
     """
     separator_cost = len(FRAGMENT_SEPARATOR)
     kept: list[str] = []
-    used = 0
+    used = reserved
     for index, part in enumerate(parts):
         cost = len(part) + (separator_cost if kept else 0)
         if kept and used + cost > REMINDER_BUDGET_CHARS:
@@ -950,13 +957,25 @@ async def build_combined_reminder(
             if content and content.strip():
                 parts.append(content.strip())
 
-    if adhoc_reminders:
-        for r in adhoc_reminders:
-            if r and r.strip():
-                parts.append(r.strip())
+    # Caller-supplied directives go first, so they survive truncation. They are
+    # specific to this turn — a peer's attribution, the analyze_image directive
+    # for a non-vision model — while hook output is ambient and reproducible on
+    # the next turn. Appending them last meant ambient content could crowd out
+    # the one instruction the turn actually depended on.
+    direct = [r.strip() for r in (adhoc_reminders or []) if r and r.strip()]
+    parts = direct + parts
 
+    # Sanitize before measuring: this is the text that gets sent. wrap_in_system
+    # _reminder sanitizes again, which is a no-op on already-clean text.
+    parts = [sanitize_untrusted_text(part) for part in parts]
     parts = _dedupe_fragments(parts)
-    parts = _apply_budget(parts, chat_id)
+
+    # The trigger is prepended inside the block, so it spends from the same
+    # budget; without this the cap covered only part of what the model reads.
+    trigger_cost = (
+        len(sanitize_untrusted_text(display_trigger)) if display_trigger else 0
+    )
+    parts = _apply_budget(parts, chat_id, reserved=trigger_cost)
 
     if not parts:
         logger.debug(f"[system-reminder] chat={chat_id} — no content, skipping")

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -1014,6 +1014,44 @@ def _apply_budget(parts: list[str], chat_id: str, reserved: int = 0) -> list[str
     return kept
 
 
+def canonical_trigger_constituents(
+    display_trigger: Union[str, Sequence[str], None],
+) -> list[str]:
+    """The trigger's reminders exactly as they will be delivered.
+
+    Sanitized first and deduplicated second, because sanitizing is what decides
+    whether two inputs are the same text: a delimiter and its literal
+    ``[reminder-delimiter]`` spelling differ on the way in and are identical on
+    the way out, so deduplicating first kept both and sent the reminder twice.
+
+    A string is one constituent, not a join to be taken apart — boundaries
+    cannot be recovered from a rendered join, since a reminder containing the
+    separator splits into pieces that were never reminders.
+
+    One definition because two things need the answer: the block the model reads
+    and the row the transcript keeps. Computing it twice is how they came to
+    disagree.
+    """
+    items = (
+        [display_trigger]
+        if isinstance(display_trigger, str)
+        else list(display_trigger or [])
+    )
+    cleaned = [
+        sanitize_untrusted_text(item).strip() for item in items if item and item.strip()
+    ]
+    return _dedupe_fragments([item for item in cleaned if item])
+
+
+def canonical_display_trigger(
+    display_trigger: Union[str, Sequence[str], None],
+) -> Optional[str]:
+    """The trigger as one string, for the block and for the transcript row."""
+    return (
+        TRIGGER_SEPARATOR.join(canonical_trigger_constituents(display_trigger)) or None
+    )
+
+
 async def build_combined_reminder(
     chat_id: str,
     deps: Any,
@@ -1089,38 +1127,21 @@ async def build_combined_reminder(
     # ad-hoc fragment, and the trigger is prepended inside the block — so the
     # model saw it twice and it was charged twice. Dropping the fragment keeps
     # the content (the trigger envelope carries it) and halves the cost.
-    # A string is one constituent, not a join to be taken apart. Every earlier
-    # version of this recovered the boundaries by splitting the rendered
-    # trigger, which is unrecoverable in general and wrong whenever a reminder
-    # contains the separator itself.
-    _constituents = (
-        [display_trigger]
-        if isinstance(display_trigger, str)
-        else list(display_trigger or [])
-    )
-    _constituents = _dedupe_fragments(
-        [c.strip() for c in _constituents if c and c.strip()]
-    )
-    # Deduplicated like any other repeated content: the fragments already are,
-    # so leaving the trigger alone meant one repeated reminder went out in full
-    # twice and could clear the cap on its own through the oversized exemption.
+    _constituents = canonical_trigger_constituents(display_trigger)
     display_trigger = TRIGGER_SEPARATOR.join(_constituents) or None
 
     if _constituents:
         # The same strings arrive as fragments, and the trigger is prepended
         # inside the block, so without this the model reads and pays for each
-        # one twice.
-        charged = {sanitize_untrusted_text(c).strip() for c in _constituents}
-        charged.add(sanitize_untrusted_text(display_trigger).strip())
+        # one twice. Matched on the delivered text, which is what both sides
+        # now hold.
+        charged = set(_constituents)
+        charged.add(display_trigger)
         parts = [part for part in parts if part not in charged]
 
     # The trigger is prepended inside the block, so it spends from the same
     # budget; without this the cap covered only part of what the model reads.
-    trigger_cost = (
-        len(render_trigger_block(sanitize_untrusted_text(display_trigger)))
-        if display_trigger
-        else 0
-    )
+    trigger_cost = len(render_trigger_block(display_trigger)) if display_trigger else 0
     parts = _apply_budget(parts, chat_id, reserved=trigger_cost)
 
     if not parts and not display_trigger:

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
-from concurrent.futures import ThreadPoolExecutor
+import threading
 import os
 import re
 import secrets
@@ -847,25 +847,19 @@ def clear_per_turn_hooks() -> None:
 #: How long any one reminder provider may take before it is dropped for the turn.
 HOOK_TIMEOUT_SECONDS = 2.0
 
-#: Threads available to reminder providers doing blocking work.
+#: Concurrent blocking providers allowed at once.
 #:
-#: Deliberately separate from asyncio's default executor. Cancelling the await
-#: on a timed-out provider does not stop the thread — Python cannot kill one —
-#: so a wedged filesystem or database leaves workers occupied. On the shared
-#: executor those stragglers would eventually starve every other to_thread
-#: caller in the process; here the damage is bounded to this pool, and the turn
-#: itself is unaffected because the await still times out.
+#: Deliberately not a ThreadPoolExecutor. Its workers are non-daemon and joined
+#: at interpreter exit, so one genuinely wedged read — the case this exists to
+#: survive — would hang every server stop, reload and resource-guard recycle,
+#: long after the turn itself returned. Daemon threads let the process leave.
+#:
+#: The bound matters for the same reason the pool did: a stuck thread cannot be
+#: killed, so without a ceiling they accumulate. At saturation a provider is
+#: skipped rather than queued, because queueing behind wedged work is how a
+#: transient stall becomes a permanent one.
 _PROVIDER_THREADS = 4
-_provider_executor: Optional[ThreadPoolExecutor] = None
-
-
-def _get_provider_executor() -> ThreadPoolExecutor:
-    global _provider_executor
-    if _provider_executor is None:
-        _provider_executor = ThreadPoolExecutor(
-            max_workers=_PROVIDER_THREADS, thread_name_prefix="reminder-provider"
-        )
-    return _provider_executor
+_provider_slots = threading.Semaphore(_PROVIDER_THREADS)
 
 
 async def run_provider_blocking(fn: Callable[..., Any], *args: Any) -> Any:
@@ -873,14 +867,42 @@ async def run_provider_blocking(fn: Callable[..., Any], *args: Any) -> Any:
 
     Providers that do synchronous I/O must call this. A provider that blocks
     before its first await cannot be timed out at all, because cancelling needs
-    the loop to run — so an unreachable network mount or a wedged database stalls
-    every turn regardless of HOOK_TIMEOUT_SECONDS.
+    the loop to run — so an unreachable network mount or a wedged database
+    stalls every turn regardless of HOOK_TIMEOUT_SECONDS.
 
-    Only safe for read-only work: a thread that outlives its cancelled await
-    keeps going, so anything it writes lands after the provider was abandoned.
+    Only safe for read-only work. The thread is not cancellable: when the caller
+    times out, the work carries on to completion, so anything it writes lands
+    after the provider was abandoned.
     """
+    if not _provider_slots.acquire(blocking=False):
+        logger.warning("Reminder provider threads are saturated; skipping provider")
+        return None
+
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_get_provider_executor(), fn, *args)
+    future: asyncio.Future = loop.create_future()
+
+    def _deliver(setter: Callable[..., None], value: Any) -> None:
+        if not future.done():
+            setter(value)
+
+    def _worker() -> None:
+        try:
+            result = fn(*args)
+        except BaseException as exc:  # noqa: BLE001 - relayed to the awaiter
+            try:
+                loop.call_soon_threadsafe(_deliver, future.set_exception, exc)
+            except RuntimeError:
+                pass  # loop already closed; nobody is waiting
+        else:
+            try:
+                loop.call_soon_threadsafe(_deliver, future.set_result, result)
+            except RuntimeError:
+                pass
+        finally:
+            _provider_slots.release()
+
+    threading.Thread(target=_worker, name="reminder-provider", daemon=True).start()
+    return await future
 
 
 #: Ceiling on the assembled reminder body, in characters.
@@ -1007,6 +1029,14 @@ async def build_combined_reminder(
     parts = [sanitize_untrusted_text(part) for part in parts]
     parts = _dedupe_fragments(parts)
 
+    # A reminder-only turn passes the same text as display_trigger and as an
+    # ad-hoc fragment, and the trigger is prepended inside the block — so the
+    # model saw it twice and it was charged twice. Dropping the fragment keeps
+    # the content (the trigger envelope carries it) and halves the cost.
+    if display_trigger:
+        _trigger = sanitize_untrusted_text(display_trigger).strip()
+        parts = [part for part in parts if part != _trigger]
+
     # The trigger is prepended inside the block, so it spends from the same
     # budget; without this the cap covered only part of what the model reads.
     trigger_cost = (
@@ -1014,9 +1044,14 @@ async def build_combined_reminder(
     )
     parts = _apply_budget(parts, chat_id, reserved=trigger_cost)
 
-    if not parts:
+    if not parts and not display_trigger:
         logger.debug(f"[system-reminder] chat={chat_id} — no content, skipping")
         return None
+    if not parts:
+        # Dropping the duplicate fragment can empty the body while a trigger is
+        # still owed: a reminder-only turn's whole visible record is that
+        # trigger, so returning None here would lose the row entirely.
+        logger.debug(f"[system-reminder] chat={chat_id} — trigger only")
 
     # The separator is in-band, so a fragment carrying it verbatim would split
     # into two and let its own content pose as a separate provider's. Goal and

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -847,6 +847,15 @@ def clear_per_turn_hooks() -> None:
 #: How long any one reminder provider may take before it is dropped for the turn.
 HOOK_TIMEOUT_SECONDS = 2.0
 
+#: How a reminder-only turn's individual reminders are joined into one display
+#: trigger.
+#:
+#: Defined here rather than at the join site because both sides need it: the
+#: caller joins with it, and the dedupe below has to split on it to recognise
+#: the constituents it is also handed as fragments. Two copies of that string
+#: is how the multi-reminder case shipped duplicated.
+TRIGGER_SEPARATOR = "\n\n---\n\n"
+
 #: Concurrent blocking providers allowed at once.
 #:
 #: Deliberately not a ThreadPoolExecutor. Its workers are non-daemon and joined
@@ -914,7 +923,15 @@ async def run_provider_blocking(fn: Callable[..., Any], *args: Any) -> Any:
         finally:
             _provider_slots.release()
 
-    threading.Thread(target=_worker, name="reminder-provider", daemon=True).start()
+    try:
+        threading.Thread(target=_worker, name="reminder-provider", daemon=True).start()
+    except BaseException:
+        # The slot is released by the worker's finally, so a thread that never
+        # starts never gives it back. Four of those and the pool is gone for the
+        # life of the process — every provider would then wait out its deadline
+        # and plan, skill and repository context would vanish from every turn.
+        _provider_slots.release()
+        raise
     return await future
 
 
@@ -1047,8 +1064,18 @@ async def build_combined_reminder(
     # model saw it twice and it was charged twice. Dropping the fragment keeps
     # the content (the trigger envelope carries it) and halves the cost.
     if display_trigger:
+        # Every constituent, not just the whole. A reminder-only turn passes the
+        # joined trigger here and the same strings individually as fragments, so
+        # matching only the join left each piece duplicated whenever there was
+        # more than one — and the model paid for all of it twice.
         _trigger = sanitize_untrusted_text(display_trigger).strip()
-        parts = [part for part in parts if part != _trigger]
+        charged = {_trigger}
+        charged.update(
+            piece.strip()
+            for piece in _trigger.split(TRIGGER_SEPARATOR)
+            if piece.strip()
+        )
+        parts = [part for part in parts if part not in charged]
 
     # The trigger is prepended inside the block, so it spends from the same
     # budget; without this the cap covered only part of what the model reads.

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -971,7 +971,13 @@ def _dedupe_fragments(parts: list[str]) -> list[str]:
     return unique
 
 
-def _apply_budget(parts: list[str], chat_id: str, reserved: int = 0) -> list[str]:
+def _apply_budget(
+    parts: list[str],
+    chat_id: str,
+    reserved: int = 0,
+    separator: str = FRAGMENT_SEPARATOR,
+    exempt_first: Optional[bool] = None,
+) -> list[str]:
     """Keep the assembled body under REMINDER_BUDGET_CHARS.
 
     Fragments arrive already sanitized, because that is what gets sent.
@@ -988,21 +994,25 @@ def _apply_budget(parts: list[str], chat_id: str, reserved: int = 0) -> list[str
     middle: half a plan snapshot is worse than none, because the model cannot
     tell it is reading a fragment.
 
-    One fragment may exceed the cap on its own, and only one: an empty body is
+    One item may exceed the cap on its own, and only one: an empty body is
     indistinguishable from a provider that produced nothing, so something has to
-    survive. That exemption is spent by the trigger when there is one. The
-    trigger is already going out, so nothing is lost by holding every fragment
-    to the cap behind it — whereas exempting the first fragment *as well* let a
-    5,900-character trigger and an ordinary plan reminder clear 6,400 together,
-    which is the cap failing in exactly the case it was added for.
+    survive. *exempt_first* says whether this call is the one that may spend
+    that allowance; it defaults to "only if nothing has been delivered yet".
+
+    It is a parameter rather than an inference because the two are not the same
+    question. Reserving space for an envelope is not delivering content, and
+    inferring the exemption from ``reserved`` meant reserving 71 characters for
+    the trigger's tags silently withdrew the exemption and dropped a single
+    oversized reminder — the whole turn — on the floor.
     """
-    separator_cost = len(FRAGMENT_SEPARATOR)
+    separator_cost = len(separator)
     kept: list[str] = []
     used = reserved
     for index, part in enumerate(parts):
         cost = len(part) + (separator_cost if kept else 0)
-        delivered = bool(kept) or reserved > 0
-        if delivered and used + cost > REMINDER_BUDGET_CHARS:
+        may_exempt = exempt_first if exempt_first is not None else reserved == 0
+        protected = not kept and may_exempt
+        if not protected and used + cost > REMINDER_BUDGET_CHARS:
             dropped = len(parts) - index
             logger.warning(
                 f"[system-reminder] chat={chat_id} over budget: dropped {dropped} "
@@ -1128,6 +1138,22 @@ async def build_combined_reminder(
     # model saw it twice and it was charged twice. Dropping the fragment keeps
     # the content (the trigger envelope carries it) and halves the cost.
     _constituents = canonical_trigger_constituents(display_trigger)
+
+    # The trigger is budgeted as its constituents, not as one indivisible
+    # string. Joining first made the whole thing a single item, and a single
+    # item is exactly what the oversized exemption waves through — so two
+    # unrelated 4,000-character reminders sailed past a 6,000-character cap
+    # together. Budgeting first means the exemption covers one reminder, which
+    # is the most that cannot be helped.
+    _constituents = _apply_budget(
+        _constituents,
+        chat_id,
+        reserved=len(render_trigger_block("")) if _constituents else 0,
+        separator=TRIGGER_SEPARATOR,
+        # The trigger goes out first, so this is the pass that may keep one
+        # oversized item. The envelope it reserves for is not content.
+        exempt_first=True,
+    )
     display_trigger = TRIGGER_SEPARATOR.join(_constituents) or None
 
     if _constituents:

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -96,6 +96,21 @@ _DISPLAY_TRIGGER_RE = re.compile(
 )
 
 
+def render_trigger_block(display_trigger: str) -> str:
+    """The trigger exactly as it appears inside the block.
+
+    One definition, because two things need it: the wrap that emits it and the
+    budget that has to charge for it. Sizing the trigger by its bare text left
+    the envelope uncounted, so a trigger and a fragment that each fit could
+    still clear the cap together.
+    """
+    return (
+        f"<{DISPLAY_TRIGGER_TAG}>\n"
+        f"{display_trigger.strip()}\n"
+        f"</{DISPLAY_TRIGGER_TAG}>\n\n"
+    )
+
+
 def wrap_in_system_reminder(content: str, display_trigger: Optional[str] = None) -> str:
     """Wrap content in a hidden reminder block.
 
@@ -119,12 +134,7 @@ def wrap_in_system_reminder(content: str, display_trigger: Optional[str] = None)
 
     body = content.strip()
     if display_trigger and display_trigger.strip():
-        body = (
-            f"<{DISPLAY_TRIGGER_TAG}>\n"
-            f"{display_trigger.strip()}\n"
-            f"</{DISPLAY_TRIGGER_TAG}>\n\n"
-            f"{body}"
-        )
+        body = render_trigger_block(display_trigger) + body
     if os.environ.get("SUZENT_XML_SYSTEM_REMINDER"):
         return (
             f'\n<{REMINDER_TAG} nonce="{RUNTIME_NONCE}">\n{body}\n</{REMINDER_TAG}>\n'
@@ -974,16 +984,23 @@ def _apply_budget(parts: list[str], chat_id: str, reserved: int = 0) -> list[str
 
     Whole fragments are dropped from the end rather than characters from the
     middle: half a plan snapshot is worse than none, because the model cannot
-    tell it is reading a fragment. The first fragment is always kept, even alone
-    over budget — truncating to nothing is indistinguishable from a provider
-    that produced nothing, and the caller cannot tell the difference.
+    tell it is reading a fragment.
+
+    One fragment may exceed the cap on its own, and only one: an empty body is
+    indistinguishable from a provider that produced nothing, so something has to
+    survive. That exemption is spent by the trigger when there is one. The
+    trigger is already going out, so nothing is lost by holding every fragment
+    to the cap behind it — whereas exempting the first fragment *as well* let a
+    5,900-character trigger and an ordinary plan reminder clear 6,400 together,
+    which is the cap failing in exactly the case it was added for.
     """
     separator_cost = len(FRAGMENT_SEPARATOR)
     kept: list[str] = []
     used = reserved
     for index, part in enumerate(parts):
         cost = len(part) + (separator_cost if kept else 0)
-        if kept and used + cost > REMINDER_BUDGET_CHARS:
+        delivered = bool(kept) or reserved > 0
+        if delivered and used + cost > REMINDER_BUDGET_CHARS:
             dropped = len(parts) - index
             logger.warning(
                 f"[system-reminder] chat={chat_id} over budget: dropped {dropped} "
@@ -1080,7 +1097,9 @@ async def build_combined_reminder(
     # The trigger is prepended inside the block, so it spends from the same
     # budget; without this the cap covered only part of what the model reads.
     trigger_cost = (
-        len(sanitize_untrusted_text(display_trigger)) if display_trigger else 0
+        len(render_trigger_block(sanitize_untrusted_text(display_trigger)))
+        if display_trigger and display_trigger.strip()
+        else 0
     )
     parts = _apply_budget(parts, chat_id, reserved=trigger_cost)
 

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -919,19 +919,21 @@ async def run_provider_blocking(fn: Callable[..., Any], *args: Any) -> Any:
 
     def _worker() -> None:
         try:
-            result = fn(*args)
+            setter, value = future.set_result, fn(*args)
         except BaseException as exc:  # noqa: BLE001 - relayed to the awaiter
-            try:
-                loop.call_soon_threadsafe(_deliver, future.set_exception, exc)
-            except RuntimeError:
-                pass  # loop already closed; nobody is waiting
-        else:
-            try:
-                loop.call_soon_threadsafe(_deliver, future.set_result, result)
-            except RuntimeError:
-                pass
+            setter, value = future.set_exception, exc
         finally:
+            # Before waking the awaiter, not after. Releasing afterwards let the
+            # caller resume while this thread still held the slot, so the pool
+            # read as short by one for however long the handoff took — briefly
+            # under-subscribed under load, and a genuine race in any check made
+            # the moment a provider returns.
             _provider_slots.release()
+
+        try:
+            loop.call_soon_threadsafe(_deliver, setter, value)
+        except RuntimeError:
+            pass  # loop already closed; nobody is waiting
 
     try:
         threading.Thread(target=_worker, name="reminder-provider", daemon=True).start()
@@ -1096,7 +1098,12 @@ async def build_combined_reminder(
         if isinstance(display_trigger, str)
         else list(display_trigger or [])
     )
-    _constituents = [c.strip() for c in _constituents if c and c.strip()]
+    _constituents = _dedupe_fragments(
+        [c.strip() for c in _constituents if c and c.strip()]
+    )
+    # Deduplicated like any other repeated content: the fragments already are,
+    # so leaving the trigger alone meant one repeated reminder went out in full
+    # twice and could clear the cap on its own through the oversized exemption.
     display_trigger = TRIGGER_SEPARATOR.join(_constituents) or None
 
     if _constituents:

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -1160,6 +1160,12 @@ async def build_combined_reminder(
     # model saw it twice and it was charged twice. Dropping the fragment keeps
     # the content (the trigger envelope carries it) and halves the cost.
     _constituents = canonical_trigger_constituents(display_trigger)
+    # Before budgeting. These are the strings the caller also handed in as
+    # fragments, and whether the trigger kept them has no bearing on that: one
+    # dropped or cut by the trigger's budget would otherwise reappear as an
+    # ordinary fragment, so the model would read a reminder the transcript says
+    # was not delivered.
+    _offered = set(_constituents)
 
     # The trigger is budgeted as its constituents, not as one indivisible
     # string. Joining first made the whole thing a single item, and a single
@@ -1178,13 +1184,13 @@ async def build_combined_reminder(
     )
     display_trigger = TRIGGER_SEPARATOR.join(_constituents) or None
 
-    if _constituents:
+    if _offered:
         # The same strings arrive as fragments, and the trigger is prepended
         # inside the block, so without this the model reads and pays for each
-        # one twice. Matched on the delivered text, which is what both sides
-        # now hold.
-        charged = set(_constituents)
-        charged.add(display_trigger)
+        # one twice.
+        charged = set(_offered)
+        if display_trigger:
+            charged.add(display_trigger)
         parts = [part for part in parts if part not in charged]
 
     # The trigger is prepended inside the block, so it spends from the same

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -616,9 +616,12 @@ async def startup():
     except Exception as e:
         logger.warning(f"Failed to start genai-prices updater: {e}")
 
+    # Registration order is priority order under the reminder budget, so the
+    # goal objective goes first: a large skill catalog crowding it out leaves
+    # the agent working on a goal it can no longer see.
+    register_global_hook(plan_reminder_hook)
     register_global_hook(skills_reminder_hook)
     register_global_hook(repository_agents_reminder_hook)
-    register_global_hook(plan_reminder_hook)
     register_per_turn_hook(_memory_rag_hook)
 
     from suzent.tools.browsing_tool import BrowserSessionManager

--- a/src/suzent/skills/hooks.py
+++ b/src/suzent/skills/hooks.py
@@ -134,23 +134,35 @@ async def skills_reminder_hook(chat_id: str, deps: Any) -> Optional[str]:
 
     sandbox_enabled = getattr(deps, "sandbox_enabled", True)
 
-    lines = []
-    for skill in skill_mgr.loader.list_skills():
-        if not skill_mgr.is_skill_enabled(skill.id):
-            continue
-        name = skill.metadata.name
-        if sandbox_enabled:
-            from suzent.tools.filesystem.path_resolver import PathResolver
+    def _render() -> list[str]:
+        # In host mode this calls Path.resolve() per skill, which touches the
+        # filesystem. Blocking before the first await makes the provider
+        # deadline unenforceable — an unreachable network mount would stall not
+        # just this hook but every provider sharing the loop.
+        rendered: list[str] = []
+        for skill in skill_mgr.loader.list_skills():
+            if not skill_mgr.is_skill_enabled(skill.id):
+                continue
+            name = skill.metadata.name
+            if sandbox_enabled:
+                from suzent.tools.filesystem.path_resolver import PathResolver
 
-            location = skill.virtual_path or PathResolver.get_skill_virtual_path(name)
-        else:
-            location = str(skill.path.resolve())
-        lines.append(
-            _one_line(
-                f"- {skill.id}: {skill.metadata.description} "
-                f"(Name: {name}; Location: {location})"
+                location = skill.virtual_path or PathResolver.get_skill_virtual_path(
+                    name
+                )
+            else:
+                location = str(skill.path.resolve())
+            rendered.append(
+                _one_line(
+                    f"- {skill.id}: {skill.metadata.description} "
+                    f"(Name: {name}; Location: {location})"
+                )
             )
-        )
+        return rendered
+
+    from suzent.core.system_reminder import run_provider_blocking
+
+    lines = await run_provider_blocking(_render)
 
     if not lines:
         return None

--- a/src/suzent/tools/plan_hooks.py
+++ b/src/suzent/tools/plan_hooks.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Optional
 
 from suzent.database import get_database
@@ -69,10 +70,20 @@ def advance_goal_turn(
 async def plan_reminder_hook(chat_id: str, deps: Any) -> Optional[str]:
     """Inject the active project Goal and open Tasks into the system reminder.
 
-    Pure read. Reminder providers run on every path that assembles a prompt, so
-    anything that mutates here is charged to turns the user never took — see
-    advance_goal_turn.
+    Pure read, and deliberately so: reminder providers run on every path that
+    assembles a prompt, so anything mutating here is charged to turns the user
+    never took — see advance_goal_turn.
+
+    The body is synchronous database access, which is why it runs on a worker
+    thread. A provider that blocks the event loop cannot be timed out, because
+    cancelling needs the loop to run, so a stalled database would otherwise hold
+    the turn open past the provider deadline. Being read-only is what makes that
+    safe: a thread that outlives its cancelled await changes nothing.
     """
+    return await asyncio.to_thread(_build_plan_reminder, chat_id)
+
+
+def _build_plan_reminder(chat_id: str) -> Optional[str]:
     db = get_database()
     project_id = db.get_chat_project_id(chat_id)
     if not project_id:

--- a/src/suzent/tools/plan_hooks.py
+++ b/src/suzent/tools/plan_hooks.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import Any, Optional
 
 from suzent.database import get_database
@@ -80,7 +79,9 @@ async def plan_reminder_hook(chat_id: str, deps: Any) -> Optional[str]:
     the turn open past the provider deadline. Being read-only is what makes that
     safe: a thread that outlives its cancelled await changes nothing.
     """
-    return await asyncio.to_thread(_build_plan_reminder, chat_id)
+    from suzent.core.system_reminder import run_provider_blocking
+
+    return await run_provider_blocking(_build_plan_reminder, chat_id)
 
 
 def _build_plan_reminder(chat_id: str) -> Optional[str]:

--- a/tests/core/test_snapshot_carries_trigger_row.py
+++ b/tests/core/test_snapshot_carries_trigger_row.py
@@ -180,13 +180,30 @@ class _Part:
         self.timestamp = stamp
 
 
+def _prompt(*reminders):
+    """The prompt as it was actually sent.
+
+    trigger_rows_for_snapshot reads the trigger back out of this rather than
+    re-deriving it from the reminders, so the tests hand it the same thing the
+    turn does: every rule the builder applied is already in the text.
+    """
+    from suzent.core.system_reminder import (
+        canonical_display_trigger,
+        wrap_in_system_reminder,
+    )
+
+    trigger = canonical_display_trigger(list(reminders))
+    body = trigger or ""
+    return wrap_in_system_reminder(body, display_trigger=trigger) if trigger else ""
+
+
 def test_a_cron_turn_yields_a_stamped_row():
     from datetime import datetime, timezone
 
     from suzent.core.chat_processor import trigger_rows_for_snapshot
 
     stamp = datetime(2026, 9, 2, 4, tzinfo=timezone.utc)
-    rows = trigger_rows_for_snapshot("Cron: digest", False, _Part(stamp))
+    rows = trigger_rows_for_snapshot(_prompt("Cron: digest"), False, _Part(stamp))
 
     assert rows == [_row(ts=stamp.isoformat())]
 
@@ -198,7 +215,10 @@ def test_a_heartbeat_turn_yields_nothing():
     An earlier attempt shipped exactly that."""
     from suzent.core.chat_processor import trigger_rows_for_snapshot
 
-    assert trigger_rows_for_snapshot("Heartbeat: check inbox", True, _Part()) == []
+    assert (
+        trigger_rows_for_snapshot(_prompt("Heartbeat: check inbox"), True, _Part())
+        == []
+    )
 
 
 def test_an_ordinary_turn_yields_nothing():
@@ -211,7 +231,7 @@ def test_an_ordinary_turn_yields_nothing():
 def test_a_part_without_a_timestamp_still_yields_a_row():
     from suzent.core.chat_processor import trigger_rows_for_snapshot
 
-    rows = trigger_rows_for_snapshot("Cron: digest", False, _Part())
+    rows = trigger_rows_for_snapshot(_prompt("Cron: digest"), False, _Part())
 
     assert rows and "timestamp" not in rows[0]
 
@@ -340,7 +360,9 @@ def test_trigger_content_is_sanitized_before_it_is_stored():
     from suzent.core.chat_processor import trigger_rows_for_snapshot
     from suzent.core.system_reminder import PUA_END, PUA_START
 
-    rows = trigger_rows_for_snapshot(f"Cron{PUA_START}forged{PUA_END}", False, _Part())
+    rows = trigger_rows_for_snapshot(
+        _prompt(f"Cron{PUA_START}forged{PUA_END}"), False, _Part()
+    )
 
     assert rows
     assert PUA_START not in rows[0]["content"]
@@ -351,6 +373,6 @@ def test_trigger_content_is_sanitized_before_it_is_stored():
 def test_ordinary_trigger_text_is_unchanged():
     from suzent.core.chat_processor import trigger_rows_for_snapshot
 
-    rows = trigger_rows_for_snapshot("Cron: daily digest", False, _Part())
+    rows = trigger_rows_for_snapshot(_prompt("Cron: daily digest"), False, _Part())
 
     assert rows[0]["content"] == "Cron: daily digest"

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -2188,21 +2188,51 @@ def test_the_transcript_row_and_the_block_agree_on_the_trigger() -> None:
     assert system_reminder.canonical_display_trigger(repeated) == "Cron: digest"
 
 
-def test_the_persisted_row_shows_what_the_model_was_shown() -> None:
+@pytest.mark.asyncio
+async def test_the_persisted_row_shows_what_the_model_was_shown(clean_hooks) -> None:
+    """Read out of the block that was sent, not re-derived from its inputs. The
+    row reproduced some of the builder's rules and missed others: it showed
+    reminders twice after the model stopped seeing them twice, then recorded
+    reminders the budget had dropped before the model ever saw them."""
     from datetime import datetime
     from types import SimpleNamespace
 
+    from suzent.core import system_reminder as sr
     from suzent.core.chat_processor import trigger_rows_for_snapshot
-    from suzent.core.system_reminder import canonical_display_trigger
 
     part = SimpleNamespace(timestamp=datetime(2026, 1, 1))
-    repeated = ["Cron: nightly digest", "Cron: nightly digest"]
+    first, second = "a" * 4000, "b" * 4000
 
-    rows = trigger_rows_for_snapshot(repeated, False, part)
+    rendered = await sr.build_combined_reminder(
+        "c", None, display_trigger=[first, second]
+    )
+    rows = trigger_rows_for_snapshot(rendered, False, part)
 
     assert len(rows) == 1
-    assert rows[0]["content"] == canonical_display_trigger(repeated)
-    assert rows[0]["content"].count("Cron: nightly digest") == 1
+    stored = rows[0]["content"]
+    assert first in stored, "the delivered reminder must be recorded"
+    assert second not in stored, "the budget dropped it; the transcript must agree"
+    assert stored == sr.extract_system_reminder_display_trigger(rendered)
+
+
+@pytest.mark.asyncio
+async def test_a_repeated_reminder_is_recorded_once(clean_hooks) -> None:
+    from datetime import datetime
+    from types import SimpleNamespace
+
+    from suzent.core import system_reminder as sr
+    from suzent.core.chat_processor import trigger_rows_for_snapshot
+
+    repeated = "Cron: nightly digest"
+    rendered = await sr.build_combined_reminder(
+        "c", None, display_trigger=[repeated, repeated]
+    )
+
+    rows = trigger_rows_for_snapshot(
+        rendered, False, SimpleNamespace(timestamp=datetime(2026, 1, 1))
+    )
+
+    assert rows[0]["content"].count(repeated) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -1967,35 +1967,20 @@ def test_every_filesystem_reading_provider_renders_off_loop() -> None:
 
 @pytest.mark.asyncio
 async def test_every_constituent_of_a_joined_trigger_is_charged_once(clean_hooks):
-    """A reminder-only turn passes the joined trigger and the same strings
-    individually. Matching only the join left each piece duplicated whenever
-    there was more than one, so the model read — and paid for — all of it twice."""
+    """A reminder-only turn hands over its reminders and the same strings arrive
+    as fragments. Each one has to be recognised, not just the whole: matching
+    only the join left every piece duplicated once there was more than one."""
     from suzent.core import system_reminder as sr
 
     first, second = "Cron: nightly digest", "Cron: weekly rollup"
-    joined = sr.TRIGGER_SEPARATOR.join([first, second])
 
     result = await sr.build_combined_reminder(
-        "c", None, adhoc_reminders=[first, second], display_trigger=joined
+        "c", None, adhoc_reminders=[first, second], display_trigger=[first, second]
     )
 
     assert result is not None
     assert result.count(first) == 1
     assert result.count(second) == 1
-
-
-def test_the_join_separator_has_one_definition() -> None:
-    """The caller joins with it and the dedupe splits on it. Two copies of that
-    string is how the multi-reminder case shipped duplicated."""
-    import inspect
-
-    from suzent.core import chat_processor, system_reminder
-
-    source = inspect.getsource(chat_processor.ChatProcessor.process_turn)
-
-    assert "TRIGGER_SEPARATOR" in source
-    assert '"\\n\\n---\\n\\n".join' not in source
-    assert system_reminder.TRIGGER_SEPARATOR == "\n\n---\n\n"
 
 
 @pytest.mark.asyncio
@@ -2089,3 +2074,52 @@ async def test_one_oversized_fragment_still_survives_without_a_trigger(clean_hoo
     result = await sr.build_combined_reminder("c", None, adhoc_reminders=[huge])
 
     assert result is not None and huge in result
+
+
+@pytest.mark.asyncio
+async def test_a_reminder_containing_the_separator_is_still_charged_once(clean_hooks):
+    """Boundaries cannot be recovered from a rendered join. A reminder whose own
+    text contains the separator — a Markdown rule is enough — split into pieces
+    that matched no fragment, so it was sent twice and spent the budget twice."""
+    from suzent.core import system_reminder as sr
+
+    tricky = f"Cron: digest{sr.TRIGGER_SEPARATOR}see attached"
+    plain = "Cron: weekly rollup"
+
+    result = await sr.build_combined_reminder(
+        "c", None, adhoc_reminders=[tricky, plain], display_trigger=[tricky, plain]
+    )
+
+    assert result is not None
+    assert result.count("see attached") == 1
+    assert result.count(plain) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_single_string_trigger_is_one_constituent(clean_hooks):
+    """Not a join to be taken apart — that reading is what made a reminder
+    containing the separator unrecoverable."""
+    from suzent.core import system_reminder as sr
+
+    trigger = f"Cron: digest{sr.TRIGGER_SEPARATOR}see attached"
+
+    result = await sr.build_combined_reminder(
+        "c", None, adhoc_reminders=[trigger], display_trigger=trigger
+    )
+
+    assert result is not None
+    assert result.count("see attached") == 1
+
+
+def test_the_caller_hands_over_constituents_not_a_join() -> None:
+    """Joining belongs to the module that deduplicates, because only there can
+    the two agree. Three rounds of this bug were the join and the split
+    disagreeing across a module boundary."""
+    import inspect
+
+    from suzent.core import chat_processor
+
+    source = inspect.getsource(chat_processor.ChatProcessor.process_turn)
+
+    assert "TRIGGER_SEPARATOR.join" not in source
+    assert '"\n\n---\n\n"' not in source

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -1864,3 +1864,32 @@ async def test_a_trigger_only_turn_still_produces_a_reminder(clean_hooks):
 
     assert result is not None
     assert sr.extract_system_reminder_display_trigger(result) == scheduled
+
+
+def test_every_filesystem_reading_provider_renders_off_loop() -> None:
+    """A provider that blocks before its first await makes its own deadline
+    unenforceable — wait_for cannot interrupt work sitting on the loop it runs
+    on — and starves the providers scheduled beside it.
+
+    The framework cannot offload this for them: hooks are coroutines, and
+    driving an arbitrary one in a foreign loop would break anything loop-affine
+    inside it. So each hook that touches the filesystem has to route that work
+    through run_provider_blocking itself, and this is the check that it did.
+    Three hooks read paths and the first two rounds each moved one, so the
+    assertion is over the set rather than over the ones remembered.
+    """
+    import inspect
+
+    from suzent.core.repository_context import repository_agents_reminder_hook
+    from suzent.skills.hooks import skills_reminder_hook
+    from suzent.tools.plan_hooks import plan_reminder_hook
+
+    for hook in (
+        repository_agents_reminder_hook,
+        skills_reminder_hook,
+        plan_reminder_hook,
+    ):
+        source = inspect.getsource(hook)
+        assert "run_provider_blocking" in source, (
+            f"{hook.__name__} reads the filesystem on the event loop"
+        )

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -92,7 +92,9 @@ async def test_combined_reminder_merges_global_and_adhoc():
     clear_global_hooks()
 
     assert result is not None
-    assert "global\n\n---\n\nadhoc" in result
+    # Caller directives come first: they are specific to this turn and must
+    # survive truncation, while hook output is ambient and returns next turn.
+    assert "adhoc\n\n---\n\nglobal" in result
 
 
 def test_rebuild_strips_reminder_from_display_messages():
@@ -1616,3 +1618,65 @@ async def test_one_oversized_fragment_is_still_delivered(clean_hooks, monkeypatc
     sr.register_global_hook(huge)
 
     assert "IMPORTANT" in await sr.build_combined_reminder("c", None)
+
+
+@pytest.mark.asyncio
+async def test_budget_measures_the_sanitized_text(clean_hooks, monkeypatch):
+    """Sanitizing expands each one-character PUA delimiter into
+    `[reminder-delimiter]`, so a raw body under the cap could arrive many times
+    over it. Goal, task and memory text is user-influenced, so this is reachable."""
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 1000)
+
+    async def delimiters(chat_id, deps):
+        return PUA_START * 300  # 300 raw chars -> ~6000 after sanitizing
+
+    async def later(chat_id, deps):
+        return "SHOULD_BE_DROPPED"
+
+    sr.register_global_hook(delimiters)
+    sr.register_global_hook(later)
+
+    body = extract_system_reminder_content(await sr.build_combined_reminder("c", None))
+
+    assert "SHOULD_BE_DROPPED" not in body, "measured the raw text, not what is sent"
+
+
+@pytest.mark.asyncio
+async def test_the_display_trigger_spends_from_the_same_budget(
+    clean_hooks, monkeypatch
+):
+    """It is prepended inside the block, so a cap that ignores it covers only
+    part of what the model reads."""
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 400)
+    sr.register_global_hook(_sized_hook("KEEP", 100))
+    sr.register_global_hook(_sized_hook("DROP", 100))
+
+    body = extract_system_reminder_content(
+        await sr.build_combined_reminder("c", None, display_trigger="T" * 350)
+    )
+
+    assert "KEEP" in body
+    assert "DROP" not in body
+
+
+@pytest.mark.asyncio
+async def test_caller_directives_outrank_ambient_hooks(clean_hooks, monkeypatch):
+    """A peer's attribution or the analyze_image directive is specific to this
+    turn; skill and plan content is ambient and returns next turn."""
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 100)
+    sr.register_global_hook(_sized_hook("AMBIENT", 250))
+
+    body = extract_system_reminder_content(
+        await sr.build_combined_reminder(
+            "c", None, adhoc_reminders=["DIRECTIVE: inspect the image"]
+        )
+    )
+
+    assert "DIRECTIVE" in body
+    assert "AMBIENT" not in body

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -2153,3 +2153,53 @@ async def test_the_slot_is_free_the_moment_the_provider_returns():
     for _ in range(20):
         await sr.run_provider_blocking(lambda: "done")
         assert sr._provider_slots._value == before, "slot still held on return"
+
+
+@pytest.mark.asyncio
+async def test_constituents_that_sanitize_alike_are_sent_once(clean_hooks):
+    """Sanitizing decides whether two inputs are the same text: a delimiter and
+    its literal [reminder-delimiter] spelling differ going in and are identical
+    coming out. Deduplicating first kept both and sent the reminder twice."""
+    from suzent.core import system_reminder as sr
+
+    raw = f"{sr.PUA_START}Cron: nightly digest"
+    spelled = sr.sanitize_untrusted_text(raw)
+    assert raw != spelled, "precondition: these differ before sanitizing"
+
+    result = await sr.build_combined_reminder("c", None, display_trigger=[raw, spelled])
+
+    assert result is not None
+    assert result.count("Cron: nightly digest") == 1
+
+
+def test_the_transcript_row_and_the_block_agree_on_the_trigger() -> None:
+    """Two renderings of the same thing is how the model came to see a reminder
+    once while the transcript kept showing it twice."""
+    import inspect
+
+    from suzent.core import chat_processor, system_reminder
+
+    source = inspect.getsource(chat_processor.trigger_rows_for_snapshot)
+
+    assert "canonical_display_trigger" in source
+    assert "TRIGGER_SEPARATOR" not in source
+
+    repeated = ["Cron: digest", "Cron: digest"]
+    assert system_reminder.canonical_display_trigger(repeated) == "Cron: digest"
+
+
+def test_the_persisted_row_shows_what_the_model_was_shown() -> None:
+    from datetime import datetime
+    from types import SimpleNamespace
+
+    from suzent.core.chat_processor import trigger_rows_for_snapshot
+    from suzent.core.system_reminder import canonical_display_trigger
+
+    part = SimpleNamespace(timestamp=datetime(2026, 1, 1))
+    repeated = ["Cron: nightly digest", "Cron: nightly digest"]
+
+    rows = trigger_rows_for_snapshot(repeated, False, part)
+
+    assert len(rows) == 1
+    assert rows[0]["content"] == canonical_display_trigger(repeated)
+    assert rows[0]["content"].count("Cron: nightly digest") == 1

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -1648,7 +1648,13 @@ async def test_the_display_trigger_spends_from_the_same_budget(
     clean_hooks, monkeypatch
 ):
     """It is prepended inside the block, so a cap that ignores it covers only
-    part of what the model reads."""
+    part of what the model reads.
+
+    Sized so the first fragment fits behind the trigger and the second does not.
+    The original numbers only passed through the first-fragment exemption, which
+    no longer applies once a trigger has been delivered — the case where that
+    exemption let the cap be exceeded outright.
+    """
     from suzent.core import system_reminder as sr
 
     monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 400)
@@ -1656,7 +1662,7 @@ async def test_the_display_trigger_spends_from_the_same_budget(
     sr.register_global_hook(_sized_hook("DROP", 100))
 
     body = extract_system_reminder_content(
-        await sr.build_combined_reminder("c", None, display_trigger="T" * 350)
+        await sr.build_combined_reminder("c", None, display_trigger="T" * 200)
     )
 
     assert "KEEP" in body
@@ -2015,3 +2021,71 @@ async def test_a_slot_survives_a_thread_that_never_starts() -> None:
         threading.Thread = original
 
     assert sr._provider_slots._value == before, "slot leaked"
+
+
+# --- the cap holds on the text that is actually sent -------------------------
+
+
+def _reminder_body(rendered: str) -> str:
+    """What the model reads inside the block, trigger included.
+
+    Measured on the wrapped output rather than on the fragment list, because the
+    trigger is prepended during wrapping — a budget checked before that point
+    covers only part of what is sent.
+    """
+    from suzent.core.system_reminder import PUA_END, PUA_START, RUNTIME_NONCE
+
+    inner = rendered.split(PUA_START, 1)[1].rsplit(PUA_END, 1)[0]
+    return inner.replace(RUNTIME_NONCE, "").strip()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "trigger_len,fragment_lens",
+    [
+        (5900, [500]),  # the reported case: trigger nearly fills the cap
+        (5900, [500, 500, 500]),
+        (100, [5000, 5000]),
+        (0, [500, 500]),
+        (3000, [3000]),
+        (10, [10]),
+    ],
+)
+async def test_the_cap_holds_on_the_assembled_body(
+    clean_hooks, trigger_len, fragment_lens
+):
+    """Measured on what is sent, not on what this module happens to hold. The
+    trigger is prepended inside the block, so a budget that counted only
+    fragments capped part of what the model reads."""
+    from suzent.core import system_reminder as sr
+
+    trigger = ("T" * trigger_len) or None
+    fragments = [chr(97 + i) * n for i, n in enumerate(fragment_lens)]
+
+    result = await sr.build_combined_reminder(
+        "c", None, adhoc_reminders=fragments, display_trigger=trigger
+    )
+
+    assert result is not None
+    body = _reminder_body(result)
+    if trigger_len > sr.REMINDER_BUDGET_CHARS:
+        # A single item larger than the whole cap is the one thing that cannot
+        # be honoured; it must not also license a second one.
+        assert body.count("T") == trigger_len
+    else:
+        assert len(body) <= sr.REMINDER_BUDGET_CHARS, (
+            f"{len(body)} chars sent against a {sr.REMINDER_BUDGET_CHARS} cap"
+        )
+
+
+@pytest.mark.asyncio
+async def test_one_oversized_fragment_still_survives_without_a_trigger(clean_hooks):
+    """The exemption exists so an empty body cannot be mistaken for a provider
+    that produced nothing. With no trigger, nothing else is delivering."""
+    from suzent.core import system_reminder as sr
+
+    huge = "x" * (sr.REMINDER_BUDGET_CHARS + 1000)
+
+    result = await sr.build_combined_reminder("c", None, adhoc_reminders=[huge])
+
+    assert result is not None and huge in result

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -2312,3 +2312,33 @@ async def test_nothing_is_exempt_from_the_cap(clean_hooks):
     assert "exempt" not in source.lower().split('"""')[-1], (
         "no code path may skip the cap check"
     )
+
+
+@pytest.mark.asyncio
+async def test_a_trigger_constituent_the_budget_dropped_is_not_resent(clean_hooks):
+    """The same strings arrive as fragments. Charging only the ones the trigger
+    kept let a dropped constituent reappear as an ordinary fragment — the model
+    reading a reminder the transcript says was never delivered."""
+    from suzent.core import system_reminder as sr
+
+    # The window the finding names: the first reminder leaves less room than the
+    # separator costs, so the second is dropped from the trigger — and then fits
+    # as a fragment, because a fragment pays no separator when it is first.
+    second = "b" * 7
+    first = "a" * (
+        sr.REMINDER_BUDGET_CHARS - len(sr.render_trigger_block("")) - len(second) - 1
+    )
+
+    rendered = await sr.build_combined_reminder(
+        "c", None, adhoc_reminders=[first, second], display_trigger=[first, second]
+    )
+
+    assert rendered is not None
+    body = _reminder_body(rendered)
+    shown = sr.extract_system_reminder_display_trigger(rendered)
+
+    # Whatever the budget decided, the block and the row have to agree on it.
+    assert (second in body) == (second in shown), (
+        "a constituent the trigger dropped came back as a fragment"
+    )
+    assert len(body) <= sr.REMINDER_BUDGET_CHARS

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -2203,3 +2203,37 @@ def test_the_persisted_row_shows_what_the_model_was_shown() -> None:
     assert len(rows) == 1
     assert rows[0]["content"] == canonical_display_trigger(repeated)
     assert rows[0]["content"].count("Cron: nightly digest") == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("count", [2, 3, 5])
+async def test_the_trigger_is_budgeted_as_its_constituents(clean_hooks, count):
+    """Joining first made the whole trigger one item, and one item is exactly
+    what the oversized exemption waves through — so several unrelated 4,000
+    character reminders cleared a 6,000 character cap together."""
+    from suzent.core import system_reminder as sr
+
+    reminders = [f"{chr(97 + i)}" * 4000 for i in range(count)]
+
+    result = await sr.build_combined_reminder("c", None, display_trigger=reminders)
+
+    assert result is not None
+    body = _reminder_body(result)
+    # One reminder may exceed the cap alone; a second one may not join it.
+    assert len(body) <= sr.REMINDER_BUDGET_CHARS, (
+        f"{len(body)} chars sent against a {sr.REMINDER_BUDGET_CHARS} cap"
+    )
+    assert reminders[0] in body, "the first reminder must still be delivered"
+
+
+@pytest.mark.asyncio
+async def test_one_oversized_constituent_still_survives(clean_hooks):
+    """The exemption is one item, and it still exists: an empty body cannot be
+    told apart from a turn that had nothing to say."""
+    from suzent.core import system_reminder as sr
+
+    huge = "x" * (sr.REMINDER_BUDGET_CHARS + 1000)
+
+    result = await sr.build_combined_reminder("c", None, display_trigger=[huge])
+
+    assert result is not None and huge in result

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -1680,3 +1680,57 @@ async def test_caller_directives_outrank_ambient_hooks(clean_hooks, monkeypatch)
 
     assert "DIRECTIVE" in body
     assert "AMBIENT" not in body
+
+
+@pytest.mark.asyncio
+async def test_a_blocking_provider_cannot_hold_the_turn_open(clean_hooks, monkeypatch):
+    """asyncio.wait_for needs the loop running to cancel anything, so a provider
+    that blocks it cannot be timed out. Providers doing synchronous work must
+    hand it to a thread — plan_reminder_hook wraps its database access this way."""
+    import asyncio as _asyncio
+    import time
+
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "HOOK_TIMEOUT_SECONDS", 0.05)
+
+    async def blocking_but_threaded(chat_id, deps):
+        await _asyncio.to_thread(time.sleep, 1.0)
+        return "slow"
+
+    async def quick(chat_id, deps):
+        return "quick"
+
+    sr.register_global_hook(blocking_but_threaded)
+    sr.register_global_hook(quick)
+
+    started = time.monotonic()
+    result = await sr.build_combined_reminder("c", None)
+    elapsed = time.monotonic() - started
+
+    assert "quick" in result
+    assert elapsed < 0.5, f"deadline could not fire: {elapsed:.2f}s"
+
+
+def test_the_plan_hook_does_its_database_work_off_the_loop():
+    import inspect
+
+    from suzent.tools import plan_hooks
+
+    source = inspect.getsource(plan_hooks.plan_reminder_hook)
+
+    assert "to_thread" in source
+
+
+def test_the_goal_fragment_outranks_ambient_catalogues():
+    """Registration order is priority order under the budget, so a large skill
+    catalog must not be able to hide the objective the agent is working on."""
+    import inspect
+
+    from suzent import server
+
+    source = inspect.getsource(server)
+    plan = source.index("register_global_hook(plan_reminder_hook)")
+    skills = source.index("register_global_hook(skills_reminder_hook)")
+
+    assert plan < skills

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -1447,3 +1447,172 @@ def test_every_registered_history_processor_takes_a_run_context():
         make_compaction_history_processor,
     ):
         assert takes_run_context(factory()), factory.__name__
+
+
+# ---------------------------------------------------------------------------
+# Provider budget, isolation and concurrency
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clean_hooks():
+    from suzent.core.system_reminder import clear_global_hooks, clear_per_turn_hooks
+
+    clear_global_hooks()
+    clear_per_turn_hooks()
+    yield
+    clear_global_hooks()
+    clear_per_turn_hooks()
+
+
+@pytest.mark.asyncio
+async def test_a_hung_global_hook_cannot_stall_the_turn(clean_hooks, monkeypatch):
+    """Global hooks previously had no timeout at all, so one hung provider
+    blocked every message indefinitely."""
+    import asyncio as _asyncio
+
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "HOOK_TIMEOUT_SECONDS", 0.05)
+
+    async def hangs(chat_id, deps):
+        await _asyncio.sleep(30)
+        return "never"
+
+    async def works(chat_id, deps):
+        return "delivered"
+
+    sr.register_global_hook(hangs)
+    sr.register_global_hook(works)
+
+    result = await _asyncio.wait_for(sr.build_combined_reminder("c", None), timeout=5)
+
+    assert "delivered" in result
+    assert "never" not in result
+
+
+@pytest.mark.asyncio
+async def test_a_failing_provider_does_not_lose_the_others(clean_hooks):
+    from suzent.core import system_reminder as sr
+
+    async def broken(chat_id, deps):
+        raise RuntimeError("provider exploded")
+
+    async def works(chat_id, deps):
+        return "delivered"
+
+    sr.register_global_hook(broken)
+    sr.register_global_hook(works)
+
+    assert "delivered" in await sr.build_combined_reminder("c", None)
+
+
+def _slow_hook(label: str, delay: float = 0.1):
+    """A distinct coroutine per call — registration de-duplicates by identity."""
+
+    async def hook(chat_id, deps):
+        import asyncio as _asyncio
+
+        await _asyncio.sleep(delay)
+        return label
+
+    hook.__name__ = f"slow_{label}"
+    return hook
+
+
+def _sized_hook(label: str, size: int):
+    async def hook(chat_id, deps):
+        return label + "x" * size
+
+    hook.__name__ = f"sized_{label}"
+    return hook
+
+
+@pytest.mark.asyncio
+async def test_providers_run_concurrently(clean_hooks):
+    """Serially these take 0.3s; together, about 0.1s."""
+    import time
+
+    from suzent.core import system_reminder as sr
+
+    for label in ("a", "b", "c"):
+        sr.register_global_hook(_slow_hook(label))
+
+    started = time.monotonic()
+    await sr.build_combined_reminder("c", None)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.25, f"looks serial: {elapsed:.2f}s"
+
+
+@pytest.mark.asyncio
+async def test_identical_fragments_are_not_paid_for_twice(clean_hooks):
+    from suzent.core import system_reminder as sr
+
+    async def one(chat_id, deps):
+        return "[ACTIVE TASKS] #1 ship it"
+
+    async def two(chat_id, deps):
+        return "[ACTIVE TASKS] #1 ship it"
+
+    sr.register_global_hook(one)
+    sr.register_global_hook(two)
+
+    result = await sr.build_combined_reminder("c", None)
+
+    assert result.count("[ACTIVE TASKS] #1 ship it") == 1
+
+
+@pytest.mark.asyncio
+async def test_the_body_stays_within_budget(clean_hooks, monkeypatch):
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 500)
+
+    for i in range(6):
+        sr.register_global_hook(_sized_hook(f"F{i}", 200))
+
+    result = await sr.build_combined_reminder("c", None)
+    body = extract_system_reminder_content(result)
+
+    assert len(body) <= 500 + len(sr.FRAGMENT_SEPARATOR)
+
+
+@pytest.mark.asyncio
+async def test_truncation_drops_whole_fragments_from_the_end(clean_hooks, monkeypatch):
+    """Registration order is priority order, and half a fragment is worse than
+    none because the model cannot tell it is reading one."""
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 300)
+
+    async def first(chat_id, deps):
+        return "FIRST" + "a" * 200
+
+    async def later(chat_id, deps):
+        return "LATER" + "b" * 200
+
+    sr.register_global_hook(first)
+    sr.register_global_hook(later)
+
+    body = extract_system_reminder_content(await sr.build_combined_reminder("c", None))
+
+    assert "FIRST" in body
+    assert "LATER" not in body
+    assert body.endswith("a" * 200), "the kept fragment must be intact"
+
+
+@pytest.mark.asyncio
+async def test_one_oversized_fragment_is_still_delivered(clean_hooks, monkeypatch):
+    """Truncating to nothing is indistinguishable from a provider that produced
+    nothing, and the caller cannot tell the difference."""
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 50)
+
+    async def huge(chat_id, deps):
+        return "IMPORTANT" + "x" * 500
+
+    sr.register_global_hook(huge)
+
+    assert "IMPORTANT" in await sr.build_combined_reminder("c", None)

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -1605,19 +1605,25 @@ async def test_truncation_drops_whole_fragments_from_the_end(clean_hooks, monkey
 
 
 @pytest.mark.asyncio
-async def test_one_oversized_fragment_is_still_delivered(clean_hooks, monkeypatch):
-    """Truncating to nothing is indistinguishable from a provider that produced
-    nothing, and the caller cannot tell the difference."""
+async def test_one_oversized_fragment_is_cut_rather_than_dropped(
+    clean_hooks, monkeypatch
+):
+    """Dropping it is indistinguishable from a provider that produced nothing,
+    and sending it whole is the cap failing. Cut, and say so."""
     from suzent.core import system_reminder as sr
 
-    monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 50)
+    monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 200)
 
     async def huge(chat_id, deps):
         return "IMPORTANT" + "x" * 500
 
     sr.register_global_hook(huge)
 
-    assert "IMPORTANT" in await sr.build_combined_reminder("c", None)
+    body = _reminder_body(await sr.build_combined_reminder("c", None))
+
+    assert "IMPORTANT" in body
+    assert sr.TRUNCATION_MARKER.strip() in body
+    assert len(body) <= sr.REMINDER_BUDGET_CHARS
 
 
 @pytest.mark.asyncio
@@ -2064,16 +2070,20 @@ async def test_the_cap_holds_on_the_assembled_body(
 
 
 @pytest.mark.asyncio
-async def test_one_oversized_fragment_still_survives_without_a_trigger(clean_hooks):
-    """The exemption exists so an empty body cannot be mistaken for a provider
-    that produced nothing. With no trigger, nothing else is delivering."""
+async def test_an_oversized_fragment_is_cut_to_fit_without_a_trigger(clean_hooks):
+    """With no trigger nothing else is delivering, so this fragment is the whole
+    turn — it has to survive, and it has to fit."""
     from suzent.core import system_reminder as sr
 
     huge = "x" * (sr.REMINDER_BUDGET_CHARS + 1000)
 
     result = await sr.build_combined_reminder("c", None, adhoc_reminders=[huge])
 
-    assert result is not None and huge in result
+    assert result is not None
+    body = _reminder_body(result)
+    assert body.startswith("x")
+    assert body.endswith(sr.TRUNCATION_MARKER.strip())
+    assert len(body) <= sr.REMINDER_BUDGET_CHARS
 
 
 @pytest.mark.asyncio
@@ -2257,13 +2267,48 @@ async def test_the_trigger_is_budgeted_as_its_constituents(clean_hooks, count):
 
 
 @pytest.mark.asyncio
-async def test_one_oversized_constituent_still_survives(clean_hooks):
-    """The exemption is one item, and it still exists: an empty body cannot be
-    told apart from a turn that had nothing to say."""
+@pytest.mark.parametrize("size", [5940, 5999, 6000, 6001, 7000])
+async def test_an_oversized_trigger_is_cut_to_fit(clean_hooks, size):
+    """The envelope counts. A trigger just under the cap still renders over it
+    once its tags are added, which is the window the last finding landed in —
+    and the fix must not turn that into a dropped turn."""
     from suzent.core import system_reminder as sr
 
-    huge = "x" * (sr.REMINDER_BUDGET_CHARS + 1000)
+    huge = "x" * size
 
     result = await sr.build_combined_reminder("c", None, display_trigger=[huge])
 
-    assert result is not None and huge in result
+    assert result is not None, "the turn's only content must not vanish"
+    body = _reminder_body(result)
+    assert "x" in body
+    assert len(body) <= sr.REMINDER_BUDGET_CHARS, (
+        f"{len(body)} chars sent against a {sr.REMINDER_BUDGET_CHARS} cap"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_cut_reminder_says_it_was_cut(clean_hooks):
+    """Silently trimmed text is worse than either the cut or the overshoot: it
+    reads as complete and is not."""
+    from suzent.core import system_reminder as sr
+
+    result = await sr.build_combined_reminder(
+        "c", None, display_trigger=["x" * (sr.REMINDER_BUDGET_CHARS + 1000)]
+    )
+
+    assert sr.TRUNCATION_MARKER.strip() in _reminder_body(result)
+
+
+@pytest.mark.asyncio
+async def test_nothing_is_exempt_from_the_cap(clean_hooks):
+    """Five findings on this PR were an item claiming to be the one thing that
+    could not be helped. Now nothing claims it."""
+    import inspect
+
+    from suzent.core import system_reminder as sr
+
+    source = inspect.getsource(sr._apply_budget)
+
+    assert "exempt" not in source.lower().split('"""')[-1], (
+        "no code path may skip the cap check"
+    )

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -1749,8 +1749,12 @@ def test_provider_threads_are_daemons_and_bounded():
 
 
 @pytest.mark.asyncio
-async def test_saturated_provider_threads_skip_rather_than_queue():
-    """Queueing behind wedged work is how a transient stall becomes permanent."""
+async def test_a_busy_pool_waits_instead_of_dropping_the_provider():
+    """Ordinary concurrency is not a wedged provider. Three blocking hooks per
+    turn against four process-wide slots means two simultaneous turns already
+    exceed the pool — dropping there would silently lose context from healthy
+    requests."""
+    import asyncio
     import threading
 
     from suzent.core import system_reminder as sr
@@ -1759,9 +1763,69 @@ async def test_saturated_provider_threads_skip_rather_than_queue():
     original = sr._provider_slots
     sr._provider_slots = exhausted
     try:
-        assert await sr.run_provider_blocking(lambda: "should not run") is None
+        waiting = asyncio.create_task(sr.run_provider_blocking(lambda: "ran"))
+        await asyncio.sleep(0.05)
+        assert not waiting.done(), "gave up instead of waiting for a slot"
+
+        exhausted.release()
+        assert await asyncio.wait_for(waiting, timeout=1.0) == "ran"
     finally:
         sr._provider_slots = original
+
+
+@pytest.mark.asyncio
+async def test_waiting_for_a_slot_is_bounded_by_the_callers_deadline():
+    """Waiting is only safe because it ends. A pool that never frees up must
+    fail the provider on its own deadline rather than queue behind the block."""
+    import asyncio
+    import threading
+    import time
+
+    from suzent.core import system_reminder as sr
+
+    original = sr._provider_slots
+    sr._provider_slots = threading.Semaphore(0)
+    try:
+        started = time.monotonic()
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                sr.run_provider_blocking(lambda: "never"), timeout=0.1
+            )
+        assert time.monotonic() - started < 0.5
+    finally:
+        sr._provider_slots = original
+
+
+@pytest.mark.asyncio
+async def test_waiting_for_a_slot_does_not_block_the_loop():
+    """The wait must yield: blocking the acquire would block the loop, which is
+    the exact failure this function exists to prevent."""
+    import asyncio
+    import threading
+
+    from suzent.core import system_reminder as sr
+
+    original = sr._provider_slots
+    sr._provider_slots = threading.Semaphore(0)
+    ticks = 0
+
+    async def _tick():
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    ticker = asyncio.create_task(_tick())
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                sr.run_provider_blocking(lambda: "never"), timeout=0.2
+            )
+    finally:
+        ticker.cancel()
+        sr._provider_slots = original
+
+    assert ticks > 5, f"event loop was blocked while waiting for a slot ({ticks})"
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -1957,3 +1957,61 @@ def test_every_filesystem_reading_provider_renders_off_loop() -> None:
         assert "run_provider_blocking" in source, (
             f"{hook.__name__} reads the filesystem on the event loop"
         )
+
+
+@pytest.mark.asyncio
+async def test_every_constituent_of_a_joined_trigger_is_charged_once(clean_hooks):
+    """A reminder-only turn passes the joined trigger and the same strings
+    individually. Matching only the join left each piece duplicated whenever
+    there was more than one, so the model read — and paid for — all of it twice."""
+    from suzent.core import system_reminder as sr
+
+    first, second = "Cron: nightly digest", "Cron: weekly rollup"
+    joined = sr.TRIGGER_SEPARATOR.join([first, second])
+
+    result = await sr.build_combined_reminder(
+        "c", None, adhoc_reminders=[first, second], display_trigger=joined
+    )
+
+    assert result is not None
+    assert result.count(first) == 1
+    assert result.count(second) == 1
+
+
+def test_the_join_separator_has_one_definition() -> None:
+    """The caller joins with it and the dedupe splits on it. Two copies of that
+    string is how the multi-reminder case shipped duplicated."""
+    import inspect
+
+    from suzent.core import chat_processor, system_reminder
+
+    source = inspect.getsource(chat_processor.ChatProcessor.process_turn)
+
+    assert "TRIGGER_SEPARATOR" in source
+    assert '"\\n\\n---\\n\\n".join' not in source
+    assert system_reminder.TRIGGER_SEPARATOR == "\n\n---\n\n"
+
+
+@pytest.mark.asyncio
+async def test_a_slot_survives_a_thread_that_never_starts() -> None:
+    """The worker's finally releases the slot, so a thread that fails to start
+    never gives it back. Four of those and the pool is gone for the life of the
+    process."""
+    import threading
+
+    from suzent.core import system_reminder as sr
+
+    before = sr._provider_slots._value
+
+    def _no_thread(*args, **kwargs):
+        raise RuntimeError("can't start new thread")
+
+    original = threading.Thread
+    threading.Thread = _no_thread
+    try:
+        with pytest.raises(RuntimeError, match="can't start new thread"):
+            await sr.run_provider_blocking(lambda: "never")
+    finally:
+        threading.Thread = original
+
+    assert sr._provider_slots._value == before, "slot leaked"

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -2123,3 +2123,33 @@ def test_the_caller_hands_over_constituents_not_a_join() -> None:
 
     assert "TRIGGER_SEPARATOR.join" not in source
     assert '"\n\n---\n\n"' not in source
+
+
+@pytest.mark.asyncio
+async def test_a_repeated_trigger_constituent_is_sent_once(clean_hooks):
+    """Fragments are deduplicated, so leaving the trigger alone sent one
+    repeated reminder in full twice — and two 4,000-character copies clear the
+    cap on their own through the oversized-trigger exemption."""
+    from suzent.core import system_reminder as sr
+
+    reminder = "Cron: nightly digest"
+
+    result = await sr.build_combined_reminder(
+        "c", None, display_trigger=[reminder, reminder]
+    )
+
+    assert result is not None
+    assert result.count(reminder) == 1
+
+
+@pytest.mark.asyncio
+async def test_the_slot_is_free_the_moment_the_provider_returns():
+    """Released before the awaiter is woken, not after. The other order let the
+    caller resume while the worker still held the slot, so the pool read as
+    short by one for the length of the handoff."""
+    from suzent.core import system_reminder as sr
+
+    before = sr._provider_slots._value
+    for _ in range(20):
+        await sr.run_provider_blocking(lambda: "done")
+        assert sr._provider_slots._value == before, "slot still held on return"

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -1733,14 +1733,58 @@ def test_blocking_providers_use_the_bounded_pool(module: str, func: str):
     assert "asyncio.to_thread" not in source
 
 
-def test_the_provider_pool_is_separate_and_bounded():
-    from suzent.core.system_reminder import _get_provider_executor, _PROVIDER_THREADS
+def test_provider_threads_are_daemons_and_bounded():
+    """ThreadPoolExecutor joins its workers at interpreter exit, so one wedged
+    read — the case this exists to survive — would hang every server stop and
+    reload. Daemon threads let the process leave."""
+    import inspect
 
-    executor = _get_provider_executor()
+    from suzent.core import system_reminder as sr
 
-    assert executor._max_workers == _PROVIDER_THREADS
-    # Not asyncio's default executor, whose stragglers would affect everything.
-    assert "reminder-provider" in executor._thread_name_prefix
+    source = inspect.getsource(sr.run_provider_blocking)
+
+    assert "daemon=True" in source
+    assert "ThreadPoolExecutor(" not in inspect.getsource(sr), "must not construct one"
+    assert sr._provider_slots._value <= sr._PROVIDER_THREADS
+
+
+@pytest.mark.asyncio
+async def test_saturated_provider_threads_skip_rather_than_queue():
+    """Queueing behind wedged work is how a transient stall becomes permanent."""
+    import threading
+
+    from suzent.core import system_reminder as sr
+
+    exhausted = threading.Semaphore(0)
+    original = sr._provider_slots
+    sr._provider_slots = exhausted
+    try:
+        assert await sr.run_provider_blocking(lambda: "should not run") is None
+    finally:
+        sr._provider_slots = original
+
+
+@pytest.mark.asyncio
+async def test_a_provider_thread_slot_is_released_after_use():
+    from suzent.core import system_reminder as sr
+
+    before = sr._provider_slots._value
+    await sr.run_provider_blocking(lambda: "done")
+
+    assert sr._provider_slots._value == before
+
+
+@pytest.mark.asyncio
+async def test_a_failing_blocking_provider_relays_its_error():
+    from suzent.core import system_reminder as sr
+
+    def boom():
+        raise RuntimeError("disk on fire")
+
+    with pytest.raises(RuntimeError, match="disk on fire"):
+        await sr.run_provider_blocking(boom)
+
+    assert sr._provider_slots._value == sr._PROVIDER_THREADS
 
 
 @pytest.mark.asyncio
@@ -1781,3 +1825,42 @@ def test_the_goal_fragment_outranks_ambient_catalogues():
     skills = source.index("register_global_hook(skills_reminder_hook)")
 
     assert plan < skills
+
+
+@pytest.mark.asyncio
+async def test_the_trigger_text_is_not_charged_twice(clean_hooks, monkeypatch):
+    """A reminder-only turn passes the same text as display_trigger and as an
+    ad-hoc fragment, and the trigger is prepended inside the block — so a large
+    scheduled reminder produced a body twice its size and defeated the cap."""
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "REMINDER_BUDGET_CHARS", 6000)
+    scheduled = "Cron: " + "x" * 3000
+
+    result = await sr.build_combined_reminder(
+        "c", None, adhoc_reminders=[scheduled], display_trigger=scheduled
+    )
+
+    # Once in the whole block: the trigger envelope carries it, so the duplicate
+    # fragment is redundant. The model still reads it; it is charged once.
+    assert result.count("x" * 3000) == 1, "the trigger text appeared twice"
+    assert len(result) < 6000
+    from suzent.core.system_reminder import extract_system_reminder_display_trigger
+
+    assert extract_system_reminder_display_trigger(result).startswith("Cron:")
+
+
+@pytest.mark.asyncio
+async def test_a_trigger_only_turn_still_produces_a_reminder(clean_hooks):
+    """Dropping the duplicate fragment can empty the body while a trigger is
+    still owed. A reminder-only turn's whole visible record is that trigger, so
+    returning nothing would lose the row."""
+    from suzent.core import system_reminder as sr
+
+    scheduled = "Cron: nightly digest"
+    result = await sr.build_combined_reminder(
+        "c", None, adhoc_reminders=[scheduled], display_trigger=scheduled
+    )
+
+    assert result is not None
+    assert sr.extract_system_reminder_display_trigger(result) == scheduled

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -1712,14 +1712,61 @@ async def test_a_blocking_provider_cannot_hold_the_turn_open(clean_hooks, monkey
     assert elapsed < 0.5, f"deadline could not fire: {elapsed:.2f}s"
 
 
-def test_the_plan_hook_does_its_database_work_off_the_loop():
+@pytest.mark.parametrize(
+    "module,func",
+    [
+        ("suzent.tools.plan_hooks", "plan_reminder_hook"),
+        ("suzent.core.repository_context", "repository_agents_reminder_hook"),
+    ],
+)
+def test_blocking_providers_use_the_bounded_pool(module: str, func: str):
+    """Both do synchronous I/O — SQLite reads and Path.resolve(). A provider
+    that blocks before its first await cannot be timed out at all, and using
+    asyncio's default executor would let stuck workers starve unrelated
+    to_thread callers."""
+    import importlib
     import inspect
 
-    from suzent.tools import plan_hooks
+    source = inspect.getsource(getattr(importlib.import_module(module), func))
 
-    source = inspect.getsource(plan_hooks.plan_reminder_hook)
+    assert "run_provider_blocking" in source
+    assert "asyncio.to_thread" not in source
 
-    assert "to_thread" in source
+
+def test_the_provider_pool_is_separate_and_bounded():
+    from suzent.core.system_reminder import _get_provider_executor, _PROVIDER_THREADS
+
+    executor = _get_provider_executor()
+
+    assert executor._max_workers == _PROVIDER_THREADS
+    # Not asyncio's default executor, whose stragglers would affect everything.
+    assert "reminder-provider" in executor._thread_name_prefix
+
+
+@pytest.mark.asyncio
+async def test_a_wedged_provider_does_not_delay_the_turn(clean_hooks, monkeypatch):
+    """The thread cannot be killed, but the turn must not wait for it."""
+    import time
+
+    from suzent.core import system_reminder as sr
+
+    monkeypatch.setattr(sr, "HOOK_TIMEOUT_SECONDS", 0.05)
+
+    async def wedged(chat_id, deps):
+        return await sr.run_provider_blocking(time.sleep, 1.0)
+
+    async def quick(chat_id, deps):
+        return "quick"
+
+    sr.register_global_hook(wedged)
+    sr.register_global_hook(quick)
+
+    started = time.monotonic()
+    result = await sr.build_combined_reminder("c", None)
+    elapsed = time.monotonic() - started
+
+    assert "quick" in result
+    assert elapsed < 0.5, f"turn waited for the wedged provider: {elapsed:.2f}s"
 
 
 def test_the_goal_fragment_outranks_ambient_catalogues():

--- a/tests/skills/test_skills_reminder_dedupe.py
+++ b/tests/skills/test_skills_reminder_dedupe.py
@@ -548,3 +548,36 @@ async def test_an_untokenized_legacy_block_does_not_suppress_the_catalog() -> No
     legacy = f"{PUA_START}\n{ours}\n{PUA_END}"
 
     assert await _run(manager, history_text=legacy) is not None
+
+
+# --- the catalog is rendered off the event loop ------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_wedged_skill_path_does_not_stall_the_loop() -> None:
+    """In host mode the catalog calls Path.resolve() per skill. Done on the
+    loop, an unreachable network mount stalls every other provider too — and the
+    provider deadline cannot fire, because the deadline is enforced by the same
+    loop the blocked call is sitting on."""
+    import asyncio
+    import time
+
+    blocked = _skill("slow")
+    blocked.path = SimpleNamespace(resolve=lambda: time.sleep(1.5) or "/host/slow")
+
+    ticks = 0
+
+    async def _tick() -> None:
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0.02)
+            ticks += 1
+
+    ticker = asyncio.create_task(_tick())
+    try:
+        await _run(_Manager([blocked]), sandbox_enabled=False)
+    finally:
+        ticker.cancel()
+
+    # Rendering took ~1.5s. On the loop the ticker would not have run at all.
+    assert ticks > 10, f"event loop was blocked during rendering ({ticks} ticks)"


### PR DESCRIPTION
P1-2 from the prompt/reminder audit. **Replaces #178**, which GitHub auto-closed when its base branch (`fix/goal-turn-count-lifecycle`, now merged as #177) was deleted. Same branch, same commits, rebased onto `main`; the review history and my replies are on #178.

## What was wrong

Four gaps in how reminder providers are combined:

| Gap | Effect |
|---|---|
| Global hooks had **no timeout** (only per-turn hooks did) | one hung provider stalled every message indefinitely |
| Providers ran **serially** | each slow one delayed all those after it |
| **No dedupe** | two providers emitting the same text paid twice |
| **No ceiling** on the assembled body | unbounded growth into the prompt |

## What I deliberately did not build

The audit proposed a structured `ReminderFragment` carrying `priority`, `max_chars` and `dedupe_key`. Declared sizes drift from what is actually emitted — the same mistake that cost several rounds elsewhere in this work — so the budget measures the **assembled, sanitized text** and dedupe compares actual strings. Priority is registration order, which `gather` preserves.

## Fixed during review on #178

- **Budget measured raw text** while `wrap_in_system_reminder` sanitizes afterwards, and sanitizing expands each PUA delimiter into `[reminder-delimiter]` — a body under the cap could arrive many times over it. It measures the sanitized text now, which is what the PR claimed from the start and did not do.
- **The display trigger was unbudgeted**, leaving cron, heartbeat and sub-agent turns unbounded.
- **Ad-hoc reminders were dropped first** despite being the turn-specific directives (peer attribution, the `analyze_image` instruction) while hook output is ambient. They come first now.
- **The goal fragment could be crowded out** by a large skill catalog, leaving the agent working on a goal it could not see. Plan is registered first.
- **A blocking provider could not be timed out** at all, because `wait_for` needs the loop to run. `plan_reminder_hook`'s synchronous DB access runs on a worker thread — safe precisely because #177 made that hook a pure read.

## Tests

14 cases covering timeouts, isolation, concurrency, dedupe, the budget, truncation boundaries, sanitized measurement, trigger accounting, directive priority, and blocking providers. Each was checked against the unfixed code.

Suite 1878 passed, ruff clean.