### PR TITLE
refactor(prompts): scope two rules that overfired

### DIFF
--- a/src/suzent/agent_manager.py
+++ b/src/suzent/agent_manager.py
@@ -423,7 +423,6 @@ def create_agent(config: Dict[str, Any]) -> Agent[AgentDeps, str]:
         session_guidance_items=session_guidance_items,
         enabled_model_ids=enabled_models,
         current_model_id=model_id,
-        equipped_tool_names=enabled_tool_names,
     )
 
     # Store metadata for later introspection

--- a/src/suzent/agent_manager.py
+++ b/src/suzent/agent_manager.py
@@ -423,6 +423,7 @@ def create_agent(config: Dict[str, Any]) -> Agent[AgentDeps, str]:
         session_guidance_items=session_guidance_items,
         enabled_model_ids=enabled_models,
         current_model_id=model_id,
+        equipped_tool_names=enabled_tool_names,
     )
 
     # Store metadata for later introspection

--- a/src/suzent/prompts.py
+++ b/src/suzent/prompts.py
@@ -398,19 +398,19 @@ def build_base_instructions_section(base_instructions: str = "") -> str:
 def build_enabled_models_section(
     enabled_model_ids: list[str] | None = None,
     current_model_id: str | None = None,
-    equipped_tool_names: Any = None,
 ) -> str:
     """The catalogue of ids usable as ``model_override``.
 
-    Only AgentTool accepts that argument, so a run without it cannot act on
-    this list. Beyond the tokens, the list is part of the cached prefix and
-    changes whenever a model is enabled or disabled — so a chat that can never
-    spawn a sub-agent was having its prompt cache invalidated by an unrelated
-    settings toggle.
+    Only AgentTool accepts that argument, but the list cannot be gated on
+    AgentTool being equipped: it is ``deferrable``, so an unequipped AgentTool is
+    registered for tool search instead, and its ``model_override`` schema would
+    then point at a Models section that is not there.
+
+    Moving the catalogue into AgentTool's own schema would survive that, since
+    the schema travels with the tool when it loads. That is the shape any future
+    attempt at this should take.
     """
     if not enabled_model_ids:
-        return ""
-    if equipped_tool_names is not None and "AgentTool" not in set(equipped_tool_names):
         return ""
 
     models_list = "\n".join(f"- `{model_id}`" for model_id in enabled_model_ids)
@@ -483,32 +483,24 @@ Place the marker immediately after the phrase it supports, before punctuation. F
 - The markers are rendered as small badges and stripped from display, so never mention or describe them in prose."""
 
 
-#: Tools that label their output with source ids. Only these can produce
-#: something to cite, so only these make the citation rules worth their weight.
-CITING_TOOL_NAMES: frozenset[str] = frozenset({"WebSearchTool", "WebpageTool"})
+def build_citation_section(_: Any = None) -> str:
+    """Return the static citation rules.
 
-
-def build_citation_section(equipped_tool_names: Any = None) -> str:
-    """Return the static citation rules, when anything could produce a citation.
-
-    The rules are constant, so the string stays cacheable; the source *list* is
+    The rules are constant (so this string is cacheable); the source *list* is
     not injected here — tools embed source ids in their own output.
 
-    Gated on equipment rather than on whether sources exist yet. The model has
-    to know the marker syntax *before* the first tool call, so waiting for a
-    source would teach it the format one turn too late; but a run with no
-    citing tool equipped can never see a source id at all, and was carrying
-    1,681 characters of syntax and examples for a format it could not use.
+    Unconditional, and it has to be. Gating on the equipped tool set was tried
+    and reverted: ``get_deferred_tool_functions(exclude=enabled_tool_names)``
+    registers every deferrable tool that is *not* equipped, so WebSearchTool and
+    WebpageTool stay reachable through tool search in exactly the runs where the
+    gate removed the rules. The model would then receive ``t0_src_N`` ids having
+    never been taught the marker syntax, and answer from web sources with no
+    working citations.
 
-    Equipment is known when the agent is built, including for deferred tools —
-    deferring the schema does not defer the decision to equip.
+    Trimming this section therefore has to come from the text, not from the
+    injection: a few lines of syntax always present, with the examples moved to
+    the guidance of the tools that emit source ids.
     """
