### PR TITLE
fix(llm): stop self-hosted servers thinking through the whole token budget

### DIFF
--- a/src/suzent/llm.py
+++ b/src/suzent/llm.py
@@ -28,10 +28,30 @@ def _litellm():
     return _ll
 
 
+#: Self-hosted OpenAI-compatible servers. Mirrors model_factory's set of the
+#: same name; duplicated rather than imported because llm.py is a leaf and
+#: model_factory pulls in the whole provider stack.
+_LOCAL_OPENAI_SERVER_PROVIDERS: frozenset[str] = frozenset({"vllm", "sglang"})
+
+
 def _litellm_model_and_kwargs(
     model: Optional[str],
-) -> tuple[Optional[str], Dict[str, str]]:
-    """Return LiteLLM model/auth args matching the provider registry."""
+) -> tuple[Optional[str], Dict[str, Any]]:
+    """Return LiteLLM model/auth args matching the provider registry.
+
+    Utility calls here are one-shot extractions — a classification, a summary,
+    a rewrite — and they are billed a token budget, not a wall-clock one. A
+    self-hosted server keeps whatever its chat template defaults to, and for
+    Qwen3 and friends that is thinking on at xhigh effort, so the reasoning is
+    charged against ``max_tokens`` before a single character of the answer is
+    generated. Measured against a real classifier prompt on SGLang: 1,616
+    tokens with thinking, 130 without, for the same verdict.
+
+    That is not merely wasteful. When the reasoning outruns the budget the
+    response is a 200 with an empty ``content``, which reaches the caller as
+    ``Expecting value: line 1 column 1 (char 0)`` from json — a parse error for
+    something that was never a parse problem.
+    """
     if not model:
         return model, {}
 
