### PR TITLE
fix(paths): show each mode only the paths it can actually open

### DIFF
--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -401,15 +401,15 @@ def _stripped_image_notice(model_id: str | None, count: int) -> str:
     return STRIPPED_IMAGE_NOTICE_TEMPLATE.format(model_id=model_id, count=count)
 
 
-def _stripped_image_reminder(virtual_paths: list[str]) -> str | None:
+def _stripped_image_reminder(agent_paths: list[str]) -> str | None:
     """Render the hidden model-only directive, or ``None`` if nothing stripped."""
-    if not virtual_paths:
+    if not agent_paths:
         return None
     from suzent.prompts import STRIPPED_IMAGE_REMINDER_TEMPLATE
 
     return STRIPPED_IMAGE_REMINDER_TEMPLATE.format(
-        count=len(virtual_paths),
-        paths=", ".join(virtual_paths),
+        count=len(agent_paths),
+        paths=", ".join(agent_paths),
     )
 
 
@@ -635,6 +635,15 @@ class ChatProcessor:
 
                 uploads_virtual_path = "/workspace/uploads"
                 uploads_host_path = resolver.resolve(uploads_virtual_path)
+                # What the agent is told, in the vocabulary of the filesystem it
+                # actually has. In host mode the environment section tells it not
+                # to use virtual paths, so handing it one here contradicts the
+                # instruction and only works because PathResolver quietly
+                # translates — shell tools have no such translation, so the same
+                # path fails the moment the agent reaches for one.
+                uploads_agent_path = (
+                    uploads_virtual_path if sandbox_enabled else str(uploads_host_path)
+                )
                 uploads_host_path.mkdir(parents=True, exist_ok=True)
 
                 for file_item in files:
@@ -642,11 +651,14 @@ class ChatProcessor:
                         if "mime_type" in file_item:
                             # It's an AG-UI pre-uploaded file
                             v_path = file_item.get("path")
+                            _host = str(resolver.resolve(v_path)) if v_path else None
                             result = {
-                                "final_path": str(resolver.resolve(v_path))
-                                if v_path
-                                else None,
-                                "virtual_path": v_path,
+                                "final_path": _host,
+                                # The client speaks virtual paths; the agent is
+                                # told the one its own tools accept.
+                                "agent_path": (
+                                    v_path if (sandbox_enabled or not _host) else _host
+                                ),
                                 "filename": file_item.get("filename"),
                                 "is_image": file_item.get("mime_type", "").startswith(
                                     "image/"
@@ -655,11 +667,11 @@ class ChatProcessor:
                         else:
                             # It's a social tool attachment
                             result = self._process_social_attachment(
-                                file_item, uploads_host_path, uploads_virtual_path
+                                file_item, uploads_host_path, uploads_agent_path
                             )
                     else:
                         result = await self._process_upload_file(
-                            file_item, uploads_host_path, uploads_virtual_path
+                            file_item, uploads_host_path, uploads_agent_path
                         )
 
                     if result["is_image"] and not _vision_ok:
@@ -668,9 +680,9 @@ class ChatProcessor:
                         # and record the virtual path so we can tell the model, via
                         # a hidden system reminder, to inspect it with analyze_image
                         # (the directive must not appear in the user's bubble).
-                        name = result.get("filename") or result["virtual_path"]
+                        name = result.get("filename") or result["agent_path"]
                         stripped_image_names.append(name)
-                        stripped_image_paths.append(result["virtual_path"])
+                        stripped_image_paths.append(result["agent_path"])
                     elif result["is_image"]:
                         try:
                             # pydantic-ai uses BinaryContent for images
@@ -684,14 +696,14 @@ class ChatProcessor:
                                 BinaryContent(data=image_data, media_type=media_type)
                             )
                             attachment_context += (
-                                f"\n[User attached an image: {result['virtual_path']}]"
+                                f"\n[User attached an image: {result['agent_path']}]"
                             )
                         except Exception as e:
                             logger.error(f"Failed to load image: {e}")
                             attachment_context += f"\n[Failed to load attached image: {result.get('filename')}]"
-                    elif result["virtual_path"]:
+                    elif result["agent_path"]:
                         attachment_context += (
-                            f"\n[User attached a file: {result['virtual_path']}]"
+                            f"\n[User attached a file: {result['agent_path']}]"
                         )
 
             except Exception as e:
@@ -1810,7 +1822,7 @@ class ChatProcessor:
         )
 
     async def _process_upload_file(
-        self, file_obj, host_path: Path, virtual_path_prefix: str
+        self, file_obj, host_path: Path, agent_path_prefix: str
     ) -> Dict:
         """Handle Starlette UploadFile."""
         filename = getattr(file_obj, "filename", "unnamed")