-    if equipped_tool_names is None:
-        # No opinion offered: keep the rules. A caller that does not know what
-        # is equipped is not evidence that nothing is.
-        return CITATION_RULES_SECTION
-    if not (CITING_TOOL_NAMES & set(equipped_tool_names)):
-        return ""
     return CITATION_RULES_SECTION
 
 
@@ -578,7 +570,6 @@ def register_dynamic_instructions(
     session_guidance_items: list[str] | None = None,
     enabled_model_ids: list[str] | None = None,
     current_model_id: str | None = None,
-    equipped_tool_names: Any = None,
 ) -> None:
     @agent.instructions
     def inject_date_context(_: Any) -> str:
@@ -620,7 +611,6 @@ def register_dynamic_instructions(
             lambda: build_enabled_models_section(
                 enabled_model_ids,
                 current_model_id=current_model_id,
-                equipped_tool_names=equipped_tool_names,
             ),
         )
 
@@ -633,11 +623,10 @@ def register_dynamic_instructions(
         )
 
     @agent.instructions
-    def inject_citation_rules(_: Any) -> str:
+    def inject_citation_rules(ctx: Any) -> str:
         # Static rules only; source ids travel in tool output and source metadata
-        # travels in citation_sources stream events. Equipment is fixed when the
-        # agent is built, so this reads the build-time set rather than deps.
-        return build_citation_section(equipped_tool_names)
+        # travels in citation_sources stream events.
+        return build_citation_section(ctx.deps)
 
     @agent.instructions
     def inject_permission_mode(ctx: Any) -> str:

--- a/src/suzent/prompts.py
+++ b/src/suzent/prompts.py
@@ -32,16 +32,11 @@ thing to distrust.
 """
 
 STATIC_INSTRUCTIONS = f"""# Role
-You are Suzent, a digital coworker.
-
-# Language Requirement
-You should respond in the language of the user's query.
+You are Suzent, a digital coworker. Respond in the language of the user's query.
 
 # Task Management
-**MUST** make todo plans when a task requires:
-- Multiple steps or tools.
-- Information synthesis from several sources.
-- Breaking down an ambiguous goal into action items.
+Create a persistent todo plan only for work that is long, cross-turn, delegated, or
+independently verifiable. Short multi-tool turns need an internal plan, not a durable one.
 
 # Behavioral Guidelines
 - Bias toward action for clear requests; avoid unnecessary confirmation.
@@ -51,7 +46,8 @@ You should respond in the language of the user's query.
 # Output Efficiency & Tone
 - Go straight to the point. Lead with the answer or action.
 - Skip filler words, unnecessary transitions, and narrating your thought process.
-- Focus text output ONLY on: (1) Decisions needing user input, (2) High-level milestones, (3) Blockers.
+- Progress updates: decisions needing input, milestones, and blockers only.
+- Final answers: what the request needs — this trims narration, not substance.
 - Do not repeat the user's prompt back to them.
 
 # Failure Handling SOP
@@ -402,8 +398,19 @@ def build_base_instructions_section(base_instructions: str = "") -> str:
 def build_enabled_models_section(
     enabled_model_ids: list[str] | None = None,
     current_model_id: str | None = None,
+    equipped_tool_names: Any = None,
 ) -> str:
+    """The catalogue of ids usable as ``model_override``.
+
+    Only AgentTool accepts that argument, so a run without it cannot act on
+    this list. Beyond the tokens, the list is part of the cached prefix and
+    changes whenever a model is enabled or disabled — so a chat that can never
+    spawn a sub-agent was having its prompt cache invalidated by an unrelated
+    settings toggle.
+    """
     if not enabled_model_ids:
+        return ""
+    if equipped_tool_names is not None and "AgentTool" not in set(equipped_tool_names):
         return ""
 
     models_list = "\n".join(f"- `{model_id}`" for model_id in enabled_model_ids)
@@ -476,12 +483,32 @@ Place the marker immediately after the phrase it supports, before punctuation. F
 - The markers are rendered as small badges and stripped from display, so never mention or describe them in prose."""
 
 
-def build_citation_section(deps: Any) -> str:
-    """Return the static citation rules.
+#: Tools that label their output with source ids. Only these can produce
+#: something to cite, so only these make the citation rules worth their weight.
+CITING_TOOL_NAMES: frozenset[str] = frozenset({"WebSearchTool", "WebpageTool"})
 
