### PR TITLE
refactor(dream): give the dream agent paths its own filesystem uses

### DIFF
--- a/src/suzent/core/dream_runner.py
+++ b/src/suzent/core/dream_runner.py
@@ -937,10 +937,12 @@ class DreamRunner(BaseBrain):
                 logger.warning(f"[dream] could not read confirmations: {e}")
                 confirmations = []
 
+        roots = self._dream_roots()
         return await self._run_forked_agent(
             DREAM_CHAT_ID,
-            memory_context.DREAM_SYSTEM_PROMPT,
-            memory_context.DREAM_INSTRUCTIONS.format(
+            memory_context.build_dream_system_prompt(roots),
+            memory_context.build_dream_instructions(
+                roots,
                 start=start,
                 end=end,
                 confirmations=memory_context.format_confirmations_block(confirmations),
@@ -950,11 +952,39 @@ class DreamRunner(BaseBrain):
 
     async def _run_lint_agent(self) -> str:
         """Lint phase: editorial audit/repair of the existing vault. Returns the summary."""
+        roots = self._dream_roots()
         return await self._run_forked_agent(
             DREAM_LINT_CHAT_ID,
-            memory_context.LINT_SYSTEM_PROMPT,
-            memory_context.LINT_INSTRUCTIONS,
+            memory_context.build_lint_system_prompt(roots),
+            memory_context.build_lint_instructions(roots),
         )
+
+    def _dream_roots(self) -> "memory_context.DreamRoots":
+        """The vault and log directories in the vocabulary this run's tools use.
+
+        Host mode resolves the mapped volume, which is the same directory the
+        runner itself works on — `lifecycle.resolve_notebook_dir()` points the
+        markdown store at that mapping too, so agent and runner describe one
+        directory one way.
+        """
+        from suzent.config import CONFIG
+        from suzent.config.model import get_effective_volumes
+        from suzent.tools.filesystem.path_resolver import PathResolver
+
+        sandbox_enabled = bool(CONFIG.sandbox_enabled)
+        resolver = None
+        if not sandbox_enabled:
+            try:
+                resolver = PathResolver(
+                    chat_id=DREAM_CHAT_ID,
+                    sandbox_enabled=False,
+                    custom_volumes=get_effective_volumes([]),
+                )
+            except Exception as e:
+                # Falls back to the sandbox spelling, which PathResolver maps in
+                # either mode — a worse prompt, not a broken one.
+                logger.warning(f"[dream] could not resolve host roots: {e}")
+        return memory_context.resolve_dream_roots(sandbox_enabled, resolver)
 
     async def _run_forked_agent(
         self,

--- a/src/suzent/memory/memory_context.py
+++ b/src/suzent/memory/memory_context.py
@@ -372,9 +372,23 @@ def resolve_dream_roots(sandbox_enabled: bool, path_resolver: Any = None) -> Dre
 
     def _host(virtual: str, fallback: str) -> str:
         try:
-            return str(path_resolver.resolve(virtual)).replace("\\", "/")
+            host = str(path_resolver.resolve(virtual)).replace("\\", "/")
         except Exception:
             return fallback
+
+        # Only publish a host path the agent's own tools will read back as
+        # itself. A vault that genuinely lives under a reserved prefix —
+        # /mnt/data/vault:/mnt/notebook is an ordinary Linux mapping — would be
+        # taken for a virtual path on the way in: /mnt/... raises "no matching
+        # custom mount", and /shared/... or /workspace/... is worse, silently
+        # resolving to a different tree. The virtual spelling is correct in
+        # those cases, so keep it.
+        try:
+            if str(path_resolver.resolve(host)).replace("\\", "/") != host:
+                return fallback
+        except Exception:
+            return fallback
+        return host
 
     return DreamRoots(
         memory_root=_host(DREAM_MEMORY_ROOT, DREAM_MEMORY_ROOT),

--- a/src/suzent/memory/memory_context.py
+++ b/src/suzent/memory/memory_context.py
@@ -4,6 +4,7 @@ Memory system prompt templates and context formatting.
 Centralizes all prompt engineering for the memory system.
 """
 
+from dataclasses import dataclass
 from typing import Dict, List, Any, Optional
 
 from suzent.memory.markdown_store import MEMORY_GENERATED_END
@@ -324,11 +325,10 @@ Max 2000 words. Respond with the summary only.
 
 # ===== Dream consolidation (autonomous wiki keeper) =====
 
-# Virtual roots used in the dream/lint prompts. PathResolver maps these in BOTH
-# sandbox and host mode, so the agent's file tools resolve them regardless of mode.
-# Centralized here so the paths live in one place rather than scattered across the
-# prompt strings below.
-DREAM_MEMORY_ROOT = "/shared/memory"  # daily logs: {DREAM_MEMORY_ROOT}/archive/*.md
+# Sandbox roots for the dream/lint prompts. Only used when the agent is actually
+# in a sandbox — see DreamRoots, which picks the vocabulary the agent's own
+# filesystem speaks.
+DREAM_MEMORY_ROOT = "/shared/memory"  # daily logs: {memory_root}/archive/*.md
 DREAM_NOTEBOOK_ROOT = "/mnt/notebook"  # the vault the agent maintains
 
 # Where the dream drops fact lines it has folded into the vault and wants dropped
@@ -336,30 +336,91 @@ DREAM_NOTEBOOK_ROOT = "/mnt/notebook"  # the vault the agent maintains
 # lines into tombstones and reindexes the affected logs, keeping index mutation out
 # of the agent's hands and the daily logs append-only.
 DREAM_SUPERSEDED_FILENAME = "superseded.txt"
-DREAM_SUPERSEDED_PATH = f"{DREAM_NOTEBOOK_ROOT}/.state/{DREAM_SUPERSEDED_FILENAME}"
 
-DREAM_SYSTEM_PROMPT = f"""You are Suzent's memory consolidation agent ("dream"). You run \
+
+@dataclass(frozen=True)
+class DreamRoots:
+    """Where the dream agent's two directories are, in its own vocabulary.
+
+    Host paths in host mode, sandbox paths in sandbox mode — the same rule the
+    rest of the prompt follows. These used to be fixed virtual constants for
+    both modes, which worked only because PathResolver translates them and the
+    dream agent happens to hold no shell tool. That made the vault the one place
+    where a host-mode agent was told a path its shell could not open, and made
+    the runner (which reads the same files by host path) and the agent describe
+    one directory two ways.
+    """
+
+    memory_root: str
+    notebook_root: str
+
+    @property
+    def superseded_path(self) -> str:
+        """Where the agent appends facts it has folded into the vault."""
+        return f"{self.notebook_root}/.state/{DREAM_SUPERSEDED_FILENAME}"
+
+
+def resolve_dream_roots(sandbox_enabled: bool, path_resolver: Any = None) -> DreamRoots:
+    """Pick the roots for this run.
+
+    Falls back to the sandbox spelling whenever the host location cannot be
+    determined: a virtual path that PathResolver can map is better than a
+    half-resolved host path that exists nowhere.
+    """
+    if sandbox_enabled or path_resolver is None:
+        return DreamRoots(DREAM_MEMORY_ROOT, DREAM_NOTEBOOK_ROOT)
+
+    def _host(virtual: str, fallback: str) -> str:
+        try:
+            return str(path_resolver.resolve(virtual)).replace("\\", "/")
+        except Exception:
+            return fallback
+
+    return DreamRoots(
+        memory_root=_host(DREAM_MEMORY_ROOT, DREAM_MEMORY_ROOT),
+        notebook_root=_host(DREAM_NOTEBOOK_ROOT, DREAM_NOTEBOOK_ROOT),
+    )
+
+
+def build_dream_system_prompt(roots: DreamRoots) -> str:
+    """The dream agent's standing prompt, in paths its own tools accept."""
+    return f"""You are Suzent's memory consolidation agent ("dream"). You run \
 autonomously to turn the raw, append-only daily memory logs into a clean, durable, \
 cross-referenced knowledge vault.
 
 Tools: read_file, write_file, edit_file, glob_search, grep_search, memory_search.
 Filesystem:
-- Daily logs (READ-ONLY source): {DREAM_MEMORY_ROOT}/archive/YYYY-MM-DD.md  — NEVER edit or delete these.
-- The vault (your workspace):     {DREAM_NOTEBOOK_ROOT}/  — schema.md, index.md, log.md, zoned pages.
+- Daily logs (READ-ONLY source): {roots.memory_root}/archive/YYYY-MM-DD.md  — NEVER edit or delete these.
+- The vault (your workspace):     {roots.notebook_root}/  — schema.md, index.md, log.md, zoned pages.
 
 Rules:
-- ALWAYS read {DREAM_NOTEBOOK_ROOT}/schema.md first; follow its zones, naming, and frontmatter exactly.
+- ALWAYS read {roots.notebook_root}/schema.md first; follow its zones, naming, and frontmatter exactly.
 - Improve existing pages; never create near-duplicates. Search before you write.
 - Preserve history: when a fact changes over time, record "currently X; previously Y" — never silently overwrite.
 - Only remove a statement when it is a genuine correction or an exact duplicate.
 - Do NOT write to log.md — the runner records consolidation events there. Put conflicts on content pages.
-- {DREAM_SUPERSEDED_PATH} is append-only and write-only for you: read it if you must, never clear it.
+- {roots.superseded_path} is append-only and write-only for you: read it if you must, never clear it.
 """
 
-DREAM_INSTRUCTIONS = f"""Consolidate the daily memory logs dated after {{start}} through {{end}} into the vault.
 
-1. Orient: read schema.md and index.md; glob_search {DREAM_NOTEBOOK_ROOT} for existing pages.
-2. Read the logs: {DREAM_MEMORY_ROOT}/archive/*.md dated after {{start}} through {{end}}.
+def build_dream_instructions(
+    roots: DreamRoots,
+    *,
+    start: str,
+    end: str,
+    confirmations: str,
+    revisits: str,
+) -> str:
+    """The per-run consolidation brief.
+
+    Takes its values directly rather than returning a template for the caller
+    to ``.format()``: the old two-pass shape meant every literal brace in the
+    text had to be escaped for a pass that had not happened yet.
+    """
+    return f"""Consolidate the daily memory logs dated after {start} through {end} into the vault.
+
+1. Orient: read schema.md and index.md; glob_search {roots.notebook_root} for existing pages.
+2. Read the logs: {roots.memory_root}/archive/*.md dated after {start} through {end}.
 3. For each distinct fact/topic:
    a. Find the page it belongs to (index.md + glob_search/grep_search + memory_search).
       Personal facts about the user -> 3_Personal/ ; domain knowledge -> 2_Wiki/.
@@ -375,7 +436,7 @@ DREAM_INSTRUCTIONS = f"""Consolidate the daily memory logs dated after {{start}}
                                                        claim you already hold.
       - New, non-conflicting                        -> add under the right section.
       - Correction (new entry shows old was wrong)  -> replace the wrong statement.
-      - Change over time (both true at diff. times) -> rewrite as "Currently X (since {{end}});
+      - Change over time (both true at diff. times) -> rewrite as "Currently X (since {end});
                                                        previously Y." Apply the schema's lifecycle fields.
       - Genuine conflict you can't confidently resolve -> keep the more recent claim, add a
         `> [!warning] Conflicting claims: <A> vs <B> (<dates>)` callout on the relevant
@@ -384,11 +445,11 @@ DREAM_INSTRUCTIONS = f"""Consolidate the daily memory logs dated after {{start}}
    c. Convert relative dates ("yesterday") to absolute.
    d. Retire what you folded in: append the exact log fact text (the part after the
       `- [category] ` prefix, without the trailing backtick tags) to
-      {DREAM_SUPERSEDED_PATH}, one per line, for any line that is now fully represented
+      {roots.superseded_path}, one per line, for any line that is now fully represented
       on a page AND adds nothing the page does not say. The runner drops those from the
       search index; the daily logs themselves stay untouched. When in doubt, leave it
       out — a duplicate in the index is cheaper than a fact that vanishes.
-   e. Lifecycle on {DREAM_NOTEBOOK_ROOT}/3_Personal/ pages, whether or not this vault's
+   e. Lifecycle on {roots.notebook_root}/3_Personal/ pages, whether or not this vault's
       schema.md mentions it (older vaults were seeded before these rules existed):
       - A repeated claim gets a marker on its bullet: `(confirmed 12x, last YYYY-MM-DD)`.
         Absent marker means confirmed once. Increment it and set the date; a claim the user
@@ -402,13 +463,13 @@ DREAM_INSTRUCTIONS = f"""Consolidate the daily memory logs dated after {{start}}
    is the only record that they recurred. For each, find the claim on its page and bump
    its marker by the count shown (step 3e); do not add a bullet, and do not treat one
    as a correction — a contradicting restatement never reaches this list.
-{{confirmations}}
+{confirmations}
 5. Claims due for a revisit. Re-confirm each against the logs you just read: if it is
    supported, refresh the date; if it is contradicted, apply the correction case; if the
    logs say nothing either way, leave it and let lint decide. Never delete here.
    A page listed as `stale_after unset` predates the rule and has no expiry at all: give
    it one from step 3's category table while you are there, whatever the logs say.
-{{revisits}}
+{revisits}
 6. Add `## Related` links using the schema's link style.
 7. Update index.md. Do NOT write the watermark to log.md — the runner records it.
 
@@ -446,25 +507,31 @@ def format_revisits_block(rows: Optional[List[dict]]) -> str:
 
 # ---- Lint phase: periodic editorial audit of the vault (runs after ingest catches up) ----
 
-LINT_SYSTEM_PROMPT = f"""You are Suzent's memory consolidation agent ("dream"), running your \
+
+def build_lint_system_prompt(roots: DreamRoots) -> str:
+    """The lint pass's standing prompt."""
+    return f"""You are Suzent's memory consolidation agent ("dream"), running your \
 periodic LINT pass: an editorial health-check of the notebook vault. You do NOT ingest new daily \
 logs here — you audit and repair what already exists so the knowledge graph stays consistent and \
 does not silently decay.
 
 Tools: read_file, write_file, edit_file, glob_search, grep_search, memory_search.
 Filesystem:
-- The vault (your workspace): {DREAM_NOTEBOOK_ROOT}/  — schema.md, index.md, log.md, zoned pages.
+- The vault (your workspace): {roots.notebook_root}/  — schema.md, index.md, log.md, zoned pages.
 
 Rules:
-- ALWAYS read {DREAM_NOTEBOOK_ROOT}/schema.md first; follow its zones, naming, and frontmatter exactly.
+- ALWAYS read {roots.notebook_root}/schema.md first; follow its zones, naming, and frontmatter exactly.
 - Repair conservatively. Fix links/structure freely; only delete a page if it is truly obsolete.
 - Never fabricate facts. When a contradiction needs human judgement, FLAG it, do not guess.
 - Do NOT write the lint log entry to log.md — the runner records that. Put callouts on content pages.
 """
 
-LINT_INSTRUCTIONS = f"""Run an editorial lint pass over the notebook vault.
 
-1. Orient: read schema.md and index.md; glob_search {DREAM_NOTEBOOK_ROOT} for ALL pages (many live outside index.md).
+def build_lint_instructions(roots: DreamRoots) -> str:
+    """The lint pass brief."""
+    return f"""Run an editorial lint pass over the notebook vault.
+
+1. Orient: read schema.md and index.md; glob_search {roots.notebook_root} for ALL pages (many live outside index.md).
 2. Contradictions: read related pages; where claims conflict, resolve with the better-supported/more
    recent claim. If it needs human judgement, add a `> [!warning] Contradiction: <desc>` callout on the
    page AND prepend a `> [!alert] Contradiction found in <schema-compliant link>` line near the top of index.md.
@@ -483,6 +550,7 @@ LINT_INSTRUCTIONS = f"""Run an editorial lint pass over the notebook vault.
 Do NOT append the lint entry to log.md — the runner records it.
 Return a one-paragraph summary: contradictions found/resolved, links/orphans fixed, pages flagged, gaps.
 """
+
 
 # Deterministic post-step run by the runner (not the agent): regenerate the
 # always-visible MEMORY.md from the vault's personal facts + recall signal.

--- a/tests/memory/test_claim_lifecycle_prompts.py
+++ b/tests/memory/test_claim_lifecycle_prompts.py
@@ -13,13 +13,29 @@ SCHEMA = "skills/notebook/schema_example.md"
 OKF = "skills/notebook/okf.md"
 
 
+def _dream_text() -> str:
+    return memory_context.build_dream_instructions(
+        memory_context.resolve_dream_roots(sandbox_enabled=True),
+        start="2026-01-01",
+        end="2026-01-02",
+        confirmations="   (none pending)",
+        revisits="   (none due)",
+    )
+
+
+def _lint_text() -> str:
+    return memory_context.build_lint_instructions(
+        memory_context.resolve_dream_roots(sandbox_enabled=True)
+    )
+
+
 def _read(path):
     with open(path, encoding="utf-8") as f:
         return f.read()
 
 
 def test_duplicates_are_confirmed_not_restated():
-    text = memory_context.DREAM_INSTRUCTIONS
+    text = _dream_text()
 
     assert "confirmed 12x, last YYYY-MM-DD" in text
     assert "Never add a second" in text
@@ -27,16 +43,18 @@ def test_duplicates_are_confirmed_not_restated():
 
 def test_a_contradicting_repeat_is_not_a_confirmation():
     """Otherwise a reversal would be counted as evidence for the thing it reverses."""
-    assert "CONTRADICTS" in memory_context.DREAM_INSTRUCTIONS
+    assert "CONTRADICTS" in _dream_text()
 
 
 def test_lifecycle_rules_do_not_depend_on_the_seeded_schema():
-    assert "whether or not this vault's" in memory_context.DREAM_INSTRUCTIONS
-    assert "stale_after" in memory_context.DREAM_INSTRUCTIONS
+    text = _dream_text()
+
+    assert "whether or not this vault's" in text
+    assert "stale_after" in text
 
 
 def test_lint_never_deletes_or_unconfirms_a_stale_personal_claim():
-    text = memory_context.LINT_INSTRUCTIONS
+    text = _lint_text()
 
     assert "never delete it" in text
     assert "never reset a claim's confirmation marker" in text

--- a/tests/memory/test_dream_prompt.py
+++ b/tests/memory/test_dream_prompt.py
@@ -5,8 +5,17 @@ from suzent.memory import memory_context
 
 def test_dream_conflict_instructions_do_not_write_log_md():
     """Conflict handling must happen on content pages, not the runner-owned log."""
+    roots = memory_context.resolve_dream_roots(sandbox_enabled=True)
     instructions = (
-        memory_context.DREAM_SYSTEM_PROMPT + "\n" + memory_context.DREAM_INSTRUCTIONS
+        memory_context.build_dream_system_prompt(roots)
+        + "\n"
+        + memory_context.build_dream_instructions(
+            roots,
+            start="2026-01-01",
+            end="2026-01-02",
+            confirmations="   (none pending)",
+            revisits="   (none due)",
+        )
     )
 
     assert "prepend `[!alert]" not in instructions

--- a/tests/memory/test_dream_queues.py
+++ b/tests/memory/test_dream_queues.py
@@ -100,7 +100,8 @@ def test_an_unreadable_vault_yields_an_empty_queue():
 
 
 def test_the_instructions_carry_both_queues_and_never_delete():
-    text = memory_context.DREAM_INSTRUCTIONS.format(
+    text = memory_context.build_dream_instructions(
+        memory_context.resolve_dream_roots(sandbox_enabled=True),
         start="2026-01-01",
         end="2026-01-02",
         confirmations=memory_context.format_confirmations_block(

--- a/tests/memory/test_dream_supersede.py
+++ b/tests/memory/test_dream_supersede.py
@@ -50,8 +50,17 @@ def _log(store, date, *lines):
 
 
 def test_duplicate_rule_no_longer_says_do_nothing():
-    assert "-> do nothing" not in memory_context.DREAM_INSTRUCTIONS
-    assert memory_context.DREAM_SUPERSEDED_PATH in memory_context.DREAM_INSTRUCTIONS
+    roots = memory_context.resolve_dream_roots(sandbox_enabled=True)
+    text = memory_context.build_dream_instructions(
+        roots,
+        start="2026-01-01",
+        end="2026-01-02",
+        confirmations="   (none pending)",
+        revisits="   (none due)",
+    )
+
+    assert "-> do nothing" not in text
+    assert roots.superseded_path in text
 
 
 # --- store ---

--- a/tests/memory/test_dream_uses_mode_native_paths.py
+++ b/tests/memory/test_dream_uses_mode_native_paths.py
@@ -20,11 +20,18 @@ from suzent.memory.memory_context import (
 
 
 class _Resolver:
+    """A resolver that maps the virtual roots and echoes host paths back.
+
+    The echo matters: resolve_dream_roots only publishes a host path that reads
+    back as itself, which is how it detects a vault sitting under a reserved
+    prefix.
+    """
+
     def __init__(self, mapping: dict[str, str]):
         self._mapping = mapping
 
-    def resolve(self, virtual: str) -> str:
-        return self._mapping[virtual]
+    def resolve(self, path: str) -> str:
+        return self._mapping.get(path, path)
 
 
 def test_sandbox_keeps_the_sandbox_spelling():
@@ -131,3 +138,58 @@ def test_the_dream_agent_holds_no_shell_tool():
     from suzent.tools.registry import SHELL_TOOL_CLASS_NAMES
 
     assert not (set(CONFIG.memory_dream_tools) & set(SHELL_TOOL_CLASS_NAMES))
+
+
+# --- host paths that collide with a reserved prefix --------------------------
+
+
+def test_a_vault_under_a_reserved_prefix_keeps_the_virtual_spelling():
+    """`/mnt/data/vault:/mnt/notebook` is an ordinary Linux mapping. Published
+    as a host path it would be read back as a *virtual* one: /mnt/... raises
+    "no matching custom mount", so every read, glob and write fails."""
+    from suzent.tools.filesystem.path_resolver import PathResolver
+
+    resolver = PathResolver(
+        chat_id="dream",
+        sandbox_enabled=False,
+        custom_volumes=["/mnt/data/vault:/mnt/notebook"],
+    )
+
+    roots = resolve_dream_roots(sandbox_enabled=False, path_resolver=resolver)
+
+    assert roots.notebook_root == DREAM_NOTEBOOK_ROOT
+    # The point of keeping it: the agent's own tools can still open it.
+    assert str(resolver.resolve(roots.notebook_root)) == "/mnt/data/vault"
+
+
+def test_a_silently_remapped_host_path_is_rejected_too():
+    """Worse than the raising case: a host root under /shared or /workspace
+    resolves without error, to a different tree."""
+
+    class _Remapper:
+        def resolve(self, path: str) -> str:
+            if path == DREAM_NOTEBOOK_ROOT:
+                return "/shared/vault"
+            if path == DREAM_MEMORY_ROOT:
+                return "/host/logs"
+            # what a resolver does with a /shared-prefixed path
+            return "/somewhere/else/vault"
+
+    roots = resolve_dream_roots(sandbox_enabled=False, path_resolver=_Remapper())
+
+    assert roots.notebook_root == DREAM_NOTEBOOK_ROOT
+
+
+def test_an_ordinary_host_vault_is_still_published():
+    """The guard must not swallow the normal case."""
+    from suzent.tools.filesystem.path_resolver import PathResolver
+
+    resolver = PathResolver(
+        chat_id="dream",
+        sandbox_enabled=False,
+        custom_volumes=["/Users/x/vault:/mnt/notebook"],
+    )
+
+    roots = resolve_dream_roots(sandbox_enabled=False, path_resolver=resolver)
+
+    assert roots.notebook_root == "/Users/x/vault"

--- a/tests/memory/test_dream_uses_mode_native_paths.py
+++ b/tests/memory/test_dream_uses_mode_native_paths.py
@@ -112,8 +112,18 @@ def test_the_superseded_path_follows_the_roots():
 
 def test_the_agent_and_the_runner_mean_the_same_vault():
     """resolve_notebook_dir() is what points the markdown store at the mapped
-    volume. In host mode the agent's notebook_root has to be that same
-    directory, or the runner reads a vault the agent never wrote to."""
+    volume. The agent's root has to name that same directory, or the runner
+    reads a vault the agent never wrote to.
+
+    Compared after resolution, not as text. Which spelling the agent gets
+    depends on where the checkout lives: a repo under /workspace makes the
+    mapped host path collide with a reserved prefix, so the round-trip guard
+    correctly keeps /mnt/notebook. Both spellings are right; only the directory
+    they land on has to match, and asserting on the text made this pass on a
+    laptop and fail in a container.
+    """
+    from pathlib import Path
+
     from suzent.config import CONFIG
     from suzent.config.model import get_effective_volumes
     from suzent.memory.lifecycle import resolve_notebook_dir
@@ -127,7 +137,10 @@ def test_the_agent_and_the_runner_mean_the_same_vault():
     )
     roots = resolve_dream_roots(sandbox_enabled=False, path_resolver=resolver)
 
-    assert roots.notebook_root.rstrip("/") == resolve_notebook_dir().rstrip("/")
+    agent_vault = Path(resolver.resolve(roots.notebook_root)).resolve()
+    runner_vault = Path(resolve_notebook_dir()).resolve()
+
+    assert agent_vault == runner_vault
 
 
 def test_the_dream_agent_holds_no_shell_tool():

--- a/tests/memory/test_dream_uses_mode_native_paths.py
+++ b/tests/memory/test_dream_uses_mode_native_paths.py
@@ -1,0 +1,133 @@
+"""The dream agent is told its two directories the way its own tools take them.
+
+This was the last place a host-mode agent was handed virtual paths. It worked
+— PathResolver maps `/mnt/notebook` in host mode too, and the dream tool set
+happens to contain no shell tool, so nothing could receive a path it could not
+resolve. But the safety was accidental: it held only while that tool list stayed
+free of a shell, and it left the runner (which works on host paths) and the
+agent describing one directory two different ways.
+"""
+
+import pytest
+
+from suzent.memory import memory_context
+from suzent.memory.memory_context import (
+    DREAM_MEMORY_ROOT,
+    DREAM_NOTEBOOK_ROOT,
+    DreamRoots,
+    resolve_dream_roots,
+)
+
+
+class _Resolver:
+    def __init__(self, mapping: dict[str, str]):
+        self._mapping = mapping
+
+    def resolve(self, virtual: str) -> str:
+        return self._mapping[virtual]
+
+
+def test_sandbox_keeps_the_sandbox_spelling():
+    roots = resolve_dream_roots(sandbox_enabled=True)
+
+    assert roots.memory_root == DREAM_MEMORY_ROOT
+    assert roots.notebook_root == DREAM_NOTEBOOK_ROOT
+
+
+def test_host_gets_host_paths():
+    resolver = _Resolver(
+        {
+            DREAM_MEMORY_ROOT: "/Users/x/.suzent/shared/memory",
+            DREAM_NOTEBOOK_ROOT: "/Users/x/vault",
+        }
+    )
+
+    roots = resolve_dream_roots(sandbox_enabled=False, path_resolver=resolver)
+
+    assert roots.memory_root == "/Users/x/.suzent/shared/memory"
+    assert roots.notebook_root == "/Users/x/vault"
+
+
+def test_an_unresolvable_root_falls_back_rather_than_half_resolving():
+    """A virtual path PathResolver can map beats a host path that exists
+    nowhere."""
+
+    class _Broken:
+        def resolve(self, virtual: str) -> str:
+            raise ValueError("no matching custom mount is registered")
+
+    roots = resolve_dream_roots(sandbox_enabled=False, path_resolver=_Broken())
+
+    assert roots.notebook_root == DREAM_NOTEBOOK_ROOT
+
+
+def test_no_prompt_mentions_the_other_mode():
+    """The whole point: neither mode reads text addressed to the other."""
+    host = DreamRoots("/Users/x/logs", "/Users/x/vault")
+    sandbox = resolve_dream_roots(sandbox_enabled=True)
+
+    def _all(roots: DreamRoots) -> str:
+        return "\n".join(
+            [
+                memory_context.build_dream_system_prompt(roots),
+                memory_context.build_dream_instructions(
+                    roots,
+                    start="2026-01-01",
+                    end="2026-01-02",
+                    confirmations="   (none)",
+                    revisits="   (none)",
+                ),
+                memory_context.build_lint_system_prompt(roots),
+                memory_context.build_lint_instructions(roots),
+            ]
+        )
+
+    host_text = _all(host)
+    assert "/mnt/" not in host_text
+    assert "/shared/memory" not in host_text
+    assert "/Users/x/vault" in host_text
+
+    sandbox_text = _all(sandbox)
+    assert "/Users/x" not in sandbox_text
+    assert DREAM_NOTEBOOK_ROOT in sandbox_text
+
+
+def test_the_superseded_path_follows_the_roots():
+    """The agent appends to it and the runner reads it, so the two must land on
+    the same file."""
+    host = DreamRoots("/m", "/Users/x/vault")
+
+    assert host.superseded_path.startswith("/Users/x/vault/.state/")
+    assert resolve_dream_roots(sandbox_enabled=True).superseded_path.startswith(
+        DREAM_NOTEBOOK_ROOT
+    )
+
+
+def test_the_agent_and_the_runner_mean_the_same_vault():
+    """resolve_notebook_dir() is what points the markdown store at the mapped
+    volume. In host mode the agent's notebook_root has to be that same
+    directory, or the runner reads a vault the agent never wrote to."""
+    from suzent.config import CONFIG
+    from suzent.config.model import get_effective_volumes
+    from suzent.memory.lifecycle import resolve_notebook_dir
+    from suzent.tools.filesystem.path_resolver import PathResolver
+
+    if CONFIG.sandbox_enabled:
+        pytest.skip("host-mode invariant")
+
+    resolver = PathResolver(
+        chat_id="dream", sandbox_enabled=False, custom_volumes=get_effective_volumes([])
+    )
+    roots = resolve_dream_roots(sandbox_enabled=False, path_resolver=resolver)
+
+    assert roots.notebook_root.rstrip("/") == resolve_notebook_dir().rstrip("/")
+
+
+def test_the_dream_agent_holds_no_shell_tool():
+    """Not required any more — host paths work with any tool — but the tool list
+    is small and a shell in it would mean the dream can run commands during an
+    unattended background job. Worth noticing if it ever changes."""
+    from suzent.config import CONFIG
+    from suzent.tools.registry import SHELL_TOOL_CLASS_NAMES
+
+    assert not (set(CONFIG.memory_dream_tools) & set(SHELL_TOOL_CLASS_NAMES))


### PR DESCRIPTION
Follow-up to #183, which fixed the same class of problem for uploads, the environment section and Directory Mappings. Dream consolidation was the last holdout, and the only one that had a plausible-sounding reason to stay.

## Why it was an exception, and why the reason does not hold

The dream/lint prompts are module-level f-strings built at import, before any mode is known:

```python
DREAM_MEMORY_ROOT = "/shared/memory"
DREAM_NOTEBOOK_ROOT = "/mnt/notebook"
```

So in host mode — the default — the agent was told its vault is at `/mnt/notebook`. That worked, for two reasons neither of which was written down:

1. `PathResolver` maps virtual paths in host mode too, so the file tools resolve them.
2. The dream tool set contains no shell tool, so nothing could receive a path it was unable to resolve.

The second is the load-bearing one, and it is an accident of a config list. Add a shell tool to `CONFIG.memory_dream_tools` for some future phase and the exception breaks silently, inside an unattended background job.

## The part that was already inconsistent

The runner works on **host** paths: `lifecycle.resolve_notebook_dir()` points the markdown store at the mapped volume. The agent was told the **mount point**. One directory, two vocabularies, agreeing only because a translation layer sat between them — including for `.state/superseded.txt`, which the agent appends to and the runner reads.

A test now pins that they agree:

```python
assert roots.notebook_root.rstrip("/") == resolve_notebook_dir().rstrip("/")
```

On this machine that is `/Users/suzy/suzent/.suzent/notebook` on both sides.

## What changed

`DREAM_SYSTEM_PROMPT`, `DREAM_INSTRUCTIONS`, `LINT_SYSTEM_PROMPT` and `LINT_INSTRUCTIONS` become builders taking a `DreamRoots`, which resolves the mapped volume in host mode and keeps the sandbox spelling in sandbox mode. Unresolvable roots fall back to the sandbox spelling — a virtual path PathResolver can map beats a half-resolved host path that exists nowhere.

`DREAM_INSTRUCTIONS` also stops being double-templated: it was an f-string that later took `.format()`, so every literal brace had to be escaped for a pass that had not happened yet. The builder takes `start`, `end`, `confirmations` and `revisits` directly.

The prompt text itself is unchanged — the four literals were moved mechanically, with only the root identifiers substituted.

## Kept

`suppress_environment_context=True`. Its original reason (a host-mode warning contradicting the prompt) is gone with #183, but a background job still has no use for cwd and shell text.

A test also notes that the dream tool set holds no shell tool. That is no longer *required* for correctness — host paths work with any tool — but the list is small and a shell in it would mean the dream can run commands unattended, which is worth noticing if it ever changes.

## Verification

7 new tests. Four existing test files referenced the old constants and were updated to the builders rather than deleted. Suite 1985 passed, ruff clean.