@@ -1823,18 +1835,18 @@ class ChatProcessor:
         with open(target_path, "wb") as f:
             f.write(content)
 
-        virtual_path = f"{virtual_path_prefix}/{target_path.name}"
-        logger.info(f"Saved uploaded file to {virtual_path}")
+        agent_path = f"{agent_path_prefix}/{target_path.name}"
+        logger.info(f"Saved uploaded file to {agent_path}")
 
         return {
             "final_path": str(target_path),
-            "virtual_path": virtual_path,
+            "agent_path": agent_path,
             "filename": filename,
             "is_image": content_type.startswith("image/"),
         }
 
     def _process_social_attachment(
-        self, att_dict: Dict, host_path: Path, virtual_path_prefix: str
+        self, att_dict: Dict, host_path: Path, agent_path_prefix: str
     ) -> Dict:
         """Handle social attachment dict."""
         src_path = att_dict.get("path")
@@ -1842,17 +1854,17 @@ class ChatProcessor:
         att_type = att_dict.get("type")
 
         if not src_path or not os.path.exists(src_path):
-            return {"final_path": None, "virtual_path": None, "is_image": False}
+            return {"final_path": None, "agent_path": None, "is_image": False}
 
         safe_name = sanitize_filename(filename)
         target_path = _resolve_target_path(host_path, safe_name)
 
         shutil.move(src_path, target_path)
 
-        virtual_path = f"{virtual_path_prefix}/{target_path.name}"
+        agent_path = f"{agent_path_prefix}/{target_path.name}"
         return {
             "final_path": str(target_path),
-            "virtual_path": virtual_path,
+            "agent_path": agent_path,
             "filename": filename,
             "is_image": att_type == "image",
         }

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -1836,7 +1836,11 @@ class ChatProcessor:
             f.write(content)
 
         agent_path = f"{agent_path_prefix}/{target_path.name}"