-    The rules are constant (so this string is cacheable); the source *list* is
+
+def build_citation_section(equipped_tool_names: Any = None) -> str:
+    """Return the static citation rules, when anything could produce a citation.
+
+    The rules are constant, so the string stays cacheable; the source *list* is
     not injected here — tools embed source ids in their own output.
+
+    Gated on equipment rather than on whether sources exist yet. The model has
+    to know the marker syntax *before* the first tool call, so waiting for a
+    source would teach it the format one turn too late; but a run with no
+    citing tool equipped can never see a source id at all, and was carrying
+    1,681 characters of syntax and examples for a format it could not use.
+
+    Equipment is known when the agent is built, including for deferred tools —
+    deferring the schema does not defer the decision to equip.
     """
+    if equipped_tool_names is None:
+        # No opinion offered: keep the rules. A caller that does not know what
+        # is equipped is not evidence that nothing is.
+        return CITATION_RULES_SECTION
+    if not (CITING_TOOL_NAMES & set(equipped_tool_names)):
+        return ""
     return CITATION_RULES_SECTION
 
 
@@ -551,6 +578,7 @@ def register_dynamic_instructions(
     session_guidance_items: list[str] | None = None,
     enabled_model_ids: list[str] | None = None,
     current_model_id: str | None = None,
+    equipped_tool_names: Any = None,
 ) -> None:
     @agent.instructions
     def inject_date_context(_: Any) -> str:
@@ -592,6 +620,7 @@ def register_dynamic_instructions(
             lambda: build_enabled_models_section(
                 enabled_model_ids,
                 current_model_id=current_model_id,
+                equipped_tool_names=equipped_tool_names,
             ),
         )
 
@@ -604,10 +633,11 @@ def register_dynamic_instructions(
         )
 
     @agent.instructions
-    def inject_citation_rules(ctx: Any) -> str:
+    def inject_citation_rules(_: Any) -> str:
         # Static rules only; source ids travel in tool output and source metadata
-        # travels in citation_sources stream events.
-        return build_citation_section(ctx.deps)
+        # travels in citation_sources stream events. Equipment is fixed when the
+        # agent is built, so this reads the build-time set rather than deps.
+        return build_citation_section(equipped_tool_names)
 
     @agent.instructions
     def inject_permission_mode(ctx: Any) -> str:

--- a/tests/prompts/test_always_on_prompt_trim.py
+++ b/tests/prompts/test_always_on_prompt_trim.py
@@ -41,50 +41,41 @@ def test_the_terseness_rule_is_scoped_to_progress_updates():
     assert "Focus text output ONLY on" not in STATIC_INSTRUCTIONS
 
 
-# --- P2-3: citation rules ----------------------------------------------------
+# --- P2-3 / P2-4: why these two are still always-on --------------------------
 
 
-def test_citation_rules_are_dropped_when_nothing_can_be_cited():
-    """1,681 characters of marker syntax for a format the run cannot produce."""
-    assert build_citation_section({"ReadFileTool", "RunCommandTool"}) == ""
+def test_every_unequipped_deferrable_tool_stays_reachable():
+    """The constraint that killed the obvious version of P2-3 and P2-4.
+
+    get_deferred_tool_functions(exclude=enabled_tool_names) registers every
+    deferrable tool that is *not* equipped, unconditionally. So "not in the
+    equipped set" does not mean "cannot be used" — it means the opposite: the
+    tool is in the search pool. Gating a prompt section on equipment removes it
+    in exactly the runs where the tool can still appear.
+    """
+    from suzent.tools.registry import _all_tool_classes, get_deferred_tool_functions
+
+    for name in ("WebSearchTool", "WebpageTool", "AgentTool"):
+        cls = next(c for c in _all_tool_classes() if c.name == name)
+        assert getattr(cls, "deferrable", True), f"{name} is no longer deferrable"
+
+    reachable = {t.name for t in get_deferred_tool_functions(set())}
+    assert reachable, "nothing deferrable at all — the premise has changed"
 
 
-def test_citation_rules_survive_when_a_citing_tool_is_equipped():
-    for tool in ("WebSearchTool", "WebpageTool"):
-        assert build_citation_section({"ReadFileTool", tool}) == CITATION_RULES_SECTION
-
-
-def test_the_rules_arrive_before_the_first_source_not_after():
-    """Gated on equipment, never on whether a source exists yet: the model needs
-    the marker syntax before the first tool call, so waiting for a source would
-    teach it the format one turn too late."""
-    assert build_citation_section({"WebSearchTool"}) == CITATION_RULES_SECTION
-
-
-def test_an_unknown_equipment_set_keeps_the_rules():
-    """A caller that does not say what is equipped is not evidence that nothing
-    is. The safe direction here is to keep them."""
+def test_citation_rules_are_unconditional():
+    """A run that reaches WebSearchTool through tool search receives t0_src_N
+    ids. If the rules were gated away it would answer from web sources having
+    never been taught the marker syntax — web claims with no working
+    citations."""
     assert build_citation_section(None) == CITATION_RULES_SECTION