@@ -69,6 +89,10 @@ def _litellm_model_and_kwargs(
         if spec.base_url and spec.api_type == "openai" and _model_name:
             litellm_model = f"openai/{_model_name}"
 
+    if provider in _LOCAL_OPENAI_SERVER_PROVIDERS:
+        # Templates that do not read enable_thinking ignore the extra kwarg.
+        kwargs["extra_body"] = {"chat_template_kwargs": {"enable_thinking": False}}
+
     return litellm_model, kwargs
 
 
@@ -100,6 +124,32 @@ def _model_supports_reasoning(model: Optional[str]) -> bool:
         return False
 
     return caps.supports_reasoning if caps is not None else False
+
+
+#: Token budget for one structured extraction.
+#:
+#: Generous because it is shared with reasoning: on a server whose chat template
+#: leaves thinking on, the think block is charged here too, and a budget spent
+#: before the answer starts yields an empty response rather than a short one.
+STRUCTURED_OUTPUT_MAX_TOKENS = 4000
+
+
+class EmptyCompletionError(ValueError):
+    """The model returned a 200 with no content.
+
+    Distinct from a parse failure on purpose. ``json.loads("")`` reports
+    ``Expecting value: line 1 column 1 (char 0)``, which reads as malformed
+    output and sends the reader looking for a formatting bug; the actual event
+    is that the model said nothing, and the usual cause is a reasoning model
+    spending the whole token budget before it began to answer.
+    """
+
+    def __init__(self, model: Optional[str] = None) -> None:
+        super().__init__(
+            f"Model {model or '<unknown>'} returned an empty completion "
+            f"(no content). If it is a reasoning model, the token budget was "
+            f"likely spent on reasoning before any answer was produced."
+        )
 
 
 def _parse_json_response(content: str) -> Any:
@@ -406,55 +456,56 @@ class LLMClient:
         Raises:
             ValueError: If response cannot be validated against the model
         """
-        if not _model_supports_response_schema(self.model):
+        if _model_supports_response_schema(self.model):
+            messages = []
+            if system:
+                messages.append({"role": "system", "content": system})
+            messages.append({"role": "user", "content": prompt})
+
+            try:
+                model, auth_kwargs = _litellm_model_and_kwargs(self.model)
+                # Use Pydantic model directly as response_format
+                # LiteLLM converts this to json_schema format automatically
+                response = await _litellm().acompletion(
+                    model=model,
+                    messages=messages,
+                    temperature=temperature,
+                    response_format=response_model,
+                    **auth_kwargs,
+                )
+
+                content = response.choices[0].message.content
+                if not (content or "").strip():
+                    raise EmptyCompletionError(self.model)
+
+                # Validate and parse with Pydantic
+                return response_model.model_validate_json(content)
+            except Exception as e:
+                logger.warning(
+                    f"Structured extraction failed, retrying with JSON prompt fallback: {e}"
+                )
+        else:
             logger.debug(
                 f"Model {self.model} does not advertise response schema support; using JSON prompt fallback"
             )
+
+        # Reached by both routes, so both get the same wrapping. Returning the
+        # fallback directly from the branch above put it outside this handler:
+        # a model that answered with an empty body raised a bare json error out
+        # of the library, and the caller reported a parse failure for a call
+        # that never got as far as parsing.
+        try:
             return await self._extract_with_prompt_json(
                 prompt=prompt,
                 response_model=response_model,
                 system=system,
                 temperature=temperature,
             )
-
-        messages = []
-        if system:
-            messages.append({"role": "system", "content": system})
-        messages.append({"role": "user", "content": prompt})
-
-        try:
-            model, auth_kwargs = _litellm_model_and_kwargs(self.model)
-            # Use Pydantic model directly as response_format
-            # LiteLLM converts this to json_schema format automatically
-            response = await _litellm().acompletion(
-                model=model,
-                messages=messages,
-                temperature=temperature,
-                response_format=response_model,
-                **auth_kwargs,
-            )
-
-            content = response.choices[0].message.content
-
-            # Validate and parse with Pydantic
-            return response_model.model_validate_json(content)
-
-        except Exception as e:
-            logger.warning(
-                f"Structured extraction failed, retrying with JSON prompt fallback: {e}"
-            )
-            try:
-                return await self._extract_with_prompt_json(
-                    prompt=prompt,
-                    response_model=response_model,
-                    system=system,
-                    temperature=temperature,
-                )
-            except Exception as retry_error:
-                logger.error(f"Structured extraction failed: {retry_error}")
-                raise ValueError(
-                    f"Failed to extract structured data: {retry_error}"
-                ) from retry_error
+        except Exception as retry_error:
+            logger.error(f"Structured extraction failed: {retry_error}")
+            raise ValueError(
+                f"Failed to extract structured data: {retry_error}"
+            ) from retry_error
 
     async def _extract_with_prompt_json(
         self,
@@ -474,8 +525,13 @@ class LLMClient:
             prompt=json_prompt,
             system=system,
             temperature=temperature,
-            max_tokens=2000,
+            # Headroom. A thinking model spends this budget on reasoning before
+            # it writes any JSON, and a request that runs out mid-thought
+            # returns nothing at all rather than something short.
+            max_tokens=STRUCTURED_OUTPUT_MAX_TOKENS,
         )
+        if not (content or "").strip():
+            raise EmptyCompletionError(self.model)
         return response_model.model_validate(_parse_json_response(content))
 
     async def extract_structured(

--- a/src/suzent/llm.py
+++ b/src/suzent/llm.py
@@ -34,23 +34,45 @@ def _litellm():
 _LOCAL_OPENAI_SERVER_PROVIDERS: frozenset[str] = frozenset({"vllm", "sglang"})
 
 
-def _litellm_model_and_kwargs(
-    model: Optional[str],
-) -> tuple[Optional[str], Dict[str, Any]]:
-    """Return LiteLLM model/auth args matching the provider registry.
+def _chat_template_kwargs(model: Optional[str]) -> Dict[str, Any]:
+    """Chat-completion-only arguments for self-hosted OpenAI servers.
 
-    Utility calls here are one-shot extractions — a classification, a summary,
-    a rewrite — and they are billed a token budget, not a wall-clock one. A
-    self-hosted server keeps whatever its chat template defaults to, and for
-    Qwen3 and friends that is thinking on at xhigh effort, so the reasoning is
-    charged against ``max_tokens`` before a single character of the answer is
-    generated. Measured against a real classifier prompt on SGLang: 1,616
-    tokens with thinking, 130 without, for the same verdict.
+    A utility call is billed a token budget. A self-hosted server keeps
+    whatever its chat template defaults to, and for Qwen3 and friends that is
+    thinking on at xhigh effort, so the reasoning is charged against
+    ``max_tokens`` before a single character of the answer exists. Measured
+    against a real classifier prompt on SGLang: 1,616 tokens with thinking, 130
+    without, for the same verdict.
 
     That is not merely wasteful. When the reasoning outruns the budget the
     response is a 200 with an empty ``content``, which reaches the caller as
     ``Expecting value: line 1 column 1 (char 0)`` from json — a parse error for
     something that was never a parse problem.
+
+    Kept out of ``_litellm_model_and_kwargs`` because that helper also serves
+    ``/v1/embeddings`` and ``/v1/images/generations``. LiteLLM expands
+    ``extra_body`` into whichever body it is building, and a strict
+    OpenAI-compatible server rejects an unknown field — so putting a chat-only
+    argument in the shared path would have broken memory indexing to pay for a
+    classifier fix.
+    """
+    if not model:
+        return {}
+    provider, _, _ = model.partition("/")
+    if provider not in _LOCAL_OPENAI_SERVER_PROVIDERS:
+        return {}
+    # Templates that do not read enable_thinking ignore the extra kwarg.
+    return {"extra_body": {"chat_template_kwargs": {"enable_thinking": False}}}
+
+
+def _litellm_model_and_kwargs(
+    model: Optional[str],
+) -> tuple[Optional[str], Dict[str, Any]]:
+    """Return LiteLLM model/auth args matching the provider registry.
+
+    Shared by every endpoint — chat, embeddings, image generation — so only
+    arguments all of them accept belong here. Chat-only arguments go in
+    ``_chat_template_kwargs``.
     """
     if not model:
         return model, {}
@@ -88,10 +110,6 @@ def _litellm_model_and_kwargs(
 
         if spec.base_url and spec.api_type == "openai" and _model_name:
             litellm_model = f"openai/{_model_name}"
-
-    if provider in _LOCAL_OPENAI_SERVER_PROVIDERS:
-        # Templates that do not read enable_thinking ignore the extra kwarg.
-        kwargs["extra_body"] = {"chat_template_kwargs": {"enable_thinking": False}}
 
     return litellm_model, kwargs
 
@@ -380,6 +398,7 @@ class LLMClient:
                 "temperature": temperature,
                 "max_tokens": max_tokens,
                 **auth_kwargs,
+                **_chat_template_kwargs(self.model),
             }
             if response_format is not None:
                 completion_kwargs["response_format"] = response_format
@@ -472,6 +491,7 @@ class LLMClient:
                     temperature=temperature,
                     response_format=response_model,
                     **auth_kwargs,
+                    **_chat_template_kwargs(self.model),
                 )
 
                 content = response.choices[0].message.content