-        logger.info(f"Saved uploaded file to {agent_path}")
+        # Filename only. In host mode the prefix is a real home directory, so
+        # logging the full path would put the account name in the log for every
+        # attachment — and the directory is fixed per install, so it tells a
+        # reader nothing the filename does not.
+        logger.info(f"Saved uploaded file {target_path.name}")
 
         return {
             "final_path": str(target_path),

--- a/src/suzent/prompts.py
+++ b/src/suzent/prompts.py
@@ -148,9 +148,12 @@ You are in a sandbox environment. Your current working directory is the project 
 Env vars available: PROJECT_PATH=/workspace, SHARED_PATH=/shared, PROJECT_SLUG, and CHAT_ID.
 """
 
+# No prohibition on virtual paths here, deliberately: naming a path scheme is
+# how a model learns the scheme exists. Host mode simply never shows one, so
+# there is nothing to forbid — and the old wording forbade `/mnt/...` on the
+# same turn that Directory Mappings listed `/mnt/...` as available.
 EXECUTION_MODE_SECTION_HOST = """# Environment: Host
 You are on the host machine ({os_name}). Use host paths (e.g., `{workspace_root}`).
-Do NOT use virtual `/mnt/...` paths.
 Env vars available: PROJECT_PATH (your cwd, shared across chats in this project), SHARED_PATH, WORKSPACE_ROOT, and MOUNT_* for mapped volumes.
 Current Shell: {shell_type}
 """
@@ -342,9 +345,17 @@ def build_execution_mode_section(
 
 
 def build_custom_volumes_section(deps: Any) -> str:
-    """Build directory mapping section for configured custom volumes."""
+    """Build directory mapping section for configured custom volumes.
+
+    In host mode the mount point is not shown. It is not a path the agent can
+    use: the filesystem tools would translate it, but a shell command would not,
+    and listing it under "available for your use" invited exactly that. The
+    host path is the whole answer there, so the mapping is not a mapping.
+    """
     if not deps.custom_volumes:
         return ""
+
+    sandbox_enabled = bool(getattr(deps, "sandbox_enabled", True))
 
     volumes_info = []
     volume_metadata = getattr(deps, "custom_volume_metadata", {}) or {}
@@ -375,13 +386,18 @@ def build_custom_volumes_section(deps: Any) -> str:
             details = "Git repo: No"
         elif status:
             details = f"Git repo: Unknown, status={status}"
-        elif parsed:
-            details = "Host Path:Virtual Name"
         else:
-            details = "Host Path:Virtual Name"
+            details = (
+                "Host Path:Virtual Name" if sandbox_enabled else "Mapped directory"
+            )
 
         if parsed:
-            volumes_info.append(f"- {host_path}:{mount_point} ({details})")
+            # One path, the one this agent can open. The pair went to both modes,
+            # so each was reading half a line addressed to the other: the sandbox
+            # agent saw host paths the section above calls inaccessible, and the
+            # host agent saw mount points its shell cannot resolve.
+            usable = mount_point if sandbox_enabled else host_path
+            volumes_info.append(f"- {usable} ({details})")
         else:
             volumes_info.append(f"- {v} ({details})")
 

--- a/tests/core/test_agent_sees_its_own_mode_paths.py
+++ b/tests/core/test_agent_sees_its_own_mode_paths.py
@@ -113,3 +113,23 @@ def test_the_skill_catalogue_already_follows_the_rule(sandbox: bool):
 
     assert "if sandbox_enabled:" in source
     assert "skill.path.resolve()" in source
+
+
+@pytest.mark.asyncio
+async def test_the_upload_log_line_carries_no_host_path(tmp_path: Path):
+    """In host mode the prefix is a real home directory, so logging the full
+    path would put the account name in the log for every attachment — and the
+    directory is fixed per install, so it tells a reader nothing the filename
+    does not."""
+    from loguru import logger
+
+    captured: list[str] = []
+    sink_id = logger.add(captured.append, level="INFO")
+    try:
+        await ChatProcessor()._process_upload_file(_Upload(), tmp_path, str(tmp_path))
+    finally:
+        logger.remove(sink_id)
+
+    logged = "".join(captured)
+    assert "photo.png" in logged, "the filename is the useful part"
+    assert str(tmp_path) not in logged, "the host directory reached the log"

--- a/tests/core/test_agent_sees_its_own_mode_paths.py
+++ b/tests/core/test_agent_sees_its_own_mode_paths.py
@@ -51,26 +51,55 @@ def test_the_vision_reminder_repeats_whatever_it_is_given(tmp_path: Path):
     assert "/workspace" not in text
 
 
-def test_host_mode_is_told_not_to_use_virtual_paths():
-    """The instruction the old upload path contradicted. Kept as a test so the
-    two cannot drift back into disagreeing."""
+def test_host_mode_never_mentions_the_virtual_scheme():
+    """Not "told not to use /mnt" — never shown it. Naming a path scheme is how
+    a model learns the scheme exists, and the prohibition used to arrive in the
+    same prompt as a Directory Mappings block offering /mnt paths for use."""
     from suzent.prompts import build_execution_mode_section
 
     section = build_execution_mode_section(
         sandbox_enabled=False, workspace_root="/Users/x/proj", shell_type="zsh"
     )
 
-    assert "Do NOT use virtual" in section
+    assert "/mnt" not in section
+    assert "Do NOT use virtual" not in section
 
 
-def test_sandbox_mode_is_not_told_that():
+def test_sandbox_mode_does_describe_its_own_mounts():
+    """The mirror: /mnt is real there, so it is named."""
     from suzent.prompts import build_execution_mode_section
 
     section = build_execution_mode_section(
         sandbox_enabled=True, workspace_root="/workspace", shell_type="bash"
     )
 
-    assert "Do NOT use virtual" not in section
+    assert "/mnt/..." in section
+
+
+@pytest.mark.parametrize(
+    "sandbox,expected,forbidden",
+    [
+        (False, "/Users/suzy/Obsidian", "/mnt/notebook"),
+        (True, "/mnt/notebook", "/Users/suzy/Obsidian"),
+    ],
+)
+def test_directory_mappings_list_one_usable_path(sandbox, expected, forbidden):
+    """The host:mount pair went to both modes, so each read half a line meant
+    for the other."""
+    from types import SimpleNamespace
+
+    from suzent.prompts import build_custom_volumes_section
+
+    deps = SimpleNamespace(
+        custom_volumes=["/Users/suzy/Obsidian:/mnt/notebook"],
+        custom_volume_metadata={},
+        sandbox_enabled=sandbox,
+    )
+
+    section = build_custom_volumes_section(deps)
+
+    assert expected in section
+    assert forbidden not in section
 
 
 @pytest.mark.parametrize("sandbox", [True, False])

--- a/tests/core/test_agent_sees_its_own_mode_paths.py
+++ b/tests/core/test_agent_sees_its_own_mode_paths.py
@@ -1,0 +1,86 @@
+"""The agent is told paths in the vocabulary of the filesystem it actually has.
+
+Host mode shows host paths; sandbox mode shows sandbox paths. No translation
+layer between the two, and no hardcoded virtual literal that happens to work
+because PathResolver quietly maps it.
+
+The uploads path broke this: it was hardcoded to /workspace/uploads in both
+modes. It "worked" because PathResolver resolves virtual paths in host mode
+too — but the host-mode environment section tells the agent not to use virtual
+paths, and a shell tool has no resolver, so the same path fails the moment the
+agent reaches for one instead of analyze_image.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from suzent.core.chat_processor import ChatProcessor, _stripped_image_reminder
+
+
+class _Upload:
+    filename = "photo.png"
+    content_type = "image/png"
+
+    async def read(self) -> bytes:
+        return b"\x89PNG\r\n\x1a\n"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sandbox", [True, False])
+async def test_the_upload_path_matches_the_mode(tmp_path: Path, sandbox: bool):
+    prefix = "/workspace/uploads" if sandbox else str(tmp_path)
+
+    result = await ChatProcessor()._process_upload_file(_Upload(), tmp_path, prefix)
+
+    assert result["agent_path"].startswith(prefix)
+    if not sandbox:
+        assert not result["agent_path"].startswith("/workspace"), (
+            "host mode was handed a virtual path"
+        )
+
+
+def test_the_vision_reminder_repeats_whatever_it_is_given(tmp_path: Path):
+    """It formats, it does not translate — so the decision belongs upstream,
+    where the mode is known."""
+    host = str(tmp_path / "photo.png")
+
+    text = _stripped_image_reminder([host])
+
+    assert host in text
+    assert "/workspace" not in text
+
+
+def test_host_mode_is_told_not_to_use_virtual_paths():
+    """The instruction the old upload path contradicted. Kept as a test so the
+    two cannot drift back into disagreeing."""
+    from suzent.prompts import build_execution_mode_section
+
+    section = build_execution_mode_section(
+        sandbox_enabled=False, workspace_root="/Users/x/proj", shell_type="zsh"
+    )
+
+    assert "Do NOT use virtual" in section
+
+
+def test_sandbox_mode_is_not_told_that():
+    from suzent.prompts import build_execution_mode_section
+
+    section = build_execution_mode_section(
+        sandbox_enabled=True, workspace_root="/workspace", shell_type="bash"
+    )
+
+    assert "Do NOT use virtual" not in section
+
+
+@pytest.mark.parametrize("sandbox", [True, False])
+def test_the_skill_catalogue_already_follows_the_rule(sandbox: bool):
+    """Pinned because it is the reference implementation of the principle: the
+    listing shows virtual paths only in sandbox mode."""
+    from suzent.skills.hooks import skills_reminder_hook
+    import inspect
+
+    source = inspect.getsource(skills_reminder_hook)
+
+    assert "if sandbox_enabled:" in source
+    assert "skill.path.resolve()" in source

--- a/tests/prompts/test_prompt_architecture.py
+++ b/tests/prompts/test_prompt_architecture.py
@@ -129,7 +129,7 @@ def test_register_dynamic_instructions_environment_uses_host_paths():
     result = funcs["inject_environment_context"](ctx)
 
     assert "# Environment: Host" in result
-    assert "Do NOT use virtual `/mnt/...` paths." in result
+    assert "/mnt" not in result
 
 
 def test_register_dynamic_instructions_stateless_keeps_environment_context():

--- a/tests/prompts/test_prompt_path_modes.py
+++ b/tests/prompts/test_prompt_path_modes.py
@@ -133,5 +133,8 @@ def test_prompt_assembly_host_mode_has_no_virtual_notebook_paths():
         ]
     )
 