+    assert build_citation_section(object()) == CITATION_RULES_SECTION
 
 
-# --- P2-4: the model catalogue -----------------------------------------------
-
-
-def test_the_model_list_is_dropped_without_the_tool_that_uses_it():
-    """model_override is an AgentTool argument. Beyond the tokens, the list sits
-    in the cached prefix and changes whenever a model is toggled — so a chat
-    that cannot spawn a sub-agent had its cache invalidated by an unrelated
-    settings change."""
-    assert build_enabled_models_section(MODELS, "m", {"ReadFileTool"}) == ""
-
-
-def test_the_model_list_survives_with_agent_tool():
-    section = build_enabled_models_section(MODELS, "m", {"AgentTool"})
-
-    assert all(model in section for model in MODELS)
-
-
-def test_an_unknown_equipment_set_keeps_the_model_list():
-    section = build_enabled_models_section(MODELS, "m", None)
+def test_the_model_catalogue_is_unconditional():
+    """AgentTool's model_override schema points at this section. Gating it on
+    AgentTool being equipped would leave the schema referring to a section that
+    is not in the prompt."""
+    section = build_enabled_models_section(MODELS, "m")
 
     assert all(model in section for model in MODELS)

--- a/tests/prompts/test_always_on_prompt_trim.py
+++ b/tests/prompts/test_always_on_prompt_trim.py
@@ -1,0 +1,90 @@
+"""What every turn pays for, whether or not it can use it.
+
+The static core and the two catalogue sections are part of the cached prefix,
+so their cost is small per turn — but two of the rules in them fire when they
+should not, and two of the sections describe capabilities the run may not have.
+"""
+
+from suzent.prompts import (
+    CITATION_RULES_SECTION,
+    STATIC_INSTRUCTIONS,
+    build_citation_section,
+    build_enabled_models_section,
+)
+
+MODELS = ["openai/gpt-4.1-mini", "gemini/gemini-3.1-pro-preview"]
+
+
+# --- P2-1: the todo trigger --------------------------------------------------
+
+
+def test_a_short_multi_tool_turn_does_not_demand_a_todo():
+    """ "Multiple steps or tools" fires on "read two files and summarise", so an
+    ordinary question left a durable task behind for the user to tidy up."""
+    section = STATIC_INSTRUCTIONS[
+        STATIC_INSTRUCTIONS.index("# Task Management") :
+    ].split("#", 2)[1]
+
+    assert "Multiple steps or tools" not in section
+    for signal in ("long", "cross-turn", "delegated", "independently verifiable"):
+        assert signal in section, signal
+
+
+# --- P2-2: the output rule ---------------------------------------------------
+
+
+def test_the_terseness_rule_is_scoped_to_progress_updates():
+    """It reads as a rule for every response, so explanations and final reports
+    were being held to a format meant for status lines."""
+    assert "Progress updates:" in STATIC_INSTRUCTIONS
+    assert "Final answers:" in STATIC_INSTRUCTIONS
+    assert "Focus text output ONLY on" not in STATIC_INSTRUCTIONS
+
+
+# --- P2-3: citation rules ----------------------------------------------------
+
+
+def test_citation_rules_are_dropped_when_nothing_can_be_cited():
+    """1,681 characters of marker syntax for a format the run cannot produce."""
+    assert build_citation_section({"ReadFileTool", "RunCommandTool"}) == ""
+
+
+def test_citation_rules_survive_when_a_citing_tool_is_equipped():
+    for tool in ("WebSearchTool", "WebpageTool"):
+        assert build_citation_section({"ReadFileTool", tool}) == CITATION_RULES_SECTION
+
+
+def test_the_rules_arrive_before_the_first_source_not_after():
+    """Gated on equipment, never on whether a source exists yet: the model needs
+    the marker syntax before the first tool call, so waiting for a source would
+    teach it the format one turn too late."""
+    assert build_citation_section({"WebSearchTool"}) == CITATION_RULES_SECTION
+
+
+def test_an_unknown_equipment_set_keeps_the_rules():
+    """A caller that does not say what is equipped is not evidence that nothing
+    is. The safe direction here is to keep them."""
+    assert build_citation_section(None) == CITATION_RULES_SECTION
+
+
+# --- P2-4: the model catalogue -----------------------------------------------
+
+
+def test_the_model_list_is_dropped_without_the_tool_that_uses_it():
+    """model_override is an AgentTool argument. Beyond the tokens, the list sits
+    in the cached prefix and changes whenever a model is toggled — so a chat
+    that cannot spawn a sub-agent had its cache invalidated by an unrelated
+    settings change."""
+    assert build_enabled_models_section(MODELS, "m", {"ReadFileTool"}) == ""
+
+
+def test_the_model_list_survives_with_agent_tool():
+    section = build_enabled_models_section(MODELS, "m", {"AgentTool"})
+
+    assert all(model in section for model in MODELS)
+
+
+def test_an_unknown_equipment_set_keeps_the_model_list():
+    section = build_enabled_models_section(MODELS, "m", None)
+
+    assert all(model in section for model in MODELS)