--- a/tests/core/test_llm_key_resolution.py
+++ b/tests/core/test_llm_key_resolution.py
@@ -349,30 +349,67 @@ def test_extract_with_schema_uses_prompt_json_for_unsupported_models(
 # --- self-hosted servers keep their chat-template defaults -------------------
 
 
-def test_a_self_hosted_server_is_told_not_to_think(monkeypatch):
+def test_a_self_hosted_server_is_told_not_to_think():
     """A utility call is billed a token budget, and a local server keeps
     whatever its chat template defaults to — thinking on, for Qwen3 and
     friends. The reasoning is then charged against max_tokens before a single
     character of the answer exists. Measured on SGLang with a real classifier
     prompt: 1,616 tokens with thinking, 130 without, same verdict."""
-    monkeypatch.setattr(llm, "resolve_api_key", lambda provider: None)
-
     for provider in ("sglang", "vllm"):
-        _model, kwargs = llm._litellm_model_and_kwargs(f"{provider}/qwen3-27b")
-
-        assert kwargs["extra_body"] == {
-            "chat_template_kwargs": {"enable_thinking": False}
+        assert llm._chat_template_kwargs(f"{provider}/qwen3-27b") == {
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}
         }, provider
 
 
-def test_hosted_providers_are_left_alone(monkeypatch):
+def test_hosted_providers_are_left_alone():
     """The switch is a local-server chat-template kwarg. Sending it to a hosted
     API is at best ignored and at worst a 400."""
+    assert llm._chat_template_kwargs("gemini/gemini-2.5-flash") == {}
+    assert llm._chat_template_kwargs(None) == {}
+
+
+def test_the_switch_stays_out_of_non_chat_endpoints(monkeypatch):
+    """The model/auth helper also serves /v1/embeddings and
+    /v1/images/generations. LiteLLM expands extra_body into whichever body it
+    is building, and a strict OpenAI-compatible server rejects an unknown
+    field — so a chat-only argument in the shared path would break memory
+    indexing to pay for a classifier fix."""
     monkeypatch.setattr(llm, "resolve_api_key", lambda provider: None)
 
-    _model, kwargs = llm._litellm_model_and_kwargs("gemini/gemini-2.5-flash")
+    _model, kwargs = llm._litellm_model_and_kwargs("sglang/qwen3-27b")
 
     assert "extra_body" not in kwargs
+
+
+def test_embeddings_do_not_carry_chat_arguments(monkeypatch):
+    """The end the previous test guards: an embedding request must not gain a
+    chat_template_kwargs field."""
+    monkeypatch.setattr(llm, "resolve_api_key", lambda provider: None)
+    fake_litellm = SimpleNamespace(aembedding=AsyncMock())
+    generator = EmbeddingGenerator(model="sglang/bge-m3")
+    fake_litellm.aembedding.return_value = SimpleNamespace(
+        data=[{"embedding": [0.1] * generator.dimension}]
+    )
+    monkeypatch.setattr(llm, "_litellm", lambda: fake_litellm)
+
+    asyncio.run(generator.generate("hello"))
+
+    assert "extra_body" not in fake_litellm.aembedding.await_args.kwargs
+
+
+def test_chat_completions_do_carry_it(monkeypatch):
+    monkeypatch.setattr(llm, "resolve_api_key", lambda provider: None)
+    fake_litellm = SimpleNamespace(acompletion=AsyncMock())
+    fake_litellm.acompletion.return_value = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+    )
+    monkeypatch.setattr(llm, "_litellm", lambda: fake_litellm)
+
+    asyncio.run(LLMClient(model="sglang/qwen3-27b").complete("hello"))
+
+    assert fake_litellm.acompletion.await_args.kwargs["extra_body"] == {
+        "chat_template_kwargs": {"enable_thinking": False}
+    }
 
 
 # --- an empty answer is not a malformed one ----------------------------------