-    assert "Do NOT use virtual `/mnt/...` paths." in prompt
-    assert "/mnt/notebook" not in prompt
+    # Not "told not to use /mnt" — never shown /mnt at all. Naming a scheme is
+    # how a model learns it exists, and the prohibition used to sit in the same
+    # prompt as a Directory Mappings block listing /mnt paths as available.
+    assert "/mnt" not in prompt
+    assert "Do NOT use virtual" not in prompt


### PR DESCRIPTION
**Principle:** what the agent is shown should be native to the filesystem it actually has — host paths in host mode, sandbox paths in sandbox mode. No translation layer in between, no hardcoded literal that happens to work, and no mention of the other mode's scheme.

Three violations, all of which had the agent reading text addressed to the other mode.

## 1. Uploads were hardcoded to `/workspace/uploads`

```python
uploads_virtual_path = "/workspace/uploads"   # both modes, no branch
```

A host-mode agent was told *"The user attached 1 image(s) at /workspace/uploads/photo.png — use analyze_image"*.

It "worked": `PathResolver.resolve()` maps that to the host path in host mode too. But the translation belongs to the *filesystem tools*, not the agent — reach for `file` or `python -c` instead and the path does not exist. It only worked if the agent guessed the right tool, having just been told the path was the wrong kind.