### PR DESCRIPTION
Phase A of the prompt audit. **Scope reduced after review: P2-1 and P2-2 only** — see the bottom for why P2-3 and P2-4 were reverted.

## P2-1 — the todo trigger fires on almost anything

> **MUST** make todo plans when a task requires: Multiple steps or tools.

"Read two files and summarise" qualifies. An ordinary question left a durable task behind for the user to tidy up. Now scoped to work that is long, cross-turn, delegated, or independently verifiable.

## P2-2 — a progress-update rule applied to final answers

> Focus text output ONLY on: (1) Decisions needing user input, (2) High-level milestones, (3) Blockers.

Right for a status line, wrong for an explanation, a report, or a walkthrough — all of which are the answer, not narration about it. Split in two so the terseness applies where it belongs.

## On the budget test

These rewrites initially pushed `STATIC_INSTRUCTIONS` from 3,468 to 3,686, breaching the 3,500 ceiling from #174. That test's docstring says the ceiling exists so growth is argued for in a diff, so rather than raise it during a trimming phase I tightened the wording and folded `# Role` and `# Language Requirement` into one line — the heading cost more than the sentence beneath it. Final: **3,486**.

## P2-3 and P2-4 — attempted, reverted, and why

I gated the citation rules on a citing tool being equipped, and the model catalogue on `AgentTool` being equipped. Both are wrong, and review caught it.

`get_deferred_tool_functions(exclude=enabled_tool_names)` registers every deferrable tool that is **not** equipped, unconditionally — and `WebSearchTool`, `WebpageTool` and `AgentTool` are all `deferrable=True`. So absence from the equipped set does not mean the tool is unusable; it means the tool is *in the search pool*. The gates removed their section in exactly the runs where the tool could still appear.

For citations that is a correctness bug: a run that reaches `WebSearchTool` through tool search gets `t0_src_N` ids having never been taught the marker syntax, and answers from web sources with no working citations. For the catalogue it left `model_override`'s schema pointing at a section that was not in the prompt.

A test now pins the constraint so the same gate cannot be reintroduced, and each builder's docstring records the approach that survives it:

- **Citations** — trim the *text*, not the injection: a few lines of syntax always present, the 1,300 characters of examples moved into the guidance of the tools that emit source ids.
- **Catalogue** — move it into AgentTool's own schema, which travels with the tool when it loads.

Both are real changes rather than one-line gates, so they belong in their own PR.

## Verification

5 tests: two pinning the P2-1/P2-2 behaviour (both fail against the unfixed code), three pinning the deferral constraint and the two unconditional sections. Suite 1978 passed, ruff clean.