--- a/tests/core/test_llm_key_resolution.py
+++ b/tests/core/test_llm_key_resolution.py
@@ -344,3 +344,112 @@ def test_extract_with_schema_uses_prompt_json_for_unsupported_models(
         "Return only valid JSON matching this JSON schema"
         in kwargs["messages"][0]["content"]
     )
+
+
+# --- self-hosted servers keep their chat-template defaults -------------------
+
+
+def test_a_self_hosted_server_is_told_not_to_think(monkeypatch):
+    """A utility call is billed a token budget, and a local server keeps
+    whatever its chat template defaults to — thinking on, for Qwen3 and
+    friends. The reasoning is then charged against max_tokens before a single
+    character of the answer exists. Measured on SGLang with a real classifier
+    prompt: 1,616 tokens with thinking, 130 without, same verdict."""
+    monkeypatch.setattr(llm, "resolve_api_key", lambda provider: None)
+
+    for provider in ("sglang", "vllm"):
+        _model, kwargs = llm._litellm_model_and_kwargs(f"{provider}/qwen3-27b")
+
+        assert kwargs["extra_body"] == {
+            "chat_template_kwargs": {"enable_thinking": False}
+        }, provider
+
+
+def test_hosted_providers_are_left_alone(monkeypatch):
+    """The switch is a local-server chat-template kwarg. Sending it to a hosted
+    API is at best ignored and at worst a 400."""
+    monkeypatch.setattr(llm, "resolve_api_key", lambda provider: None)
+
+    _model, kwargs = llm._litellm_model_and_kwargs("gemini/gemini-2.5-flash")
+
+    assert "extra_body" not in kwargs
+
+
+# --- an empty answer is not a malformed one ----------------------------------
+
+
+class _Verdict(BaseModel):
+    ok: bool
+
+
+def test_an_empty_completion_is_reported_as_one(monkeypatch):
+    """json.loads("") says 'Expecting value: line 1 column 1 (char 0)', which
+    reads as malformed output and sends the reader hunting for a formatting
+    bug. The model said nothing — usually a reasoning model that spent the
+    whole budget before answering — and the error should say so."""
+    monkeypatch.setattr(llm, "_model_supports_response_schema", lambda model: False)
+
+    async def empty(self, **kwargs):
+        return ""
+
+    monkeypatch.setattr(LLMClient, "complete", empty)
+
+    try:
+        asyncio.run(
+            LLMClient(model="sglang/qwen3-27b").extract_with_schema(
+                prompt="p", response_model=_Verdict
+            )
+        )
+    except ValueError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("expected the extraction to fail")
+
+    assert "empty completion" in message
+    assert "reasoning" in message
+    assert "Expecting value" not in message
+
+
+def test_the_fallback_path_gets_the_same_wrapping(monkeypatch):
+    """It used to return straight out of the branch, outside the handler below
+    it, so a failure there escaped as whatever the library raised — a bare json
+    error, with nothing naming the extraction that failed."""
+    monkeypatch.setattr(llm, "_model_supports_response_schema", lambda model: False)
+
+    async def garbage(self, **kwargs):
+        return "not json at all"
+
+    monkeypatch.setattr(LLMClient, "complete", garbage)
+
+    try:
+        asyncio.run(
+            LLMClient(model="sglang/qwen3-27b").extract_with_schema(
+                prompt="p", response_model=_Verdict
+            )
+        )
+    except ValueError as exc:
+        assert "Failed to extract structured data" in str(exc)
+    else:
+        raise AssertionError("expected the extraction to fail")
+
+
+def test_structured_extraction_has_budget_headroom(monkeypatch):
+    """The budget is shared with reasoning, and a request that runs out
+    mid-thought returns nothing at all rather than something short."""
+    monkeypatch.setattr(llm, "_model_supports_response_schema", lambda model: False)
+    seen = {}
+
+    async def capture(self, **kwargs):
+        seen.update(kwargs)
+        return '{"ok": true}'
+
+    monkeypatch.setattr(LLMClient, "complete", capture)
+
+    asyncio.run(
+        LLMClient(model="sglang/qwen3-27b").extract_with_schema(
+            prompt="p", response_model=_Verdict
+        )
+    )
+
+    assert seen["max_tokens"] == llm.STRUCTURED_OUTPUT_MAX_TOKENS
+    assert llm.STRUCTURED_OUTPUT_MAX_TOKENS >= 4000