Three model-facing strings carried it (vision reminder, attached-image note, attached-file note). All now show the mode-native path, decided once where the mode is known. `virtual_path` → `agent_path`, since that is what it is.

## 2. Host mode named the scheme it was forbidding

> Use host paths (e.g. `/Users/suzy/proj`). **Do NOT use virtual `/mnt/...` paths.**

Naming a path scheme is how a model learns the scheme exists. Worse, that prohibition arrived in the same prompt as violation 3, which offered `/mnt/...` paths for use.

Removed. Host mode never shows a virtual path now, so there is nothing to forbid.

## 3. Directory Mappings showed `host:mount` to both modes

```
- /Users/suzy/Obsidian:/mnt/notebook (Notebook vault mount)
```

Each mode was reading half a line meant for the other: the sandbox agent saw host paths the environment section calls inaccessible, the host agent saw mount points its shell cannot resolve. Now:

| Mode | Shown |
|---|---|
| host | `- /Users/suzy/Obsidian (Notebook vault mount)` |
| sandbox | `- /mnt/notebook (Notebook vault mount)` |

## Scope

Everything else already followed the rule and is unchanged: the skill catalogue, repository agent listings, grep results and core memory all branch on `sandbox_enabled` and show host paths in host mode.

Dream consolidation stays as the one deliberate exception — it ships a fixed prompt in virtual paths for both modes and sets `suppress_environment_context=True`, so the contradicting instruction is not present. That is the pattern the three above were missing.

## Verification

12 tests. Three pre-existing tests pinned the old wording (`assert "Do NOT use virtual ..." in prompt`) and were updated to assert the stronger property — `/mnt` does not appear in a host-mode prompt at all — rather than deleted.

Suite 1987 passed, ruff clean.