### PR DESCRIPTION
## The symptom

```
Auto classifier unavailable: Expecting value: line 1 column 1 (char 0)
```

Four occurrences in the local audit log, all the same action (`ssh … 'cat > /opt/torrent/caddy/Caddyfile'`), all after the `cheap` role was pointed at a self-hosted SGLang model. That json message means **empty input**, not malformed input — the model returned nothing.

## The cause

A utility call is billed a token budget. A self-hosted OpenAI-compatible server keeps whatever its chat template defaults to, and for Qwen3 that is thinking **on at xhigh effort** — so the reasoning is charged against `max_tokens` before any answer exists. `model_factory` already sends `chat_template_kwargs: {enable_thinking: …}` for `vllm`/`sglang`; `LLMClient` builds its own request and never did.

## Measured, not inferred

Against the live server, replaying the real transcript and the real failing action:

| Variant | Tokens | Result |
|---|---|---|
| As sent today | **1,616–1,669 / 2,000** | parses, at 81–83% of cap |
| `enable_thinking: false` | **130 / 2,000** | parses, same verdict |
| `max_tokens: 4000` | 1,616 / 4,000 | parses, headroom |
| native `response_format` schema | **2,000 / 2,000** | **truncated, fails to parse** |

Running at 81% of budget is why this failed intermittently (3 succeeded, 4 failed) rather than always. The mechanism is confirmed directly: at `max_tokens=50` the server returns `content: ''` with the thinking in `reasoning_content`, and `json.loads` raises that exact string.

**Honest limit:** I could not reproduce an over-budget run at the real 2,000 cap — the closest was 83%. The last-20-message window differs from what it held at the time. Overflow is the only cause consistent with every observation, but I did not watch it happen.

## What changed

1. Send the chat-template switch for `vllm`/`sglang` — the direct fix, and it removes 92% of the token cost of every utility call to these servers.
2. The no-schema branch returned outside the error handler below it, so failures escaped unwrapped. Both routes share it now.
3. An empty completion raises `EmptyCompletionError` naming the likely cause instead of a json parse error.
4. Structured-extraction budget 2,000 → 4,000, since it is shared with reasoning.

Fixes 2–4 are provider-independent.

## Deliberately not done

Marking these models `supports_response_schema: true`. It looks like the obvious fix — skip the fragile prompt-JSON path entirely — and testing showed it makes things **worse**: schema mode still thinks, then clips the constrained output at the cap. It would have raised the failure rate.

## Verification

- End-to-end through the real classifier against the live server: 3/3 clean, 5.7–9.8s each.
- 4 new tests, all verified failing against the unfixed code.
- Suite 1970 passed, ruff clean.

## Impact beyond the classifier

Every `LLMClient` utility call to a self-hosted server was paying for xhigh reasoning — memory extraction, summarisation, title generation. Interactively the failure degrades to a permission prompt; in a headless run `engine.py` turns it into a **hard deny**, so tool calls were being blocked by an empty completion.