### PR TITLE
feat(output): keep the truncated tail on disk instead of discarding it

### DIFF
--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -982,6 +982,7 @@ def _apply_budget(
     reserved: int = 0,
     separator: str = FRAGMENT_SEPARATOR,
     truncate_first: Optional[bool] = None,
+    deps: Any = None,
 ) -> list[str]:
     """Keep the assembled body under REMINDER_BUDGET_CHARS.
 
@@ -1025,14 +1026,30 @@ def _apply_budget(
         cost = len(part) + (separator_cost if kept else 0)
         if used + cost > REMINDER_BUDGET_CHARS:
             if not kept and may_truncate:
-                room = REMINDER_BUDGET_CHARS - used - len(TRUNCATION_MARKER)
+                # The whole fragment goes to disk before the cut, so the marker
+                # can say where the rest is. A reminder is the one place the
+                # model cannot ask for the missing part later — the block is
+                # gone next turn — so the pointer matters more here than for a
+                # tool result it could simply run again.
+                spilled = None
+                if deps is not None:
+                    from suzent.tools.overflow import spill_overflow
+
+                    spilled = spill_overflow(part, deps=deps, kind="reminder")
+                marker = (
+                    f"\n\n[truncated: over the system-reminder budget — "
+                    f"full text: {spilled}]"
+                    if spilled
+                    else TRUNCATION_MARKER
+                )
+                room = REMINDER_BUDGET_CHARS - used - len(marker)
                 if room > 0:
                     logger.warning(
                         f"[system-reminder] chat={chat_id} over budget: truncated "
                         f"{len(part)} chars to {room} at "
                         f"{used}/{REMINDER_BUDGET_CHARS}"
                     )
-                    kept.append(part[:room] + TRUNCATION_MARKER)
+                    kept.append(part[:room] + marker)
                     used = REMINDER_BUDGET_CHARS
                     continue
             dropped = len(parts) - index
@@ -1178,6 +1195,7 @@ async def build_combined_reminder(
         chat_id,
         reserved=len(render_trigger_block("")) if _constituents else 0,
         separator=TRIGGER_SEPARATOR,
+        deps=deps,
         # The trigger goes out first, so this is the pass that may spend the
         # last resort. The envelope it reserves for is not content.
         truncate_first=True,
@@ -1196,7 +1214,7 @@ async def build_combined_reminder(
     # The trigger is prepended inside the block, so it spends from the same
     # budget; without this the cap covered only part of what the model reads.
     trigger_cost = len(render_trigger_block(display_trigger)) if display_trigger else 0
-    parts = _apply_budget(parts, chat_id, reserved=trigger_cost)
+    parts = _apply_budget(parts, chat_id, reserved=trigger_cost, deps=deps)
 
     if not parts and not display_trigger:
         logger.debug(f"[system-reminder] chat={chat_id} — no content, skipping")

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -1032,13 +1032,15 @@ def _apply_budget(
                 # gone next turn — so the pointer matters more here than for a
                 # tool result it could simply run again.
                 spilled = None
+                hint = ""
                 if deps is not None:
-                    from suzent.tools.overflow import spill_overflow
+                    from suzent.tools.overflow import retention_hint, spill_overflow
 
                     spilled = spill_overflow(part, deps=deps, kind="reminder")
+                    hint = retention_hint()
                 marker = (
                     f"\n\n[truncated: over the system-reminder budget — "
-                    f"full text: {spilled}]"
+                    f"full text ({hint}): {spilled}]"
                     if spilled
                     else TRUNCATION_MARKER
                 )

--- a/src/suzent/core/system_reminder.py
+++ b/src/suzent/core/system_reminder.py
@@ -976,7 +976,7 @@ def _dedupe_fragments(parts: list[str]) -> list[str]:
     return unique
 
 
-def _apply_budget(
+async def _apply_budget(
     parts: list[str],
     chat_id: str,
     reserved: int = 0,
@@ -1031,19 +1031,23 @@ def _apply_budget(
                 # model cannot ask for the missing part later — the block is
                 # gone next turn — so the pointer matters more here than for a
                 # tool result it could simply run again.
-                spilled = None
-                hint = ""
+                # Awaited here rather than pre-computed: only the one item that
+                # actually gets cut is worth writing to disk, and which item
+                # that is falls out of the budget arithmetic.
+                marker = TRUNCATION_MARKER
                 if deps is not None:
-                    from suzent.tools.overflow import retention_hint, spill_overflow
+                    from suzent.tools.overflow import (
+                        retention_hint,
+                        spill_overflow_async,
+                    )
 
-                    spilled = spill_overflow(part, deps=deps, kind="reminder")
-                    hint = retention_hint()
-                marker = (
-                    f"\n\n[truncated: over the system-reminder budget — "
-                    f"full text ({hint}): {spilled}]"
-                    if spilled
-                    else TRUNCATION_MARKER
-                )
+                    spill = await spill_overflow_async(part, deps=deps, kind="reminder")
+                    if spill is not None:
+                        label = "partial text" if spill.clipped else "full text"
+                        marker = (
+                            f"\n\n[truncated: over the system-reminder budget — "
+                            f"{label} ({retention_hint()}): {spill.path}]"
+                        )
                 room = REMINDER_BUDGET_CHARS - used - len(marker)
                 if room > 0:
                     logger.warning(
@@ -1192,7 +1196,7 @@ async def build_combined_reminder(
     # unrelated 4,000-character reminders sailed past a 6,000-character cap
     # together. Budgeting first means the exemption covers one reminder, which
     # is the most that cannot be helped.
-    _constituents = _apply_budget(
+    _constituents = await _apply_budget(
         _constituents,
         chat_id,
         reserved=len(render_trigger_block("")) if _constituents else 0,
@@ -1216,7 +1220,7 @@ async def build_combined_reminder(
     # The trigger is prepended inside the block, so it spends from the same
     # budget; without this the cap covered only part of what the model reads.
     trigger_cost = len(render_trigger_block(display_trigger)) if display_trigger else 0
-    parts = _apply_budget(parts, chat_id, reserved=trigger_cost, deps=deps)
+    parts = await _apply_budget(parts, chat_id, reserved=trigger_cost, deps=deps)
 
     if not parts and not display_trigger:
         logger.debug(f"[system-reminder] chat={chat_id} — no content, skipping")

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -915,13 +915,14 @@ async def shutdown():
     # Cancel any pending ask_question futures so their tasks can exit cleanly
     pending_questions.cancel_all()
 
-    resource_guard = getattr(app.state, "service_resource_guard", None)
-    if resource_guard is not None and not resource_guard.done():
-        resource_guard.cancel()
-        try:
-            await resource_guard
-        except asyncio.CancelledError:
-            pass
+    for task_name in ("service_resource_guard", "overflow_sweeper"):
+        task = getattr(app.state, task_name, None)
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
     if agent_inbox_dispatcher:
         await _stop(agent_inbox_dispatcher.stop(), "AgentInboxDispatcher")

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -598,6 +598,7 @@ async def startup():
     from suzent.core.system_reminder import register_global_hook, register_per_turn_hook
     from suzent.skills.hooks import skills_reminder_hook
     from suzent.core.repository_context import repository_agents_reminder_hook
+    from suzent.tools.overflow import sweep_overflow
     from suzent.tools.plan_hooks import plan_reminder_hook
     from suzent.database import get_database
 
@@ -832,6 +833,11 @@ async def startup():
 
     # Silently refresh model lists for all configured providers in the background.
     asyncio.create_task(_refresh_provider_models())
+
+    # Spilled tool output is pruned when the next spill is written, which means
+    # not at all once output stops overflowing. This is the pass that collects
+    # what the previous run left behind.
+    asyncio.create_task(asyncio.to_thread(sweep_overflow))
 
 
 def ensure_app_data():

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -599,7 +599,7 @@ async def startup():
     from suzent.skills.hooks import skills_reminder_hook
     from suzent.core.repository_context import repository_agents_reminder_hook
     from suzent.tools.overflow import (
-        sweep_overflow,
+        sweep_overflow_in_background,
         sweep_overflow_periodically,
     )
     from suzent.tools.plan_hooks import plan_reminder_hook
@@ -809,7 +809,7 @@ async def startup():
     #
     # Spilled output is otherwise pruned only when the next spill is written,
     # which is to say not at all once output stops overflowing.
-    asyncio.create_task(asyncio.to_thread(sweep_overflow))
+    sweep_overflow_in_background()
     existing_sweeper = getattr(app.state, "overflow_sweeper", None)
     if existing_sweeper is None or existing_sweeper.done():
         app.state.overflow_sweeper = asyncio.create_task(

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -801,6 +801,21 @@ async def startup():
 
     logger.info("Node system initialized")
 
+    # Before the duplicate-social guard below, which returns early. shutdown()
+    # cancels the sweeper but leaves social_brain set, so on an in-process
+    # restart that return would skip both the startup sweep and the periodic
+    # one — leaving retention and the root quota unenforced until the process
+    # itself restarts.
+    #
+    # Spilled output is otherwise pruned only when the next spill is written,
+    # which is to say not at all once output stops overflowing.
+    asyncio.create_task(asyncio.to_thread(sweep_overflow))
+    existing_sweeper = getattr(app.state, "overflow_sweeper", None)
+    if existing_sweeper is None or existing_sweeper.done():
+        app.state.overflow_sweeper = asyncio.create_task(
+            sweep_overflow_periodically(), name="overflow_sweeper"
+        )
+
     global social_brain, channel_manager
     if social_brain is not None:
         logger.warning("Social brain already initialized, skipping duplicate startup.")
@@ -836,16 +851,6 @@ async def startup():
 
     # Silently refresh model lists for all configured providers in the background.
     asyncio.create_task(_refresh_provider_models())
-
-    # Spilled tool output is pruned when the next spill is written, which means
-    # not at all once output stops overflowing. This is the pass that collects
-    # what the previous run left behind.
-    asyncio.create_task(asyncio.to_thread(sweep_overflow))
-    # And keep sweeping: a write only prunes its own chat's directory, so the
-    # deployment-wide quota and the retention window are enforced nowhere else.
-    app.state.overflow_sweeper = asyncio.create_task(
-        sweep_overflow_periodically(), name="overflow_sweeper"
-    )
 
 
 def ensure_app_data():

--- a/src/suzent/server.py
+++ b/src/suzent/server.py
@@ -598,7 +598,10 @@ async def startup():
     from suzent.core.system_reminder import register_global_hook, register_per_turn_hook
     from suzent.skills.hooks import skills_reminder_hook
     from suzent.core.repository_context import repository_agents_reminder_hook
-    from suzent.tools.overflow import sweep_overflow
+    from suzent.tools.overflow import (
+        sweep_overflow,
+        sweep_overflow_periodically,
+    )
     from suzent.tools.plan_hooks import plan_reminder_hook
     from suzent.database import get_database
 
@@ -838,6 +841,11 @@ async def startup():
     # not at all once output stops overflowing. This is the pass that collects
     # what the previous run left behind.
     asyncio.create_task(asyncio.to_thread(sweep_overflow))
+    # And keep sweeping: a write only prunes its own chat's directory, so the
+    # deployment-wide quota and the retention window are enforced nowhere else.
+    app.state.overflow_sweeper = asyncio.create_task(
+        sweep_overflow_periodically(), name="overflow_sweeper"
+    )
 
 
 def ensure_app_data():

--- a/src/suzent/tools/base.py
+++ b/src/suzent/tools/base.py
@@ -27,26 +27,33 @@ def truncate_tool_output(
     limit: int = OUTPUT_CHAR_LIMIT,
     *,
     keep_tail: bool = False,
-    full_output_path: Optional[str] = None,
+    spill: Any = None,
 ) -> str:
     """Truncate output to *limit* chars while reporting the omitted section.
 
-    *full_output_path* names a file holding the whole output. The part a cap
-    removes is often the part that was wanted — the failing assertion at the end
-    of a test run, the last of a build log — so the marker says where the rest
-    is rather than only that it is gone.
+    *spill* is where the output was written, if anywhere. The part a cap removes
+    is often the part that was wanted — the failing assertion at the end of a
+    test run, the last of a build log — so the marker says where the rest is
+    rather than only that it is gone.
+
+    A spill that hit its own ceiling is described as partial. Calling it the
+    full output would send a reader to a file that does not contain what the
+    marker promised, which is worse than admitting the cut twice.
     """
     if not text or len(text) <= limit:
         return text
 
     def _marker(omitted: str) -> str:
         lines = omitted.count(chr(10)) + 1
-        if full_output_path:
+        if spill is not None and getattr(spill, "path", None):
             from suzent.tools.overflow import retention_hint
 
+            label = (
+                "partial output" if getattr(spill, "clipped", False) else "full output"
+            )
             return (
-                f"... [{lines} lines truncated — full output "
-                f"({retention_hint()}): {full_output_path}]"
+                f"... [{lines} lines truncated — {label} "
+                f"({retention_hint()}): {spill.path}]"
             )
         return f"... [{lines} lines truncated]"
 

--- a/src/suzent/tools/base.py
+++ b/src/suzent/tools/base.py
@@ -27,16 +27,30 @@ def truncate_tool_output(
     limit: int = OUTPUT_CHAR_LIMIT,
     *,
     keep_tail: bool = False,
+    full_output_path: Optional[str] = None,
 ) -> str:
-    """Truncate output to *limit* chars while reporting the omitted section."""
+    """Truncate output to *limit* chars while reporting the omitted section.
+
+    *full_output_path* names a file holding the whole output. The part a cap
+    removes is often the part that was wanted — the failing assertion at the end
+    of a test run, the last of a build log — so the marker says where the rest
+    is rather than only that it is gone.
+    """
     if not text or len(text) <= limit:
         return text
+
+    def _marker(omitted: str) -> str:
+        lines = omitted.count(chr(10)) + 1
+        if full_output_path:
+            return f"... [{lines} lines truncated — full output: {full_output_path}]"
+        return f"... [{lines} lines truncated]"
+
     if keep_tail:
         omitted = text[:-limit]
-        return f"... [{omitted.count(chr(10)) + 1} lines truncated]\n" + text[-limit:]
+        return _marker(omitted) + "\n" + text[-limit:]
 
     omitted = text[limit:]
-    return text[:limit] + f"\n... [{omitted.count(chr(10)) + 1} lines truncated]"
+    return text[:limit] + "\n" + _marker(omitted)
 
 
 class ToolCapability(str, Enum):

--- a/src/suzent/tools/base.py
+++ b/src/suzent/tools/base.py
@@ -42,7 +42,12 @@ def truncate_tool_output(
     def _marker(omitted: str) -> str:
         lines = omitted.count(chr(10)) + 1
         if full_output_path:
-            return f"... [{lines} lines truncated — full output: {full_output_path}]"
+            from suzent.tools.overflow import retention_hint
+
+            return (
+                f"... [{lines} lines truncated — full output "
+                f"({retention_hint()}): {full_output_path}]"
+            )
         return f"... [{lines} lines truncated]"
 
     if keep_tail:

--- a/src/suzent/tools/browsing_tool.py
+++ b/src/suzent/tools/browsing_tool.py
@@ -12,6 +12,9 @@ from starlette.websockets import WebSocket
 from pydantic import Field
 from suzent.tools.base import Tool, ToolGroup, ToolErrorCode, ToolResult
 from suzent.logger import get_logger
+from pydantic_ai import RunContext
+
+from suzent.core.agent_deps import AgentDeps
 
 logger = get_logger(__name__)
 
@@ -654,6 +657,7 @@ class BrowsingTool(Tool):
 
     async def forward(
         self,
+        ctx: RunContext[AgentDeps],
         command: Annotated[
             Literal[
                 "open",

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -472,11 +472,32 @@ def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[Sp
     if resolver is None:
         return None
 
-    try:
-        shared_host = Path(resolver.resolve("/shared"))
-    except Exception as e:
-        logger.debug(f"[overflow] no shared root: {e}")
-        return None
+    # The canonical shared directory, not whatever /shared currently maps to.
+    #
+    # A custom volume can target /shared, and PathResolver gives that mapping
+    # priority — so resolving it would write .overflow into the user's own
+    # directory, force-chmod it 0755, and leave the files somewhere the sweep
+    # (which knows only the canonical path) never looks. Deriving the root from
+    # config keeps the writer and the collector talking about one directory.
+    from suzent.config import CONFIG
+
+    shared_host = Path(CONFIG.sandbox_data_path) / "shared"
+
+    # In sandbox mode the agent reaches it as /shared — unless that mount has
+    # been redirected, in which case there is no path to advertise and the plain
+    # marker is the honest answer.
+    if getattr(deps, "sandbox_enabled", True):
+        try:
+            mapped = Path(resolver.resolve("/shared")).resolve()
+        except Exception as e:
+            logger.debug(f"[overflow] no shared root: {e}")
+            return None
+        if mapped != shared_host.resolve():
+            logger.debug(
+                "[overflow] /shared is remapped by a custom volume; "
+                "truncating without a pointer"
+            )
+            return None
 
     chat = _chat_segment(deps)
     payload, clipped = _clip(text)
@@ -529,6 +550,17 @@ async def sweep_overflow_periodically() -> None:
 #: and the plain marker on expiry.
 SPILL_TIMEOUT_SECONDS = 2.0
 
+#: Concurrent spill workers allowed at once.
+#:
+#: A timed-out spill is abandoned, not cancelled — Python cannot kill a thread —
+#: so permanently wedged storage means every oversized result leaves another
+#: worker parked forever. Without a ceiling those accumulate until the process
+#: runs out of threads and takes otherwise healthy tool calls down with it. At
+#: saturation a spill is skipped rather than queued, because queueing behind
+#: wedged work is how a transient stall becomes a permanent one.
+_SPILL_THREADS = 4
+_spill_slots = threading.Semaphore(_SPILL_THREADS)
+
 
 def spill_overflow_bounded(
     text: str, *, deps: Any, kind: str = "output"
@@ -545,10 +577,19 @@ def spill_overflow_bounded(
     cancelled, so a late write simply lands in the spill directory and is
     collected by the sweep like any other file.
     """
+    if not _spill_slots.acquire(blocking=False):
+        logger.warning(
+            "[overflow] spill workers saturated; truncating without a pointer"
+        )
+        return None
+
     result: list[Optional[Spill]] = [None]
 
     def _worker() -> None:
-        result[0] = spill_overflow(text, deps=deps, kind=kind)
+        try:
+            result[0] = spill_overflow(text, deps=deps, kind=kind)
+        finally:
+            _spill_slots.release()
 
     thread = threading.Thread(target=_worker, name="overflow-spill", daemon=True)
     thread.start()
@@ -577,17 +618,10 @@ async def spill_overflow_async(
     background; it lands in the spill directory and is collected by the sweep
     like any other file.
     """
-    try:
-        return await asyncio.wait_for(
-            asyncio.to_thread(spill_overflow, text, deps=deps, kind=kind),
-            timeout=SPILL_TIMEOUT_SECONDS,
-        )
-    except asyncio.TimeoutError:
-        logger.warning(
-            f"[overflow] spill exceeded {SPILL_TIMEOUT_SECONDS}s — truncating "
-            f"without a pointer"
-        )
-        return None
+    # Through the same bounded worker as the sync path, not to_thread: an
+    # abandoned write on the default executor occupies one of its threads
+    # forever, and that executor is shared with everything else that offloads.
+    return await asyncio.to_thread(spill_overflow_bounded, text, deps=deps, kind=kind)
 
 
 def _sweep_by_path(root: Path) -> None:

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -901,45 +901,43 @@ async def spill_overflow_async(
     accepted: list[bool] = [False]
 
     def _deliver(value: Optional[Spill]) -> None:
-        # Runs on the loop, which is the only place that can see whether the
-        # future was already cancelled — but it does no filesystem work: an
-        # unlink on the same wedged volume would stall every chat, after the
-        # caller's deadline has already expired. It answers, and the worker acts.
-        try:
-            if future.done():
-                accepted[0] = False
-                return
+        # Runs on the loop and does no filesystem work: an unlink on the same
+        # wedged volume would stall every chat, after the caller's deadline has
+        # already expired. It hands the value over; the coroutine decides
+        # whether it was really received, and the worker acts on that.
+        if not future.done():
             future.set_result(value)
-            accepted[0] = value is not None
-        finally:
-            settled.set()
 
     def _worker() -> None:
         spill = None
         try:
-            payload, clipped = _encode_bounded(head, dropped)
-            spill = _spill_payload(payload, clipped, deps=snapshot, kind=kind)
-        except BaseException as e:  # noqa: BLE001 - a spill never fails its caller
-            logger.debug(f"[overflow] spill failed: {e}")
-        finally:
-            _spill_slots.release()
+            try:
+                payload, clipped = _encode_bounded(head, dropped)
+                spill = _spill_payload(payload, clipped, deps=snapshot, kind=kind)
+            except BaseException as e:  # noqa: BLE001 - never fails its caller
+                logger.debug(f"[overflow] spill failed: {e}")
 
-        try:
-            loop.call_soon_threadsafe(_deliver, spill)
-        except RuntimeError:
-            # Loop already closed; nobody is waiting, so nobody owns the file.
-            if spill is not None:
+            try:
+                loop.call_soon_threadsafe(_deliver, spill)
+            except RuntimeError:
+                # Loop already closed; nobody is waiting, so nobody owns this.
+                if spill is not None:
+                    _discard(spill)
+                return
+
+            if spill is None:
+                return
+            settled.wait(timeout=SPILL_TIMEOUT_SECONDS)
+            if accepted[0]:
+                _prune_after_accept(snapshot)
+            else:
                 _discard(spill)
-            return
-
-        if spill is None:
-            return
-        # Wait for the loop's answer, then do the filesystem work here.
-        settled.wait(timeout=SPILL_TIMEOUT_SECONDS)
-        if accepted[0]:
-            _prune_after_accept(snapshot)
-        else:
-            _discard(spill)
+        finally:
+            # After the pruning and the cleanup, not before them. Releasing at
+            # the end of the write let the next oversized result take the slot
+            # and park another thread in the filesystem work below it, which is
+            # the accumulation the bound exists to prevent.
+            _spill_slots.release()
 
     if not _spill_slots.acquire(blocking=False):
         logger.warning(
@@ -955,8 +953,9 @@ async def spill_overflow_async(
         return None
 
     try:
-        return await asyncio.wait_for(future, timeout=SPILL_TIMEOUT_SECONDS)
+        spill = await asyncio.wait_for(future, timeout=SPILL_TIMEOUT_SECONDS)
     except asyncio.TimeoutError:
+        settled.set()
         logger.warning(
             f"[overflow] spill exceeded {SPILL_TIMEOUT_SECONDS}s — truncating "
             f"without a pointer"
@@ -964,9 +963,18 @@ async def spill_overflow_async(
         return None
     except BaseException:
         # Cancellation reaches here too — a client disconnecting, a social turn
-        # superseded. Both leave the future done-but-unreadable, which _deliver
-        # reads as "nobody took it", so the worker discards rather than prunes.
+        # superseded. Nobody receives the pointer, so the worker discards.
+        settled.set()
         raise
+
+    # Only now, with the value in hand and no await between here and the
+    # return, is it true that the caller received it. Setting the future is not
+    # the same event: a cancellation queued after _deliver ran would still stop
+    # the coroutine, and the worker would have kept and pruned a file whose
+    # path reached nobody.
+    accepted[0] = spill is not None
+    settled.set()
+    return spill
 
 
 def _sweep_by_path(root: Path) -> None:

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -57,6 +57,15 @@ OVERFLOW_TTL_SECONDS = 24 * 60 * 60
 OVERFLOW_MAX_FILES = 200
 OVERFLOW_MAX_TOTAL_BYTES = 50 * 1024 * 1024
 
+#: Deployment-wide ceiling, enforced by the sweep.
+#:
+#: Pruning on write only ever sees one chat's directory, so the per-chat
+#: allowance multiplies by the number of chats: a hundred of them retain 5 GiB
+#: while every directory is individually within bounds. Inbound channels mean
+#: chats can be created by someone other than the owner, so that count is not
+#: self-limiting.
+OVERFLOW_MAX_ROOT_BYTES = 250 * 1024 * 1024
+
 #: Ceiling on one spill. A foreground shell command reads its whole output into
 #: memory and this writes all of it.
 OVERFLOW_MAX_FILE_BYTES = 5 * 1024 * 1024
@@ -114,24 +123,42 @@ def _chat_segment(deps: Any) -> str:
     return _SAFE_SEGMENT.sub("-", raw)[:64] or "shared"
 
 
-def _open_child_dir(name: str, *, parent_fd: Optional[int], base: Path) -> int:
+def _open_child_dir(name: str, parent_fd: int) -> int:
     """Open (creating if needed) a subdirectory, refusing to follow a symlink.
 
     Taken relative to *parent_fd* so a directory swapped for a symlink after the
-    parent was opened cannot redirect the write. Without dir_fd support the same
-    steps run against a path.
+    parent was opened cannot redirect the write.
     """
     flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
-    if parent_fd is None:
-        target = base / name
-        target.mkdir(mode=_DIR_MODE, parents=True, exist_ok=True)
-        return os.open(target, flags)
-
     try:
         os.mkdir(name, _DIR_MODE, dir_fd=parent_fd)
     except FileExistsError:
         pass
     return os.open(name, flags, dir_fd=parent_fd)
+
+
+def _spill_by_path(payload: bytes, directory: Path, name: str) -> bool:
+    """Write the spill without directory descriptors.
+
+    For platforms where ``dir_fd`` is unsupported — Windows — which are also the
+    ones with no bind-mounted sandbox writing into this tree, so the pinning it
+    would buy has nothing to defend against. Keeping the fd-based code and
+    merely passing ``dir_fd=None`` was not a fallback at all: ``os.open`` raises
+    NotImplementedError there, which no ``except OSError`` catches, turning an
+    oversized tool result into a failed tool call.
+    """
+    try:
+        directory.mkdir(mode=_DIR_MODE, parents=True, exist_ok=True)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(directory / name, flags, _FILE_MODE)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+    except (OSError, NotImplementedError, ValueError) as e:
+        logger.debug(f"[overflow] could not write spill: {e}")
+        return False
+
+    _prune_path(directory)
+    return True
 
 
 def _clip(text: str) -> tuple[bytes, bool]:
@@ -141,14 +168,55 @@ def _clip(text: str) -> tuple[bytes, bool]:
     resulting file is not valid UTF-8 — so the reader that was supposed to
     rescue the output fails to open it.
     """
-    payload = text.encode("utf-8", "replace")
-    if len(payload) <= OVERFLOW_MAX_FILE_BYTES:
+    # Slice the string first. Encoding the whole thing to find out it is too
+    # long allocates a second full-size copy while the original result is still
+    # live, so a command that prints hundreds of MiB costs that twice over to
+    # write five. A UTF-8 character is at least one byte, so the first
+    # OVERFLOW_MAX_FILE_BYTES characters always contain at least that many
+    # bytes — enough to fill the file — and at most four times as many, which
+    # is the bound this buys.
+    head = text[:OVERFLOW_MAX_FILE_BYTES]
+    payload = head.encode("utf-8", "replace")
+    if len(payload) <= OVERFLOW_MAX_FILE_BYTES and len(head) == len(text):
         return payload, False
 
     note = SPILL_CLIPPED_NOTE.encode("utf-8")
     keep = OVERFLOW_MAX_FILE_BYTES - len(note)
-    head = payload[:keep].decode("utf-8", "ignore").encode("utf-8")
-    return head + note, True
+    # Decode-then-encode so the cut lands on a character boundary: slicing
+    # encoded bytes can split a code point, and the file the reader was meant
+    # to open would not be valid UTF-8.
+    return payload[:keep].decode("utf-8", "ignore").encode("utf-8") + note, True
+
+
+def _prune_path(directory: Path) -> None:
+    """The path-based twin of _prune_fd, for platforms without dir_fd."""
+    try:
+        entries = []
+        for path in directory.glob("*.txt"):
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            entries.append((stat.st_mtime, stat.st_size, path))
+    except OSError:
+        return
+
+    entries.sort(reverse=True)
+    cutoff = time.time() - OVERFLOW_TTL_SECONDS
+    running = 0
+    for index, (mtime, size, path) in enumerate(entries):
+        drop = (
+            index >= OVERFLOW_MAX_FILES
+            or mtime < cutoff
+            or running + size > OVERFLOW_MAX_TOTAL_BYTES
+        )
+        try:
+            if drop:
+                path.unlink(missing_ok=True)
+            else:
+                running += size
+        except OSError:
+            continue
 
 
 def _prune_fd(dir_fd: int) -> None:
@@ -184,6 +252,56 @@ def _prune_fd(dir_fd: int) -> None:
             continue
 
 
+def _spill_pinned(payload: bytes, shared_host: Path, chat: str, name: str) -> bool:
+    """Write the spill with every directory on the path pinned.
+
+    Resolving a path and then using it is a race the agent can win: it may
+    replace a directory between the two. Each step is therefore taken relative
+    to a descriptor already opened with O_NOFOLLOW, so a swap after resolution
+    cannot redirect the write — or the prune that follows it, which unlinks.
+    """
+    root_fd = overflow_fd = chat_fd = None
+    try:
+        shared_host.mkdir(parents=True, exist_ok=True)
+        root_fd = os.open(shared_host, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        overflow_fd = _open_child_dir(".overflow", root_fd)
+        chat_fd = _open_child_dir(chat, overflow_fd)
+
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            fd = os.open(name, flags, _FILE_MODE, dir_fd=chat_fd)
+        except OSError as e:
+            if e.errno in (errno.EEXIST, errno.ELOOP):
+                logger.warning(f"[overflow] refusing to write over {name}: {e}")
+            else:
+                logger.debug(f"[overflow] could not create spill: {e}")
+            return False
+
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(payload)
+        except OSError as e:
+            logger.debug(f"[overflow] could not write spill: {e}")
+            try:
+                os.unlink(name, dir_fd=chat_fd)
+            except OSError:
+                pass
+            return False
+
+        _prune_fd(chat_fd)
+        return True
+    except OSError as e:
+        logger.debug(f"[overflow] no spill directory: {e}")
+        return False
+    finally:
+        for handle_fd in (chat_fd, overflow_fd, root_fd):
+            if handle_fd is not None:
+                try:
+                    os.close(handle_fd)
+                except OSError:
+                    pass
+
+
 def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[Spill]:
     """Write *text* somewhere this chat can read it; return where it went.
 
@@ -206,57 +324,14 @@ def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[Sp
         return None
 
     chat = _chat_segment(deps)
-    root_fd = None
-    overflow_fd = None
-    chat_fd = None
-    try:
-        if _HAVE_DIR_FD:
-            shared_host.mkdir(parents=True, exist_ok=True)
-            root_fd = os.open(shared_host, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
-            overflow_fd = _open_child_dir(
-                ".overflow", parent_fd=root_fd, base=shared_host
-            )
-            chat_fd = _open_child_dir(chat, parent_fd=overflow_fd, base=shared_host)
-        else:
-            chat_fd = _open_child_dir(
-                chat, parent_fd=None, base=shared_host / ".overflow"
-            )
+    payload, clipped = _clip(text)
+    name = f"{kind}-{secrets.token_hex(16)}.txt"
 
-        payload, clipped = _clip(text)
-        name = f"{kind}-{secrets.token_hex(16)}.txt"
-        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
-
-        try:
-            fd = os.open(name, flags, _FILE_MODE, dir_fd=chat_fd)
-        except OSError as e:
-            if e.errno in (errno.EEXIST, errno.ELOOP):
-                logger.warning(f"[overflow] refusing to write over {name}: {e}")
-            else:
-                logger.debug(f"[overflow] could not create spill: {e}")
+    if not _HAVE_DIR_FD:
+        if not _spill_by_path(payload, shared_host / ".overflow" / chat, name):
             return None
-
-        try:
-            with os.fdopen(fd, "wb") as handle:
-                handle.write(payload)
-        except OSError as e:
-            logger.debug(f"[overflow] could not write spill: {e}")
-            try:
-                os.unlink(name, dir_fd=chat_fd)
-            except OSError:
-                pass
-            return None
-
-        _prune_fd(chat_fd)
-    except OSError as e:
-        logger.debug(f"[overflow] no spill directory: {e}")
+    elif not _spill_pinned(payload, shared_host, chat, name):
         return None
-    finally:
-        for handle_fd in (chat_fd, overflow_fd, root_fd):
-            if handle_fd is not None:
-                try:
-                    os.close(handle_fd)
-                except OSError:
-                    pass
 
     if getattr(deps, "sandbox_enabled", True):
         return Spill(f"{OVERFLOW_VIRTUAL_DIR}/{chat}/{name}", clipped)
@@ -307,6 +382,7 @@ def sweep_overflow() -> None:
         return
 
     swept = 0
+    survivors: list[tuple[float, int, str, str]] = []
     try:
         for entry in os.scandir(root_fd):
             if not entry.is_dir(follow_symlinks=False):
@@ -318,7 +394,16 @@ def sweep_overflow() -> None:
             try:
                 before = sum(1 for _ in os.scandir(chat_fd))
                 _prune_fd(chat_fd)
-                after = sum(1 for _ in os.scandir(chat_fd))
+                after = 0
+                for kept in os.scandir(chat_fd):
+                    after += 1
+                    try:
+                        stat = kept.stat(follow_symlinks=False)
+                    except OSError:
+                        continue
+                    survivors.append(
+                        (stat.st_mtime, stat.st_size, entry.name, kept.name)
+                    )
                 swept += before - after
             finally:
                 os.close(chat_fd)
@@ -327,6 +412,26 @@ def sweep_overflow() -> None:
                     os.rmdir(entry.name, dir_fd=root_fd)
                 except OSError:
                     pass
+
+        # The root ceiling, across every chat. Newest first, so what goes is the
+        # least likely to still be referenced by a live conversation.
+        survivors.sort(reverse=True)
+        running = 0
+        for _mtime, size, chat_name, file_name in survivors:
+            if running + size <= OVERFLOW_MAX_ROOT_BYTES:
+                running += size
+                continue
+            try:
+                chat_fd = os.open(chat_name, flags, dir_fd=root_fd)
+            except OSError:
+                continue
+            try:
+                os.unlink(file_name, dir_fd=chat_fd)
+                swept += 1
+            except OSError:
+                pass
+            finally:
+                os.close(chat_fd)
     except OSError:
         pass
     finally:

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -7,6 +7,12 @@ tells the model that content is missing without giving it any way to read it.
 
 So the full text is written to a file and the marker carries the path.
 
+One known limitation: a spill with no newlines — minified JSON, one enormous
+value — cannot be read past the first chunk, because the read tool pages by
+whole lines and that single line is itself over the cap. The pointer is honest
+but unusable for that shape of output; fixing it means byte-range reads in
+ReadFileTool, which is that tool's change to make.
+
 Two properties are load-bearing and easy to lose:
 
 * **The write must not become a capability.** The agent can write inside
@@ -864,6 +870,14 @@ async def spill_overflow_async(
             f"without a pointer"
         )
         return None
+    except BaseException:
+        # Cancellation reaches here too — a client disconnecting, a social turn
+        # superseded — and it means what the timeout means: nobody will receive
+        # this pointer, so the file the worker may still write must not be left
+        # counting against the quotas. Catching only TimeoutError covered the
+        # deadline and not the commoner way a caller goes away.
+        abandoned.set()
+        raise
 
 
 def _sweep_by_path(root: Path) -> None:

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -488,7 +488,15 @@ def _spill_pinned(
 
 
 def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[Spill]:
-    """Write *text* somewhere this chat can read it; return where it went.
+    """Clip *text* and write it somewhere this chat can read it."""
+    payload, clipped = _clip(text)
+    return _spill_payload(payload, clipped, deps=deps, kind=kind)
+
+
+def _spill_payload(
+    payload: bytes, clipped: bool, *, deps: Any, kind: str = "output"
+) -> Optional[Spill]:
+    """Write an already-bounded *payload*; return where it went.
 
     Returns None when there is nowhere to write, which is not an error: the
     caller still truncates, it just cannot offer the rest. Losing the tail is
@@ -530,7 +538,6 @@ def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[Sp
             return None
 
     chat = _chat_segment(deps)
-    payload, clipped = _clip(text)
     name = f"{kind}-{secrets.token_hex(16)}.txt"
 
     sandboxed = bool(getattr(deps, "sandbox_enabled", True))
@@ -607,6 +614,14 @@ def spill_overflow_bounded(
     cancelled, so a late write simply lands in the spill directory and is
     collected by the sweep like any other file.
     """
+    # Clipped here, in the caller, before any worker can capture it.
+    #
+    # An abandoned worker lives as long as the wedged storage does, so handing
+    # it the original string means holding the whole of a hundreds-of-megabyte
+    # result for that entire time. The semaphore bounds threads, not bytes; four
+    # such workers are four copies of the largest output the process has seen.
+    payload, clipped = _clip(text)
+
     if not _spill_slots.acquire(blocking=False):
         logger.warning(
             "[overflow] spill workers saturated; truncating without a pointer"
@@ -617,7 +632,7 @@ def spill_overflow_bounded(
 
     def _worker() -> None:
         try:
-            result[0] = spill_overflow(text, deps=deps, kind=kind)
+            result[0] = _spill_payload(payload, clipped, deps=deps, kind=kind)
         finally:
             _spill_slots.release()
 
@@ -657,10 +672,24 @@ async def spill_overflow_async(
     background; it lands in the spill directory and is collected by the sweep
     like any other file.
     """
-    # Through the same bounded worker as the sync path, not to_thread: an
+    # Through the same bounded worker as the sync path, not a bare to_thread: an
     # abandoned write on the default executor occupies one of its threads
     # forever, and that executor is shared with everything else that offloads.
-    return await asyncio.to_thread(spill_overflow_bounded, text, deps=deps, kind=kind)
+    #
+    # Still wrapped in a deadline, because that shared executor can be saturated
+    # by unrelated work — the coroutine would then sit queued, never reaching
+    # the join that was supposed to bound it. Routing through the bounded pool
+    # is what made this necessary and is exactly when I removed it.
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(spill_overflow_bounded, text, deps=deps, kind=kind),
+            timeout=SPILL_TIMEOUT_SECONDS * 2,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "[overflow] spill did not start in time — truncating without a pointer"
+        )
+        return None
 
 
 def _sweep_by_path(root: Path) -> None:

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -193,12 +193,26 @@ def retention_hint() -> str:
     return f"kept up to {longest // 3600}h"
 
 
-def _in_grace(mtime: float, now: float) -> bool:
-    """True while a spill is too young to evict.
+def _implausibly_dated(mtime: float, now: float) -> bool:
+    """True for a timestamp far enough ahead of the clock to be untrustworthy.
 
-    Two-sided on purpose: see OVERFLOW_CLOCK_SKEW_SECONDS.
+    A backward clock step leaves every already-published spill stamped in the
+    future. Read literally, such a stamp is both forever young and forever
+    short of the TTL cutoff, so the file outlives the retention the marker
+    advertises by however long the rollback was. Treating it as undatable and
+    expiring it keeps the promise; the alternative — believing it — cannot.
     """
-    return now - OVERFLOW_GRACE_SECONDS <= mtime <= now + OVERFLOW_CLOCK_SKEW_SECONDS
+    return mtime > now + OVERFLOW_CLOCK_SKEW_SECONDS
+
+
+def _in_grace(mtime: float, now: float) -> bool:
+    """True while a spill is too young to evict."""
+    return not _implausibly_dated(mtime, now) and mtime >= now - OVERFLOW_GRACE_SECONDS
+
+
+def _past_ttl(mtime: float, now: float) -> bool:
+    """True once a spill has outlived its retention, or lost its datability."""
+    return mtime < now - OVERFLOW_TTL_SECONDS or _implausibly_dated(mtime, now)
 
 
 def _shared_root() -> Path:
@@ -399,18 +413,17 @@ def _prune_path(directory: Path, protect: Optional[str] = None) -> None:
     # will ever collect it.
     for stale in directory.glob(f"*{PARTIAL_SUFFIX}"):
         try:
-            if stale.stat().st_mtime < time.time() - OVERFLOW_TTL_SECONDS:
+            if _past_ttl(stale.stat().st_mtime, time.time()):
                 stale.unlink(missing_ok=True)
         except OSError:
             continue
 
-    cutoff = time.time() - OVERFLOW_TTL_SECONDS
     now = time.time()
     running = 0
     for index, (mtime, size, path) in enumerate(entries):
         over = (
             index >= OVERFLOW_MAX_FILES
-            or mtime < cutoff
+            or _past_ttl(mtime, now)
             or running + size > OVERFLOW_MAX_TOTAL_BYTES
         )
         protected = path.name == protect or _in_grace(mtime, now)
@@ -551,9 +564,7 @@ def _prune_fd(dir_fd: int, protect: Optional[str] = None) -> None:
             if not entry.name.endswith(PARTIAL_SUFFIX):
                 continue
             try:
-                if entry.stat(follow_symlinks=False).st_mtime < (
-                    time.time() - OVERFLOW_TTL_SECONDS
-                ):
+                if _past_ttl(entry.stat(follow_symlinks=False).st_mtime, time.time()):
                     os.unlink(entry.name, dir_fd=dir_fd)
             except OSError:
                 continue
@@ -561,13 +572,12 @@ def _prune_fd(dir_fd: int, protect: Optional[str] = None) -> None:
         pass
 
     entries.sort(reverse=True)
-    cutoff = time.time() - OVERFLOW_TTL_SECONDS
     now = time.time()
     running = 0
     for index, (mtime, size, name) in enumerate(entries):
         over = (
             index >= OVERFLOW_MAX_FILES
-            or mtime < cutoff
+            or _past_ttl(mtime, now)
             or running + size > OVERFLOW_MAX_TOTAL_BYTES
         )
         # Undeletable is not the same as uncounted. Skipping fresh files

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import asyncio
 import errno
 import hashlib
+import math
 import os
 import re
 import secrets
@@ -213,6 +214,20 @@ def _in_grace(mtime: float, now: float) -> bool:
 def _past_ttl(mtime: float, now: float) -> bool:
     """True once a spill has outlived its retention, or lost its datability."""
     return mtime < now - OVERFLOW_TTL_SECONDS or _implausibly_dated(mtime, now)
+
+
+def _age_key(mtime: float, now: float) -> float:
+    """The timestamp to sort a spill by, with undatable ones sorted oldest.
+
+    The root scan orders newest-first and evicts from the tail, on the theory
+    that the newest file is the one a live conversation is most likely to be
+    holding a pointer to. A future-dated stamp defeats that theory exactly: a
+    file left over from before a clock step sorts ahead of everything real, so
+    it keeps its budget while genuinely current spills are evicted and their
+    advertised pointers break. Sorting it as oldest puts it first in line
+    instead, which is where a timestamp nobody can believe belongs.
+    """
+    return -math.inf if _implausibly_dated(mtime, now) else mtime
 
 
 def _abandoned(mtime: float, now: float) -> bool:
@@ -486,7 +501,12 @@ def _enforce_root_quota_fd(
                     except OSError:
                         continue
                     survivors.append(
-                        (stat.st_mtime, stat.st_size, entry.name, kept.name)
+                        (
+                            _age_key(stat.st_mtime, time.time()),
+                            stat.st_size,
+                            entry.name,
+                            kept.name,
+                        )
                     )
             finally:
                 os.close(chat_fd)
@@ -535,7 +555,9 @@ def _enforce_root_quota_path(
                     stat = path.stat()
                 except OSError:
                     continue
-                survivors.append((stat.st_mtime, stat.st_size, path))
+                survivors.append(
+                    (_age_key(stat.st_mtime, time.time()), stat.st_size, path)
+                )
     except OSError:
         return 0
 

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -290,6 +290,13 @@ def _spill_pinned(payload: bytes, shared_host: Path, chat: str, name: str) -> bo
     try:
         shared_host.mkdir(parents=True, exist_ok=True)
         root_fd = os.open(shared_host, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        # The mount root as well. Forcing the mode on .overflow, the chat
+        # directory and the file, but not on the directory they all sit inside,
+        # leaves a 0700 root under umask 0077 — every descendant correct and
+        # none of them reachable. /shared is the sandbox's own mount and has to
+        # be traversable by it regardless; a 0700 root breaks memory too, not
+        # only spills.
+        _force_mode(root_fd, _DIR_MODE)
         overflow_fd = _open_child_dir(".overflow", root_fd)
         chat_fd = _open_child_dir(chat, overflow_fd)
 

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -3,19 +3,31 @@
 A cap keeps a single tool result from swallowing the context window, but the
 tail it removes is usually the part someone wanted: the failing assertion at the
 end of a test run, the last hundred lines of a build log. Truncating to a marker
-tells the model that content is missing without giving it any way to go and
-read it.
+tells the model that content is missing without giving it any way to read it.
 
-So the full text is written to a file and the marker carries the path. The model
-decides whether the rest is worth a read; nothing is silently lost either way.
+So the full text is written to a file and the marker carries the path.
+
+Two properties are load-bearing and easy to lose:
+
+* **The write must not become a capability.** The agent can write inside
+  ``/shared`` — including replacing the directories on this path — so every step
+  is taken relative to a pinned directory descriptor and refuses to follow a
+  symlink. Resolving a path and then using it is a race the agent can win.
+* **A spill is private to its chat.** It holds raw tool output and reminder
+  text, which is conversation content. ``/shared`` is mounted into every
+  session, so an unscoped directory is readable by every other chat on the
+  deployment; random filenames are no help against a directory listing.
 """
 
 from __future__ import annotations
 
+import asyncio
 import errno
 import os
+import re
 import secrets
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
@@ -23,80 +35,217 @@ from suzent.logger import get_logger
 
 logger = get_logger(__name__)
 
-#: Virtual home for spilled output. Under /shared rather than the project
-#: workspace so it is not mistaken for the user's files, and so a spill from one
-#: chat is readable by a sub-agent working on the same task.
+#: Virtual home for spilled output, under /shared so a spill survives the
+#: container and so the sweep can find every chat's files in one place.
 OVERFLOW_VIRTUAL_DIR = "/shared/.overflow"
 
-#: How long a spill file is worth keeping. Long enough that the model can read
-#: it later in the same session, short enough that a week of build logs does not
-#: accumulate on disk.
+#: How long a spill is worth keeping. Long enough to read it later in the same
+#: session, short enough that a week of build logs does not accumulate.
 OVERFLOW_TTL_SECONDS = 24 * 60 * 60
 
-#: Ceiling on files kept, whatever their age. A single runaway session can write
-#: thousands; the TTL alone would not bound that until tomorrow.
+#: Per-chat ceilings. A single runaway session can write thousands of files, and
+#: 200 files of any size is not a bound on disk, so both apply.
 OVERFLOW_MAX_FILES = 200
-
-#: Ceiling on one spill. A foreground shell command reads its whole output into
-#: memory and this writes all of it, so without a per-file bound a single
-#: `cat` of something large lands on disk in full.
-OVERFLOW_MAX_FILE_BYTES = 5 * 1024 * 1024
-
-#: Ceiling on the directory. The count bound alone permits 200 files of any
-#: size, which is not a bound on disk at all.
 OVERFLOW_MAX_TOTAL_BYTES = 50 * 1024 * 1024
 
-#: Appended when the spill itself had to be cut. Rare, and better said than not:
-#: a file that silently holds part of the output is worse than the truncation it
-#: was meant to relieve.
+#: Ceiling on one spill. A foreground shell command reads its whole output into
+#: memory and this writes all of it.
+OVERFLOW_MAX_FILE_BYTES = 5 * 1024 * 1024
+
+#: Written into a spill that had to be cut. The marker says so as well; this is
+#: for whoever opens the file directly.
 SPILL_CLIPPED_NOTE = "\n\n[spill clipped: output exceeded the per-file limit]"
 
+_SAFE_SEGMENT = re.compile(r"[^A-Za-z0-9_-]")
 
-def _prune(directory: Path) -> None:
-    """Best-effort cleanup. A spill that cannot be pruned is still a spill.
+#: dir_fd is POSIX-only. Where it is missing there is also no bind-mounted
+#: sandbox writing into this directory, so plain path operations are used.
+_HAVE_DIR_FD = os.open in os.supports_dir_fd and os.unlink in os.supports_dir_fd
 
-    Bounded three ways, because each alone leaves a hole: age lets a burst sit
-    until tomorrow, count permits 200 files of any size, and bytes alone would
-    keep one ancient file forever.
-    """
-    try:
-        files = sorted(
-            (p for p in directory.glob("*.txt") if p.is_file()),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        )
-    except OSError:
-        return
 
-    cutoff = time.time() - OVERFLOW_TTL_SECONDS
-    running_total = 0
-    for index, path in enumerate(files):
-        try:
-            size = path.stat().st_size
-            too_many = index >= OVERFLOW_MAX_FILES
-            too_old = path.stat().st_mtime < cutoff
-            too_big = running_total + size > OVERFLOW_MAX_TOTAL_BYTES
-            if too_many or too_old or too_big:
-                path.unlink(missing_ok=True)
-                continue
-            running_total += size
-        except OSError:
-            continue
+@dataclass(frozen=True)
+class Spill:
+    """Where the overflow went, and whether all of it got there."""
+
+    path: str
+    clipped: bool
 
 
 def retention_hint() -> str:
     """How long a spill lasts, for the marker that points at one.
 
     The marker outlives the file: the path goes into conversation history, the
-    file expires. A resumed or compacted session can therefore read a pointer to
-    something already collected. Saying the window up front turns a puzzling
-    missing file into an expected one, and costs a few characters on results
-    that were over budget anyway.
-
-    Derived from the TTL rather than written out, so the two cannot drift.
+    file expires. Saying the window turns a puzzling missing file into an
+    expected one. Derived from the TTL so the two cannot drift.
     """
-    hours = OVERFLOW_TTL_SECONDS // 3600
-    return f"kept {hours}h"
+    return f"kept {OVERFLOW_TTL_SECONDS // 3600}h"
+
+
+def _chat_segment(deps: Any) -> str:
+    """A directory name for this chat, safe to place in a path."""
+    raw = str(getattr(deps, "chat_id", "") or "shared")
+    return _SAFE_SEGMENT.sub("-", raw)[:64] or "shared"
+
+
+def _open_child_dir(name: str, *, parent_fd: Optional[int], base: Path) -> int:
+    """Open (creating if needed) a subdirectory, refusing to follow a symlink.
+
+    Taken relative to *parent_fd* so a directory swapped for a symlink after the
+    parent was opened cannot redirect the write. Without dir_fd support the same
+    steps run against a path.
+    """
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    if parent_fd is None:
+        target = base / name
+        target.mkdir(mode=0o700, parents=True, exist_ok=True)
+        return os.open(target, flags)
+
+    try:
+        os.mkdir(name, 0o700, dir_fd=parent_fd)
+    except FileExistsError:
+        pass
+    return os.open(name, flags, dir_fd=parent_fd)
+
+
+def _clip(text: str) -> tuple[bytes, bool]:
+    """Encode *text*, cut to the per-file ceiling on a character boundary.
+
+    Slicing the encoded bytes can land inside a multi-byte code point, and the
+    resulting file is not valid UTF-8 — so the reader that was supposed to
+    rescue the output fails to open it.
+    """
+    payload = text.encode("utf-8", "replace")
+    if len(payload) <= OVERFLOW_MAX_FILE_BYTES:
+        return payload, False
+
+    note = SPILL_CLIPPED_NOTE.encode("utf-8")
+    keep = OVERFLOW_MAX_FILE_BYTES - len(note)
+    head = payload[:keep].decode("utf-8", "ignore").encode("utf-8")
+    return head + note, True
+
+
+def _prune_fd(dir_fd: int) -> None:
+    """Apply the retention bounds inside one pinned directory."""
+    try:
+        entries = []
+        for entry in os.scandir(dir_fd):
+            if not entry.name.endswith(".txt"):
+                continue
+            try:
+                stat = entry.stat(follow_symlinks=False)
+            except OSError:
+                continue
+            entries.append((stat.st_mtime, stat.st_size, entry.name))
+    except OSError:
+        return
+
+    entries.sort(reverse=True)
+    cutoff = time.time() - OVERFLOW_TTL_SECONDS
+    running = 0
+    for index, (mtime, size, name) in enumerate(entries):
+        drop = (
+            index >= OVERFLOW_MAX_FILES
+            or mtime < cutoff
+            or running + size > OVERFLOW_MAX_TOTAL_BYTES
+        )
+        try:
+            if drop:
+                os.unlink(name, dir_fd=dir_fd)
+            else:
+                running += size
+        except OSError:
+            continue
+
+
+def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[Spill]:
+    """Write *text* somewhere this chat can read it; return where it went.
+
+    Returns None when there is nowhere to write, which is not an error: the
+    caller still truncates, it just cannot offer the rest. Losing the tail is
+    better than failing the tool call that produced it.
+
+    The path handed back is in the vocabulary of the agent's own filesystem —
+    host paths in host mode, virtual in sandbox — because a path it cannot open
+    invites a read that fails.
+    """
+    resolver = getattr(deps, "path_resolver", None)
+    if resolver is None:
+        return None
+
+    try:
+        shared_host = Path(resolver.resolve("/shared"))
+    except Exception as e:
+        logger.debug(f"[overflow] no shared root: {e}")
+        return None
+
+    chat = _chat_segment(deps)
+    root_fd = None
+    overflow_fd = None
+    chat_fd = None
+    try:
+        if _HAVE_DIR_FD:
+            shared_host.mkdir(parents=True, exist_ok=True)
+            root_fd = os.open(shared_host, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+            overflow_fd = _open_child_dir(
+                ".overflow", parent_fd=root_fd, base=shared_host
+            )
+            chat_fd = _open_child_dir(chat, parent_fd=overflow_fd, base=shared_host)
+        else:
+            chat_fd = _open_child_dir(
+                chat, parent_fd=None, base=shared_host / ".overflow"
+            )
+
+        payload, clipped = _clip(text)
+        name = f"{kind}-{secrets.token_hex(16)}.txt"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+
+        try:
+            fd = os.open(name, flags, 0o600, dir_fd=chat_fd)
+        except OSError as e:
+            if e.errno in (errno.EEXIST, errno.ELOOP):
+                logger.warning(f"[overflow] refusing to write over {name}: {e}")
+            else:
+                logger.debug(f"[overflow] could not create spill: {e}")
+            return None
+
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(payload)
+        except OSError as e:
+            logger.debug(f"[overflow] could not write spill: {e}")
+            try:
+                os.unlink(name, dir_fd=chat_fd)
+            except OSError:
+                pass
+            return None
+
+        _prune_fd(chat_fd)
+    except OSError as e:
+        logger.debug(f"[overflow] no spill directory: {e}")
+        return None
+    finally:
+        for handle_fd in (chat_fd, overflow_fd, root_fd):
+            if handle_fd is not None:
+                try:
+                    os.close(handle_fd)
+                except OSError:
+                    pass
+
+    if getattr(deps, "sandbox_enabled", True):
+        return Spill(f"{OVERFLOW_VIRTUAL_DIR}/{chat}/{name}", clipped)
+    return Spill(str(shared_host / ".overflow" / chat / name), clipped)
+
+
+async def spill_overflow_async(
+    text: str, *, deps: Any, kind: str = "output"
+) -> Optional[Spill]:
+    """Spill without holding the event loop.
+
+    Up to 5 MiB of write plus a directory scan; on a slow volume, or with
+    several overflows at once, doing that inline stalls every other chat the
+    loop is serving.
+    """
+    return await asyncio.to_thread(spill_overflow, text, deps=deps, kind=kind)
 
 
 def sweep_overflow() -> None:
@@ -105,86 +254,34 @@ def sweep_overflow() -> None:
     Pruning otherwise happens only on write, so the bounds hold exactly while
     output keeps overflowing and stop the moment it does not: the last spill of
     a session sits there until the next one, which may be never. Nothing else
-    will collect it — this lives in the user's data directory, not in a temp
+    collects these — they live in the user's data directory, not a temp
     directory the OS sweeps.
 
-    Called at startup, which is also when yesterday's files are most likely to
-    be both stale and forgotten.
+    Per-chat bounds mean the directory total scales with the number of chats,
+    which is why this also drops chat directories once they are empty.
     """
     from suzent.config import CONFIG
 
-    directory = Path(CONFIG.sandbox_data_path) / "shared" / ".overflow"
-    if not directory.is_dir():
+    root = Path(CONFIG.sandbox_data_path) / "shared" / ".overflow"
+    if not root.is_dir():
         return
-    before = len(list(directory.glob("*.txt")))
-    _prune(directory)
-    after = len(list(directory.glob("*.txt")))
-    if before != after:
-        logger.info(f"[overflow] swept {before - after} stale spill(s)")
 
-
-def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[str]:
-    """Write *text* somewhere the agent can read it; return that path.
-
-    Returns None when there is nowhere to write, which is not an error: the
-    caller still truncates, it just cannot offer the rest. Losing the tail is
-    better than failing the tool call that produced it.
-
-    The path handed back is in the vocabulary of the agent's own filesystem —
-    host paths in host mode, virtual in sandbox — because a path it cannot open
-    is worse than no path at all: it invites a read that fails.
-    """
-    resolver = getattr(deps, "path_resolver", None)
-    if resolver is None:
-        return None
-
-    try:
-        host_dir = Path(resolver.resolve(OVERFLOW_VIRTUAL_DIR))
-        host_dir.mkdir(parents=True, exist_ok=True)
-    except Exception as e:
-        logger.debug(f"[overflow] no spill directory: {e}")
-        return None
-
-    payload = text.encode("utf-8", "replace")
-    if len(payload) > OVERFLOW_MAX_FILE_BYTES:
-        keep = OVERFLOW_MAX_FILE_BYTES - len(SPILL_CLIPPED_NOTE)
-        payload = payload[:keep] + SPILL_CLIPPED_NOTE.encode("utf-8")
-
-    # Unpredictable, and created without following anything already at the path.
-    #
-    # The name used to be derived from the output's own hash and the current
-    # second, which a sandboxed agent can compute: pre-place a symlink there,
-    # emit output that overflows, and the host process follows the link and
-    # overwrites whatever it points at — no PathResolver check involved, since
-    # the write is ours, not the agent's. O_EXCL refuses an existing path
-    # (symlink included) and O_NOFOLLOW refuses to traverse one; the random name
-    # means there is nothing to aim at in the first place.
-    name = f"{kind}-{secrets.token_hex(16)}.txt"
-    host_path = host_dir / name
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
-
-    try:
-        fd = os.open(host_path, flags, 0o600)
-    except OSError as e:
-        if e.errno in (errno.EEXIST, errno.ELOOP):
-            logger.warning(f"[overflow] refusing to write over an existing path: {e}")
-        else:
-            logger.debug(f"[overflow] could not create spill: {e}")
-        return None
-
-    try:
-        with os.fdopen(fd, "wb") as handle:
-            handle.write(payload)
-    except OSError as e:
-        logger.debug(f"[overflow] could not write spill: {e}")
+    swept = 0
+    for chat_dir in root.iterdir():
+        if not chat_dir.is_dir():
+            continue
         try:
-            host_path.unlink(missing_ok=True)
+            before = len(list(chat_dir.glob("*.txt")))
+            fd = os.open(chat_dir, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+            try:
+                _prune_fd(fd)
+            finally:
+                os.close(fd)
+            swept += before - len(list(chat_dir.glob("*.txt")))
+            if not any(chat_dir.iterdir()):
+                chat_dir.rmdir()
         except OSError:
-            pass
-        return None
+            continue
 
-    _prune(host_dir)
-
-    if getattr(deps, "sandbox_enabled", True):
-        return f"{OVERFLOW_VIRTUAL_DIR}/{name}"
-    return str(host_path)
+    if swept:
+        logger.info(f"[overflow] swept {swept} stale spill(s)")

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -84,6 +84,21 @@ def _prune(directory: Path) -> None:
             continue
 
 
+def retention_hint() -> str:
+    """How long a spill lasts, for the marker that points at one.
+
+    The marker outlives the file: the path goes into conversation history, the
+    file expires. A resumed or compacted session can therefore read a pointer to
+    something already collected. Saying the window up front turns a puzzling
+    missing file into an expected one, and costs a few characters on results
+    that were over budget anyway.
+
+    Derived from the TTL rather than written out, so the two cannot drift.
+    """
+    hours = OVERFLOW_TTL_SECONDS // 3600
+    return f"kept {hours}h"
+
+
 def sweep_overflow() -> None:
     """Apply the retention bounds without needing a spill to trigger them.
 

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -76,7 +76,13 @@ SPILL_CLIPPED_NOTE = "\n\n[spill clipped: output exceeded the per-file limit]"
 
 _SAFE_SEGMENT = re.compile(r"[^A-Za-z0-9_-]")
 
-#: Readable beyond the creating user, deliberately.
+#: Readable beyond the creating user, deliberately, and applied after creation.
+#:
+#: Creation modes are masked by the process umask, so a service started with
+#: umask 0077 turns these into 0700/0600 — exactly the permissions that make the
+#: marker point at a file the sandbox cannot open. The modes below are therefore
+#: set with fchmod on the descriptor already opened, which umask does not touch
+#: and which cannot be redirected by a path swapped underneath.
 #:
 #: Bind mounts preserve numeric ownership, and the sandbox image runs as a fixed
 #: uid 1000 that need not match the host service's. Files written 0600 by the
@@ -123,6 +129,19 @@ def _chat_segment(deps: Any) -> str:
     return _SAFE_SEGMENT.sub("-", raw)[:64] or "shared"
 
 
+def _force_mode(fd: int, mode: int) -> None:
+    """Set the mode the creation flags only requested.
+
+    umask subtracts from a creation mode and never from fchmod, so this is the
+    difference between the intended permissions and whatever the service happens
+    to have been started with.
+    """
+    try:
+        os.fchmod(fd, mode)
+    except OSError as e:
+        logger.debug(f"[overflow] could not set mode {oct(mode)}: {e}")
+
+
 def _open_child_dir(name: str, parent_fd: int) -> int:
     """Open (creating if needed) a subdirectory, refusing to follow a symlink.
 
@@ -134,7 +153,9 @@ def _open_child_dir(name: str, parent_fd: int) -> int:
         os.mkdir(name, _DIR_MODE, dir_fd=parent_fd)
     except FileExistsError:
         pass
-    return os.open(name, flags, dir_fd=parent_fd)
+    fd = os.open(name, flags, dir_fd=parent_fd)
+    _force_mode(fd, _DIR_MODE)
+    return fd
 
 
 def _spill_by_path(payload: bytes, directory: Path, name: str) -> bool:
@@ -149,8 +170,13 @@ def _spill_by_path(payload: bytes, directory: Path, name: str) -> bool:
     """
     try:
         directory.mkdir(mode=_DIR_MODE, parents=True, exist_ok=True)
+        try:
+            directory.chmod(_DIR_MODE)
+        except OSError:
+            pass
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
         fd = os.open(directory / name, flags, _FILE_MODE)
+        _force_mode(fd, _FILE_MODE)
         with os.fdopen(fd, "wb") as handle:
             handle.write(payload)
     except (OSError, NotImplementedError, ValueError) as e:
@@ -278,6 +304,7 @@ def _spill_pinned(payload: bytes, shared_host: Path, chat: str, name: str) -> bo
             return False
 
         try:
+            _force_mode(fd, _FILE_MODE)
             with os.fdopen(fd, "wb") as handle:
                 handle.write(payload)
         except OSError as e:

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -76,22 +76,28 @@ SPILL_CLIPPED_NOTE = "\n\n[spill clipped: output exceeded the per-file limit]"
 
 _SAFE_SEGMENT = re.compile(r"[^A-Za-z0-9_-]")
 
-#: Readable beyond the creating user, deliberately, and applied after creation.
+#: Permissions, which differ by execution mode because the reader does.
 #:
-#: Creation modes are masked by the process umask, so a service started with
-#: umask 0077 turns these into 0700/0600 — exactly the permissions that make the
-#: marker point at a file the sandbox cannot open. The modes below are therefore
-#: set with fchmod on the descriptor already opened, which umask does not touch
-#: and which cannot be redirected by a path swapped underneath.
+#: In host mode the agent *is* this process: same uid, so the tightest bits work
+#: and the spill stays private to the account that owns the data. That is the
+#: default configuration and the one that should not be weakened.
 #:
-#: Bind mounts preserve numeric ownership, and the sandbox image runs as a fixed
-#: uid 1000 that need not match the host service's. Files written 0600 by the
-#: service would then be unreadable by the very agent the marker points at — a
-#: path that exists and cannot be opened, which is the failure the whole spill
-#: is meant to avoid. Given that one chat can read another's spills anyway on a
-#: shared mount, the tighter mode bought nothing it did not also break.
-_DIR_MODE = 0o755
-_FILE_MODE = 0o644
+#: In sandbox mode the reader is a container running as a fixed uid 1000 that
+#: need not match the service's, and bind mounts preserve numeric ownership — so
+#: the file has to be world-readable or the marker points at something the agent
+#: cannot open. That is a real cost: on a multi-user host any local account can
+#: then read raw tool output. It buys the feature in sandbox mode and nothing
+#: else, and the way out is ownership or a dedicated mount, not more permission
+#: bits — three rounds of tightening and loosening these constants is what
+#: showed that the bits are the wrong instrument.
+#:
+#: Applied with fchmod rather than as creation flags: umask subtracts from a
+#: creation mode and never from fchmod, and the descriptor is already pinned so
+#: nothing can be swapped underneath it.
+_PRIVATE_DIR_MODE = 0o700
+_PRIVATE_FILE_MODE = 0o600
+_SHARED_DIR_MODE = 0o755
+_SHARED_FILE_MODE = 0o644
 
 #: dir_fd is POSIX-only. Where it is missing there is also no bind-mounted
 #: sandbox writing into this directory, so plain path operations are used.
@@ -142,7 +148,7 @@ def _force_mode(fd: int, mode: int) -> None:
         logger.debug(f"[overflow] could not set mode {oct(mode)}: {e}")
 
 
-def _open_child_dir(name: str, parent_fd: int) -> int:
+def _open_child_dir(name: str, parent_fd: int, dir_mode: int) -> int:
     """Open (creating if needed) a subdirectory, refusing to follow a symlink.
 
     Taken relative to *parent_fd* so a directory swapped for a symlink after the
@@ -150,15 +156,17 @@ def _open_child_dir(name: str, parent_fd: int) -> int:
     """
     flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
     try:
-        os.mkdir(name, _DIR_MODE, dir_fd=parent_fd)
+        os.mkdir(name, dir_mode, dir_fd=parent_fd)
     except FileExistsError:
         pass
     fd = os.open(name, flags, dir_fd=parent_fd)
-    _force_mode(fd, _DIR_MODE)
+    _force_mode(fd, dir_mode)
     return fd
 
 
-def _spill_by_path(payload: bytes, directory: Path, name: str) -> bool:
+def _spill_by_path(
+    payload: bytes, directory: Path, name: str, dir_mode: int, file_mode: int
+) -> bool:
     """Write the spill without directory descriptors.
 
     For platforms where ``dir_fd`` is unsupported — Windows — which are also the
@@ -169,14 +177,14 @@ def _spill_by_path(payload: bytes, directory: Path, name: str) -> bool:
     oversized tool result into a failed tool call.
     """
     try:
-        directory.mkdir(mode=_DIR_MODE, parents=True, exist_ok=True)
+        directory.mkdir(mode=dir_mode, parents=True, exist_ok=True)
         try:
-            directory.chmod(_DIR_MODE)
+            directory.chmod(dir_mode)
         except OSError:
             pass
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
-        fd = os.open(directory / name, flags, _FILE_MODE)
-        _force_mode(fd, _FILE_MODE)
+        fd = os.open(directory / name, flags, file_mode)
+        _force_mode(fd, file_mode)
         with os.fdopen(fd, "wb") as handle:
             handle.write(payload)
     except (OSError, NotImplementedError, ValueError) as e:
@@ -278,7 +286,14 @@ def _prune_fd(dir_fd: int) -> None:
             continue
 
 
-def _spill_pinned(payload: bytes, shared_host: Path, chat: str, name: str) -> bool:
+def _spill_pinned(
+    payload: bytes,
+    shared_host: Path,
+    chat: str,
+    name: str,
+    dir_mode: int,
+    file_mode: int,
+) -> bool:
     """Write the spill with every directory on the path pinned.
 
     Resolving a path and then using it is a race the agent can win: it may
@@ -296,13 +311,13 @@ def _spill_pinned(payload: bytes, shared_host: Path, chat: str, name: str) -> bo
         # none of them reachable. /shared is the sandbox's own mount and has to
         # be traversable by it regardless; a 0700 root breaks memory too, not
         # only spills.
-        _force_mode(root_fd, _DIR_MODE)
-        overflow_fd = _open_child_dir(".overflow", root_fd)
-        chat_fd = _open_child_dir(chat, overflow_fd)
+        _force_mode(root_fd, dir_mode)
+        overflow_fd = _open_child_dir(".overflow", root_fd, dir_mode)
+        chat_fd = _open_child_dir(chat, overflow_fd, dir_mode)
 
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
         try:
-            fd = os.open(name, flags, _FILE_MODE, dir_fd=chat_fd)
+            fd = os.open(name, flags, file_mode, dir_fd=chat_fd)
         except OSError as e:
             if e.errno in (errno.EEXIST, errno.ELOOP):
                 logger.warning(f"[overflow] refusing to write over {name}: {e}")
@@ -311,7 +326,7 @@ def _spill_pinned(payload: bytes, shared_host: Path, chat: str, name: str) -> bo
             return False
 
         try:
-            _force_mode(fd, _FILE_MODE)
+            _force_mode(fd, file_mode)
             with os.fdopen(fd, "wb") as handle:
                 handle.write(payload)
         except OSError as e:
@@ -361,10 +376,16 @@ def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[Sp
     payload, clipped = _clip(text)
     name = f"{kind}-{secrets.token_hex(16)}.txt"
 
+    sandboxed = bool(getattr(deps, "sandbox_enabled", True))
+    dir_mode = _SHARED_DIR_MODE if sandboxed else _PRIVATE_DIR_MODE
+    file_mode = _SHARED_FILE_MODE if sandboxed else _PRIVATE_FILE_MODE
+
     if not _HAVE_DIR_FD:
-        if not _spill_by_path(payload, shared_host / ".overflow" / chat, name):
+        if not _spill_by_path(
+            payload, shared_host / ".overflow" / chat, name, dir_mode, file_mode
+        ):
             return None
-    elif not _spill_pinned(payload, shared_host, chat, name):
+    elif not _spill_pinned(payload, shared_host, chat, name, dir_mode, file_mode):
         return None
 
     if getattr(deps, "sandbox_enabled", True):

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import asyncio
 import errno
+import hashlib
 import os
 import re
 import secrets
@@ -188,9 +189,16 @@ def _chat_segment(deps: Any) -> str:
     cannot contradict each other.
     """
     raw = str(getattr(deps, "chat_id", "") or "shared")
-    safe = _SAFE_SEGMENT.sub("-", raw)[:64] or "shared"
+    safe = _SAFE_SEGMENT.sub("-", raw) or "shared"
     prefix = "sandbox" if getattr(deps, "sandbox_enabled", True) else "host"
-    return f"{prefix}-{safe}"
+    if len(safe) <= 48:
+        return f"{prefix}-{safe}"
+    # A plain truncation merges two chats whose ids share a prefix — and A2A
+    # context ids are built by prefixing an accepted 64-character value, so they
+    # differ exactly where a 64-character cut discards. Merged chats then share
+    # one quota and evict each other's advertised spills.
+    digest = hashlib.sha1(raw.encode("utf-8", "replace")).hexdigest()[:12]
+    return f"{prefix}-{safe[:48]}-{digest}"
 
 
 def _force_mode(fd: int, mode: int) -> None:
@@ -329,7 +337,7 @@ def _clip(text: str) -> tuple[bytes, bool]:
     return _encode_bounded(head, dropped)
 
 
-def _prune_path(directory: Path) -> None:
+def _prune_path(directory: Path, protect: Optional[str] = None) -> None:
     """The path-based twin of _prune_fd, for platforms without dir_fd."""
     try:
         entries = []
@@ -342,6 +350,7 @@ def _prune_path(directory: Path) -> None:
     except OSError:
         return
 
+    entries = [e for e in entries if e[2].name != protect]
     entries.sort(reverse=True)
     cutoff = time.time() - OVERFLOW_TTL_SECONDS
     running = 0
@@ -360,7 +369,9 @@ def _prune_path(directory: Path) -> None:
             continue
 
 
-def _enforce_root_quota_fd(root_fd: int) -> int:
+def _enforce_root_quota_fd(
+    root_fd: int, protect: Optional[tuple[str, str]] = None
+) -> int:
     """Hold the deployment-wide ceiling across every chat directory.
 
     Separate from the per-chat prune because the two answer different
@@ -385,6 +396,8 @@ def _enforce_root_quota_fd(root_fd: int) -> int:
                     try:
                         stat = kept.stat(follow_symlinks=False)
                     except OSError:
+                        continue
+                    if protect == (entry.name, kept.name):
                         continue
                     survivors.append(
                         (stat.st_mtime, stat.st_size, entry.name, kept.name)
@@ -417,7 +430,9 @@ def _enforce_root_quota_fd(root_fd: int) -> int:
     return removed
 
 
-def _enforce_root_quota_path(root: Path) -> int:
+def _enforce_root_quota_path(
+    root: Path, protect: Optional[tuple[str, str]] = None
+) -> int:
     """The path-based twin of _enforce_root_quota_fd."""
     survivors: list[tuple[float, int, Path]] = []
     try:
@@ -428,6 +443,8 @@ def _enforce_root_quota_path(root: Path) -> int:
                 try:
                     stat = path.stat()
                 except OSError:
+                    continue
+                if protect == (chat_dir.name, path.name):
                     continue
                 survivors.append((stat.st_mtime, stat.st_size, path))
     except OSError:
@@ -448,7 +465,7 @@ def _enforce_root_quota_path(root: Path) -> int:
     return removed
 
 
-def _prune_fd(dir_fd: int) -> None:
+def _prune_fd(dir_fd: int, protect: Optional[str] = None) -> None:
     """Apply the retention bounds inside one pinned directory."""
     try:
         entries = []
@@ -458,6 +475,8 @@ def _prune_fd(dir_fd: int) -> None:
             try:
                 stat = entry.stat(follow_symlinks=False)
             except OSError:
+                continue
+            if entry.name == protect:
                 continue
             entries.append((stat.st_mtime, stat.st_size, entry.name))
     except OSError:
@@ -551,7 +570,7 @@ def _spill_pinned(
                     pass
 
 
-def _prune_now(deps: Any) -> None:
+def _prune_now(deps: Any, protect: Optional[str] = None) -> None:
     """Apply the quotas after a write.
 
     Unconditional again, and that is the point of dropping the handshake: with
@@ -573,15 +592,15 @@ def _prune_now(deps: Any) -> None:
             try:
                 chat_fd = os.open(chat, flags, dir_fd=root_fd)
                 try:
-                    _prune_fd(chat_fd)
+                    _prune_fd(chat_fd, protect)
                 finally:
                     os.close(chat_fd)
-                _enforce_root_quota_fd(root_fd)
+                _enforce_root_quota_fd(root_fd, (chat, protect) if protect else None)
             finally:
                 os.close(root_fd)
         else:
-            _prune_path(root / chat)
-            _enforce_root_quota_path(root)
+            _prune_path(root / chat, protect)
+            _enforce_root_quota_path(root, (chat, protect) if protect else None)
     except OSError as e:
         logger.debug(f"[overflow] could not prune after a spill: {e}")
 
@@ -700,7 +719,11 @@ def _spill_payload(
     elif not _spill_pinned(payload, shared_host, chat, name, dir_mode, file_mode):
         return None
 
-    _prune_now(deps)
+    # The file just written is exempt: on a filesystem with coarse mtime, or
+    # after the clock steps back, it need not sort ahead of the others, and a
+    # directory already at quota would delete the very path about to be
+    # advertised.
+    _prune_now(deps, protect=name)
 
     written = shared_host / ".overflow" / chat / name
     if virtual is not None:

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -131,9 +131,19 @@ def retention_hint() -> str:
 
 
 def _chat_segment(deps: Any) -> str:
-    """A directory name for this chat, safe to place in a path."""
+    """A directory name for this chat, safe to place in a path.
+
+    Prefixed by execution mode, because the mode decides the directory's
+    permissions and a chat can switch between them. Sharing one directory meant
+    a host spill chmodded it 0700 and every sandbox path already advertised
+    from it stopped being readable — the mode of the most recent spill
+    retroactively deciding whether older ones could be opened. Separate leaves
+    cannot contradict each other.
+    """
     raw = str(getattr(deps, "chat_id", "") or "shared")
-    return _SAFE_SEGMENT.sub("-", raw)[:64] or "shared"
+    safe = _SAFE_SEGMENT.sub("-", raw)[:64] or "shared"
+    prefix = "sandbox" if getattr(deps, "sandbox_enabled", True) else "host"
+    return f"{prefix}-{safe}"
 
 
 def _force_mode(fd: int, mode: int) -> None:
@@ -143,9 +153,15 @@ def _force_mode(fd: int, mode: int) -> None:
     difference between the intended permissions and whatever the service happens
     to have been started with.
     """
+    # os.fchmod does not exist on Windows before 3.13, and AttributeError is not
+    # an OSError — uncaught, it escaped before fdopen took ownership of the
+    # descriptor, so every oversized result leaked a handle and wrote nothing.
+    setter = getattr(os, "fchmod", None)
+    if setter is None:
+        return
     try:
-        os.fchmod(fd, mode)
-    except OSError as e:
+        setter(fd, mode)
+    except (OSError, NotImplementedError) as e:
         logger.debug(f"[overflow] could not set mode {oct(mode)}: {e}")
 
 
@@ -190,10 +206,24 @@ def _spill_by_path(
         except OSError:
             pass
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
-        fd = os.open(directory / name, flags, file_mode)
-        _force_mode(fd, file_mode)
-        with os.fdopen(fd, "wb") as handle:
-            handle.write(payload)
+        target = directory / name
+        fd = os.open(target, flags, file_mode)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(payload)
+        except BaseException:
+            # fdopen owns the descriptor only once it returns; before that the
+            # raw fd is ours to close, and a leaked handle per oversized result
+            # exhausts the process.
+            os.close(fd)
+            raise
+        # By path here rather than by descriptor: this branch exists for
+        # platforms without dir_fd, which are also the ones that may lack
+        # fchmod.
+        try:
+            target.chmod(file_mode)
+        except OSError:
+            pass
     except (OSError, NotImplementedError, ValueError) as e:
         logger.debug(f"[overflow] could not write spill: {e}")
         return False
@@ -592,7 +622,16 @@ def spill_overflow_bounded(
             _spill_slots.release()
 
     thread = threading.Thread(target=_worker, name="overflow-spill", daemon=True)
-    thread.start()
+    try:
+        thread.start()
+    except BaseException as e:
+        # The worker's finally is what returns the slot, so a thread that never
+        # starts never gives it back — four of those and spilling is off for the
+        # life of the process. And a spill failure must never fail the tool call
+        # that produced the output.
+        _spill_slots.release()
+        logger.warning(f"[overflow] could not start a spill worker: {e}")
+        return None
     thread.join(timeout=SPILL_TIMEOUT_SECONDS)
     if thread.is_alive():
         logger.warning(

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -245,6 +245,13 @@ def _spill_by_path(
             pass
     except (OSError, NotImplementedError, ValueError) as e:
         logger.debug(f"[overflow] could not write spill: {e}")
+        # The descriptor-based path already does this. A half-written file that
+        # was never advertised is pure litter, and this branch skips pruning, so
+        # it sits there until the sweep.
+        try:
+            (directory / name).unlink(missing_ok=True)
+        except OSError:
+            pass
         return False
 
     _prune_path(directory)
@@ -252,23 +259,26 @@ def _spill_by_path(
     return True
 
 
-def _clip(text: str) -> tuple[bytes, bool]:
-    """Encode *text*, cut to the per-file ceiling on a character boundary.
+def _bound_chars(text: str) -> tuple[str, bool]:
+    """The prefix worth keeping, and whether anything was left behind.
 
-    Slicing the encoded bytes can land inside a multi-byte code point, and the
-    resulting file is not valid UTF-8 — so the reader that was supposed to
-    rescue the output fails to open it.
+    A slice, deliberately: cheap, and it is all the caller needs to do. Holding
+    only this bounds what an abandoned worker can retain, while the encoding —
+    which allocates up to four bytes per character — happens on the worker
+    where it cannot block the loop.
+
+    A UTF-8 character is at least one byte, so the first OVERFLOW_MAX_FILE_BYTES
+    characters always contain at least that many bytes, which is enough to fill
+    the file.
     """
-    # Slice the string first. Encoding the whole thing to find out it is too
-    # long allocates a second full-size copy while the original result is still
-    # live, so a command that prints hundreds of MiB costs that twice over to
-    # write five. A UTF-8 character is at least one byte, so the first
-    # OVERFLOW_MAX_FILE_BYTES characters always contain at least that many
-    # bytes — enough to fill the file — and at most four times as many, which
-    # is the bound this buys.
     head = text[:OVERFLOW_MAX_FILE_BYTES]
+    return head, len(head) != len(text)
+
+
+def _encode_bounded(head: str, dropped: bool) -> tuple[bytes, bool]:
+    """Encode a bounded prefix and cut it to the byte ceiling."""
     payload = head.encode("utf-8", "replace")
-    if len(payload) <= OVERFLOW_MAX_FILE_BYTES and len(head) == len(text):
+    if len(payload) <= OVERFLOW_MAX_FILE_BYTES and not dropped:
         return payload, False
 
     note = SPILL_CLIPPED_NOTE.encode("utf-8")
@@ -277,6 +287,12 @@ def _clip(text: str) -> tuple[bytes, bool]:
     # encoded bytes can split a code point, and the file the reader was meant
     # to open would not be valid UTF-8.
     return payload[:keep].decode("utf-8", "ignore").encode("utf-8") + note, True
+
+
+def _clip(text: str) -> tuple[bytes, bool]:
+    """Bound and encode in one step, for callers already off the event loop."""
+    head, dropped = _bound_chars(text)
+    return _encode_bounded(head, dropped)
 
 
 def _prune_path(directory: Path) -> None:
@@ -751,7 +767,10 @@ async def spill_overflow_async(
     # the deadline bounded the caller's latency and not the retained bytes. And
     # the executor's threads are shared with everything else that offloads, so
     # an abandoned write there is one fewer thread for unrelated work.
-    payload, clipped = _clip(text)
+    # Sliced here, encoded in the worker. The slice is what bounds retention;
+    # the encode is what costs — up to four bytes per character, on the loop,
+    # while every other chat waits.
+    head, dropped = _bound_chars(text)
 
     loop = asyncio.get_running_loop()
     future: asyncio.Future = loop.create_future()
@@ -762,6 +781,7 @@ async def spill_overflow_async(
 
     def _worker() -> None:
         try:
+            payload, clipped = _encode_bounded(head, dropped)
             spill = _spill_payload(payload, clipped, deps=deps, kind=kind)
         except BaseException as e:  # noqa: BLE001 - a spill never fails its caller
             logger.debug(f"[overflow] spill failed: {e}")

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -177,7 +177,13 @@ def _spill_by_path(
     oversized tool result into a failed tool call.
     """
     try:
-        directory.mkdir(mode=dir_mode, parents=True, exist_ok=True)
+        # Ancestors shared between modes, leaf private — see _spill_pinned.
+        directory.parent.mkdir(mode=_SHARED_DIR_MODE, parents=True, exist_ok=True)
+        try:
+            directory.parent.chmod(_SHARED_DIR_MODE)
+        except OSError:
+            pass
+        directory.mkdir(mode=dir_mode, exist_ok=True)
         try:
             directory.chmod(dir_mode)
         except OSError:
@@ -311,8 +317,14 @@ def _spill_pinned(
         # none of them reachable. /shared is the sandbox's own mount and has to
         # be traversable by it regardless; a 0700 root breaks memory too, not
         # only spills.
-        _force_mode(root_fd, dir_mode)
-        overflow_fd = _open_child_dir(".overflow", root_fd, dir_mode)
+        # The mount root and .overflow are shared between execution modes, so
+        # their mode cannot depend on which one is spilling right now: a host
+        # spill setting them 0700 would make every path already advertised to a
+        # sandbox container unreadable until some later sandbox spill happened
+        # to set them back. Traversal is not readability — the chat directory
+        # below still carries the private mode.
+        _force_mode(root_fd, _SHARED_DIR_MODE)
+        overflow_fd = _open_child_dir(".overflow", root_fd, _SHARED_DIR_MODE)
         chat_fd = _open_child_dir(chat, overflow_fd, dir_mode)
 
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
@@ -415,16 +427,41 @@ async def sweep_overflow_periodically() -> None:
             logger.warning(f"[overflow] periodic sweep failed: {e}")
 
 
+#: How long the caller waits for a spill before giving up on it.
+#:
+#: to_thread frees the loop and bounds nothing: a wedged volume would otherwise
+#: hold reminder construction, or a tool result that has already succeeded, for
+#: as long as the storage takes. Spilling is best-effort, so it gets a deadline
+#: and the plain marker on expiry.
+SPILL_TIMEOUT_SECONDS = 2.0
+
+
 async def spill_overflow_async(
     text: str, *, deps: Any, kind: str = "output"
 ) -> Optional[Spill]:
-    """Spill without holding the event loop.
+    """Spill without holding the event loop, and without waiting forever.
 
-    Up to 5 MiB of write plus a directory scan; on a slow volume, or with
-    several overflows at once, doing that inline stalls every other chat the
-    loop is serving.
+    Up to 5 MiB of write plus a directory scan; inline, that stalls every other
+    chat the loop is serving. Off-loop but unbounded, a slow volume costs the
+    caller instead — and the caller is either a reminder being built or a tool
+    call that has already done its work. Losing the pointer beats losing
+    either.
+
+    The thread is not cancellable, so a timed-out write finishes in the
+    background; it lands in the spill directory and is collected by the sweep
+    like any other file.
     """
-    return await asyncio.to_thread(spill_overflow, text, deps=deps, kind=kind)
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(spill_overflow, text, deps=deps, kind=kind),
+            timeout=SPILL_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            f"[overflow] spill exceeded {SPILL_TIMEOUT_SECONDS}s — truncating "
+            f"without a pointer"
+        )
+        return None
 
 
 def _sweep_by_path(root: Path) -> None:

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -92,6 +92,15 @@ OVERFLOW_MAX_FILE_BYTES = 5 * 1024 * 1024
 #: for whoever opens the file directly.
 SPILL_CLIPPED_NOTE = "\n\n[spill clipped: output exceeded the per-file limit]"
 
+#: Suffix a spill wears while it is being written.
+#:
+#: Scans match ``*.txt``, so a partial file is invisible to them: the sweep or
+#: another chat's prune cannot select a half-written spill for deletion — and on
+#: POSIX that deletion succeeds silently against the open inode, leaving an
+#: advertised path with no file behind it. The rename is atomic, so the name
+#: appears only once the content is complete.
+PARTIAL_SUFFIX = ".part"
+
 _SAFE_SEGMENT = re.compile(r"[^A-Za-z0-9_-]")
 
 #: Permissions, which differ by execution mode because the reader does.
@@ -191,12 +200,12 @@ def _chat_segment(deps: Any) -> str:
     raw = str(getattr(deps, "chat_id", "") or "shared")
     safe = _SAFE_SEGMENT.sub("-", raw) or "shared"
     prefix = "sandbox" if getattr(deps, "sandbox_enabled", True) else "host"
-    if len(safe) <= 48:
-        return f"{prefix}-{safe}"
-    # A plain truncation merges two chats whose ids share a prefix — and A2A
-    # context ids are built by prefixing an accepted 64-character value, so they
-    # differ exactly where a 64-character cut discards. Merged chats then share
-    # one quota and evict each other's advertised spills.
+    # The digest is unconditional, because both ways of deriving a name are
+    # many-to-one and a conditional only covers the one you thought of. A
+    # truncation merges ids sharing a prefix; the sanitiser merges ids differing
+    # only in characters it replaces — `a2a:local:a/b` and `a2a:local:a?b` both
+    # become `a2a-local-a-b`. Merged chats share a quota and evict each other's
+    # advertised spills.
     digest = hashlib.sha1(raw.encode("utf-8", "replace")).hexdigest()[:12]
     return f"{prefix}-{safe[:48]}-{digest}"
 
@@ -265,8 +274,8 @@ def _spill_by_path(
         except OSError:
             pass
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
-        target = directory / name
-        fd = os.open(target, flags, file_mode)
+        staged = directory / (name + PARTIAL_SUFFIX)
+        fd = os.open(staged, flags, file_mode)
         # Ownership transfers at fdopen and not before. Closing the raw number
         # after the `with` has already closed it would be a double close, and in
         # a threaded server another thread can be handed that same descriptor
@@ -284,16 +293,17 @@ def _spill_by_path(
         # platforms without dir_fd, which are also the ones that may lack
         # fchmod.
         try:
-            target.chmod(file_mode)
+            staged.chmod(file_mode)
         except OSError:
             pass
+        staged.replace(directory / name)
     except (OSError, NotImplementedError, ValueError) as e:
         logger.debug(f"[overflow] could not write spill: {e}")
         # The descriptor-based path already does this. A half-written file that
         # was never advertised is pure litter, and this branch skips pruning, so
         # it sits there until the sweep.
         try:
-            (directory / name).unlink(missing_ok=True)
+            (directory / (name + PARTIAL_SUFFIX)).unlink(missing_ok=True)
         except OSError:
             pass
         return False
@@ -352,6 +362,16 @@ def _prune_path(directory: Path, protect: Optional[str] = None) -> None:
 
     entries = [e for e in entries if e[2].name != protect]
     entries.sort(reverse=True)
+    # A crash or a failed rename can leave a staged file behind. It is
+    # invisible to every scan by design, so the sweep is the only thing that
+    # will ever collect it.
+    for stale in directory.glob(f"*{PARTIAL_SUFFIX}"):
+        try:
+            if stale.stat().st_mtime < time.time() - OVERFLOW_TTL_SECONDS:
+                stale.unlink(missing_ok=True)
+        except OSError:
+            continue
+
     cutoff = time.time() - OVERFLOW_TTL_SECONDS
     running = 0
     for index, (mtime, size, path) in enumerate(entries):
@@ -482,6 +502,22 @@ def _prune_fd(dir_fd: int, protect: Optional[str] = None) -> None:
     except OSError:
         return
 
+    # Staged files are invisible to the scan above, so the sweep collects the
+    # ones a crash or a failed rename left behind.
+    try:
+        for entry in os.scandir(dir_fd):
+            if not entry.name.endswith(PARTIAL_SUFFIX):
+                continue
+            try:
+                if entry.stat(follow_symlinks=False).st_mtime < (
+                    time.time() - OVERFLOW_TTL_SECONDS
+                ):
+                    os.unlink(entry.name, dir_fd=dir_fd)
+            except OSError:
+                continue
+    except OSError:
+        pass
+
     entries.sort(reverse=True)
     cutoff = time.time() - OVERFLOW_TTL_SECONDS
     running = 0
@@ -536,8 +572,9 @@ def _spill_pinned(
         chat_fd = _open_child_dir(chat, overflow_fd, dir_mode)
 
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        staged = name + PARTIAL_SUFFIX
         try:
-            fd = os.open(name, flags, file_mode, dir_fd=chat_fd)
+            fd = os.open(staged, flags, file_mode, dir_fd=chat_fd)
         except OSError as e:
             if e.errno in (errno.EEXIST, errno.ELOOP):
                 logger.warning(f"[overflow] refusing to write over {name}: {e}")
@@ -552,7 +589,17 @@ def _spill_pinned(
         except OSError as e:
             logger.debug(f"[overflow] could not write spill: {e}")
             try:
-                os.unlink(name, dir_fd=chat_fd)
+                os.unlink(staged, dir_fd=chat_fd)
+            except OSError:
+                pass
+            return False
+
+        try:
+            os.rename(staged, name, src_dir_fd=chat_fd, dst_dir_fd=chat_fd)
+        except OSError as e:
+            logger.debug(f"[overflow] could not publish spill: {e}")
+            try:
+                os.unlink(staged, dir_fd=chat_fd)
             except OSError:
                 pass
             return False

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -158,6 +158,25 @@ def retention_hint() -> str:
     return f"kept up to {longest // 3600}h"
 
 
+def _shared_root() -> Path:
+    """The canonical shared directory, absolute.
+
+    ``sandbox_data_path`` may be relative — the documented default is
+    ``.suzent/sandbox`` — and a relative host path is worse than useless in a
+    marker: PathResolver resolves relative paths against the *chat's* working
+    directory, so the pointer would send the agent looking under its own cwd
+    for a file written next to the server's. Absolute here, once, for the
+    writer and the sweep alike.
+    """
+    from suzent.config import CONFIG
+
+    return Path(CONFIG.sandbox_data_path).expanduser().resolve() / "shared"
+
+
+def _overflow_root() -> Path:
+    return _shared_root() / ".overflow"
+
+
 def _chat_segment(deps: Any) -> str:
     """A directory name for this chat, safe to place in a path.
 
@@ -541,9 +560,7 @@ def _prune_now(deps: Any) -> None:
     behalf is a legitimate retention decision rather than an eviction by
     something that is about to vanish.
     """
-    from suzent.config import CONFIG
-
-    root = Path(CONFIG.sandbox_data_path) / "shared" / ".overflow"
+    root = _overflow_root()
     chat = _chat_segment(deps)
     try:
         if _HAVE_DIR_FD:
@@ -623,9 +640,7 @@ def _spill_payload(
     # directory, force-chmod it 0755, and leave the files somewhere the sweep
     # (which knows only the canonical path) never looks. Deriving the root from
     # config keeps the writer and the collector talking about one directory.
-    from suzent.config import CONFIG
-
-    shared_host = Path(CONFIG.sandbox_data_path) / "shared"
+    shared_host = _shared_root()
 
     # In sandbox mode the agent reaches it as /shared — unless that mount has
     # been redirected, in which case there is no path to advertise and the plain
@@ -919,9 +934,7 @@ def sweep_overflow() -> None:
     Per-chat bounds mean the directory total scales with the number of chats,
     which is why this also drops chat directories once they are empty.
     """
-    from suzent.config import CONFIG
-
-    root = Path(CONFIG.sandbox_data_path) / "shared" / ".overflow"
+    root = _overflow_root()
     if not root.is_dir():
         return
 

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -13,10 +13,19 @@ Two properties are load-bearing and easy to lose:
   ``/shared`` — including replacing the directories on this path — so every step
   is taken relative to a pinned directory descriptor and refuses to follow a
   symlink. Resolving a path and then using it is a race the agent can win.
-* **A spill is private to its chat.** It holds raw tool output and reminder
-  text, which is conversation content. ``/shared`` is mounted into every
-  session, so an unscoped directory is readable by every other chat on the
-  deployment; random filenames are no help against a directory listing.
+* **A spill is not private to its chat, by decision.** Every sandbox container
+  bind-mounts the same host ``shared`` directory and every one runs as uid
+  1000, so one chat can read another's spills whatever the mode bits say.
+  Suzent has a single owner, who has accepted that: their chats reading each
+  other is their own data reaching their own agent.
+
+  This is a property of the deployment, not of the code, so it is worth stating
+  what would change it. Inbound channels mean other people's messages become
+  chat content; if their conversations ever need to be private *from each
+  other*, the boundary has to be a per-chat mount, because permissions on one
+  shared mount with one uid cannot express it. Per-chat directories here are
+  organisation and pruning scope, not access control, and should not be
+  mistaken for it.
 """
 
 from __future__ import annotations
@@ -57,6 +66,17 @@ OVERFLOW_MAX_FILE_BYTES = 5 * 1024 * 1024
 SPILL_CLIPPED_NOTE = "\n\n[spill clipped: output exceeded the per-file limit]"
 
 _SAFE_SEGMENT = re.compile(r"[^A-Za-z0-9_-]")
+
+#: Readable beyond the creating user, deliberately.
+#:
+#: Bind mounts preserve numeric ownership, and the sandbox image runs as a fixed
+#: uid 1000 that need not match the host service's. Files written 0600 by the
+#: service would then be unreadable by the very agent the marker points at — a
+#: path that exists and cannot be opened, which is the failure the whole spill
+#: is meant to avoid. Given that one chat can read another's spills anyway on a
+#: shared mount, the tighter mode bought nothing it did not also break.
+_DIR_MODE = 0o755
+_FILE_MODE = 0o644
 
 #: dir_fd is POSIX-only. Where it is missing there is also no bind-mounted
 #: sandbox writing into this directory, so plain path operations are used.
@@ -104,11 +124,11 @@ def _open_child_dir(name: str, *, parent_fd: Optional[int], base: Path) -> int:
     flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
     if parent_fd is None:
         target = base / name
-        target.mkdir(mode=0o700, parents=True, exist_ok=True)
+        target.mkdir(mode=_DIR_MODE, parents=True, exist_ok=True)
         return os.open(target, flags)
 
     try:
-        os.mkdir(name, 0o700, dir_fd=parent_fd)
+        os.mkdir(name, _DIR_MODE, dir_fd=parent_fd)
     except FileExistsError:
         pass
     return os.open(name, flags, dir_fd=parent_fd)
@@ -179,22 +199,6 @@ def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[Sp
     if resolver is None:
         return None
 
-    # Sandbox mode gets the plain marker instead of a file.
-    #
-    # Every container bind-mounts the same host `shared` directory read-write
-    # and every one of them runs as uid 1000, so a per-chat subdirectory is a
-    # naming convention and not a boundary: chat B lists and reads chat A's
-    # spills whatever the mode bits say. Spills hold raw tool output and
-    # reminder text, which is conversation content, so the honest options are a
-    # per-chat mount or not writing the file — and a convenience feature does
-    # not get to widen the isolation model on its way in.
-    #
-    # Host mode has no such boundary to breach: the agent already reaches the
-    # whole filesystem through its shell, so the spill exposes nothing that was
-    # not reachable already.
-    if getattr(deps, "sandbox_enabled", True):
-        return None
-
     try:
         shared_host = Path(resolver.resolve("/shared"))
     except Exception as e:
@@ -223,7 +227,7 @@ def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[Sp
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
 
         try:
-            fd = os.open(name, flags, 0o600, dir_fd=chat_fd)
+            fd = os.open(name, flags, _FILE_MODE, dir_fd=chat_fd)
         except OSError as e:
             if e.errno in (errno.EEXIST, errno.ELOOP):
                 logger.warning(f"[overflow] refusing to write over {name}: {e}")

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -338,6 +338,28 @@ def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[Sp
     return Spill(str(shared_host / ".overflow" / chat / name), clipped)
 
 
+#: How often the sweep runs while the service is up.
+#:
+#: The root quota and the retention window are only enforced where the sweep
+#: reaches. Running it once at startup left both unenforced for the lifetime of
+#: a long-lived process: a chat's last spill outlives its advertised window, and
+#: the deployment-wide total is never checked at all, because a write only ever
+#: prunes its own chat's directory.
+OVERFLOW_SWEEP_INTERVAL_SECONDS = 60 * 60
+
+
+async def sweep_overflow_periodically() -> None:
+    """Keep the bounds enforced for as long as the service runs."""
+    while True:
+        try:
+            await asyncio.sleep(OVERFLOW_SWEEP_INTERVAL_SECONDS)
+            await asyncio.to_thread(sweep_overflow)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # noqa: BLE001 - a sweep failure must not end the loop
+            logger.warning(f"[overflow] periodic sweep failed: {e}")
+
+
 async def spill_overflow_async(
     text: str, *, deps: Any, kind: str = "output"
 ) -> Optional[Spill]:
@@ -348,6 +370,45 @@ async def spill_overflow_async(
     loop is serving.
     """
     return await asyncio.to_thread(spill_overflow, text, deps=deps, kind=kind)
+
+
+def _sweep_by_path(root: Path) -> None:
+    """Retention and the root quota without directory descriptors."""
+    swept = 0
+    survivors: list[tuple[float, int, Path]] = []
+    for chat_dir in root.iterdir():
+        if not chat_dir.is_dir() or chat_dir.is_symlink():
+            continue
+        try:
+            before = len(list(chat_dir.glob("*.txt")))
+            _prune_path(chat_dir)
+            kept = list(chat_dir.glob("*.txt"))
+            swept += before - len(kept)
+            for path in kept:
+                try:
+                    stat = path.stat()
+                except OSError:
+                    continue
+                survivors.append((stat.st_mtime, stat.st_size, path))
+            if not any(chat_dir.iterdir()):
+                chat_dir.rmdir()
+        except OSError:
+            continue
+
+    survivors.sort(reverse=True)
+    running = 0
+    for _mtime, size, path in survivors:
+        if running + size <= OVERFLOW_MAX_ROOT_BYTES:
+            running += size
+            continue
+        try:
+            path.unlink(missing_ok=True)
+            swept += 1
+        except OSError:
+            continue
+
+    if swept:
+        logger.info(f"[overflow] swept {swept} stale spill(s)")
 
 
 def sweep_overflow() -> None:
@@ -366,6 +427,15 @@ def sweep_overflow() -> None:
 
     root = Path(CONFIG.sandbox_data_path) / "shared" / ".overflow"
     if not root.is_dir():
+        return
+
+    if not _HAVE_DIR_FD:
+        # The same split the write path makes. Having only spill_overflow()
+        # choose an implementation left the sweep calling dir_fd operations on a
+        # platform without them, so retention and the root quota simply did not
+        # run there — the third time in this file that hardening one path and
+        # not its twin left the twin broken.
+        _sweep_by_path(root)
         return
 
     # Descended with the same no-follow discipline as the write path. A symlink

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -532,22 +532,19 @@ def _spill_pinned(
                     pass
 
 
-def _prune_after_accept(deps: Any) -> None:
-    """Apply the quotas, once a spill has actually been handed to its caller.
+def _prune_now(deps: Any) -> None:
+    """Apply the quotas after a write.
 
-    Pruning is the irreversible half of a spill, so it waits for the reversible
-    half to be accepted. Doing it during the write meant an abandoned spill
-    could evict files whose paths a live conversation held and then delete
-    itself, leaving the eviction as its only effect — and every attempt to guard
-    that with a flag left a window between the check and the scan.
-
-    Ordering removes the window instead of narrowing it: nothing that is not
-    owned by a caller ever prunes.
+    Unconditional again, and that is the point of dropping the handshake: with
+    nothing deleted out of band, a spill whose caller timed out is not a mistake
+    to be undone — it is a retained file like any other, so pruning on its
+    behalf is a legitimate retention decision rather than an eviction by
+    something that is about to vanish.
     """
     from suzent.config import CONFIG
 
     root = Path(CONFIG.sandbox_data_path) / "shared" / ".overflow"
-    chat_dir = root / _chat_segment(deps)
+    chat = _chat_segment(deps)
     try:
         if _HAVE_DIR_FD:
             flags = (
@@ -557,7 +554,7 @@ def _prune_after_accept(deps: Any) -> None:
             )
             root_fd = os.open(root, flags)
             try:
-                chat_fd = os.open(_chat_segment(deps), flags, dir_fd=root_fd)
+                chat_fd = os.open(chat, flags, dir_fd=root_fd)
                 try:
                     _prune_fd(chat_fd)
                 finally:
@@ -566,21 +563,10 @@ def _prune_after_accept(deps: Any) -> None:
             finally:
                 os.close(root_fd)
         else:
-            _prune_path(chat_dir)
+            _prune_path(root / chat)
             _enforce_root_quota_path(root)
     except OSError as e:
         logger.debug(f"[overflow] could not prune after a spill: {e}")
-
-
-def _discard(spill: Spill) -> None:
-    """Remove a spill nobody was told about."""
-    if not spill.host_path:
-        return
-    try:
-        Path(spill.host_path).unlink(missing_ok=True)
-        logger.debug("[overflow] removed a spill that finished after its deadline")
-    except OSError as e:
-        logger.debug(f"[overflow] could not remove an abandoned spill: {e}")
 
 
 def _deps_snapshot(deps: Any) -> Any:
@@ -606,10 +592,7 @@ def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[Sp
     that decision themselves and prune only once it goes their way.
     """
     payload, clipped = _clip(text)
-    spill = _spill_payload(payload, clipped, deps=deps, kind=kind)
-    if spill is not None:
-        _prune_after_accept(deps)
-    return spill
+    return _spill_payload(payload, clipped, deps=deps, kind=kind)
 
 
 def _spill_payload(
@@ -701,6 +684,8 @@ def _spill_payload(
             return None
     elif not _spill_pinned(payload, shared_host, chat, name, dir_mode, file_mode):
         return None
+
+    _prune_now(deps)
 
     written = shared_host / ".overflow" / chat / name
     if virtual is not None:
@@ -808,28 +793,13 @@ def spill_overflow_bounded(
         return None
 
     snapshot = _deps_snapshot(deps)
-    abandoned = threading.Event()
-    handover = threading.Lock()
     result: list[Optional[Spill]] = [None]
 
     def _worker() -> None:
         try:
-            spill = _spill_payload(payload, clipped, deps=snapshot, kind=kind)
-            if spill is None:
-                return
-            # One atomic decision: either the caller takes it, or nobody does.
-            with handover:
-                if abandoned.is_set():
-                    accepted = False
-                else:
-                    result[0] = spill
-                    accepted = True
-            # Both of these are filesystem work and both happen here, on the
-            # worker — never on the caller's thread and never on the loop.
-            if accepted:
-                _prune_after_accept(snapshot)
-            else:
-                _discard(spill)
+            result[0] = _spill_payload(payload, clipped, deps=snapshot, kind=kind)
+        except BaseException as e:  # noqa: BLE001 - never fails its caller
+            logger.debug(f"[overflow] spill failed: {e}")
         finally:
             _spill_slots.release()
 
@@ -837,25 +807,12 @@ def spill_overflow_bounded(
     try:
         thread.start()
     except BaseException as e:
-        # The worker's finally is what returns the slot, so a thread that never
-        # starts never gives it back — four of those and spilling is off for the
-        # life of the process. And a spill failure must never fail the tool call
-        # that produced the output.
         _spill_slots.release()
         logger.warning(f"[overflow] could not start a spill worker: {e}")
         return None
+
     thread.join(timeout=SPILL_TIMEOUT_SECONDS)
     if thread.is_alive():
-        with handover:
-            # The worker may have stored a result and still be inside its
-            # finally when the join expired. Abandoning it then would throw away
-            # a spill that is already written and already ours.
-            if result[0] is not None:
-                return result[0]
-            abandoned.set()
-        # The write may still land. Nobody was told about it, so it would sit
-        # there consuming the per-chat and root quotas and evicting spills whose
-        # paths *were* handed out — the worker removes it when it finishes.
         logger.warning(
             f"[overflow] spill exceeded {SPILL_TIMEOUT_SECONDS}s — truncating "
             f"without a pointer"
@@ -869,75 +826,42 @@ async def spill_overflow_async(
 ) -> Optional[Spill]:
     """Spill without holding the event loop, and without waiting forever.
 
-    Up to 5 MiB of write plus a directory scan; inline, that stalls every other
-    chat the loop is serving. Off-loop but unbounded, a slow volume costs the
-    caller instead — and the caller is either a reminder being built or a tool
-    call that has already done its work. Losing the pointer beats losing
-    either.
+    Sliced here, encoded and written on a thread of our own — not the shared
+    default executor, whose queue keeps a cancelled submission's references
+    until some worker dequeues it, and whose threads are joined at interpreter
+    exit.
 
-    The thread is not cancellable, so a timed-out write finishes in the
-    background; it lands in the spill directory and is collected by the sweep
-    like any other file.
+    A spill that misses the deadline is not chased. The caller gets the plain
+    marker, the write finishes in the background, and the file it leaves is an
+    ordinary spill: retained under the same TTL and quotas as any other, and
+    collected by the sweep. Trying to hand the file back or delete it after the
+    fact is what produced a run of races — every version of the handshake had a
+    window between deciding and acting, because the caller, the loop and the
+    worker cannot observe each other atomically.
     """
-    # Clipped before anything can queue it, and run on a thread of our own
-    # rather than the shared default executor.
-    #
-    # to_thread was wrong twice over here. Cancelling the future does not remove
-    # the work item from the executor's queue, so a timed-out submission keeps
-    # holding whatever it captured until some worker eventually dequeues it —
-    # the deadline bounded the caller's latency and not the retained bytes. And
-    # the executor's threads are shared with everything else that offloads, so
-    # an abandoned write there is one fewer thread for unrelated work.
-    # Sliced here, encoded in the worker. The slice is what bounds retention;
-    # the encode is what costs — up to four bytes per character, on the loop,
-    # while every other chat waits.
     head, dropped = _bound_chars(text)
     snapshot = _deps_snapshot(deps)
 
     loop = asyncio.get_running_loop()
     future: asyncio.Future = loop.create_future()
 
-    settled = threading.Event()
-    accepted: list[bool] = [False]
-
     def _deliver(value: Optional[Spill]) -> None:
-        # Runs on the loop and does no filesystem work: an unlink on the same
-        # wedged volume would stall every chat, after the caller's deadline has
-        # already expired. It hands the value over; the coroutine decides
-        # whether it was really received, and the worker acts on that.
         if not future.done():
             future.set_result(value)
 
     def _worker() -> None:
         spill = None
         try:
-            try:
-                payload, clipped = _encode_bounded(head, dropped)
-                spill = _spill_payload(payload, clipped, deps=snapshot, kind=kind)
-            except BaseException as e:  # noqa: BLE001 - never fails its caller
-                logger.debug(f"[overflow] spill failed: {e}")
-
-            try:
-                loop.call_soon_threadsafe(_deliver, spill)
-            except RuntimeError:
-                # Loop already closed; nobody is waiting, so nobody owns this.
-                if spill is not None:
-                    _discard(spill)
-                return
-
-            if spill is None:
-                return
-            settled.wait(timeout=SPILL_TIMEOUT_SECONDS)
-            if accepted[0]:
-                _prune_after_accept(snapshot)
-            else:
-                _discard(spill)
+            payload, clipped = _encode_bounded(head, dropped)
+            spill = _spill_payload(payload, clipped, deps=snapshot, kind=kind)
+        except BaseException as e:  # noqa: BLE001 - a spill never fails its caller
+            logger.debug(f"[overflow] spill failed: {e}")
         finally:
-            # After the pruning and the cleanup, not before them. Releasing at
-            # the end of the write let the next oversized result take the slot
-            # and park another thread in the filesystem work below it, which is
-            # the accumulation the bound exists to prevent.
             _spill_slots.release()
+        try:
+            loop.call_soon_threadsafe(_deliver, spill)
+        except RuntimeError:
+            pass  # loop already closed; the sweep collects the file
 
     if not _spill_slots.acquire(blocking=False):
         logger.warning(
@@ -953,28 +877,13 @@ async def spill_overflow_async(
         return None
 
     try:
-        spill = await asyncio.wait_for(future, timeout=SPILL_TIMEOUT_SECONDS)
+        return await asyncio.wait_for(future, timeout=SPILL_TIMEOUT_SECONDS)
     except asyncio.TimeoutError:
-        settled.set()
         logger.warning(
             f"[overflow] spill exceeded {SPILL_TIMEOUT_SECONDS}s — truncating "
             f"without a pointer"
         )
         return None
-    except BaseException:
-        # Cancellation reaches here too — a client disconnecting, a social turn
-        # superseded. Nobody receives the pointer, so the worker discards.
-        settled.set()
-        raise
-
-    # Only now, with the value in hand and no await between here and the
-    # return, is it true that the caller received it. Setting the future is not
-    # the same event: a cancellation queued after _deliver ran would still stop
-    # the coroutine, and the worker would have kept and pruned a file whose
-    # path reached nobody.
-    accepted[0] = spill is not None
-    settled.set()
-    return spill
 
 
 def _sweep_by_path(root: Path) -> None:

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -215,6 +215,20 @@ def _past_ttl(mtime: float, now: float) -> bool:
     return mtime < now - OVERFLOW_TTL_SECONDS or _implausibly_dated(mtime, now)
 
 
+def _abandoned(mtime: float, now: float) -> bool:
+    """True for a staged file old enough that no writer can still hold it.
+
+    Deliberately blind to the rollback rule that governs published spills. A
+    ``.part`` is not subject to the retention promise — nothing advertises it —
+    and a clock step backwards mid-write would otherwise make an active
+    writer's file look expired. Deleting it succeeds silently against the open
+    inode on POSIX: the write finishes into nothing, the rename fails, and the
+    caller gets no pointer at all. A future-dated staged file waits for the
+    clock instead, which costs one stale file and no lost output.
+    """
+    return mtime < now - OVERFLOW_TTL_SECONDS
+
+
 def _shared_root() -> Path:
     """The canonical shared directory, absolute.
 
@@ -413,7 +427,7 @@ def _prune_path(directory: Path, protect: Optional[str] = None) -> None:
     # will ever collect it.
     for stale in directory.glob(f"*{PARTIAL_SUFFIX}"):
         try:
-            if _past_ttl(stale.stat().st_mtime, time.time()):
+            if _abandoned(stale.stat().st_mtime, time.time()):
                 stale.unlink(missing_ok=True)
         except OSError:
             continue
@@ -564,7 +578,7 @@ def _prune_fd(dir_fd: int, protect: Optional[str] = None) -> None:
             if not entry.name.endswith(PARTIAL_SUFFIX):
                 continue
             try:
-                if _past_ttl(entry.stat(follow_symlinks=False).st_mtime, time.time()):
+                if _abandoned(entry.stat(follow_symlinks=False).st_mtime, time.time()):
                     os.unlink(entry.name, dir_fd=dir_fd)
             except OSError:
                 continue

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -373,8 +373,6 @@ def _prune_path(directory: Path, protect: Optional[str] = None) -> None:
     except OSError:
         return
 
-    fresh = time.time() - OVERFLOW_GRACE_SECONDS
-    entries = [e for e in entries if e[2].name != protect and e[0] < fresh]
     entries.sort(reverse=True)
     # A crash or a failed rename can leave a staged file behind. It is
     # invisible to every scan by design, so the sweep is the only thing that
@@ -387,20 +385,22 @@ def _prune_path(directory: Path, protect: Optional[str] = None) -> None:
             continue
 
     cutoff = time.time() - OVERFLOW_TTL_SECONDS
+    fresh = time.time() - OVERFLOW_GRACE_SECONDS
     running = 0
     for index, (mtime, size, path) in enumerate(entries):
-        drop = (
+        over = (
             index >= OVERFLOW_MAX_FILES
             or mtime < cutoff
             or running + size > OVERFLOW_MAX_TOTAL_BYTES
         )
+        protected = path.name == protect or mtime >= fresh
         try:
-            if drop:
+            if over and not protected:
                 path.unlink(missing_ok=True)
-            else:
-                running += size
+                continue
         except OSError:
             continue
+        running += size
 
 
 def _enforce_root_quota_fd(
@@ -438,10 +438,6 @@ def _enforce_root_quota_fd(
                         stat = kept.stat(follow_symlinks=False)
                     except OSError:
                         continue
-                    if protect == (entry.name, kept.name):
-                        continue
-                    if stat.st_mtime >= time.time() - OVERFLOW_GRACE_SECONDS:
-                        continue
                     survivors.append(
                         (stat.st_mtime, stat.st_size, entry.name, kept.name)
                     )
@@ -453,10 +449,15 @@ def _enforce_root_quota_fd(
     # Newest first, so what goes is least likely to be referenced by a live
     # conversation.
     survivors.sort(reverse=True)
+    fresh = time.time() - OVERFLOW_GRACE_SECONDS
     removed = 0
     running = 0
-    for _mtime, size, chat_name, file_name in survivors:
-        if running + size <= OVERFLOW_MAX_ROOT_BYTES:
+    for mtime, size, chat_name, file_name in survivors:
+        # Counted whether or not it can be deleted: omitting fresh files from
+        # the running total let a burst across chats exceed the deployment
+        # ceiling entirely, which is the ceiling's whole purpose.
+        protected = protect == (chat_name, file_name) or mtime >= fresh
+        if running + size <= OVERFLOW_MAX_ROOT_BYTES or protected:
             running += size
             continue
         try:
@@ -487,19 +488,17 @@ def _enforce_root_quota_path(
                     stat = path.stat()
                 except OSError:
                     continue
-                if protect == (chat_dir.name, path.name):
-                    continue
-                if stat.st_mtime >= time.time() - OVERFLOW_GRACE_SECONDS:
-                    continue
                 survivors.append((stat.st_mtime, stat.st_size, path))
     except OSError:
         return 0
 
     survivors.sort(reverse=True)
+    fresh = time.time() - OVERFLOW_GRACE_SECONDS
     removed = 0
     running = 0
-    for _mtime, size, path in survivors:
-        if running + size <= OVERFLOW_MAX_ROOT_BYTES:
+    for mtime, size, path in survivors:
+        protected = protect == (path.parent.name, path.name) or mtime >= fresh
+        if running + size <= OVERFLOW_MAX_ROOT_BYTES or protected:
             running += size
             continue
         try:
@@ -520,10 +519,6 @@ def _prune_fd(dir_fd: int, protect: Optional[str] = None) -> None:
             try:
                 stat = entry.stat(follow_symlinks=False)
             except OSError:
-                continue
-            if entry.name == protect:
-                continue
-            if stat.st_mtime >= time.time() - OVERFLOW_GRACE_SECONDS:
                 continue
             entries.append((stat.st_mtime, stat.st_size, entry.name))
     except OSError:
@@ -547,20 +542,27 @@ def _prune_fd(dir_fd: int, protect: Optional[str] = None) -> None:
 
     entries.sort(reverse=True)
     cutoff = time.time() - OVERFLOW_TTL_SECONDS
+    fresh = time.time() - OVERFLOW_GRACE_SECONDS
     running = 0
     for index, (mtime, size, name) in enumerate(entries):
-        drop = (
+        over = (
             index >= OVERFLOW_MAX_FILES
             or mtime < cutoff
             or running + size > OVERFLOW_MAX_TOTAL_BYTES
         )
+        # Undeletable is not the same as uncounted. Skipping fresh files
+        # entirely let a burst sail past both ceilings — eleven maximum spills
+        # exceed the per-chat limit while none is old enough to consider. They
+        # consume budget like anything else; they are simply the ones that
+        # displace older files rather than being displaced.
+        protected = name == protect or mtime >= fresh
         try:
-            if drop:
+            if over and not protected:
                 os.unlink(name, dir_fd=dir_fd)
-            else:
-                running += size
+                continue
         except OSError:
             continue
+        running += size
 
 
 def _spill_pinned(

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -449,9 +449,10 @@ def _prune_path(directory: Path, protect: Optional[str] = None) -> None:
 
     now = time.time()
     running = 0
-    for index, (mtime, size, path) in enumerate(entries):
+    kept = 0
+    for mtime, size, path in entries:
         over = (
-            index >= OVERFLOW_MAX_FILES
+            kept >= OVERFLOW_MAX_FILES
             or _past_ttl(mtime, now)
             or running + size > OVERFLOW_MAX_TOTAL_BYTES
         )
@@ -463,6 +464,7 @@ def _prune_path(directory: Path, protect: Optional[str] = None) -> None:
         except OSError:
             continue
         running += size
+        kept += 1
 
 
 def _enforce_root_quota_fd(
@@ -610,9 +612,14 @@ def _prune_fd(dir_fd: int, protect: Optional[str] = None) -> None:
     entries.sort(reverse=True)
     now = time.time()
     running = 0
-    for index, (mtime, size, name) in enumerate(entries):
+    kept = 0
+    for mtime, size, name in entries:
+        # The ceiling counts what is being kept, not how far down the list an
+        # entry sits. Counting positions charged a file for the entries above
+        # it that were themselves deleted — one expired spill at the head was
+        # enough to evict a valid one at the tail and break its pointer.
         over = (
-            index >= OVERFLOW_MAX_FILES
+            kept >= OVERFLOW_MAX_FILES
             or _past_ttl(mtime, now)
             or running + size > OVERFLOW_MAX_TOTAL_BYTES
         )
@@ -629,6 +636,7 @@ def _prune_fd(dir_fd: int, protect: Optional[str] = None) -> None:
         except OSError:
             continue
         running += size
+        kept += 1
 
 
 def _spill_pinned(

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -92,6 +92,19 @@ OVERFLOW_MAX_FILE_BYTES = 5 * 1024 * 1024
 #: for whoever opens the file directly.
 SPILL_CLIPPED_NOTE = "\n\n[spill clipped: output exceeded the per-file limit]"
 
+#: How long a spill is immune from pruning after it is written.
+#:
+#: Publication and advertisement are not one step: the file is renamed into
+#: place, and only then does the pointer reach the caller. Another chat's prune
+#: or the sweep can run in between, and on a coarse-mtime filesystem — or after
+#: the clock steps back — the new file need not sort as newest, so quota
+#: pressure could delete the very path about to be returned.
+#:
+#: A grace period closes that without coordination between the writer, the other
+#: writers and the sweep, which is what every attempt to synchronise them cost
+#: in this file. It buys a bounded overshoot: whatever is written in a minute.
+OVERFLOW_GRACE_SECONDS = 60
+
 #: Suffix a spill wears while it is being written.
 #:
 #: Scans match ``*.txt``, so a partial file is invisible to them: the sweep or
@@ -360,7 +373,8 @@ def _prune_path(directory: Path, protect: Optional[str] = None) -> None:
     except OSError:
         return
 
-    entries = [e for e in entries if e[2].name != protect]
+    fresh = time.time() - OVERFLOW_GRACE_SECONDS
+    entries = [e for e in entries if e[2].name != protect and e[0] < fresh]
     entries.sort(reverse=True)
     # A crash or a failed rename can leave a staged file behind. It is
     # invisible to every scan by design, so the sweep is the only thing that
@@ -426,6 +440,8 @@ def _enforce_root_quota_fd(
                         continue
                     if protect == (entry.name, kept.name):
                         continue
+                    if stat.st_mtime >= time.time() - OVERFLOW_GRACE_SECONDS:
+                        continue
                     survivors.append(
                         (stat.st_mtime, stat.st_size, entry.name, kept.name)
                     )
@@ -473,6 +489,8 @@ def _enforce_root_quota_path(
                     continue
                 if protect == (chat_dir.name, path.name):
                     continue
+                if stat.st_mtime >= time.time() - OVERFLOW_GRACE_SECONDS:
+                    continue
                 survivors.append((stat.st_mtime, stat.st_size, path))
     except OSError:
         return 0
@@ -504,6 +522,8 @@ def _prune_fd(dir_fd: int, protect: Optional[str] = None) -> None:
             except OSError:
                 continue
             if entry.name == protect:
+                continue
+            if stat.st_mtime >= time.time() - OVERFLOW_GRACE_SECONDS:
                 continue
             entries.append((stat.st_mtime, stat.st_size, entry.name))
     except OSError:
@@ -561,7 +581,20 @@ def _spill_pinned(
     root_fd = overflow_fd = chat_fd = None
     try:
         shared_host.mkdir(parents=True, exist_ok=True)
-        root_fd = os.open(shared_host, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        # Opened relative to its parent with no-follow, like every directory
+        # below it. mkdir(exist_ok=True) accepts a symlink as an existing
+        # directory, so a `shared` replaced by one would have been followed here
+        # and every pinned step below would have been pinned to the wrong tree.
+        flags = (
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        )
+        parent_fd = os.open(
+            shared_host.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        )
+        try:
+            root_fd = os.open(shared_host.name, flags, dir_fd=parent_fd)
+        finally:
+            os.close(parent_fd)
         # The mount root as well. Forcing the mode on .overflow, the chat
         # directory and the file, but not on the directory they all sit inside,
         # leaves a 0700 root under umask 0077 — every descendant correct and

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -46,7 +46,7 @@ import time
 from dataclasses import dataclass
 from types import SimpleNamespace
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 from suzent.logger import get_logger
 
@@ -215,7 +215,6 @@ def _spill_by_path(
     name: str,
     dir_mode: int,
     file_mode: int,
-    keep_check: Optional[Callable[[], bool]] = None,
 ) -> bool:
     """Write the spill without directory descriptors.
 
@@ -272,15 +271,6 @@ def _spill_by_path(
             pass
         return False
 
-    if keep_check is not None and not keep_check():
-        try:
-            (directory / name).unlink(missing_ok=True)
-        except OSError:
-            pass
-        return False
-
-    _prune_path(directory)
-    _enforce_root_quota_path(directory.parent)
     return True
 
 
@@ -479,7 +469,6 @@ def _spill_pinned(
     name: str,
     dir_mode: int,
     file_mode: int,
-    keep_check: Optional[Callable[[], bool]] = None,
 ) -> bool:
     """Write the spill with every directory on the path pinned.
 
@@ -530,22 +519,6 @@ def _spill_pinned(
                 pass
             return False
 
-        # Before pruning, because pruning is irreversible: an abandoned spill
-        # that prunes first can evict files whose paths were already handed to a
-        # live conversation, and then delete itself, leaving the eviction as the
-        # only lasting effect.
-        if keep_check is not None and not keep_check():
-            try:
-                os.unlink(name, dir_fd=chat_fd)
-            except OSError:
-                pass
-            return False
-
-        _prune_fd(chat_fd)
-        # And the root ceiling, here rather than only on the hourly timer: a
-        # burst across many chats stays within every per-chat allowance while
-        # the deployment total runs away.
-        _enforce_root_quota_fd(overflow_fd)
         return True
     except OSError as e:
         logger.debug(f"[overflow] no spill directory: {e}")
@@ -557,6 +530,46 @@ def _spill_pinned(
                     os.close(handle_fd)
                 except OSError:
                     pass
+
+
+def _prune_after_accept(deps: Any) -> None:
+    """Apply the quotas, once a spill has actually been handed to its caller.
+
+    Pruning is the irreversible half of a spill, so it waits for the reversible
+    half to be accepted. Doing it during the write meant an abandoned spill
+    could evict files whose paths a live conversation held and then delete
+    itself, leaving the eviction as its only effect — and every attempt to guard
+    that with a flag left a window between the check and the scan.
+
+    Ordering removes the window instead of narrowing it: nothing that is not
+    owned by a caller ever prunes.
+    """
+    from suzent.config import CONFIG
+
+    root = Path(CONFIG.sandbox_data_path) / "shared" / ".overflow"
+    chat_dir = root / _chat_segment(deps)
+    try:
+        if _HAVE_DIR_FD:
+            flags = (
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0)
+            )
+            root_fd = os.open(root, flags)
+            try:
+                chat_fd = os.open(_chat_segment(deps), flags, dir_fd=root_fd)
+                try:
+                    _prune_fd(chat_fd)
+                finally:
+                    os.close(chat_fd)
+                _enforce_root_quota_fd(root_fd)
+            finally:
+                os.close(root_fd)
+        else:
+            _prune_path(chat_dir)
+            _enforce_root_quota_path(root)
+    except OSError as e:
+        logger.debug(f"[overflow] could not prune after a spill: {e}")
 
 
 def _discard(spill: Spill) -> None:
@@ -586,9 +599,17 @@ def _deps_snapshot(deps: Any) -> Any:
 
 
 def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[Spill]:
-    """Clip *text* and write it somewhere this chat can read it."""
+    """Clip *text* and write it somewhere this chat can read it.
+
+    Prunes straight away: this entry point has no caller that can walk away
+    mid-write, so acceptance is immediate. The bounded and async wrappers make
+    that decision themselves and prune only once it goes their way.
+    """
     payload, clipped = _clip(text)
-    return _spill_payload(payload, clipped, deps=deps, kind=kind)
+    spill = _spill_payload(payload, clipped, deps=deps, kind=kind)
+    if spill is not None:
+        _prune_after_accept(deps)
+    return spill
 
 
 def _spill_payload(
@@ -597,7 +618,6 @@ def _spill_payload(
     *,
     deps: Any,
     kind: str = "output",
-    keep_check: Optional[Callable[[], bool]] = None,
 ) -> Optional[Spill]:
     """Write an already-bounded *payload*; return where it went.
 
@@ -677,12 +697,9 @@ def _spill_payload(
             name,
             dir_mode,
             file_mode,
-            keep_check,
         ):
             return None
-    elif not _spill_pinned(
-        payload, shared_host, chat, name, dir_mode, file_mode, keep_check
-    ):
+    elif not _spill_pinned(payload, shared_host, chat, name, dir_mode, file_mode):
         return None
 
     written = shared_host / ".overflow" / chat / name
@@ -797,25 +814,22 @@ def spill_overflow_bounded(
 
     def _worker() -> None:
         try:
-            spill = _spill_payload(
-                payload,
-                clipped,
-                deps=snapshot,
-                kind=kind,
-                keep_check=lambda: not abandoned.is_set(),
-            )
+            spill = _spill_payload(payload, clipped, deps=snapshot, kind=kind)
             if spill is None:
                 return
-            # Under the lock, because the caller can give up between the check
-            # and the assignment — and then nobody owns the file.
+            # One atomic decision: either the caller takes it, or nobody does.
             with handover:
                 if abandoned.is_set():
-                    late = spill
+                    accepted = False
                 else:
                     result[0] = spill
-                    late = None
-            if late is not None:
-                _discard(late)
+                    accepted = True
+            # Both of these are filesystem work and both happen here, on the
+            # worker — never on the caller's thread and never on the loop.
+            if accepted:
+                _prune_after_accept(snapshot)
+            else:
+                _discard(spill)
         finally:
             _spill_slots.release()
 
@@ -833,6 +847,11 @@ def spill_overflow_bounded(
     thread.join(timeout=SPILL_TIMEOUT_SECONDS)
     if thread.is_alive():
         with handover:
+            # The worker may have stored a result and still be inside its
+            # finally when the join expired. Abandoning it then would throw away
+            # a spill that is already written and already ours.
+            if result[0] is not None:
+                return result[0]
             abandoned.set()
         # The write may still land. Nobody was told about it, so it would sit
         # there consuming the per-chat and root quotas and evicting spills whose
@@ -874,41 +893,53 @@ async def spill_overflow_async(
     # while every other chat waits.
     head, dropped = _bound_chars(text)
     snapshot = _deps_snapshot(deps)
-    abandoned = threading.Event()
 
     loop = asyncio.get_running_loop()
     future: asyncio.Future = loop.create_future()
 
+    settled = threading.Event()
+    accepted: list[bool] = [False]
+
     def _deliver(value: Optional[Spill]) -> None:
-        # Runs on the loop, so it sees the future's final state. A caller
-        # cancelled after the worker's own check but before this point leaves a
-        # completed future and an unowned file; here is the one place that can
-        # tell.
-        if future.done():
-            if value is not None:
-                _discard(value)
-            return
-        future.set_result(value)
+        # Runs on the loop, which is the only place that can see whether the
+        # future was already cancelled — but it does no filesystem work: an
+        # unlink on the same wedged volume would stall every chat, after the
+        # caller's deadline has already expired. It answers, and the worker acts.
+        try:
+            if future.done():
+                accepted[0] = False
+                return
+            future.set_result(value)
+            accepted[0] = value is not None
+        finally:
+            settled.set()
 
     def _worker() -> None:
+        spill = None
         try:
             payload, clipped = _encode_bounded(head, dropped)
-            spill = _spill_payload(
-                payload,
-                clipped,
-                deps=snapshot,
-                kind=kind,
-                keep_check=lambda: not abandoned.is_set(),
-            )
+            spill = _spill_payload(payload, clipped, deps=snapshot, kind=kind)
         except BaseException as e:  # noqa: BLE001 - a spill never fails its caller
             logger.debug(f"[overflow] spill failed: {e}")
-            spill = None
         finally:
             _spill_slots.release()
+
         try:
             loop.call_soon_threadsafe(_deliver, spill)
         except RuntimeError:
-            pass  # loop already closed; nobody is waiting
+            # Loop already closed; nobody is waiting, so nobody owns the file.
+            if spill is not None:
+                _discard(spill)
+            return
+
+        if spill is None:
+            return
+        # Wait for the loop's answer, then do the filesystem work here.
+        settled.wait(timeout=SPILL_TIMEOUT_SECONDS)
+        if accepted[0]:
+            _prune_after_accept(snapshot)
+        else:
+            _discard(spill)
 
     if not _spill_slots.acquire(blocking=False):
         logger.warning(
@@ -926,7 +957,6 @@ async def spill_overflow_async(
     try:
         return await asyncio.wait_for(future, timeout=SPILL_TIMEOUT_SECONDS)
     except asyncio.TimeoutError:
-        abandoned.set()
         logger.warning(
             f"[overflow] spill exceeded {SPILL_TIMEOUT_SECONDS}s — truncating "
             f"without a pointer"
@@ -934,11 +964,8 @@ async def spill_overflow_async(
         return None
     except BaseException:
         # Cancellation reaches here too — a client disconnecting, a social turn
-        # superseded — and it means what the timeout means: nobody will receive
-        # this pointer, so the file the worker may still write must not be left
-        # counting against the quotas. Catching only TimeoutError covered the
-        # deadline and not the commoner way a caller goes away.
-        abandoned.set()
+        # superseded. Both leave the future done-but-unreadable, which _deliver
+        # reads as "nobody took it", so the worker discards rather than prunes.
         raise
 
 

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -413,6 +413,13 @@ def _enforce_root_quota_fd(
                 continue
             try:
                 for kept in os.scandir(chat_fd):
+                    # Completed spills only. A staged file belongs to a writer
+                    # that still has it open; unlinking it succeeds on POSIX and
+                    # the rename then fails, so the result loses its pointer for
+                    # a file that was never counted against anyone's quota
+                    # anyway. The other three scans filter; this one did not.
+                    if not kept.name.endswith(".txt"):
+                        continue
                     try:
                         stat = kept.stat(follow_symlinks=False)
                     except OSError:

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -72,13 +72,20 @@ class Spill:
 
 
 def retention_hint() -> str:
-    """How long a spill lasts, for the marker that points at one.
+    """How long a spill may last, for the marker that points at one.
 
     The marker outlives the file: the path goes into conversation history, the
     file expires. Saying the window turns a puzzling missing file into an
-    expected one. Derived from the TTL so the two cannot drift.
+    expected one.
+
+    "up to", because the count and byte ceilings evict early — eleven
+    maximum-sized results inside an hour will drop the first of them long before
+    the day is out. Promising a duration the storage bounds can overrule is the
+    same defect as promising a full output that was clipped.
+
+    Derived from the TTL so the two cannot drift.
     """
-    return f"kept {OVERFLOW_TTL_SECONDS // 3600}h"
+    return f"kept up to {OVERFLOW_TTL_SECONDS // 3600}h"
 
 
 def _chat_segment(deps: Any) -> str:
@@ -170,6 +177,22 @@ def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[Sp
     """
     resolver = getattr(deps, "path_resolver", None)
     if resolver is None:
+        return None
+
+    # Sandbox mode gets the plain marker instead of a file.
+    #
+    # Every container bind-mounts the same host `shared` directory read-write
+    # and every one of them runs as uid 1000, so a per-chat subdirectory is a
+    # naming convention and not a boundary: chat B lists and reads chat A's
+    # spills whatever the mode bits say. Spills hold raw tool output and
+    # reminder text, which is conversation content, so the honest options are a
+    # per-chat mount or not writing the file — and a convenience feature does
+    # not get to widen the isolation model on its way in.
+    #
+    # Host mode has no such boundary to breach: the agent already reaches the
+    # whole filesystem through its shell, so the spill exposes nothing that was
+    # not reachable already.
+    if getattr(deps, "sandbox_enabled", True):
         return None
 
     try:
@@ -266,22 +289,44 @@ def sweep_overflow() -> None:
     if not root.is_dir():
         return
 
+    # Descended with the same no-follow discipline as the write path. A symlink
+    # left as a child of .overflow would otherwise be followed twice — once by
+    # is_dir(), once by the open — and _prune_fd unlinks, so the sweep would
+    # delete *.txt files in a directory of the sandbox's choosing on the next
+    # restart. The write path was pinned and this was not; the attacker picks
+    # the weaker one.
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        root_fd = os.open(root, flags)
+    except OSError as e:
+        logger.debug(f"[overflow] cannot open the spill root: {e}")
+        return
+
     swept = 0
-    for chat_dir in root.iterdir():
-        if not chat_dir.is_dir():
-            continue
-        try:
-            before = len(list(chat_dir.glob("*.txt")))
-            fd = os.open(chat_dir, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        for entry in os.scandir(root_fd):
+            if not entry.is_dir(follow_symlinks=False):
+                continue
             try:
-                _prune_fd(fd)
+                chat_fd = os.open(entry.name, flags, dir_fd=root_fd)
+            except OSError:
+                continue
+            try:
+                before = sum(1 for _ in os.scandir(chat_fd))
+                _prune_fd(chat_fd)
+                after = sum(1 for _ in os.scandir(chat_fd))
+                swept += before - after
             finally:
-                os.close(fd)
-            swept += before - len(list(chat_dir.glob("*.txt")))
-            if not any(chat_dir.iterdir()):
-                chat_dir.rmdir()
-        except OSError:
-            continue
+                os.close(chat_fd)
+            if after == 0:
+                try:
+                    os.rmdir(entry.name, dir_fd=root_fd)
+                except OSError:
+                    pass
+    except OSError:
+        pass
+    finally:
+        os.close(root_fd)
 
     if swept:
         logger.info(f"[overflow] swept {swept} stale spill(s)")

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -38,6 +38,7 @@ import secrets
 import threading
 import time
 from dataclasses import dataclass
+from types import SimpleNamespace
 from pathlib import Path
 from typing import Any, Optional
 
@@ -116,10 +117,16 @@ _HAVE_DIR_FD = os.open in os.supports_dir_fd and os.unlink in os.supports_dir_fd
 
 @dataclass(frozen=True)
 class Spill:
-    """Where the overflow went, and whether all of it got there."""
+    """Where the overflow went, and whether all of it got there.
+
+    ``host_path`` is the file on disk; ``path`` is what the agent is told, which
+    differs in sandbox mode. Both are needed because a spill that finishes after
+    its caller gave up has to be removed, and only the host path can do that.
+    """
 
     path: str
     clipped: bool
+    host_path: Optional[str] = None
 
 
 def retention_hint() -> str:
@@ -522,6 +529,32 @@ def _spill_pinned(
                     pass
 
 
+def _discard(spill: Spill) -> None:
+    """Remove a spill nobody was told about."""
+    if not spill.host_path:
+        return
+    try:
+        Path(spill.host_path).unlink(missing_ok=True)
+        logger.debug("[overflow] removed a spill that finished after its deadline")
+    except OSError as e:
+        logger.debug(f"[overflow] could not remove an abandoned spill: {e}")
+
+
+def _deps_snapshot(deps: Any) -> Any:
+    """The three values a spill actually needs.
+
+    An abandoned worker holds its closure for as long as the storage stays
+    wedged, and AgentDeps carries the request's message history, repository
+    context and caches. Four of those is far more than the bounded payload the
+    slot limit was reasoning about.
+    """
+    return SimpleNamespace(
+        path_resolver=getattr(deps, "path_resolver", None),
+        sandbox_enabled=getattr(deps, "sandbox_enabled", True),
+        chat_id=getattr(deps, "chat_id", ""),
+    )
+
+
 def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[Spill]:
     """Clip *text* and write it somewhere this chat can read it."""
     payload, clipped = _clip(text)
@@ -610,9 +643,10 @@ def _spill_payload(
     elif not _spill_pinned(payload, shared_host, chat, name, dir_mode, file_mode):
         return None
 
+    written = shared_host / ".overflow" / chat / name
     if virtual is not None:
-        return Spill(virtual, clipped)
-    return Spill(str(shared_host / ".overflow" / chat / name), clipped)
+        return Spill(virtual, clipped, str(written))
+    return Spill(str(written), clipped, str(written))
 
 
 #: Held for the duration of a sweep, so a wedged one cannot be joined by the
@@ -714,11 +748,17 @@ def spill_overflow_bounded(
         )
         return None
 
+    snapshot = _deps_snapshot(deps)
+    abandoned = threading.Event()
     result: list[Optional[Spill]] = [None]
 
     def _worker() -> None:
         try:
-            result[0] = _spill_payload(payload, clipped, deps=deps, kind=kind)
+            spill = _spill_payload(payload, clipped, deps=snapshot, kind=kind)
+            if spill is not None and abandoned.is_set():
+                _discard(spill)
+            else:
+                result[0] = spill
         finally:
             _spill_slots.release()
 
@@ -735,6 +775,10 @@ def spill_overflow_bounded(
         return None
     thread.join(timeout=SPILL_TIMEOUT_SECONDS)
     if thread.is_alive():
+        # The write may still land. Nobody was told about it, so it would sit
+        # there consuming the per-chat and root quotas and evicting spills whose
+        # paths *were* handed out — the worker removes it when it finishes.
+        abandoned.set()
         logger.warning(
             f"[overflow] spill exceeded {SPILL_TIMEOUT_SECONDS}s — truncating "
             f"without a pointer"
@@ -771,6 +815,8 @@ async def spill_overflow_async(
     # the encode is what costs — up to four bytes per character, on the loop,
     # while every other chat waits.
     head, dropped = _bound_chars(text)
+    snapshot = _deps_snapshot(deps)
+    abandoned = threading.Event()
 
     loop = asyncio.get_running_loop()
     future: asyncio.Future = loop.create_future()
@@ -782,7 +828,10 @@ async def spill_overflow_async(
     def _worker() -> None:
         try:
             payload, clipped = _encode_bounded(head, dropped)
-            spill = _spill_payload(payload, clipped, deps=deps, kind=kind)
+            spill = _spill_payload(payload, clipped, deps=snapshot, kind=kind)
+            if spill is not None and abandoned.is_set():
+                _discard(spill)
+                spill = None
         except BaseException as e:  # noqa: BLE001 - a spill never fails its caller
             logger.debug(f"[overflow] spill failed: {e}")
             spill = None
@@ -809,6 +858,7 @@ async def spill_overflow_async(
     try:
         return await asyncio.wait_for(future, timeout=SPILL_TIMEOUT_SECONDS)
     except asyncio.TimeoutError:
+        abandoned.set()
         logger.warning(
             f"[overflow] spill exceeded {SPILL_TIMEOUT_SECONDS}s — truncating "
             f"without a pointer"

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -105,6 +105,18 @@ SPILL_CLIPPED_NOTE = "\n\n[spill clipped: output exceeded the per-file limit]"
 #: in this file. It buys a bounded overshoot: whatever is written in a minute.
 OVERFLOW_GRACE_SECONDS = 60
 
+#: How far ahead of the clock an mtime may sit and still be believed.
+#:
+#: Grace is a window, not a lower bound. If the host's clock steps backwards —
+#: an NTP correction, a VM resuming from a snapshot — every file published
+#: before the step is stamped in the future, and a one-sided ``mtime >= now -
+#: 60`` treats all of them as newborn for the whole rollback interval, which
+#: can be hours. A burst caught by that window sits above both ceilings until
+#: the clock catches up. Bounding the window on both sides costs one
+#: comparison and keeps the overshoot at a minute's worth of writes; the slack
+#: absorbs coarse filesystem timestamps and small NFS skew.
+OVERFLOW_CLOCK_SKEW_SECONDS = 5
+
 #: Suffix a spill wears while it is being written.
 #:
 #: Scans match ``*.txt``, so a partial file is invisible to them: the sweep or
@@ -179,6 +191,14 @@ def retention_hint() -> str:
     # the "full output" claim this marker already had to walk back.
     longest = OVERFLOW_TTL_SECONDS + OVERFLOW_SWEEP_INTERVAL_SECONDS
     return f"kept up to {longest // 3600}h"
+
+
+def _in_grace(mtime: float, now: float) -> bool:
+    """True while a spill is too young to evict.
+
+    Two-sided on purpose: see OVERFLOW_CLOCK_SKEW_SECONDS.
+    """
+    return now - OVERFLOW_GRACE_SECONDS <= mtime <= now + OVERFLOW_CLOCK_SKEW_SECONDS
 
 
 def _shared_root() -> Path:
@@ -385,7 +405,7 @@ def _prune_path(directory: Path, protect: Optional[str] = None) -> None:
             continue
 
     cutoff = time.time() - OVERFLOW_TTL_SECONDS
-    fresh = time.time() - OVERFLOW_GRACE_SECONDS
+    now = time.time()
     running = 0
     for index, (mtime, size, path) in enumerate(entries):
         over = (
@@ -393,7 +413,7 @@ def _prune_path(directory: Path, protect: Optional[str] = None) -> None:
             or mtime < cutoff
             or running + size > OVERFLOW_MAX_TOTAL_BYTES
         )
-        protected = path.name == protect or mtime >= fresh
+        protected = path.name == protect or _in_grace(mtime, now)
         try:
             if over and not protected:
                 path.unlink(missing_ok=True)
@@ -449,14 +469,14 @@ def _enforce_root_quota_fd(
     # Newest first, so what goes is least likely to be referenced by a live
     # conversation.
     survivors.sort(reverse=True)
-    fresh = time.time() - OVERFLOW_GRACE_SECONDS
+    now = time.time()
     removed = 0
     running = 0
     for mtime, size, chat_name, file_name in survivors:
         # Counted whether or not it can be deleted: omitting fresh files from
         # the running total let a burst across chats exceed the deployment
         # ceiling entirely, which is the ceiling's whole purpose.
-        protected = protect == (chat_name, file_name) or mtime >= fresh
+        protected = protect == (chat_name, file_name) or _in_grace(mtime, now)
         if running + size <= OVERFLOW_MAX_ROOT_BYTES or protected:
             running += size
             continue
@@ -493,11 +513,11 @@ def _enforce_root_quota_path(
         return 0
 
     survivors.sort(reverse=True)
-    fresh = time.time() - OVERFLOW_GRACE_SECONDS
+    now = time.time()
     removed = 0
     running = 0
     for mtime, size, path in survivors:
-        protected = protect == (path.parent.name, path.name) or mtime >= fresh
+        protected = protect == (path.parent.name, path.name) or _in_grace(mtime, now)
         if running + size <= OVERFLOW_MAX_ROOT_BYTES or protected:
             running += size
             continue
@@ -542,7 +562,7 @@ def _prune_fd(dir_fd: int, protect: Optional[str] = None) -> None:
 
     entries.sort(reverse=True)
     cutoff = time.time() - OVERFLOW_TTL_SECONDS
-    fresh = time.time() - OVERFLOW_GRACE_SECONDS
+    now = time.time()
     running = 0
     for index, (mtime, size, name) in enumerate(entries):
         over = (
@@ -555,7 +575,7 @@ def _prune_fd(dir_fd: int, protect: Optional[str] = None) -> None:
         # exceed the per-chat limit while none is old enough to consider. They
         # consume budget like anything else; they are simply the ones that
         # displace older files rather than being displaced.
-        protected = name == protect or mtime >= fresh
+        protected = name == protect or _in_grace(mtime, now)
         try:
             if over and not protected:
                 os.unlink(name, dir_fd=dir_fd)

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -53,6 +53,15 @@ OVERFLOW_VIRTUAL_DIR = "/shared/.overflow"
 #: session, short enough that a week of build logs does not accumulate.
 OVERFLOW_TTL_SECONDS = 24 * 60 * 60
 
+#: How often the sweep runs while the service is up.
+#:
+#: The root quota and the retention window are only enforced where the sweep
+#: reaches. Running it once at startup left both unenforced for the lifetime of
+#: a long-lived process: a chat's last spill outlives its advertised window, and
+#: the deployment-wide total is never checked at all, because a write only ever
+#: prunes its own chat's directory.
+OVERFLOW_SWEEP_INTERVAL_SECONDS = 60 * 60
+
 #: Per-chat ceilings. A single runaway session can write thousands of files, and
 #: 200 files of any size is not a bound on disk, so both apply.
 OVERFLOW_MAX_FILES = 200
@@ -127,7 +136,13 @@ def retention_hint() -> str:
 
     Derived from the TTL so the two cannot drift.
     """
-    return f"kept up to {OVERFLOW_TTL_SECONDS // 3600}h"
+    # TTL plus the sweep interval, because deletion happens on a tick and not on
+    # an alarm: a spill created just after one sweep is still inside the window
+    # at the tick that follows its expiry, and goes on the one after that. An
+    # advertised bound the ordinary schedule does not meet is the same defect as
+    # the "full output" claim this marker already had to walk back.
+    longest = OVERFLOW_TTL_SECONDS + OVERFLOW_SWEEP_INTERVAL_SECONDS
+    return f"kept up to {longest // 3600}h"
 
 
 def _chat_segment(deps: Any) -> str:
@@ -579,14 +594,11 @@ def _spill_payload(
     return Spill(str(shared_host / ".overflow" / chat / name), clipped)
 
 
-#: How often the sweep runs while the service is up.
-#:
-#: The root quota and the retention window are only enforced where the sweep
-#: reaches. Running it once at startup left both unenforced for the lifetime of
-#: a long-lived process: a chat's last spill outlives its advertised window, and
-#: the deployment-wide total is never checked at all, because a write only ever
-#: prunes its own chat's directory.
-OVERFLOW_SWEEP_INTERVAL_SECONDS = 60 * 60
+#: Held for the duration of a sweep, so a wedged one cannot be joined by the
+#: next tick. There is nothing useful for a second concurrent sweep to do — it
+#: would walk the same directories — and on storage that recovers after an
+#: outage, an hour's worth of queued sweeps would all start at once.
+_sweep_lock = threading.Lock()
 
 
 def sweep_overflow_in_background() -> None:
@@ -598,6 +610,10 @@ def sweep_overflow_in_background() -> None:
     cancellation added earlier was meant to prevent.
     """
 
+    if not _sweep_lock.acquire(blocking=False):
+        logger.debug("[overflow] a sweep is still running; skipping this tick")
+        return
+
     def _guarded() -> None:
         # The caller's try/except cannot see a thread's exception, so moving the
         # sweep off the loop moved its failures out of reach of the handler that
@@ -606,10 +622,13 @@ def sweep_overflow_in_background() -> None:
             sweep_overflow()
         except Exception as e:  # noqa: BLE001 - a sweep failure is not fatal
             logger.warning(f"[overflow] sweep failed: {e}")
+        finally:
+            _sweep_lock.release()
 
     try:
         threading.Thread(target=_guarded, name="overflow-sweep", daemon=True).start()
     except BaseException as e:
+        _sweep_lock.release()
         logger.warning(f"[overflow] could not start the sweep: {e}")
 
 

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -462,7 +462,8 @@ def _prune_path(directory: Path, protect: Optional[str] = None) -> None:
                 path.unlink(missing_ok=True)
                 continue
         except OSError:
-            continue
+            # It is still on disk, so it still occupies a slot and its bytes.
+            pass
         running += size
         kept += 1
 
@@ -532,12 +533,13 @@ def _enforce_root_quota_fd(
         try:
             chat_fd = os.open(chat_name, flags, dir_fd=root_fd)
         except OSError:
+            running += size
             continue
         try:
             os.unlink(file_name, dir_fd=chat_fd)
             removed += 1
         except OSError:
-            pass
+            running += size
         finally:
             os.close(chat_fd)
     return removed
@@ -576,7 +578,7 @@ def _enforce_root_quota_path(
             path.unlink(missing_ok=True)
             removed += 1
         except OSError:
-            continue
+            running += size
     return removed
 
 
@@ -634,7 +636,8 @@ def _prune_fd(dir_fd: int, protect: Optional[str] = None) -> None:
                 os.unlink(name, dir_fd=dir_fd)
                 continue
         except OSError:
-            continue
+            # It is still on disk, so it still occupies a slot and its bytes.
+            pass
         running += size
         kept += 1
 

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -12,7 +12,9 @@ decides whether the rest is worth a read; nothing is silently lost either way.
 
 from __future__ import annotations
 
-import hashlib
+import errno
+import os
+import secrets
 import time
 from pathlib import Path
 from typing import Any, Optional
@@ -35,9 +37,28 @@ OVERFLOW_TTL_SECONDS = 24 * 60 * 60
 #: thousands; the TTL alone would not bound that until tomorrow.
 OVERFLOW_MAX_FILES = 200
 
+#: Ceiling on one spill. A foreground shell command reads its whole output into
+#: memory and this writes all of it, so without a per-file bound a single
+#: `cat` of something large lands on disk in full.
+OVERFLOW_MAX_FILE_BYTES = 5 * 1024 * 1024
+
+#: Ceiling on the directory. The count bound alone permits 200 files of any
+#: size, which is not a bound on disk at all.
+OVERFLOW_MAX_TOTAL_BYTES = 50 * 1024 * 1024
+
+#: Appended when the spill itself had to be cut. Rare, and better said than not:
+#: a file that silently holds part of the output is worse than the truncation it
+#: was meant to relieve.
+SPILL_CLIPPED_NOTE = "\n\n[spill clipped: output exceeded the per-file limit]"
+
 
 def _prune(directory: Path) -> None:
-    """Best-effort cleanup. A spill that cannot be pruned is still a spill."""
+    """Best-effort cleanup. A spill that cannot be pruned is still a spill.
+
+    Bounded three ways, because each alone leaves a hole: age lets a burst sit
+    until tomorrow, count permits 200 files of any size, and bytes alone would
+    keep one ancient file forever.
+    """
     try:
         files = sorted(
             (p for p in directory.glob("*.txt") if p.is_file()),
@@ -48,10 +69,17 @@ def _prune(directory: Path) -> None:
         return
 
     cutoff = time.time() - OVERFLOW_TTL_SECONDS
+    running_total = 0
     for index, path in enumerate(files):
         try:
-            if index >= OVERFLOW_MAX_FILES or path.stat().st_mtime < cutoff:
+            size = path.stat().st_size
+            too_many = index >= OVERFLOW_MAX_FILES
+            too_old = path.stat().st_mtime < cutoff
+            too_big = running_total + size > OVERFLOW_MAX_TOTAL_BYTES
+            if too_many or too_old or too_big:
                 path.unlink(missing_ok=True)
+                continue
+            running_total += size
         except OSError:
             continue
 
@@ -78,14 +106,42 @@ def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[st
         logger.debug(f"[overflow] no spill directory: {e}")
         return None
 
-    digest = hashlib.sha1(text.encode("utf-8", "replace")).hexdigest()[:8]
-    name = f"{kind}-{int(time.time())}-{digest}.txt"
+    payload = text.encode("utf-8", "replace")
+    if len(payload) > OVERFLOW_MAX_FILE_BYTES:
+        keep = OVERFLOW_MAX_FILE_BYTES - len(SPILL_CLIPPED_NOTE)
+        payload = payload[:keep] + SPILL_CLIPPED_NOTE.encode("utf-8")
+
+    # Unpredictable, and created without following anything already at the path.
+    #
+    # The name used to be derived from the output's own hash and the current
+    # second, which a sandboxed agent can compute: pre-place a symlink there,
+    # emit output that overflows, and the host process follows the link and
+    # overwrites whatever it points at — no PathResolver check involved, since
+    # the write is ours, not the agent's. O_EXCL refuses an existing path
+    # (symlink included) and O_NOFOLLOW refuses to traverse one; the random name
+    # means there is nothing to aim at in the first place.
+    name = f"{kind}-{secrets.token_hex(16)}.txt"
     host_path = host_dir / name
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
 
     try:
-        host_path.write_text(text, encoding="utf-8", errors="replace")
+        fd = os.open(host_path, flags, 0o600)
+    except OSError as e:
+        if e.errno in (errno.EEXIST, errno.ELOOP):
+            logger.warning(f"[overflow] refusing to write over an existing path: {e}")
+        else:
+            logger.debug(f"[overflow] could not create spill: {e}")
+        return None
+
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
     except OSError as e:
         logger.debug(f"[overflow] could not write spill: {e}")
+        try:
+            host_path.unlink(missing_ok=True)
+        except OSError:
+            pass
         return None
 
     _prune(host_dir)

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -35,6 +35,7 @@ import errno
 import os
 import re
 import secrets
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -198,6 +199,7 @@ def _spill_by_path(
         return False
 
     _prune_path(directory)
+    _enforce_root_quota_path(directory.parent)
     return True
 
 
@@ -257,6 +259,94 @@ def _prune_path(directory: Path) -> None:
                 running += size
         except OSError:
             continue
+
+
+def _enforce_root_quota_fd(root_fd: int) -> int:
+    """Hold the deployment-wide ceiling across every chat directory.
+
+    Separate from the per-chat prune because the two answer different
+    questions, and leaving this one to the hourly sweep meant a burst of chats
+    could sit above the root ceiling for an hour — long enough to fill a volume
+    that every directory was individually respecting.
+
+    Returns the number of files removed.
+    """
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    survivors: list[tuple[float, int, str, str]] = []
+    try:
+        for entry in os.scandir(root_fd):
+            if not entry.is_dir(follow_symlinks=False):
+                continue
+            try:
+                chat_fd = os.open(entry.name, flags, dir_fd=root_fd)
+            except OSError:
+                continue
+            try:
+                for kept in os.scandir(chat_fd):
+                    try:
+                        stat = kept.stat(follow_symlinks=False)
+                    except OSError:
+                        continue
+                    survivors.append(
+                        (stat.st_mtime, stat.st_size, entry.name, kept.name)
+                    )
+            finally:
+                os.close(chat_fd)
+    except OSError:
+        return 0
+
+    # Newest first, so what goes is least likely to be referenced by a live
+    # conversation.
+    survivors.sort(reverse=True)
+    removed = 0
+    running = 0
+    for _mtime, size, chat_name, file_name in survivors:
+        if running + size <= OVERFLOW_MAX_ROOT_BYTES:
+            running += size
+            continue
+        try:
+            chat_fd = os.open(chat_name, flags, dir_fd=root_fd)
+        except OSError:
+            continue
+        try:
+            os.unlink(file_name, dir_fd=chat_fd)
+            removed += 1
+        except OSError:
+            pass
+        finally:
+            os.close(chat_fd)
+    return removed
+
+
+def _enforce_root_quota_path(root: Path) -> int:
+    """The path-based twin of _enforce_root_quota_fd."""
+    survivors: list[tuple[float, int, Path]] = []
+    try:
+        for chat_dir in root.iterdir():
+            if not chat_dir.is_dir() or chat_dir.is_symlink():
+                continue
+            for path in chat_dir.glob("*.txt"):
+                try:
+                    stat = path.stat()
+                except OSError:
+                    continue
+                survivors.append((stat.st_mtime, stat.st_size, path))
+    except OSError:
+        return 0
+
+    survivors.sort(reverse=True)
+    removed = 0
+    running = 0
+    for _mtime, size, path in survivors:
+        if running + size <= OVERFLOW_MAX_ROOT_BYTES:
+            running += size
+            continue
+        try:
+            path.unlink(missing_ok=True)
+            removed += 1
+        except OSError:
+            continue
+    return removed
 
 
 def _prune_fd(dir_fd: int) -> None:
@@ -350,6 +440,10 @@ def _spill_pinned(
             return False
 
         _prune_fd(chat_fd)
+        # And the root ceiling, here rather than only on the hourly timer: a
+        # burst across many chats stays within every per-chat allowance while
+        # the deployment total runs away.
+        _enforce_root_quota_fd(overflow_fd)
         return True
     except OSError as e:
         logger.debug(f"[overflow] no spill directory: {e}")
@@ -436,6 +530,38 @@ async def sweep_overflow_periodically() -> None:
 SPILL_TIMEOUT_SECONDS = 2.0
 
 
+def spill_overflow_bounded(
+    text: str, *, deps: Any, kind: str = "output"
+) -> Optional[Spill]:
+    """The synchronous caller's version of the same deadline.
+
+    A sync tool runs on a worker rather than the loop, so a wedged volume does
+    not stall other chats — but it does hold a tool call that has *already
+    succeeded*, which is the part worth bounding. Bounding only the async path
+    left the two halves of one rule disagreeing, which is how most of this
+    file's defects have looked.
+
+    The thread is a daemon and is never joined past the deadline: it cannot be
+    cancelled, so a late write simply lands in the spill directory and is
+    collected by the sweep like any other file.
+    """
+    result: list[Optional[Spill]] = [None]
+
+    def _worker() -> None:
+        result[0] = spill_overflow(text, deps=deps, kind=kind)
+
+    thread = threading.Thread(target=_worker, name="overflow-spill", daemon=True)
+    thread.start()
+    thread.join(timeout=SPILL_TIMEOUT_SECONDS)
+    if thread.is_alive():
+        logger.warning(
+            f"[overflow] spill exceeded {SPILL_TIMEOUT_SECONDS}s — truncating "
+            f"without a pointer"
+        )
+        return None
+    return result[0]
+
+
 async def spill_overflow_async(
     text: str, *, deps: Any, kind: str = "output"
 ) -> Optional[Spill]:
@@ -467,37 +593,19 @@ async def spill_overflow_async(
 def _sweep_by_path(root: Path) -> None:
     """Retention and the root quota without directory descriptors."""
     swept = 0
-    survivors: list[tuple[float, int, Path]] = []
     for chat_dir in root.iterdir():
         if not chat_dir.is_dir() or chat_dir.is_symlink():
             continue
         try:
             before = len(list(chat_dir.glob("*.txt")))
             _prune_path(chat_dir)
-            kept = list(chat_dir.glob("*.txt"))
-            swept += before - len(kept)
-            for path in kept:
-                try:
-                    stat = path.stat()
-                except OSError:
-                    continue
-                survivors.append((stat.st_mtime, stat.st_size, path))
+            swept += before - len(list(chat_dir.glob("*.txt")))
             if not any(chat_dir.iterdir()):
                 chat_dir.rmdir()
         except OSError:
             continue
 
-    survivors.sort(reverse=True)
-    running = 0
-    for _mtime, size, path in survivors:
-        if running + size <= OVERFLOW_MAX_ROOT_BYTES:
-            running += size
-            continue
-        try:
-            path.unlink(missing_ok=True)
-            swept += 1
-        except OSError:
-            continue
+    swept += _enforce_root_quota_path(root)
 
     if swept:
         logger.info(f"[overflow] swept {swept} stale spill(s)")
@@ -544,7 +652,6 @@ def sweep_overflow() -> None:
         return
 
     swept = 0
-    survivors: list[tuple[float, int, str, str]] = []
     try:
         for entry in os.scandir(root_fd):
             if not entry.is_dir(follow_symlinks=False):
@@ -556,16 +663,7 @@ def sweep_overflow() -> None:
             try:
                 before = sum(1 for _ in os.scandir(chat_fd))
                 _prune_fd(chat_fd)
-                after = 0
-                for kept in os.scandir(chat_fd):
-                    after += 1
-                    try:
-                        stat = kept.stat(follow_symlinks=False)
-                    except OSError:
-                        continue
-                    survivors.append(
-                        (stat.st_mtime, stat.st_size, entry.name, kept.name)
-                    )
+                after = sum(1 for _ in os.scandir(chat_fd))
                 swept += before - after
             finally:
                 os.close(chat_fd)
@@ -575,25 +673,7 @@ def sweep_overflow() -> None:
                 except OSError:
                     pass
 
-        # The root ceiling, across every chat. Newest first, so what goes is the
-        # least likely to still be referenced by a live conversation.
-        survivors.sort(reverse=True)
-        running = 0
-        for _mtime, size, chat_name, file_name in survivors:
-            if running + size <= OVERFLOW_MAX_ROOT_BYTES:
-                running += size
-                continue
-            try:
-                chat_fd = os.open(chat_name, flags, dir_fd=root_fd)
-            except OSError:
-                continue
-            try:
-                os.unlink(file_name, dir_fd=chat_fd)
-                swept += 1
-            except OSError:
-                pass
-            finally:
-                os.close(chat_fd)
+        swept += _enforce_root_quota_fd(root_fd)
     except OSError:
         pass
     finally:

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -46,7 +46,7 @@ import time
 from dataclasses import dataclass
 from types import SimpleNamespace
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from suzent.logger import get_logger
 
@@ -210,7 +210,12 @@ def _open_child_dir(name: str, parent_fd: int, dir_mode: int) -> int:
 
 
 def _spill_by_path(
-    payload: bytes, directory: Path, name: str, dir_mode: int, file_mode: int
+    payload: bytes,
+    directory: Path,
+    name: str,
+    dir_mode: int,
+    file_mode: int,
+    keep_check: Optional[Callable[[], bool]] = None,
 ) -> bool:
     """Write the spill without directory descriptors.
 
@@ -261,6 +266,13 @@ def _spill_by_path(
         # The descriptor-based path already does this. A half-written file that
         # was never advertised is pure litter, and this branch skips pruning, so
         # it sits there until the sweep.
+        try:
+            (directory / name).unlink(missing_ok=True)
+        except OSError:
+            pass
+        return False
+
+    if keep_check is not None and not keep_check():
         try:
             (directory / name).unlink(missing_ok=True)
         except OSError:
@@ -467,6 +479,7 @@ def _spill_pinned(
     name: str,
     dir_mode: int,
     file_mode: int,
+    keep_check: Optional[Callable[[], bool]] = None,
 ) -> bool:
     """Write the spill with every directory on the path pinned.
 
@@ -511,6 +524,17 @@ def _spill_pinned(
                 handle.write(payload)
         except OSError as e:
             logger.debug(f"[overflow] could not write spill: {e}")
+            try:
+                os.unlink(name, dir_fd=chat_fd)
+            except OSError:
+                pass
+            return False
+
+        # Before pruning, because pruning is irreversible: an abandoned spill
+        # that prunes first can evict files whose paths were already handed to a
+        # live conversation, and then delete itself, leaving the eviction as the
+        # only lasting effect.
+        if keep_check is not None and not keep_check():
             try:
                 os.unlink(name, dir_fd=chat_fd)
             except OSError:
@@ -568,7 +592,12 @@ def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[Sp
 
 
 def _spill_payload(
-    payload: bytes, clipped: bool, *, deps: Any, kind: str = "output"
+    payload: bytes,
+    clipped: bool,
+    *,
+    deps: Any,
+    kind: str = "output",
+    keep_check: Optional[Callable[[], bool]] = None,
 ) -> Optional[Spill]:
     """Write an already-bounded *payload*; return where it went.
 
@@ -643,10 +672,17 @@ def _spill_payload(
 
     if not _HAVE_DIR_FD:
         if not _spill_by_path(
-            payload, shared_host / ".overflow" / chat, name, dir_mode, file_mode
+            payload,
+            shared_host / ".overflow" / chat,
+            name,
+            dir_mode,
+            file_mode,
+            keep_check,
         ):
             return None
-    elif not _spill_pinned(payload, shared_host, chat, name, dir_mode, file_mode):
+    elif not _spill_pinned(
+        payload, shared_host, chat, name, dir_mode, file_mode, keep_check
+    ):
         return None
 
     written = shared_host / ".overflow" / chat / name
@@ -756,15 +792,30 @@ def spill_overflow_bounded(
 
     snapshot = _deps_snapshot(deps)
     abandoned = threading.Event()
+    handover = threading.Lock()
     result: list[Optional[Spill]] = [None]
 
     def _worker() -> None:
         try:
-            spill = _spill_payload(payload, clipped, deps=snapshot, kind=kind)
-            if spill is not None and abandoned.is_set():
-                _discard(spill)
-            else:
-                result[0] = spill
+            spill = _spill_payload(
+                payload,
+                clipped,
+                deps=snapshot,
+                kind=kind,
+                keep_check=lambda: not abandoned.is_set(),
+            )
+            if spill is None:
+                return
+            # Under the lock, because the caller can give up between the check
+            # and the assignment — and then nobody owns the file.
+            with handover:
+                if abandoned.is_set():
+                    late = spill
+                else:
+                    result[0] = spill
+                    late = None
+            if late is not None:
+                _discard(late)
         finally:
             _spill_slots.release()
 
@@ -781,10 +832,11 @@ def spill_overflow_bounded(
         return None
     thread.join(timeout=SPILL_TIMEOUT_SECONDS)
     if thread.is_alive():
+        with handover:
+            abandoned.set()
         # The write may still land. Nobody was told about it, so it would sit
         # there consuming the per-chat and root quotas and evicting spills whose
         # paths *were* handed out — the worker removes it when it finishes.
-        abandoned.set()
         logger.warning(
             f"[overflow] spill exceeded {SPILL_TIMEOUT_SECONDS}s — truncating "
             f"without a pointer"
@@ -828,16 +880,26 @@ async def spill_overflow_async(
     future: asyncio.Future = loop.create_future()
 
     def _deliver(value: Optional[Spill]) -> None:
-        if not future.done():
-            future.set_result(value)
+        # Runs on the loop, so it sees the future's final state. A caller
+        # cancelled after the worker's own check but before this point leaves a
+        # completed future and an unowned file; here is the one place that can
+        # tell.
+        if future.done():
+            if value is not None:
+                _discard(value)
+            return
+        future.set_result(value)
 
     def _worker() -> None:
         try:
             payload, clipped = _encode_bounded(head, dropped)
-            spill = _spill_payload(payload, clipped, deps=snapshot, kind=kind)
-            if spill is not None and abandoned.is_set():
-                _discard(spill)
-                spill = None
+            spill = _spill_payload(
+                payload,
+                clipped,
+                deps=snapshot,
+                kind=kind,
+                keep_check=lambda: not abandoned.is_set(),
+            )
         except BaseException as e:  # noqa: BLE001 - a spill never fails its caller
             logger.debug(f"[overflow] spill failed: {e}")
             spill = None

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -560,25 +560,18 @@ def _spill_payload(
     name = f"{kind}-{secrets.token_hex(16)}.txt"
 
     sandboxed = bool(getattr(deps, "sandbox_enabled", True))
-    dir_mode = _SHARED_DIR_MODE if sandboxed else _PRIVATE_DIR_MODE
-    file_mode = _SHARED_FILE_MODE if sandboxed else _PRIVATE_FILE_MODE
 
-    if not _HAVE_DIR_FD:
-        if not _spill_by_path(
-            payload, shared_host / ".overflow" / chat, name, dir_mode, file_mode
-        ):
-            return None
-    elif not _spill_pinned(payload, shared_host, chat, name, dir_mode, file_mode):
-        return None
-
-    if getattr(deps, "sandbox_enabled", True):
+    # Checked before anything is written.
+    #
+    # A custom volume can mask /shared/.overflow or a directory under it, and
+    # validating only afterwards meant the file was created and both quota
+    # passes had run before the answer was discarded — so a chat with a masked
+    # mount produced unreachable orphans on every oversized result, and its
+    # pruning could evict spills other chats were still pointing at. Work not
+    # worth doing is worth not doing before the side effects, not after.
+    virtual: Optional[str] = None
+    if sandboxed:
         virtual = f"{OVERFLOW_VIRTUAL_DIR}/{chat}/{name}"
-        # Checking /shared alone is not enough: a custom volume can target
-        # /shared/.overflow or a directory under it, which the sandbox accepts
-        # and which then masks the canonical tree inside the container. The
-        # marker would name a path that resolves somewhere the file is not.
-        # Verifying the final path is the only check that cannot be outflanked
-        # by a more deeply nested mount.
         written = shared_host / ".overflow" / chat / name
         try:
             if Path(resolver.resolve(virtual)).resolve() != written.resolve():
@@ -590,6 +583,18 @@ def _spill_payload(
         except Exception as e:
             logger.debug(f"[overflow] cannot verify the spill path: {e}")
             return None
+    dir_mode = _SHARED_DIR_MODE if sandboxed else _PRIVATE_DIR_MODE
+    file_mode = _SHARED_FILE_MODE if sandboxed else _PRIVATE_FILE_MODE
+
+    if not _HAVE_DIR_FD:
+        if not _spill_by_path(
+            payload, shared_host / ".overflow" / chat, name, dir_mode, file_mode
+        ):
+            return None
+    elif not _spill_pinned(payload, shared_host, chat, name, dir_mode, file_mode):
+        return None
+
+    if virtual is not None:
         return Spill(virtual, clipped)
     return Spill(str(shared_host / ".overflow" / chat / name), clipped)
 

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -208,15 +208,19 @@ def _spill_by_path(
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
         target = directory / name
         fd = os.open(target, flags, file_mode)
+        # Ownership transfers at fdopen and not before. Closing the raw number
+        # after the `with` has already closed it would be a double close, and in
+        # a threaded server another thread can be handed that same descriptor
+        # number in between — so a failed spill write could close an unrelated
+        # socket.
+        handle = None
         try:
-            with os.fdopen(fd, "wb") as handle:
-                handle.write(payload)
-        except BaseException:
-            # fdopen owns the descriptor only once it returns; before that the
-            # raw fd is ours to close, and a leaked handle per oversized result
-            # exhausts the process.
-            os.close(fd)
-            raise
+            handle = os.fdopen(fd, "wb")
+        finally:
+            if handle is None:
+                os.close(fd)
+        with handle:
+            handle.write(payload)
         # By path here rather than by descriptor: this branch exists for
         # platforms without dir_fd, which are also the ones that may lack
         # fchmod.
@@ -553,7 +557,25 @@ def _spill_payload(
         return None
 
     if getattr(deps, "sandbox_enabled", True):
-        return Spill(f"{OVERFLOW_VIRTUAL_DIR}/{chat}/{name}", clipped)
+        virtual = f"{OVERFLOW_VIRTUAL_DIR}/{chat}/{name}"
+        # Checking /shared alone is not enough: a custom volume can target
+        # /shared/.overflow or a directory under it, which the sandbox accepts
+        # and which then masks the canonical tree inside the container. The
+        # marker would name a path that resolves somewhere the file is not.
+        # Verifying the final path is the only check that cannot be outflanked
+        # by a more deeply nested mount.
+        written = shared_host / ".overflow" / chat / name
+        try:
+            if Path(resolver.resolve(virtual)).resolve() != written.resolve():
+                logger.debug(
+                    "[overflow] a custom mount masks the spill path; "
+                    "truncating without a pointer"
+                )
+                return None
+        except Exception as e:
+            logger.debug(f"[overflow] cannot verify the spill path: {e}")
+            return None
+        return Spill(virtual, clipped)
     return Spill(str(shared_host / ".overflow" / chat / name), clipped)
 
 
@@ -567,12 +589,36 @@ def _spill_payload(
 OVERFLOW_SWEEP_INTERVAL_SECONDS = 60 * 60
 
 
+def sweep_overflow_in_background() -> None:
+    """Run one sweep on a thread the process can leave behind.
+
+    Not to_thread: cancelling the coroutine does not stop the function, and the
+    default executor's threads are joined at interpreter exit — so a sweep on a
+    wedged filesystem would hold up shutdown itself, which is precisely what the
+    cancellation added earlier was meant to prevent.
+    """
+
+    def _guarded() -> None:
+        # The caller's try/except cannot see a thread's exception, so moving the
+        # sweep off the loop moved its failures out of reach of the handler that
+        # was catching them — they surfaced as unhandled thread errors instead.
+        try:
+            sweep_overflow()
+        except Exception as e:  # noqa: BLE001 - a sweep failure is not fatal
+            logger.warning(f"[overflow] sweep failed: {e}")
+
+    try:
+        threading.Thread(target=_guarded, name="overflow-sweep", daemon=True).start()
+    except BaseException as e:
+        logger.warning(f"[overflow] could not start the sweep: {e}")
+
+
 async def sweep_overflow_periodically() -> None:
     """Keep the bounds enforced for as long as the service runs."""
     while True:
         try:
             await asyncio.sleep(OVERFLOW_SWEEP_INTERVAL_SECONDS)
-            await asyncio.to_thread(sweep_overflow)
+            sweep_overflow_in_background()
         except asyncio.CancelledError:
             raise
         except Exception as e:  # noqa: BLE001 - a sweep failure must not end the loop
@@ -672,22 +718,56 @@ async def spill_overflow_async(
     background; it lands in the spill directory and is collected by the sweep
     like any other file.
     """
-    # Through the same bounded worker as the sync path, not a bare to_thread: an
-    # abandoned write on the default executor occupies one of its threads
-    # forever, and that executor is shared with everything else that offloads.
+    # Clipped before anything can queue it, and run on a thread of our own
+    # rather than the shared default executor.
     #
-    # Still wrapped in a deadline, because that shared executor can be saturated
-    # by unrelated work — the coroutine would then sit queued, never reaching
-    # the join that was supposed to bound it. Routing through the bounded pool
-    # is what made this necessary and is exactly when I removed it.
-    try:
-        return await asyncio.wait_for(
-            asyncio.to_thread(spill_overflow_bounded, text, deps=deps, kind=kind),
-            timeout=SPILL_TIMEOUT_SECONDS * 2,
+    # to_thread was wrong twice over here. Cancelling the future does not remove
+    # the work item from the executor's queue, so a timed-out submission keeps
+    # holding whatever it captured until some worker eventually dequeues it —
+    # the deadline bounded the caller's latency and not the retained bytes. And
+    # the executor's threads are shared with everything else that offloads, so
+    # an abandoned write there is one fewer thread for unrelated work.
+    payload, clipped = _clip(text)
+
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future = loop.create_future()
+
+    def _deliver(value: Optional[Spill]) -> None:
+        if not future.done():
+            future.set_result(value)
+
+    def _worker() -> None:
+        try:
+            spill = _spill_payload(payload, clipped, deps=deps, kind=kind)
+        except BaseException as e:  # noqa: BLE001 - a spill never fails its caller
+            logger.debug(f"[overflow] spill failed: {e}")
+            spill = None
+        finally:
+            _spill_slots.release()
+        try:
+            loop.call_soon_threadsafe(_deliver, spill)
+        except RuntimeError:
+            pass  # loop already closed; nobody is waiting
+
+    if not _spill_slots.acquire(blocking=False):
+        logger.warning(
+            "[overflow] spill workers saturated; truncating without a pointer"
         )
+        return None
+
+    try:
+        threading.Thread(target=_worker, name="overflow-spill", daemon=True).start()
+    except BaseException as e:
+        _spill_slots.release()
+        logger.warning(f"[overflow] could not start a spill worker: {e}")
+        return None
+
+    try:
+        return await asyncio.wait_for(future, timeout=SPILL_TIMEOUT_SECONDS)
     except asyncio.TimeoutError:
         logger.warning(
-            "[overflow] spill did not start in time — truncating without a pointer"
+            f"[overflow] spill exceeded {SPILL_TIMEOUT_SECONDS}s — truncating "
+            f"without a pointer"
         )
         return None
 

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -84,6 +84,30 @@ def _prune(directory: Path) -> None:
             continue
 
 
+def sweep_overflow() -> None:
+    """Apply the retention bounds without needing a spill to trigger them.
+
+    Pruning otherwise happens only on write, so the bounds hold exactly while
+    output keeps overflowing and stop the moment it does not: the last spill of
+    a session sits there until the next one, which may be never. Nothing else
+    will collect it — this lives in the user's data directory, not in a temp
+    directory the OS sweeps.
+
+    Called at startup, which is also when yesterday's files are most likely to
+    be both stale and forgotten.
+    """
+    from suzent.config import CONFIG
+
+    directory = Path(CONFIG.sandbox_data_path) / "shared" / ".overflow"
+    if not directory.is_dir():
+        return
+    before = len(list(directory.glob("*.txt")))
+    _prune(directory)
+    after = len(list(directory.glob("*.txt")))
+    if before != after:
+        logger.info(f"[overflow] swept {before - after} stale spill(s)")
+
+
 def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[str]:
     """Write *text* somewhere the agent can read it; return that path.
 

--- a/src/suzent/tools/overflow.py
+++ b/src/suzent/tools/overflow.py
@@ -1,0 +1,95 @@
+"""Somewhere to put the part of an output that did not fit.
+
+A cap keeps a single tool result from swallowing the context window, but the
+tail it removes is usually the part someone wanted: the failing assertion at the
+end of a test run, the last hundred lines of a build log. Truncating to a marker
+tells the model that content is missing without giving it any way to go and
+read it.
+
+So the full text is written to a file and the marker carries the path. The model
+decides whether the rest is worth a read; nothing is silently lost either way.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from suzent.logger import get_logger
+
+logger = get_logger(__name__)
+
+#: Virtual home for spilled output. Under /shared rather than the project
+#: workspace so it is not mistaken for the user's files, and so a spill from one
+#: chat is readable by a sub-agent working on the same task.
+OVERFLOW_VIRTUAL_DIR = "/shared/.overflow"
+
+#: How long a spill file is worth keeping. Long enough that the model can read
+#: it later in the same session, short enough that a week of build logs does not
+#: accumulate on disk.
+OVERFLOW_TTL_SECONDS = 24 * 60 * 60
+
+#: Ceiling on files kept, whatever their age. A single runaway session can write
+#: thousands; the TTL alone would not bound that until tomorrow.
+OVERFLOW_MAX_FILES = 200
+
+
+def _prune(directory: Path) -> None:
+    """Best-effort cleanup. A spill that cannot be pruned is still a spill."""
+    try:
+        files = sorted(
+            (p for p in directory.glob("*.txt") if p.is_file()),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+    except OSError:
+        return
+
+    cutoff = time.time() - OVERFLOW_TTL_SECONDS
+    for index, path in enumerate(files):
+        try:
+            if index >= OVERFLOW_MAX_FILES or path.stat().st_mtime < cutoff:
+                path.unlink(missing_ok=True)
+        except OSError:
+            continue
+
+
+def spill_overflow(text: str, *, deps: Any, kind: str = "output") -> Optional[str]:
+    """Write *text* somewhere the agent can read it; return that path.
+
+    Returns None when there is nowhere to write, which is not an error: the
+    caller still truncates, it just cannot offer the rest. Losing the tail is
+    better than failing the tool call that produced it.
+
+    The path handed back is in the vocabulary of the agent's own filesystem —
+    host paths in host mode, virtual in sandbox — because a path it cannot open
+    is worse than no path at all: it invites a read that fails.
+    """
+    resolver = getattr(deps, "path_resolver", None)
+    if resolver is None:
+        return None
+
+    try:
+        host_dir = Path(resolver.resolve(OVERFLOW_VIRTUAL_DIR))
+        host_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        logger.debug(f"[overflow] no spill directory: {e}")
+        return None
+
+    digest = hashlib.sha1(text.encode("utf-8", "replace")).hexdigest()[:8]
+    name = f"{kind}-{int(time.time())}-{digest}.txt"
+    host_path = host_dir / name
+
+    try:
+        host_path.write_text(text, encoding="utf-8", errors="replace")
+    except OSError as e:
+        logger.debug(f"[overflow] could not write spill: {e}")
+        return None
+
+    _prune(host_dir)
+
+    if getattr(deps, "sandbox_enabled", True):
+        return f"{OVERFLOW_VIRTUAL_DIR}/{name}"
+    return str(host_path)

--- a/src/suzent/tools/registry.py
+++ b/src/suzent/tools/registry.py
@@ -12,12 +12,14 @@ import asyncio
 import functools
 import inspect
 import re
-from typing import Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from pydantic_ai import Tool as PydanticTool
 
 from suzent.logger import get_logger
 from suzent.tools.base import ToolResult, truncate_tool_output
+from suzent.tools.overflow import spill_overflow
+
 
 # Re-exported under their original names so existing
 # `from suzent.tools.registry import ...` call sites keep working. Aliased
@@ -29,6 +31,23 @@ from suzent.tools.names import expand_tool_dependencies as expand_tool_dependenc
 from suzent.tools.names import migrate_shell_tool_names as migrate_shell_tool_names
 
 logger = get_logger(__name__)
+
+
+def _deps_from_call(args: tuple, kwargs: dict) -> Any:
+    """The AgentDeps behind this tool call, if the tool takes a RunContext.
+
+    Every tool that can produce a large result takes ``ctx`` as its first
+    parameter, but a few take none, and the wrapper is generic — so this reads
+    the deps when they are there and reports nothing when they are not, rather
+    than assuming a shape.
+    """
+    candidates = list(args) + list(kwargs.values())
+    for candidate in candidates:
+        deps = getattr(candidate, "deps", None)
+        if deps is not None:
+            return deps
+    return None
+
 
 # ---------------------------------------------------------------------------
 # Factory: Tool class → pydantic-ai function / PydanticTool
@@ -55,27 +74,41 @@ def _make_tool(
     limit = tool_cls.output_char_limit
     keep_tail = tool_cls.keep_output_tail
 
+    def _cap(result: Any, args: tuple, kwargs: dict) -> Any:
+        """Truncate an over-long message, keeping the whole of it on disk.
+
+        The spill runs only when the cap would actually bite, so an ordinary
+        result costs nothing. A failure to spill is not a failure of the tool
+        call — the output is still truncated, just without a pointer.
+        """
+        if not isinstance(result, ToolResult):
+            return result
+        message = result.message
+        if not message or len(message) <= limit:
+            return result
+
+        deps = _deps_from_call(args, kwargs)
+        path = (
+            spill_overflow(message, deps=deps, kind=tool_cls.tool_name)
+            if deps
+            else None
+        )
+        result.message = truncate_tool_output(
+            message, limit, keep_tail=keep_tail, full_output_path=path
+        )
+        return result
+
     if asyncio.iscoroutinefunction(original):
 
         @functools.wraps(original)
         async def wrapper(*args, **kwargs):
-            result = await tool_cls().forward(*args, **kwargs)
-            if isinstance(result, ToolResult):
-                result.message = truncate_tool_output(
-                    result.message, limit, keep_tail=keep_tail
-                )
-            return result
+            return _cap(await tool_cls().forward(*args, **kwargs), args, kwargs)
 
     else:
 
         @functools.wraps(original)
         def wrapper(*args, **kwargs):
-            result = tool_cls().forward(*args, **kwargs)
-            if isinstance(result, ToolResult):
-                result.message = truncate_tool_output(
-                    result.message, limit, keep_tail=keep_tail
-                )
-            return result
+            return _cap(tool_cls().forward(*args, **kwargs), args, kwargs)
 
     wrapper.__name__ = tool_cls.tool_name
 

--- a/src/suzent/tools/registry.py
+++ b/src/suzent/tools/registry.py
@@ -18,7 +18,7 @@ from pydantic_ai import Tool as PydanticTool
 
 from suzent.logger import get_logger
 from suzent.tools.base import ToolResult, truncate_tool_output
-from suzent.tools.overflow import spill_overflow
+from suzent.tools.overflow import spill_overflow, spill_overflow_async
 
 
 # Re-exported under their original names so existing
@@ -74,27 +74,20 @@ def _make_tool(
     limit = tool_cls.output_char_limit
     keep_tail = tool_cls.keep_output_tail
 
-    def _cap(result: Any, args: tuple, kwargs: dict) -> Any:
-        """Truncate an over-long message, keeping the whole of it on disk.
-
-        The spill runs only when the cap would actually bite, so an ordinary
-        result costs nothing. A failure to spill is not a failure of the tool
-        call — the output is still truncated, just without a pointer.
-        """
-        if not isinstance(result, ToolResult):
-            return result
-        message = result.message
-        if not message or len(message) <= limit:
-            return result
-
-        deps = _deps_from_call(args, kwargs)
-        path = (
-            spill_overflow(message, deps=deps, kind=tool_cls.tool_name)
-            if deps
-            else None
+    def _needs_cap(result: Any) -> bool:
+        """The spill runs only when the cap would bite, so an ordinary result
+        costs nothing."""
+        return (
+            isinstance(result, ToolResult)
+            and bool(result.message)
+            and len(result.message) > limit
         )
+
+    def _apply(result: Any, spill: Any) -> Any:
+        """A failure to spill is not a failure of the tool call — the output is
+        still truncated, just without a pointer."""
         result.message = truncate_tool_output(
-            message, limit, keep_tail=keep_tail, full_output_path=path
+            result.message, limit, keep_tail=keep_tail, spill=spill
         )
         return result
 
@@ -102,13 +95,35 @@ def _make_tool(
 
         @functools.wraps(original)
         async def wrapper(*args, **kwargs):
-            return _cap(await tool_cls().forward(*args, **kwargs), args, kwargs)
+            result = await tool_cls().forward(*args, **kwargs)
+            if not _needs_cap(result):
+                return result
+            deps = _deps_from_call(args, kwargs)
+            # Off the loop: up to 5 MiB of write plus a directory scan would
+            # otherwise stall every other chat this loop is serving.
+            spill = (
+                await spill_overflow_async(
+                    result.message, deps=deps, kind=tool_cls.tool_name
+                )
+                if deps
+                else None
+            )
+            return _apply(result, spill)
 
     else:
 
         @functools.wraps(original)
         def wrapper(*args, **kwargs):
-            return _cap(tool_cls().forward(*args, **kwargs), args, kwargs)
+            result = tool_cls().forward(*args, **kwargs)
+            if not _needs_cap(result):
+                return result
+            deps = _deps_from_call(args, kwargs)
+            spill = (
+                spill_overflow(result.message, deps=deps, kind=tool_cls.tool_name)
+                if deps
+                else None
+            )
+            return _apply(result, spill)
 
     wrapper.__name__ = tool_cls.tool_name
 

--- a/src/suzent/tools/registry.py
+++ b/src/suzent/tools/registry.py
@@ -18,7 +18,7 @@ from pydantic_ai import Tool as PydanticTool
 
 from suzent.logger import get_logger
 from suzent.tools.base import ToolResult, truncate_tool_output
-from suzent.tools.overflow import spill_overflow, spill_overflow_async
+from suzent.tools.overflow import spill_overflow_async, spill_overflow_bounded
 
 
 # Re-exported under their original names so existing
@@ -118,8 +118,12 @@ def _make_tool(
             if not _needs_cap(result):
                 return result
             deps = _deps_from_call(args, kwargs)
+            # Bounded like the async path: a wedged volume must not hold a
+            # tool call that has already done its work.
             spill = (
-                spill_overflow(result.message, deps=deps, kind=tool_cls.tool_name)
+                spill_overflow_bounded(
+                    result.message, deps=deps, kind=tool_cls.tool_name
+                )
                 if deps
                 else None
             )

--- a/src/suzent/tools/voice_tool.py
+++ b/src/suzent/tools/voice_tool.py
@@ -9,6 +9,9 @@ from suzent.tools.base import Tool, ToolGroup, ToolErrorCode, ToolResult
 from suzent.logger import get_logger
 from suzent.voice.speech import SpeechOutput
 from suzent.voice.audio_io import SoundDeviceSink
+from pydantic_ai import RunContext
+
+from suzent.core.agent_deps import AgentDeps
 
 logger = get_logger(__name__)
 
@@ -24,6 +27,7 @@ class SpeakTool(Tool):
 
     async def forward(
         self,
+        ctx: RunContext[AgentDeps],
         text: Annotated[str, Field(description="Text to speak aloud.")],
         prompt: Annotated[
             Optional[str],

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -2370,7 +2370,7 @@ async def test_an_over_budget_reminder_keeps_its_tail_on_disk(clean_hooks, tmp_p
     assert "full text" in body, "the tail was dropped with no way to reach it"
     # The window is stated because the pointer outlives the file: this path goes
     # into history, the file expires in a day.
-    assert "kept 24h" in body
+    assert "kept up to 24h" in body
 
     spilled = body.split("): ", 1)[1].split("]", 1)[0]
     from pathlib import Path

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -2370,7 +2370,7 @@ async def test_an_over_budget_reminder_keeps_its_tail_on_disk(clean_hooks, tmp_p
     assert "full text" in body, "the tail was dropped with no way to reach it"
     # The window is stated because the pointer outlives the file: this path goes
     # into history, the file expires in a day.
-    assert "kept up to 24h" in body
+    assert "kept up to 25h" in body
 
     spilled = body.split("): ", 1)[1].split("]", 1)[0]
     from pathlib import Path

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -2367,9 +2367,12 @@ async def test_an_over_budget_reminder_keeps_its_tail_on_disk(clean_hooks, tmp_p
     assert result is not None
     body = _reminder_body(result)
     assert len(body) <= sr.REMINDER_BUDGET_CHARS
-    assert "full text:" in body, "the tail was dropped with no way to reach it"
+    assert "full text" in body, "the tail was dropped with no way to reach it"
+    # The window is stated because the pointer outlives the file: this path goes
+    # into history, the file expires in a day.
+    assert "kept 24h" in body
 
-    spilled = body.split("full text: ", 1)[1].split("]", 1)[0]
+    spilled = body.split("): ", 1)[1].split("]", 1)[0]
     from pathlib import Path
 
     assert Path(spilled).read_text(encoding="utf-8") == huge

--- a/tests/core/test_system_reminder.py
+++ b/tests/core/test_system_reminder.py
@@ -2342,3 +2342,49 @@ async def test_a_trigger_constituent_the_budget_dropped_is_not_resent(clean_hook
         "a constituent the trigger dropped came back as a fragment"
     )
     assert len(body) <= sr.REMINDER_BUDGET_CHARS
+
+
+@pytest.mark.asyncio
+async def test_an_over_budget_reminder_keeps_its_tail_on_disk(clean_hooks, tmp_path):
+    """A reminder is the one place the model cannot ask for the missing part
+    later — the block is gone next turn — so the pointer matters more here than
+    for a tool result it could simply run again."""
+    from types import SimpleNamespace
+
+    from suzent.core import system_reminder as sr
+
+    class _Resolver:
+        def resolve(self, virtual: str) -> str:
+            return str(tmp_path / "overflow")
+
+    deps = SimpleNamespace(path_resolver=_Resolver(), sandbox_enabled=False)
+    huge = "z" * (sr.REMINDER_BUDGET_CHARS + 5000)
+
+    result = await sr.build_combined_reminder(
+        "c", deps, adhoc_reminders=[huge], user_message=""
+    )
+
+    assert result is not None
+    body = _reminder_body(result)
+    assert len(body) <= sr.REMINDER_BUDGET_CHARS
+    assert "full text:" in body, "the tail was dropped with no way to reach it"
+
+    spilled = body.split("full text: ", 1)[1].split("]", 1)[0]
+    from pathlib import Path
+
+    assert Path(spilled).read_text(encoding="utf-8") == huge
+
+
+@pytest.mark.asyncio
+async def test_a_reminder_without_deps_still_truncates(clean_hooks):
+    """Spilling is an improvement on the marker, not a precondition for it."""
+    from suzent.core import system_reminder as sr
+
+    huge = "z" * (sr.REMINDER_BUDGET_CHARS + 5000)
+
+    result = await sr.build_combined_reminder("c", None, adhoc_reminders=[huge])
+
+    assert result is not None
+    body = _reminder_body(result)
+    assert len(body) <= sr.REMINDER_BUDGET_CHARS
+    assert "truncated" in body

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -89,18 +89,21 @@ def test_sandbox_mode_gets_the_virtual_path(tmp_path):
     assert spill.path.startswith(f"{OVERFLOW_VIRTUAL_DIR}/chat-1/")
 
 
-def test_the_spill_is_readable_by_a_different_uid(deps, tmp_path):
+def test_a_sandbox_spill_is_readable_by_a_different_uid(tmp_path):
     """Bind mounts preserve numeric ownership and the sandbox image runs as a
     fixed uid 1000, which need not match the host service's. A 0600 file would
-    be unreadable by the very agent the marker points at — a path that exists
-    and cannot be opened, which is the failure the spill exists to avoid."""
-    spill = spill_overflow("x" * 100, deps=deps, kind="t")
+    be unreadable by the very agent the marker points at.
 
-    file_mode = os.stat(spill.path).st_mode & 0o777
-    dir_mode = os.stat(_chat_dir(tmp_path)).st_mode & 0o777
+    Sandbox only: host mode reads the file as the same uid that wrote it, so it
+    gains nothing from the looser bits and pays for them on a multi-user host.
+    """
+    spill_overflow("x" * 100, deps=_deps(tmp_path, sandbox=True), kind="t")
 
-    assert file_mode & 0o044, f"others cannot read the spill ({oct(file_mode)})"
-    assert dir_mode & 0o011, f"others cannot traverse the directory ({oct(dir_mode)})"
+    chat_dir = _chat_dir(tmp_path)
+    written = next(chat_dir.glob("*.txt"))
+
+    assert os.stat(written).st_mode & 0o044, "the sandbox cannot read the spill"
+    assert os.stat(chat_dir).st_mode & 0o011, "the sandbox cannot traverse to it"
 
 
 def test_chat_directories_are_organisation_not_access_control(tmp_path):
@@ -604,28 +607,62 @@ def test_every_registered_tool_can_reach_its_deps():
 
 
 @pytest.mark.parametrize("umask_value", [0o077, 0o022, 0o000])
-def test_the_modes_survive_a_restrictive_umask(tmp_path, umask_value):
-    """Creation modes are masked by the process umask, so a service started with
-    umask 0077 turns 0755/0644 into 0700/0600 — exactly the permissions that
-    make the marker point at a file the sandbox cannot open."""
+def test_sandbox_spills_stay_reachable_under_any_umask(tmp_path, umask_value):
+    """Creation modes are masked by the umask, so a service started with 0077
+    turns 0755/0644 into 0700/0600 — the permissions that make the marker point
+    at a file the sandbox cannot open.
+
+    Checked all the way up to the mount root: correct descendants under an
+    unreachable root are still unreachable, which is how the previous version of
+    this test passed while /shared sat at 0700.
+    """
     previous = os.umask(umask_value)
     try:
         spill = spill_overflow(
-            "x" * 100, deps=_deps(tmp_path, chat_id=f"u{umask_value:o}"), kind="t"
+            "x" * 100,
+            deps=_deps(tmp_path, chat_id=f"u{umask_value:o}", sandbox=True),
+            kind="t",
         )
     finally:
         os.umask(previous)
 
-    # Every directory between the mount root and the file, not just the leaf:
-    # correct descendants under an unreachable root are still unreachable.
-    assert os.stat(spill.path).st_mode & 0o044, "the file is not readable"
-    walked = Path(spill.path).parent
+    host_file = (
+        tmp_path / "shared" / ".overflow" / f"u{umask_value:o}" / Path(spill.path).name
+    )
+    assert os.stat(host_file).st_mode & 0o044, "the file is not readable"
+    walked = host_file.parent
     while True:
         mode = os.stat(walked).st_mode & 0o777
         assert mode & 0o011, f"umask {umask_value:o} left {walked} at {mode:o}"
         if walked == tmp_path / "shared":
             break
         walked = walked.parent
+
+
+@pytest.mark.parametrize("umask_value", [0o077, 0o000])
+def test_host_spills_are_private(tmp_path, umask_value):
+    """In host mode the agent is this process — same uid — so the tightest bits
+    work and nothing is gained by letting every local account read raw tool
+    output. Forced past the umask in the other direction too: 0000 must not
+    leave them world-readable."""
+    previous = os.umask(umask_value)
+    try:
+        spill = spill_overflow(
+            "x" * 100, deps=_deps(tmp_path, chat_id=f"h{umask_value:o}"), kind="t"
+        )
+    finally:
+        os.umask(previous)
+
+    file_mode = os.stat(spill.path).st_mode & 0o777
+    dir_mode = os.stat(Path(spill.path).parent).st_mode & 0o777
+
+    assert file_mode & 0o077 == 0, (
+        f"host spill is group/world accessible ({file_mode:o})"
+    )
+    assert dir_mode & 0o077 == 0, (
+        f"host spill dir is group/world accessible ({dir_mode:o})"
+    )
+    assert file_mode & 0o600, "the owner cannot read its own spill"
 
 
 def test_the_path_fallback_also_survives_the_umask(tmp_path, monkeypatch):
@@ -635,13 +672,16 @@ def test_the_path_fallback_also_survives_the_umask(tmp_path, monkeypatch):
     previous = os.umask(0o077)
     try:
         spill = overflow.spill_overflow(
-            "x" * 100, deps=_deps(tmp_path, chat_id="fallback"), kind="t"
+            "x" * 100,
+            deps=_deps(tmp_path, chat_id="fallback", sandbox=True),
+            kind="t",
         )
     finally:
         os.umask(previous)
 
-    assert os.stat(spill.path).st_mode & 0o044
-    assert os.stat(Path(spill.path).parent).st_mode & 0o011
+    host_file = tmp_path / "shared" / ".overflow" / "fallback" / Path(spill.path).name
+    assert os.stat(host_file).st_mode & 0o044
+    assert os.stat(host_file.parent).st_mode & 0o011
 
 
 def test_the_voice_verification_script_still_calls_correctly():
@@ -665,3 +705,18 @@ def test_the_voice_verification_script_still_calls_correctly():
     assert calls, "the script no longer calls forward(); update this test"
     for call in calls:
         assert len(call.args) >= 2, "forward() takes ctx first, then the text"
+
+
+@pytest.mark.asyncio
+async def test_the_sweeper_is_cancelled_at_shutdown():
+    """An infinite task the lifespan never cancels keeps running after
+    shutdown, and each restart adds another — so an embedded server or an
+    in-process restart accumulates hourly sweepers."""
+    import inspect
+
+    from suzent import server
+
+    source = inspect.getsource(server.shutdown)
+
+    assert "overflow_sweeper" in source, "the sweeper outlives the application"
+    assert "cancel()" in source

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -197,3 +197,44 @@ def test_the_directory_is_bounded_in_bytes_not_only_in_count(deps, monkeypatch):
     total = sum(p.stat().st_size for p in directory.glob("*.txt"))
 
     assert total <= 20_000 + 2_100, total
+
+
+# --- who collects the last spill of a session ---------------------------------
+
+
+def test_the_sweep_collects_what_no_later_spill_would(tmp_path, monkeypatch):
+    """Pruning otherwise runs only on write, so the bounds hold exactly while
+    output keeps overflowing and stop the moment it does not. Nothing else
+    collects these — they live in the user's data directory, not a temp
+    directory the OS sweeps."""
+    import os
+    import time
+
+    from suzent.tools.overflow import OVERFLOW_TTL_SECONDS, sweep_overflow
+
+    shared = tmp_path / "shared" / ".overflow"
+    shared.mkdir(parents=True)
+    stale = shared / "t-old.txt"
+    stale.write_text("yesterday", encoding="utf-8")
+    old = time.time() - OVERFLOW_TTL_SECONDS - 60
+    os.utime(stale, (old, old))
+    fresh = shared / "t-new.txt"
+    fresh.write_text("today", encoding="utf-8")
+
+    from suzent.config import CONFIG
+
+    monkeypatch.setattr(CONFIG, "sandbox_data_path", str(tmp_path), raising=False)
+
+    sweep_overflow()
+
+    assert not stale.exists(), "a spill older than the TTL survived a sweep"
+    assert fresh.exists(), "the sweep took a spill that was still current"
+
+
+def test_the_sweep_is_harmless_with_no_directory(tmp_path, monkeypatch):
+    from suzent.config import CONFIG
+    from suzent.tools.overflow import sweep_overflow
+
+    monkeypatch.setattr(CONFIG, "sandbox_data_path", str(tmp_path), raising=False)
+
+    sweep_overflow()  # must not raise

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1323,41 +1323,6 @@ def test_a_failed_fallback_write_leaves_no_file(tmp_path, monkeypatch):
     assert not chat_dir.exists() or list(chat_dir.glob("*.txt")) == []
 
 
-def test_a_spill_that_lands_after_the_deadline_is_removed(deps, tmp_path, monkeypatch):
-    """Storage that is slow but recovers writes a file nobody was told about —
-    it consumes the per-chat and root quotas and can evict spills whose paths
-    *were* handed out."""
-    import threading
-
-    import suzent.tools.overflow as overflow
-
-    monkeypatch.setattr(
-        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
-    )
-    monkeypatch.setattr(overflow, "SPILL_TIMEOUT_SECONDS", 0.05)
-
-    real = overflow._spill_payload
-
-    def _slow(payload, clipped, **kw):
-        time.sleep(0.3)
-        return real(payload, clipped, **kw)
-
-    monkeypatch.setattr(overflow, "_spill_payload", _slow)
-
-    assert overflow.spill_overflow_bounded("x" * 100, deps=deps, kind="t") is None
-
-    for _ in range(100):
-        if list(_chat_dir(tmp_path).glob("*.txt")):
-            time.sleep(0.01)
-        else:
-            break
-    time.sleep(0.3)
-
-    assert list(_chat_dir(tmp_path).glob("*.txt")) == [], (
-        "a late spill was left behind, unadvertised"
-    )
-
-
 def test_the_worker_does_not_retain_the_whole_request(deps, monkeypatch):
     """AgentDeps carries the request's message history, repository context and
     caches. Four abandoned workers holding those is far more than the bounded
@@ -1399,13 +1364,18 @@ def test_the_snapshot_carries_what_a_spill_needs():
     assert not hasattr(snap, "extra")
 
 
+# --- what happens to a spill nobody waited for --------------------------------
+
+
 @pytest.mark.asyncio
-async def test_cancellation_abandons_the_spill_like_a_timeout(
+async def test_a_late_spill_becomes_an_ordinary_retained_file(
     deps, tmp_path, monkeypatch
 ):
-    """A client disconnecting or a superseded social turn cancels the caller,
-    which means the same thing as the deadline: nobody receives this pointer, so
-    the file the worker may still write must not count against the quotas."""
+    """Not chased, not deleted out of band. Every version of the handshake that
+    tried to hand the file back or remove it after the fact had a window between
+    deciding and acting — the caller, the loop and the worker cannot observe
+    each other atomically. A missed deadline now leaves a file under the same
+    TTL and quotas as any other, which the sweep collects."""
     import asyncio
     import threading
 
@@ -1414,247 +1384,54 @@ async def test_cancellation_abandons_the_spill_like_a_timeout(
     monkeypatch.setattr(
         overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
     )
-    real = overflow._spill_payload
-
-    def _slow(payload, clipped, **kw):
-        time.sleep(0.3)
-        return real(payload, clipped, **kw)
-
-    monkeypatch.setattr(overflow, "_spill_payload", _slow)
-
-    task = asyncio.create_task(
-        overflow.spill_overflow_async("x" * 100, deps=deps, kind="t")
-    )
-    await asyncio.sleep(0.05)
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
-
-    # Awaited, not slept: the worker asks the loop whether its result was taken,
-    # so a blocking sleep here would stop the very callback under test.
-    for _ in range(60):
-        await asyncio.sleep(0.02)
-        if not list(_chat_dir(tmp_path).glob("*.txt")):
-            break
-
-    assert list(_chat_dir(tmp_path).glob("*.txt")) == [], (
-        "a cancelled spill left an unadvertised file behind"
-    )
-
-
-def test_an_abandoned_spill_does_not_prune_first(tmp_path, monkeypatch):
-    """Pruning is irreversible. An abandoned spill that prunes before checking
-    can evict files whose paths a live conversation already holds, then delete
-    itself — leaving the eviction as its only lasting effect."""
-    import threading
-
-    import suzent.tools.overflow as overflow
-
-    monkeypatch.setattr(
-        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
-    )
-    monkeypatch.setattr(overflow, "OVERFLOW_MAX_ROOT_BYTES", 4_000)
     monkeypatch.setattr(overflow, "SPILL_TIMEOUT_SECONDS", 0.05)
 
-    advertised = spill_overflow(
-        "y" * 3_000, deps=_deps(tmp_path, chat_id="live"), kind="t"
-    )
-    kept = Path(advertised.host_path)
-
-    real_write = overflow._spill_pinned
-
-    def _slow(*args, **kwargs):
-        time.sleep(0.3)
-        return real_write(*args, **kwargs)
-
-    monkeypatch.setattr(overflow, "_spill_pinned", _slow)
-
-    assert (
-        overflow.spill_overflow_bounded(
-            "z" * 3_000, deps=_deps(tmp_path, chat_id="slow"), kind="t"
-        )
-        is None
-    )
-    time.sleep(0.6)
-
-    assert kept.exists(), "an abandoned spill evicted an advertised one"
-
-
-@pytest.mark.asyncio
-async def test_a_cancel_racing_delivery_still_discards(deps, tmp_path, monkeypatch):
-    """The worker's own check can pass a moment before the caller gives up.
-    Delivery runs on the loop, so it is the one place that can see the future's
-    final state."""
-    import asyncio
-    import threading
-
-    import suzent.tools.overflow as overflow
-
-    monkeypatch.setattr(
-        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
-    )
-
     real = overflow._spill_payload
 
     def _slow(payload, clipped, **kw):
-        kw.pop("keep_check", None)
-        time.sleep(0.2)
+        time.sleep(0.3)
         return real(payload, clipped, **kw)
 
     monkeypatch.setattr(overflow, "_spill_payload", _slow)
 
-    task = asyncio.create_task(
-        overflow.spill_overflow_async("x" * 100, deps=deps, kind="t")
-    )
-    await asyncio.sleep(0.1)
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    assert await overflow.spill_overflow_async("x" * 100, deps=deps, kind="t") is None
 
     for _ in range(60):
         await asyncio.sleep(0.02)
-        if not list(_chat_dir(tmp_path).glob("*.txt")):
+        if list(_chat_dir(tmp_path).glob("*.txt")):
             break
 
-    assert list(_chat_dir(tmp_path).glob("*.txt")) == [], (
-        "a spill delivered after cancellation was left behind"
-    )
+    written = list(_chat_dir(tmp_path).glob("*.txt"))
+    assert written, "the late write never landed"
+    assert written[0].read_text(encoding="utf-8") == "x" * 100
 
 
-@pytest.mark.asyncio
-async def test_the_loop_does_no_filesystem_work_for_a_spill(deps, monkeypatch):
-    """_deliver runs on the loop and only answers yes or no. An unlink there
-    would stall every chat on the same wedged volume the caller already gave up
-    waiting for."""
-    import asyncio
+def test_the_sweep_collects_a_late_spill(deps, tmp_path, monkeypatch):
+    """The retention path is what cleans these up, so it has to actually reach
+    them."""
+    from suzent.config import CONFIG
+    import suzent.tools.overflow as overflow
+    from suzent.tools.overflow import OVERFLOW_TTL_SECONDS, sweep_overflow
+
+    spill = spill_overflow("x" * 100, deps=deps, kind="t")
+    old = time.time() - OVERFLOW_TTL_SECONDS - 60
+    os.utime(spill.host_path, (old, old))
+
+    monkeypatch.setattr(CONFIG, "sandbox_data_path", str(tmp_path), raising=False)
+    sweep_overflow()
+
+    assert not Path(spill.host_path).exists()
+    _ = overflow
+
+
+def test_no_out_of_band_deletion_remains():
+    """The handshake is gone on purpose; a future 'cleanup' that deletes a
+    written spill outside the sweep brings the races back with it."""
     import inspect
-    import threading
 
     import suzent.tools.overflow as overflow
 
-    source = inspect.getsource(overflow.spill_overflow_async)
-    deliver = source[source.index("def _deliver") : source.index("def _worker")]
-
-    assert "_discard" not in deliver, "the loop callback deletes files"
-    assert "_prune" not in deliver, "the loop callback prunes"
-
-    ran_on: list[str] = []
-    monkeypatch.setattr(
-        overflow,
-        "_discard",
-        lambda spill: ran_on.append(threading.current_thread().name),
-    )
-    monkeypatch.setattr(
-        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
-    )
-
-    task = asyncio.create_task(
-        overflow.spill_overflow_async("x" * 100, deps=deps, kind="t")
-    )
-    await asyncio.sleep(0)
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
-    for _ in range(60):
-        await asyncio.sleep(0.02)
-        if ran_on:
-            break
-
-    assert ran_on, "the abandoned spill was never discarded"
-    assert all(n.startswith("overflow-spill") for n in ran_on), (
-        f"cleanup ran on {ran_on}"
-    )
-
-
-def test_a_stored_result_is_accepted_rather_than_abandoned(deps, monkeypatch):
-    """The worker can store its result and still be inside its finally when the
-    join expires. Abandoning then throws away a spill that is already written
-    and already ours."""
-    import threading
-
-    import suzent.tools.overflow as overflow
-
-    monkeypatch.setattr(
-        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
-    )
-    monkeypatch.setattr(overflow, "SPILL_TIMEOUT_SECONDS", 0.05)
-
-    real = overflow._prune_after_accept
-
-    def _slow_prune(snapshot):
-        # Stands in for a worker that has stored its result but not yet exited.
-        time.sleep(0.3)
-        return real(snapshot)
-
-    monkeypatch.setattr(overflow, "_prune_after_accept", _slow_prune)
-
-    spill = overflow.spill_overflow_bounded("x" * 100, deps=deps, kind="t")
-
-    assert spill is not None, "a written, stored spill was thrown away"
-    assert Path(spill.host_path).exists()
-
-
-@pytest.mark.asyncio
-async def test_the_slot_covers_the_cleanup_too(deps, monkeypatch):
-    """Releasing at the end of the write let the next oversized result take the
-    slot and park another thread in the pruning below it — the accumulation the
-    bound exists to prevent."""
-    import asyncio
-    import threading
-
-    import suzent.tools.overflow as overflow
-
-    monkeypatch.setattr(overflow, "_spill_slots", threading.Semaphore(1))
-
-    in_cleanup = threading.Event()
-    finish = threading.Event()
-
-    def _slow_prune(snapshot):
-        in_cleanup.set()
-        finish.wait(timeout=5)
-
-    monkeypatch.setattr(overflow, "_prune_after_accept", _slow_prune)
-
-    first = asyncio.create_task(
-        overflow.spill_overflow_async("x" * 100, deps=deps, kind="t")
-    )
-    assert await asyncio.to_thread(in_cleanup.wait, 2), "cleanup never started"
-
-    # The one slot is still held by the worker doing filesystem work.
-    assert overflow._spill_slots._value == 0, "the slot was freed before cleanup"
-
-    finish.set()
-    await first
-
-
-@pytest.mark.asyncio
-async def test_acceptance_means_the_caller_received_it(deps, tmp_path, monkeypatch):
-    """Setting the future is not the same event as the caller returning: a
-    cancellation queued after _deliver ran still stops the coroutine, and the
-    worker would keep and prune a file whose path reached nobody."""
-    import asyncio
-    import threading
-
-    import suzent.tools.overflow as overflow
-
-    monkeypatch.setattr(
-        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
-    )
-
-    task = asyncio.create_task(
-        overflow.spill_overflow_async("x" * 100, deps=deps, kind="t")
-    )
-    # Cancel while the worker is between delivering and the coroutine resuming.
-    await asyncio.sleep(0)
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
-
-    for _ in range(80):
-        await asyncio.sleep(0.02)
-        if not list(_chat_dir(tmp_path).glob("*.txt")):
-            break
-
-    assert list(_chat_dir(tmp_path).glob("*.txt")) == [], (
-        "a spill the caller never received was kept"
-    )
+    for fn in (overflow.spill_overflow_bounded, overflow.spill_overflow_async):
+        source = inspect.getsource(fn)
+        assert "unlink" not in source, f"{fn.__name__} deletes a spill directly"
+        assert "_discard" not in source, f"{fn.__name__} deletes a spill directly"

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -415,8 +415,8 @@ async def test_the_async_spill_does_not_hold_the_loop(deps, monkeypatch):
 
     monkeypatch.setattr(
         overflow,
-        "spill_overflow",
-        lambda text, **kw: time.sleep(0.2) or Spill("/tmp/x.txt", False),
+        "_spill_payload",
+        lambda payload, clipped, **kw: time.sleep(0.2) or Spill("/tmp/x.txt", False),
     )
 
     ticks = 0
@@ -807,15 +807,21 @@ async def test_a_wedged_volume_does_not_hold_the_caller(deps, monkeypatch):
     """to_thread frees the loop and bounds nothing. The caller is either a
     reminder being built or a tool call that has already done its work — losing
     the pointer beats losing either."""
+    import threading
     import time
 
     import suzent.tools.overflow as overflow
 
     monkeypatch.setattr(overflow, "SPILL_TIMEOUT_SECONDS", 0.05)
+    # The worker calls _spill_payload; patching spill_overflow would leave the
+    # thread doing the real thing.
     monkeypatch.setattr(
         overflow,
-        "spill_overflow",
-        lambda text, **kw: time.sleep(2) or Spill("/x", False),
+        "_spill_payload",
+        lambda payload, clipped, **kw: time.sleep(1) or Spill("/x", False),
+    )
+    monkeypatch.setattr(
+        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
     )
 
     started = time.monotonic()
@@ -846,15 +852,21 @@ def test_the_synchronous_spill_is_bounded_too(deps, monkeypatch):
     does not stall other chats — but it holds a tool call that has *already
     succeeded*. Bounding only the async path left two halves of one rule
     disagreeing."""
+    import threading
     import time
 
     import suzent.tools.overflow as overflow
 
     monkeypatch.setattr(overflow, "SPILL_TIMEOUT_SECONDS", 0.05)
+    # The worker calls _spill_payload; patching spill_overflow would leave the
+    # thread doing the real thing.
     monkeypatch.setattr(
         overflow,
-        "spill_overflow",
-        lambda text, **kw: time.sleep(2) or Spill("/x", False),
+        "_spill_payload",
+        lambda payload, clipped, **kw: time.sleep(1) or Spill("/x", False),
+    )
+    monkeypatch.setattr(
+        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
     )
 
     started = time.monotonic()
@@ -923,8 +935,15 @@ def test_abandoned_spill_workers_are_bounded(deps, monkeypatch):
 
     import suzent.tools.overflow as overflow
 
+    # A private semaphore: parked workers never release, so draining the
+    # module-level one would silently disable spilling for every later test.
+    monkeypatch.setattr(
+        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
+    )
     monkeypatch.setattr(overflow, "SPILL_TIMEOUT_SECONDS", 0.02)
-    monkeypatch.setattr(overflow, "spill_overflow", lambda text, **kw: time.sleep(30))
+    monkeypatch.setattr(
+        overflow, "_spill_payload", lambda payload, clipped, **kw: time.sleep(1)
+    )
 
     before = threading.active_count()
     for _ in range(20):
@@ -1007,3 +1026,58 @@ def test_a_platform_without_fchmod_still_writes(tmp_path, monkeypatch):
 
     assert spill is not None
     assert Path(spill.path).read_text(encoding="utf-8") == "x" * 100
+
+
+def test_an_abandoned_worker_does_not_hold_the_whole_output(deps, monkeypatch):
+    """The semaphore bounds threads, not bytes. Handing the worker the original
+    string means an abandoned one holds the whole of a hundreds-of-megabyte
+    result for as long as the storage stays wedged — four of those being four
+    copies of the largest output the process has seen."""
+    import time
+
+    import suzent.tools.overflow as overflow
+
+    captured: list[int] = []
+
+    def _wedged(payload, clipped, **kw):
+        captured.append(len(payload))
+        time.sleep(1)
+
+    import threading
+
+    monkeypatch.setattr(
+        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
+    )
+    monkeypatch.setattr(overflow, "SPILL_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_FILE_BYTES", 1_000)
+    monkeypatch.setattr(overflow, "_spill_payload", _wedged)
+
+    assert overflow.spill_overflow_bounded("x" * 5_000_000, deps=deps, kind="t") is None
+
+    assert captured, "the worker never ran"
+    assert captured[0] <= 1_000, (
+        f"the worker captured {captured[0]} bytes of a 5,000,000-char result"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_saturated_executor_does_not_strand_the_caller(deps, monkeypatch):
+    """The bounded pool's join only starts once the coroutine reaches a worker.
+    On a shared default executor saturated by unrelated work it can sit queued
+    instead — routing through the pool is what made the outer deadline
+    necessary, and is exactly when I removed it."""
+    import time
+
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "SPILL_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(
+        overflow, "spill_overflow_bounded", lambda text, **kw: time.sleep(1)
+    )
+
+    started = time.monotonic()
+    result = await overflow.spill_overflow_async("payload", deps=deps, kind="t")
+    elapsed = time.monotonic() - started
+
+    assert result is None
+    assert elapsed < 2.0, f"the caller waited {elapsed:.2f}s on a stuck executor"

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1598,3 +1598,46 @@ def test_the_sweep_collects_a_stranded_staged_file(tmp_path, monkeypatch):
     sweep_overflow()
 
     assert not stranded.exists(), "a stranded staged file was never collected"
+
+
+def test_no_scan_can_select_a_staged_file(tmp_path, monkeypatch):
+    """Every scan has to filter to completed spills, not just the ones I
+    remembered: unlinking a staged file succeeds on POSIX while its writer holds
+    it open, and the rename then fails, so the result loses its pointer for a
+    file that was never counted against a quota anyway."""
+    import suzent.tools.overflow as overflow
+    from suzent.tools.overflow import PARTIAL_SUFFIX
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_ROOT_BYTES", 10)
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_TOTAL_BYTES", 10)
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_FILES", 1)
+
+    chat_dir = _chat_dir(tmp_path, "victim")
+    chat_dir.mkdir(parents=True)
+    staged = chat_dir / f"t-inflight.txt{PARTIAL_SUFFIX}"
+    staged.write_text("z" * 5_000, encoding="utf-8")
+
+    # Any spill now runs both quota passes against a directory well over its
+    # ceilings, with a staged file sitting in it.
+    spill_overflow("y" * 100, deps=_deps(tmp_path, chat_id="other"), kind="t")
+
+    assert staged.exists(), "a quota scan deleted a file that was still being written"
+
+
+def test_every_scan_filters_to_completed_spills():
+    """Stated over the set, because three of the four filtered and the fourth
+    was the one that mattered."""
+    import inspect
+
+    import suzent.tools.overflow as overflow
+
+    for fn in (
+        overflow._prune_fd,
+        overflow._prune_path,
+        overflow._enforce_root_quota_fd,
+        overflow._enforce_root_quota_path,
+    ):
+        source = inspect.getsource(fn)
+        assert '".txt"' in source or '"*.txt"' in source, (
+            f"{fn.__name__} scans without filtering to completed spills"
+        )

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1366,7 +1366,7 @@ def test_the_worker_does_not_retain_the_whole_request(deps, monkeypatch):
 
     seen: list[Any] = []
 
-    def _capture(payload, clipped, *, deps, kind):
+    def _capture(payload, clipped, *, deps, kind, keep_check=None):
         seen.append(deps)
         return None
 
@@ -1434,4 +1434,83 @@ async def test_cancellation_abandons_the_spill_like_a_timeout(
 
     assert list(_chat_dir(tmp_path).glob("*.txt")) == [], (
         "a cancelled spill left an unadvertised file behind"
+    )
+
+
+def test_an_abandoned_spill_does_not_prune_first(tmp_path, monkeypatch):
+    """Pruning is irreversible. An abandoned spill that prunes before checking
+    can evict files whose paths a live conversation already holds, then delete
+    itself — leaving the eviction as its only lasting effect."""
+    import threading
+
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(
+        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
+    )
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_ROOT_BYTES", 4_000)
+    monkeypatch.setattr(overflow, "SPILL_TIMEOUT_SECONDS", 0.05)
+
+    advertised = spill_overflow(
+        "y" * 3_000, deps=_deps(tmp_path, chat_id="live"), kind="t"
+    )
+    kept = Path(advertised.host_path)
+
+    real_write = overflow._spill_pinned
+
+    def _slow(*args, **kwargs):
+        time.sleep(0.3)
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(overflow, "_spill_pinned", _slow)
+
+    assert (
+        overflow.spill_overflow_bounded(
+            "z" * 3_000, deps=_deps(tmp_path, chat_id="slow"), kind="t"
+        )
+        is None
+    )
+    time.sleep(0.6)
+
+    assert kept.exists(), "an abandoned spill evicted an advertised one"
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_racing_delivery_still_discards(deps, tmp_path, monkeypatch):
+    """The worker's own check can pass a moment before the caller gives up.
+    Delivery runs on the loop, so it is the one place that can see the future's
+    final state."""
+    import asyncio
+    import threading
+
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(
+        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
+    )
+
+    real = overflow._spill_payload
+
+    def _slow(payload, clipped, **kw):
+        kw.pop("keep_check", None)
+        time.sleep(0.2)
+        return real(payload, clipped, **kw)
+
+    monkeypatch.setattr(overflow, "_spill_payload", _slow)
+
+    task = asyncio.create_task(
+        overflow.spill_overflow_async("x" * 100, deps=deps, kind="t")
+    )
+    await asyncio.sleep(0.1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    for _ in range(60):
+        await asyncio.sleep(0.02)
+        if not list(_chat_dir(tmp_path).glob("*.txt")):
+            break
+
+    assert list(_chat_dir(tmp_path).glob("*.txt")) == [], (
+        "a spill delivered after cancellation was left behind"
     )

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -616,11 +616,16 @@ def test_the_modes_survive_a_restrictive_umask(tmp_path, umask_value):
     finally:
         os.umask(previous)
 
-    file_mode = os.stat(spill.path).st_mode & 0o777
-    dir_mode = os.stat(Path(spill.path).parent).st_mode & 0o777
-
-    assert file_mode & 0o044, f"umask {umask_value:o} left the file at {file_mode:o}"
-    assert dir_mode & 0o011, f"umask {umask_value:o} left the dir at {dir_mode:o}"
+    # Every directory between the mount root and the file, not just the leaf:
+    # correct descendants under an unreachable root are still unreachable.
+    assert os.stat(spill.path).st_mode & 0o044, "the file is not readable"
+    walked = Path(spill.path).parent
+    while True:
+        mode = os.stat(walked).st_mode & 0o777
+        assert mode & 0o011, f"umask {umask_value:o} left {walked} at {mode:o}"
+        if walked == tmp_path / "shared":
+            break
+        walked = walked.parent
 
 
 def test_the_path_fallback_also_survives_the_umask(tmp_path, monkeypatch):
@@ -637,3 +642,26 @@ def test_the_path_fallback_also_survives_the_umask(tmp_path, monkeypatch):
 
     assert os.stat(spill.path).st_mode & 0o044
     assert os.stat(Path(spill.path).parent).st_mode & 0o011
+
+
+def test_the_voice_verification_script_still_calls_correctly():
+    """A standalone script is not covered by the suite, so a signature change
+    breaks it silently. Adding ctx to SpeakTool.forward() bound the utterance to
+    ctx and left `text` missing."""
+    import ast
+    from pathlib import Path as _Path
+
+    source = _Path("tests/verify_voice.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "forward"
+    ]
+
+    assert calls, "the script no longer calls forward(); update this test"
+    for call in calls:
+        assert len(call.args) >= 2, "forward() takes ctx first, then the text"

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -308,7 +308,10 @@ def test_spills_do_not_accumulate_without_limit(deps, tmp_path):
 
     kept = list(_chat_dir(tmp_path).glob("*.txt"))
 
-    assert len(kept) <= OVERFLOW_MAX_FILES
+    # MAX plus the one being written: the newest file is exempt from its own
+    # prune, so the ceiling is "MAX retained, and never delete the path we are
+    # about to advertise".
+    assert len(kept) <= OVERFLOW_MAX_FILES + 1
 
 
 def test_the_directory_is_bounded_in_bytes_not_only_in_count(
@@ -1475,3 +1478,40 @@ def test_the_root_has_one_definition():
     source = inspect.getsource(overflow)
 
     assert source.count("CONFIG.sandbox_data_path") == 1
+
+
+def test_two_chats_sharing_a_prefix_get_separate_directories(tmp_path):
+    """A2A context ids are built by prefixing an accepted 64-character value, so
+    they differ exactly where a fixed-length cut discards. Merged chats share a
+    quota and evict each other's advertised spills."""
+    shared_prefix = "ctx-" + "a" * 60
+    first = spill_overflow(
+        "one", deps=_deps(tmp_path, chat_id=shared_prefix + "-alpha"), kind="t"
+    )
+    second = spill_overflow(
+        "two", deps=_deps(tmp_path, chat_id=shared_prefix + "-beta"), kind="t"
+    )
+
+    assert Path(first.host_path).parent != Path(second.host_path).parent
+    assert Path(first.host_path).read_text(encoding="utf-8") == "one"
+    assert Path(second.host_path).read_text(encoding="utf-8") == "two"
+
+
+def test_the_new_spill_survives_its_own_prune(tmp_path, monkeypatch):
+    """On coarse mtime, or after the clock steps back, the just-written file
+    need not sort ahead of the rest — and a directory at quota would delete the
+    very path about to be advertised."""
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_FILES", 2)
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_TOTAL_BYTES", 100)
+
+    # Freeze mtime so nothing can be ordered by it.
+    real_stat = os.stat
+
+    for _ in range(4):
+        spill = spill_overflow("y" * 60, deps=_deps(tmp_path), kind="t")
+        assert spill is not None
+        assert Path(spill.host_path).exists(), "the advertised file was pruned away"
+
+    _ = real_stat

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -81,15 +81,36 @@ def test_host_mode_gets_a_host_path(tmp_path):
     assert host.path.startswith(str(tmp_path))
 
 
-def test_sandbox_mode_does_not_spill_at_all(tmp_path):
-    """Directory naming is not a boundary here: every container bind-mounts the
-    same host `shared` directory read-write and every one runs as uid 1000, so
-    chat B reads chat A's spills whatever the mode bits say. Until there is a
-    per-chat mount, the sandbox gets the plain marker."""
-    assert (
-        spill_overflow("y" * 100, deps=_deps(tmp_path, sandbox=True), kind="t") is None
-    )
-    assert not (tmp_path / "shared" / ".overflow").exists()
+def test_sandbox_mode_gets_the_virtual_path(tmp_path):
+    from suzent.tools.overflow import OVERFLOW_VIRTUAL_DIR
+
+    spill = spill_overflow("y" * 100, deps=_deps(tmp_path, sandbox=True), kind="t")
+
+    assert spill.path.startswith(f"{OVERFLOW_VIRTUAL_DIR}/chat-1/")
+
+
+def test_the_spill_is_readable_by_a_different_uid(deps, tmp_path):
+    """Bind mounts preserve numeric ownership and the sandbox image runs as a
+    fixed uid 1000, which need not match the host service's. A 0600 file would
+    be unreadable by the very agent the marker points at — a path that exists
+    and cannot be opened, which is the failure the spill exists to avoid."""
+    spill = spill_overflow("x" * 100, deps=deps, kind="t")
+
+    file_mode = os.stat(spill.path).st_mode & 0o777
+    dir_mode = os.stat(_chat_dir(tmp_path)).st_mode & 0o777
+
+    assert file_mode & 0o044, f"others cannot read the spill ({oct(file_mode)})"
+    assert dir_mode & 0o011, f"others cannot traverse the directory ({oct(dir_mode)})"
+
+
+def test_chat_directories_are_organisation_not_access_control(tmp_path):
+    """Recorded so the naming is not mistaken for a boundary: on one shared
+    mount with one uid, these directories separate pruning scope and nothing
+    else. The owner has accepted that their chats can read each other."""
+    a = spill_overflow("alpha", deps=_deps(tmp_path, chat_id="a"), kind="t")
+
+    # Any other chat, running as the same uid, can read it.
+    assert Path(a.path).read_text(encoding="utf-8") == "alpha"
 
 
 def test_no_resolver_means_no_spill_rather_than_a_crash():

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1896,3 +1896,45 @@ def test_deleted_entries_do_not_consume_the_file_ceiling(tmp_path, monkeypatch):
         assert kept.exists(), (
             "an entry deleted ahead of this one still consumed the ceiling"
         )
+
+
+def test_an_undeletable_spill_still_consumes_its_budget(tmp_path, monkeypatch):
+    """A failed unlink — a file held open on Windows, a permission fault — left
+    the entry out of both totals, so the scan went on to retain older files as
+    though the bytes it could not reclaim were free. It is still on disk, so it
+    still counts."""
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_TOTAL_BYTES", 5_000)
+
+    # Newest first: the keeper fits, the stuck file is the first entry over the
+    # ceiling, and the tail only survives if its bytes were written off.
+    keeper = spill_overflow("a" * 3_000, deps=_deps(tmp_path), kind="t")
+    stuck = spill_overflow("b" * 3_000, deps=_deps(tmp_path), kind="t")
+    tail = spill_overflow("c" * 100, deps=_deps(tmp_path), kind="t")
+    for offset, spill in enumerate((keeper, stuck, tail)):
+        when = time.time() - 3_600 - offset
+        os.utime(spill.host_path, (when, when))
+
+    stuck_name = Path(stuck.host_path).name
+    real_unlink = os.unlink
+
+    def refuse_the_stuck_one(target, *args, **kwargs):
+        if str(target).endswith(stuck_name):
+            raise PermissionError(stuck_name)
+        return real_unlink(target, *args, **kwargs)
+
+    monkeypatch.setattr(os, "unlink", refuse_the_stuck_one)
+    monkeypatch.setattr(
+        Path,
+        "unlink",
+        lambda self, missing_ok=False: refuse_the_stuck_one(str(self)),
+    )
+
+    overflow.sweep_overflow()
+
+    assert Path(stuck.host_path).exists()
+    assert Path(keeper.host_path).exists()
+    assert not Path(tail.host_path).exists(), (
+        "bytes that could not be reclaimed were treated as free"
+    )

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1796,3 +1796,23 @@ def test_future_dated_spills_do_not_hold_grace_open(tmp_path, monkeypatch):
     assert Path(genuinely_fresh.host_path).exists(), (
         "grace no longer protects a spill that really is newborn"
     )
+
+
+def test_future_dated_spills_expire_within_the_advertised_retention(tmp_path):
+    """With no quota pressure at all, a future-dated spill still has to go: read
+    literally, its mtime never falls below the TTL cutoff, so it would outlive
+    the marker's "kept up to 25h" promise by however long the clock rolled
+    back — every scheduled sweep notwithstanding."""
+    import suzent.tools.overflow as overflow
+
+    rolled_back = spill_overflow("a" * 100, deps=_deps(tmp_path), kind="t")
+    ahead = time.time() + 3_600
+    os.utime(rolled_back.host_path, (ahead, ahead))
+    ordinary = spill_overflow("b" * 100, deps=_deps(tmp_path), kind="t")
+
+    overflow.sweep_overflow()
+
+    assert not Path(rolled_back.host_path).exists(), (
+        "an undatable spill outlived the advertised retention window"
+    )
+    assert Path(ordinary.host_path).exists()

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -487,3 +487,117 @@ def test_the_path_fallback_writes_without_dir_fd(tmp_path, monkeypatch):
 
     assert spill is not None
     assert Path(spill.path).read_text(encoding="utf-8") == "x" * 500
+
+
+def test_the_sweep_has_a_path_based_twin(tmp_path, monkeypatch):
+    """Only spill_overflow() chose an implementation, so on a platform without
+    dir_fd the sweep called descriptor operations that do not exist there and
+    retention simply did not run — the third time in this file that hardening
+    one path and not its twin left the twin broken."""
+    import time
+
+    from suzent.config import CONFIG
+    import suzent.tools.overflow as overflow
+    from suzent.tools.overflow import OVERFLOW_TTL_SECONDS, sweep_overflow
+
+    chat_dir = _chat_dir(tmp_path)
+    chat_dir.mkdir(parents=True)
+    stale = chat_dir / "t-old.txt"
+    stale.write_text("yesterday", encoding="utf-8")
+    old = time.time() - OVERFLOW_TTL_SECONDS - 60
+    os.utime(stale, (old, old))
+
+    monkeypatch.setattr(overflow, "_HAVE_DIR_FD", False)
+    monkeypatch.setattr(CONFIG, "sandbox_data_path", str(tmp_path), raising=False)
+    sweep_overflow()
+
+    assert not stale.exists()
+
+
+def test_the_path_sweep_also_applies_the_root_quota(tmp_path, monkeypatch):
+    from suzent.config import CONFIG
+    import suzent.tools.overflow as overflow
+    from suzent.tools.overflow import sweep_overflow
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_ROOT_BYTES", 5_000)
+    for chat in ("a", "b", "c", "d"):
+        spill_overflow("y" * 3_000, deps=_deps(tmp_path, chat_id=chat), kind="t")
+
+    monkeypatch.setattr(overflow, "_HAVE_DIR_FD", False)
+    monkeypatch.setattr(CONFIG, "sandbox_data_path", str(tmp_path), raising=False)
+    sweep_overflow()
+
+    root = tmp_path / "shared" / ".overflow"
+    total = sum(p.stat().st_size for p in root.rglob("*.txt"))
+
+    assert total <= 5_000 + 3_100, total
+
+
+@pytest.mark.asyncio
+async def test_the_sweep_keeps_running_after_startup(monkeypatch):
+    """Running it once left the root quota and the retention window unenforced
+    for the lifetime of a long-lived process — a write only ever prunes its own
+    chat's directory."""
+    import asyncio
+
+    import suzent.tools.overflow as overflow
+
+    calls = 0
+
+    def _count():
+        nonlocal calls
+        calls += 1
+
+    monkeypatch.setattr(overflow, "sweep_overflow", _count)
+    monkeypatch.setattr(overflow, "OVERFLOW_SWEEP_INTERVAL_SECONDS", 0.01)
+
+    task = asyncio.create_task(overflow.sweep_overflow_periodically())
+    await asyncio.sleep(0.08)
+    task.cancel()
+
+    assert calls > 1, f"the sweep ran {calls} time(s); it must keep running"
+
+
+@pytest.mark.asyncio
+async def test_a_failing_sweep_does_not_end_the_loop(monkeypatch):
+    """One bad sweep must not silently disable retention until the next
+    restart."""
+    import asyncio
+
+    import suzent.tools.overflow as overflow
+
+    calls = 0
+
+    def _boom():
+        nonlocal calls
+        calls += 1
+        raise OSError("disk went away")
+
+    monkeypatch.setattr(overflow, "sweep_overflow", _boom)
+    monkeypatch.setattr(overflow, "OVERFLOW_SWEEP_INTERVAL_SECONDS", 0.01)
+
+    task = asyncio.create_task(overflow.sweep_overflow_periodically())
+    await asyncio.sleep(0.08)
+    task.cancel()
+
+    assert calls > 1
+
+
+def test_every_registered_tool_can_reach_its_deps():
+    """A tool whose forward() takes no RunContext cannot spill: the wrapper has
+    nowhere to read deps from, so its oversized output is truncated with no
+    path. BrowsingTool's snapshot regularly clears 30,000 characters."""
+    import inspect
+
+    from suzent.tools.registry import _all_tool_classes
+
+    missing = []
+    for cls in _all_tool_classes():
+        try:
+            params = list(inspect.signature(cls.forward).parameters)
+        except (TypeError, ValueError):
+            continue
+        if getattr(cls, "output_char_limit", None) and "ctx" not in params:
+            missing.append(cls.name)
+
+    assert missing == [], f"these tools cannot spill their output: {missing}"

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1435,3 +1435,43 @@ def test_no_out_of_band_deletion_remains():
         source = inspect.getsource(fn)
         assert "unlink" not in source, f"{fn.__name__} deletes a spill directly"
         assert "_discard" not in source, f"{fn.__name__} deletes a spill directly"
+
+
+def test_a_relative_data_path_still_yields_an_absolute_pointer(tmp_path, monkeypatch):
+    """sandbox_data_path may be relative — the documented default is
+    `.suzent/sandbox`. A relative host path in a marker is worse than useless:
+    PathResolver resolves relative paths against the *chat's* cwd, so the agent
+    would look under its own directory for a file written next to the
+    server's."""
+    from suzent.config import CONFIG
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(CONFIG, "sandbox_data_path", "relative/sandbox", raising=False)
+
+    class _Resolver:
+        def resolve(self, virtual: str) -> str:
+            base = tmp_path / "relative" / "sandbox" / "shared"
+            return str(base / virtual[len("/shared") :].lstrip("/"))
+
+    deps = SimpleNamespace(
+        path_resolver=_Resolver(), sandbox_enabled=False, chat_id="c"
+    )
+
+    spill = spill_overflow("x" * 100, deps=deps, kind="t")
+
+    assert spill is not None
+    assert Path(spill.path).is_absolute(), f"relative pointer: {spill.path}"
+    assert Path(spill.path).read_text(encoding="utf-8") == "x" * 100
+
+
+def test_the_root_has_one_definition():
+    """Three copies of `Path(sandbox_data_path) / "shared"` is how the writer
+    and the sweep came to disagree before, and how one of them stayed
+    relative."""
+    import inspect
+
+    import suzent.tools.overflow as overflow
+
+    source = inspect.getsource(overflow)
+
+    assert source.count("CONFIG.sandbox_data_path") == 1

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1874,23 +1874,25 @@ def test_deleted_entries_do_not_consume_the_file_ceiling(tmp_path, monkeypatch):
     breaking a live pointer for nothing."""
     import suzent.tools.overflow as overflow
 
-    monkeypatch.setattr(overflow, "OVERFLOW_MAX_FILES", 2)
-
-    expired = spill_overflow("a" * 100, deps=_deps(tmp_path), kind="t")
-    ahead = time.time() + 3_600
-    os.utime(expired.host_path, (ahead, ahead))
-
     keepers = []
-    for payload in ("b", "c"):
+    for offset, payload in enumerate(("b", "c")):
         kept = spill_overflow(payload * 100, deps=_deps(tmp_path), kind="t")
-        long_ago = time.time() - 3_600 - len(keepers)
+        long_ago = time.time() - 3_600 - offset
         os.utime(kept.host_path, (long_ago, long_ago))
-        keepers.append(kept)
+        keepers.append(Path(kept.host_path))
 
+    # Planted rather than spilled: a spill of its own would prune the directory
+    # on the way out, and the point here is what the sweep sees.
+    expired = keepers[0].parent / "t-rolled-back.txt"
+    expired.write_bytes(b"x" * 100)
+    ahead = time.time() + 3_600
+    os.utime(expired, (ahead, ahead))
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_FILES", 2)
     overflow.sweep_overflow()
 
-    assert not Path(expired.host_path).exists()
+    assert not expired.exists()
     for kept in keepers:
-        assert Path(kept.host_path).exists(), (
+        assert kept.exists(), (
             "an entry deleted ahead of this one still consumed the ceiling"
         )

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -238,3 +238,26 @@ def test_the_sweep_is_harmless_with_no_directory(tmp_path, monkeypatch):
     monkeypatch.setattr(CONFIG, "sandbox_data_path", str(tmp_path), raising=False)
 
     sweep_overflow()  # must not raise
+
+
+def test_the_marker_says_how_long_the_file_lasts(deps):
+    """The pointer outlives the file: the path goes into conversation history,
+    the file expires in a day. A resumed session would otherwise read a pointer
+    to something already collected and find a puzzling absence."""
+    from suzent.tools.overflow import retention_hint
+
+    path = spill_overflow("x" * 50_000, deps=deps, kind="t")
+    out = truncate_tool_output("x" * 50_000, 100, full_output_path=path)
+
+    assert retention_hint() in out
+    assert "kept 24h" in out
+
+
+def test_the_stated_window_tracks_the_actual_ttl(monkeypatch):
+    """Written out by hand, the two would drift the first time the TTL moved."""
+    import suzent.tools.overflow as overflow
+    from suzent.tools.overflow import retention_hint
+
+    monkeypatch.setattr(overflow, "OVERFLOW_TTL_SECONDS", 3 * 60 * 60)
+
+    assert retention_hint() == "kept 3h"

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1592,3 +1592,69 @@ def test_a_stored_result_is_accepted_rather_than_abandoned(deps, monkeypatch):
 
     assert spill is not None, "a written, stored spill was thrown away"
     assert Path(spill.host_path).exists()
+
+
+@pytest.mark.asyncio
+async def test_the_slot_covers_the_cleanup_too(deps, monkeypatch):
+    """Releasing at the end of the write let the next oversized result take the
+    slot and park another thread in the pruning below it — the accumulation the
+    bound exists to prevent."""
+    import asyncio
+    import threading
+
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "_spill_slots", threading.Semaphore(1))
+
+    in_cleanup = threading.Event()
+    finish = threading.Event()
+
+    def _slow_prune(snapshot):
+        in_cleanup.set()
+        finish.wait(timeout=5)
+
+    monkeypatch.setattr(overflow, "_prune_after_accept", _slow_prune)
+
+    first = asyncio.create_task(
+        overflow.spill_overflow_async("x" * 100, deps=deps, kind="t")
+    )
+    assert await asyncio.to_thread(in_cleanup.wait, 2), "cleanup never started"
+
+    # The one slot is still held by the worker doing filesystem work.
+    assert overflow._spill_slots._value == 0, "the slot was freed before cleanup"
+
+    finish.set()
+    await first
+
+
+@pytest.mark.asyncio
+async def test_acceptance_means_the_caller_received_it(deps, tmp_path, monkeypatch):
+    """Setting the future is not the same event as the caller returning: a
+    cancellation queued after _deliver ran still stops the coroutine, and the
+    worker would keep and prune a file whose path reached nobody."""
+    import asyncio
+    import threading
+
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(
+        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
+    )
+
+    task = asyncio.create_task(
+        overflow.spill_overflow_async("x" * 100, deps=deps, kind="t")
+    )
+    # Cancel while the worker is between delivering and the coroutine resuming.
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    for _ in range(80):
+        await asyncio.sleep(0.02)
+        if not list(_chat_dir(tmp_path).glob("*.txt")):
+            break
+
+    assert list(_chat_dir(tmp_path).glob("*.txt")) == [], (
+        "a spill the caller never received was kept"
+    )

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -412,3 +412,78 @@ def test_the_retention_hint_is_an_upper_bound(deps):
     from suzent.tools.overflow import retention_hint
 
     assert retention_hint().startswith("kept up to")
+
+
+def test_the_whole_output_is_never_encoded(monkeypatch):
+    """Encoding the full string to discover it is too long allocates a second
+    copy while the original result is still live — a command printing hundreds
+    of MiB costs that twice over to write five.
+
+    A slice of a str subclass is a plain str, so if the recorder never fires the
+    full string was never encoded — which is exactly the property.
+    """
+    import suzent.tools.overflow as overflow
+
+    encoded_from: list[int] = []
+
+    class _Watched(str):
+        def encode(self, *args, **kwargs):
+            encoded_from.append(len(self))
+            return str.encode(self, *args, **kwargs)
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_FILE_BYTES", 1_000)
+
+    payload, clipped = overflow._clip(_Watched("x" * 500_000))
+
+    assert clipped is True
+    assert len(payload) <= 1_000
+    assert encoded_from == [], f"the full {500_000}-char string was encoded"
+
+
+def test_a_short_output_is_not_reported_as_clipped(monkeypatch):
+    """The bounded slice must not make an ordinary result look truncated."""
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_FILE_BYTES", 1_000)
+
+    payload, clipped = overflow._clip("short")
+
+    assert clipped is False
+    assert payload == b"short"
+
+
+def test_the_root_total_is_bounded_across_chats(tmp_path, monkeypatch):
+    """Pruning on write only ever sees one chat's directory, so the per-chat
+    allowance multiplies by the number of chats — a hundred of them retain
+    5 GiB while every directory is individually within bounds."""
+    from suzent.config import CONFIG
+    import suzent.tools.overflow as overflow
+    from suzent.tools.overflow import sweep_overflow
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_ROOT_BYTES", 5_000)
+
+    for chat in ("a", "b", "c", "d"):
+        spill_overflow("y" * 3_000, deps=_deps(tmp_path, chat_id=chat), kind="t")
+
+    monkeypatch.setattr(CONFIG, "sandbox_data_path", str(tmp_path), raising=False)
+    sweep_overflow()
+
+    root = tmp_path / "shared" / ".overflow"
+    total = sum(p.stat().st_size for p in root.rglob("*.txt"))
+
+    assert total <= 5_000 + 3_100, total
+
+
+def test_the_path_fallback_writes_without_dir_fd(tmp_path, monkeypatch):
+    """Windows has no dir_fd, and keeping the fd-based code while passing
+    dir_fd=None was not a fallback: os.open raises NotImplementedError there,
+    which no `except OSError` catches, turning an oversized tool result into a
+    failed tool call."""
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "_HAVE_DIR_FD", False)
+
+    spill = overflow.spill_overflow("x" * 500, deps=_deps(tmp_path), kind="t")
+
+    assert spill is not None
+    assert Path(spill.path).read_text(encoding="utf-8") == "x" * 500

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1733,3 +1733,42 @@ def test_the_shared_root_is_opened_without_following(tmp_path):
 
     assert spill_overflow("x" * 100, deps=_deps(tmp_path), kind="t") is None
     assert list(elsewhere.iterdir()) == [], "the write followed a symlinked root"
+
+
+def test_fresh_spills_still_count_toward_the_quota(tmp_path, monkeypatch):
+    """Undeletable is not the same as uncounted. Omitting fresh files from the
+    running totals let a burst exceed both ceilings outright: eleven maximum
+    spills pass the per-chat limit while none is old enough to consider."""
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_TOTAL_BYTES", 5_000)
+
+    aged = spill_overflow("a" * 3_000, deps=_deps(tmp_path), kind="t")
+    old_time = time.time() - 3_600
+    os.utime(aged.host_path, (old_time, old_time))
+
+    # Two fresh spills; together with the aged one they exceed the ceiling, and
+    # the aged one is the only thing that may be evicted.
+    spill_overflow("b" * 3_000, deps=_deps(tmp_path), kind="t")
+    spill_overflow("c" * 3_000, deps=_deps(tmp_path), kind="t")
+
+    assert not Path(aged.host_path).exists(), (
+        "fresh spills did not consume budget, so nothing was evicted"
+    )
+
+
+def test_fresh_spills_count_toward_the_root_quota(tmp_path, monkeypatch):
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_ROOT_BYTES", 5_000)
+
+    aged = spill_overflow("a" * 3_000, deps=_deps(tmp_path, chat_id="old"), kind="t")
+    old_time = time.time() - 3_600
+    os.utime(aged.host_path, (old_time, old_time))
+
+    spill_overflow("b" * 3_000, deps=_deps(tmp_path, chat_id="new1"), kind="t")
+    spill_overflow("c" * 3_000, deps=_deps(tmp_path, chat_id="new2"), kind="t")
+
+    assert not Path(aged.host_path).exists(), (
+        "fresh spills did not consume the deployment budget"
+    )

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -4,8 +4,13 @@ A cap stops one output swallowing the context window, but the part it removes
 is usually the part someone wanted — the failing assertion at the end of a test
 run, the last of a build log. Truncating to a bare marker tells the model that
 content is missing and gives it no way to read it.
+
+Two properties are load-bearing: the write must not become a way to reach files
+the agent could not otherwise touch, and a spill must not be readable by other
+chats sharing the same mount.
 """
 
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -15,43 +20,55 @@ from suzent.tools.base import truncate_tool_output
 from suzent.tools.overflow import (
     OVERFLOW_MAX_FILES,
     OVERFLOW_VIRTUAL_DIR,
+    Spill,
     spill_overflow,
 )
 
 
-@pytest.fixture
-def deps(tmp_path):
+def _deps(tmp_path: Path, *, chat_id: str = "chat-1", sandbox: bool = False):
     class _Resolver:
         def resolve(self, virtual: str) -> str:
-            assert virtual == OVERFLOW_VIRTUAL_DIR
-            return str(tmp_path / "overflow")
+            assert virtual == "/shared"
+            return str(tmp_path / "shared")
 
-    return SimpleNamespace(path_resolver=_Resolver(), sandbox_enabled=False)
+    return SimpleNamespace(
+        path_resolver=_Resolver(), sandbox_enabled=sandbox, chat_id=chat_id
+    )
+
+
+@pytest.fixture
+def deps(tmp_path):
+    return _deps(tmp_path)
+
+
+def _chat_dir(tmp_path: Path, chat_id: str = "chat-1") -> Path:
+    return tmp_path / "shared" / ".overflow" / chat_id
 
 
 def test_the_whole_output_is_written_not_the_kept_part(deps):
     text = "\n".join(f"line {i}" for i in range(5000))
 
-    path = spill_overflow(text, deps=deps, kind="run_command")
+    spill = spill_overflow(text, deps=deps, kind="run_command")
 
-    assert Path(path).read_text(encoding="utf-8") == text
+    assert Path(spill.path).read_text(encoding="utf-8") == text
+    assert spill.clipped is False
 
 
 def test_the_marker_names_the_file(deps):
     text = "x" * 50_000
 
-    path = spill_overflow(text, deps=deps, kind="run_command")
-    out = truncate_tool_output(text, 100, full_output_path=path)
+    spill = spill_overflow(text, deps=deps, kind="run_command")
+    out = truncate_tool_output(text, 100, spill=spill)
 
-    assert path in out
+    assert spill.path in out
     assert "full output" in out
-    assert len(out) < 500
+    assert "kept 24h" in out
 
 
-def test_a_marker_without_a_spill_still_reports_the_loss(deps):
-    """Spilling is best-effort. Losing the tail beats failing the tool call
-    that produced it, but the model still has to know it happened."""
-    out = truncate_tool_output("x" * 50_000, 100, full_output_path=None)
+def test_a_marker_without_a_spill_still_reports_the_loss():
+    """Spilling is best-effort. Losing the tail beats failing the tool call that
+    produced it, but the model still has to know it happened."""
+    out = truncate_tool_output("x" * 50_000, 100, spill=None)
 
     assert "truncated" in out
     assert "full output" not in out
@@ -60,132 +77,151 @@ def test_a_marker_without_a_spill_still_reports_the_loss(deps):
 def test_the_path_is_the_one_this_agent_can_open(tmp_path):
     """Host mode gets a host path, sandbox mode the virtual one. A path the
     agent cannot open is worse than none: it invites a read that fails."""
+    host = spill_overflow("y" * 100, deps=_deps(tmp_path), kind="t")
+    sandboxed = spill_overflow("y" * 100, deps=_deps(tmp_path, sandbox=True), kind="t")
 
-    class _Resolver:
-        def resolve(self, virtual: str) -> str:
-            return str(tmp_path / "overflow")
-
-    host = SimpleNamespace(path_resolver=_Resolver(), sandbox_enabled=False)
-    sandboxed = SimpleNamespace(path_resolver=_Resolver(), sandbox_enabled=True)
-
-    assert spill_overflow("y" * 100, deps=host, kind="t").startswith(str(tmp_path))
-    assert spill_overflow("y" * 100, deps=sandboxed, kind="t").startswith(
-        OVERFLOW_VIRTUAL_DIR
-    )
+    assert host.path.startswith(str(tmp_path))
+    assert sandboxed.path.startswith(f"{OVERFLOW_VIRTUAL_DIR}/chat-1/")
 
 
 def test_no_resolver_means_no_spill_rather_than_a_crash():
     assert spill_overflow("x" * 100, deps=SimpleNamespace(), kind="t") is None
 
 
-def test_an_unwritable_directory_degrades_quietly(tmp_path):
+def test_an_unreachable_shared_root_degrades_quietly(tmp_path):
     class _Broken:
         def resolve(self, virtual: str) -> str:
             raise ValueError("no matching custom mount is registered")
 
-    deps = SimpleNamespace(path_resolver=_Broken(), sandbox_enabled=False)
+    deps = SimpleNamespace(path_resolver=_Broken(), sandbox_enabled=False, chat_id="c")
 
     assert spill_overflow("x" * 100, deps=deps, kind="t") is None
 
 
-def test_spills_do_not_accumulate_without_limit(deps):
-    """A single runaway session can write thousands; the TTL alone would not
-    bound that until tomorrow."""
-    for i in range(OVERFLOW_MAX_FILES + 25):
-        spill_overflow(f"body {i}", deps=deps, kind="t")
-
-    directory = Path(deps.path_resolver.resolve(OVERFLOW_VIRTUAL_DIR))
-    assert len(list(directory.glob("*.txt"))) <= OVERFLOW_MAX_FILES
+# --- one chat's output is not another chat's to read --------------------------
 
 
-def test_an_expired_spill_is_removed(deps):
-    import os
-    import time
+def test_spills_are_scoped_to_their_chat(tmp_path):
+    """/shared is mounted into every session, so an unscoped directory is
+    readable by every other chat on the deployment. These files hold raw tool
+    output and reminder text — conversation content — and a random filename is
+    no defence against listing the directory."""
+    first = spill_overflow("secret alpha", deps=_deps(tmp_path, chat_id="a"), kind="t")
+    second = spill_overflow("secret beta", deps=_deps(tmp_path, chat_id="b"), kind="t")
 
-    from suzent.tools.overflow import OVERFLOW_TTL_SECONDS
-
-    stale = spill_overflow("old", deps=deps, kind="t")
-    old_time = time.time() - OVERFLOW_TTL_SECONDS - 60
-    os.utime(stale, (old_time, old_time))
-
-    spill_overflow("new", deps=deps, kind="t")
-
-    assert not Path(stale).exists()
-
-
-# --- the spill must not become a write primitive ------------------------------
+    assert "/a/" in first.path.replace(str(tmp_path), "")
+    assert "/b/" in second.path.replace(str(tmp_path), "")
+    assert list(_chat_dir(tmp_path, "a").glob("*.txt")) != []
+    assert len(list(_chat_dir(tmp_path, "a").glob("*.txt"))) == 1
 
 
-def test_a_planted_symlink_is_not_followed(deps, tmp_path, monkeypatch):
-    """The write must refuse a symlink sitting at its destination.
+def test_a_hostile_chat_id_cannot_escape_the_directory(tmp_path):
+    spill = spill_overflow(
+        "x" * 100, deps=_deps(tmp_path, chat_id="../../etc"), kind="t"
+    )
 
-    The old name was the output's own hash plus the current second, both of
-    which a sandboxed agent can compute — so it could place a symlink there,
-    emit matching output, and have the host process overwrite a file the agent
-    could never reach through PathResolver, because the write is ours. The name
-    is random now, so this pins the second half of the fix: even aimed exactly
-    at the destination, the open is refused rather than followed.
-    """
-    import os
+    assert ".." not in spill.path
+    assert str(tmp_path / "shared" / ".overflow") in spill.path
 
+
+# --- the write must not become a capability -----------------------------------
+
+
+def test_a_symlink_at_the_destination_is_not_followed(deps, tmp_path, monkeypatch):
+    """The name was once derived from the output's own hash and the current
+    second, both of which the agent can compute."""
     import suzent.tools.overflow as overflow
 
     target = tmp_path / "precious.txt"
     target.write_text("do not clobber", encoding="utf-8")
-
-    directory = Path(deps.path_resolver.resolve(OVERFLOW_VIRTUAL_DIR))
-    directory.mkdir(parents=True, exist_ok=True)
+    chat_dir = _chat_dir(tmp_path)
+    chat_dir.mkdir(parents=True, exist_ok=True)
 
     monkeypatch.setattr(overflow.secrets, "token_hex", lambda n: "aimed")
-    os.symlink(target, directory / "run_command-aimed.txt")
+    os.symlink(target, chat_dir / "run_command-aimed.txt")
 
-    result = spill_overflow("payload" * 100, deps=deps, kind="run_command")
-
-    assert result is None, "the write should be refused, not redirected"
+    assert spill_overflow("payload" * 100, deps=deps, kind="run_command") is None
     assert target.read_text(encoding="utf-8") == "do not clobber"
 
 
+def test_a_symlinked_parent_directory_is_not_followed(deps, tmp_path):
+    """O_NOFOLLOW on the final component says nothing about the directories
+    above it. Swap .overflow for a symlink after the path is resolved and an
+    unpinned write lands in the attacker's tree — and the prune that follows
+    unlinks *.txt there."""
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    bystander = elsewhere / "keepme.txt"
+    bystander.write_text("unrelated", encoding="utf-8")
+
+    shared = tmp_path / "shared"
+    shared.mkdir(parents=True, exist_ok=True)
+    os.symlink(elsewhere, shared / ".overflow")
+
+    result = spill_overflow("payload" * 100, deps=deps, kind="t")
+
+    assert result is None, "the write followed a swapped parent directory"
+    assert bystander.read_text(encoding="utf-8") == "unrelated"
+
+
 def test_the_name_is_not_derivable_from_the_output(deps):
-    """Two identical outputs must not land on the same path — a predictable name
-    is what makes the symlink race worth attempting."""
     text = "same output" * 50
 
     first = spill_overflow(text, deps=deps, kind="t")
     second = spill_overflow(text, deps=deps, kind="t")
 
-    assert first != second
-
-
-def test_an_existing_regular_file_is_never_overwritten(deps, monkeypatch):
-    """O_EXCL, not just an unlikely collision."""
-    import suzent.tools.overflow as overflow
-
-    directory = Path(deps.path_resolver.resolve(OVERFLOW_VIRTUAL_DIR))
-    directory.mkdir(parents=True, exist_ok=True)
-    monkeypatch.setattr(overflow.secrets, "token_hex", lambda n: "fixed")
-    (directory / "t-fixed.txt").write_text("existing", encoding="utf-8")
-
-    assert spill_overflow("new content", deps=deps, kind="t") is None
-    assert (directory / "t-fixed.txt").read_text(encoding="utf-8") == "existing"
+    assert first.path != second.path
 
 
 # --- disk bounds --------------------------------------------------------------
 
 
 def test_one_spill_cannot_be_arbitrarily_large(deps):
-    """A foreground shell command reads its whole output into memory, and this
-    writes all of it."""
     from suzent.tools.overflow import OVERFLOW_MAX_FILE_BYTES, SPILL_CLIPPED_NOTE
 
-    path = spill_overflow("x" * (OVERFLOW_MAX_FILE_BYTES * 2), deps=deps, kind="t")
-    written = Path(path).read_bytes()
+    spill = spill_overflow("x" * (OVERFLOW_MAX_FILE_BYTES * 2), deps=deps, kind="t")
+    written = Path(spill.path).read_bytes()
 
     assert len(written) <= OVERFLOW_MAX_FILE_BYTES
     assert written.endswith(SPILL_CLIPPED_NOTE.encode("utf-8"))
+    assert spill.clipped is True
 
 
-def test_the_directory_is_bounded_in_bytes_not_only_in_count(deps, monkeypatch):
-    """200 files of any size is not a bound on disk."""
+def test_a_clipped_spill_is_still_valid_utf8(deps):
+    """Slicing encoded bytes can land inside a multi-byte code point, and then
+    the reader meant to rescue the output cannot open the file at all."""
+    from suzent.tools.overflow import OVERFLOW_MAX_FILE_BYTES
+
+    spill = spill_overflow("é" * OVERFLOW_MAX_FILE_BYTES, deps=deps, kind="t")
+
+    Path(spill.path).read_text(encoding="utf-8")  # must not raise
+
+
+def test_a_clipped_spill_is_not_advertised_as_the_full_output(deps):
+    """Sending a reader to a file that does not hold what the marker promised is
+    worse than admitting the cut twice."""
+    from suzent.tools.overflow import OVERFLOW_MAX_FILE_BYTES
+
+    text = "x" * (OVERFLOW_MAX_FILE_BYTES * 2)
+    spill = spill_overflow(text, deps=deps, kind="t")
+    out = truncate_tool_output(text, 100, spill=spill)
+
+    assert "partial output" in out
+    assert "full output" not in out
+
+
+def test_spills_do_not_accumulate_without_limit(deps, tmp_path):
+    for i in range(OVERFLOW_MAX_FILES + 25):
+        spill_overflow(f"body {i}", deps=deps, kind="t")
+
+    kept = list(_chat_dir(tmp_path).glob("*.txt"))
+
+    assert len(kept) <= OVERFLOW_MAX_FILES
+
+
+def test_the_directory_is_bounded_in_bytes_not_only_in_count(
+    deps, tmp_path, monkeypatch
+):
     import suzent.tools.overflow as overflow
 
     monkeypatch.setattr(overflow, "OVERFLOW_MAX_TOTAL_BYTES", 20_000)
@@ -193,42 +229,71 @@ def test_the_directory_is_bounded_in_bytes_not_only_in_count(deps, monkeypatch):
     for _ in range(30):
         spill_overflow("y" * 2_000, deps=deps, kind="t")
 
-    directory = Path(deps.path_resolver.resolve(OVERFLOW_VIRTUAL_DIR))
-    total = sum(p.stat().st_size for p in directory.glob("*.txt"))
+    total = sum(p.stat().st_size for p in _chat_dir(tmp_path).glob("*.txt"))
 
     assert total <= 20_000 + 2_100, total
 
 
-# --- who collects the last spill of a session ---------------------------------
+def test_an_expired_spill_is_removed(deps, tmp_path):
+    import time
+
+    from suzent.tools.overflow import OVERFLOW_TTL_SECONDS
+
+    stale = spill_overflow("old", deps=deps, kind="t")
+    old_time = time.time() - OVERFLOW_TTL_SECONDS - 60
+    os.utime(stale.path, (old_time, old_time))
+
+    spill_overflow("new", deps=deps, kind="t")
+
+    assert not Path(stale.path).exists()
+
+
+# --- lifecycle ----------------------------------------------------------------
 
 
 def test_the_sweep_collects_what_no_later_spill_would(tmp_path, monkeypatch):
     """Pruning otherwise runs only on write, so the bounds hold exactly while
-    output keeps overflowing and stop the moment it does not. Nothing else
-    collects these — they live in the user's data directory, not a temp
-    directory the OS sweeps."""
-    import os
+    output keeps overflowing and stop the moment it does not."""
     import time
 
+    from suzent.config import CONFIG
     from suzent.tools.overflow import OVERFLOW_TTL_SECONDS, sweep_overflow
 
-    shared = tmp_path / "shared" / ".overflow"
-    shared.mkdir(parents=True)
-    stale = shared / "t-old.txt"
+    chat_dir = _chat_dir(tmp_path)
+    chat_dir.mkdir(parents=True)
+    stale = chat_dir / "t-old.txt"
     stale.write_text("yesterday", encoding="utf-8")
     old = time.time() - OVERFLOW_TTL_SECONDS - 60
     os.utime(stale, (old, old))
-    fresh = shared / "t-new.txt"
+    fresh = chat_dir / "t-new.txt"
     fresh.write_text("today", encoding="utf-8")
 
-    from suzent.config import CONFIG
-
     monkeypatch.setattr(CONFIG, "sandbox_data_path", str(tmp_path), raising=False)
-
     sweep_overflow()
 
-    assert not stale.exists(), "a spill older than the TTL survived a sweep"
-    assert fresh.exists(), "the sweep took a spill that was still current"
+    assert not stale.exists()
+    assert fresh.exists()
+
+
+def test_the_sweep_drops_a_chat_directory_once_it_is_empty(tmp_path, monkeypatch):
+    """Per-chat bounds mean the directory total scales with the number of
+    chats, so the empty shells have to go too."""
+    import time
+
+    from suzent.config import CONFIG
+    from suzent.tools.overflow import OVERFLOW_TTL_SECONDS, sweep_overflow
+
+    chat_dir = _chat_dir(tmp_path, "gone")
+    chat_dir.mkdir(parents=True)
+    stale = chat_dir / "t-old.txt"
+    stale.write_text("x", encoding="utf-8")
+    old = time.time() - OVERFLOW_TTL_SECONDS - 60
+    os.utime(stale, (old, old))
+
+    monkeypatch.setattr(CONFIG, "sandbox_data_path", str(tmp_path), raising=False)
+    sweep_overflow()
+
+    assert not chat_dir.exists()
 
 
 def test_the_sweep_is_harmless_with_no_directory(tmp_path, monkeypatch):
@@ -240,24 +305,49 @@ def test_the_sweep_is_harmless_with_no_directory(tmp_path, monkeypatch):
     sweep_overflow()  # must not raise
 
 
-def test_the_marker_says_how_long_the_file_lasts(deps):
-    """The pointer outlives the file: the path goes into conversation history,
-    the file expires in a day. A resumed session would otherwise read a pointer
-    to something already collected and find a puzzling absence."""
-    from suzent.tools.overflow import retention_hint
-
-    path = spill_overflow("x" * 50_000, deps=deps, kind="t")
-    out = truncate_tool_output("x" * 50_000, 100, full_output_path=path)
-
-    assert retention_hint() in out
-    assert "kept 24h" in out
-
-
 def test_the_stated_window_tracks_the_actual_ttl(monkeypatch):
-    """Written out by hand, the two would drift the first time the TTL moved."""
     import suzent.tools.overflow as overflow
     from suzent.tools.overflow import retention_hint
 
     monkeypatch.setattr(overflow, "OVERFLOW_TTL_SECONDS", 3 * 60 * 60)
 
     assert retention_hint() == "kept 3h"
+
+
+@pytest.mark.asyncio
+async def test_the_async_spill_does_not_hold_the_loop(deps, monkeypatch):
+    """Up to 5 MiB of write plus a directory scan; inline, that stalls every
+    other chat the loop is serving.
+
+    A real spill is too quick to observe reliably, so the blocking part is
+    replaced by a sleep — what is being tested is that the call is offloaded,
+    not how fast the disk is.
+    """
+    import asyncio
+    import time
+
+    import suzent.tools.overflow as overflow
+    from suzent.tools.overflow import spill_overflow_async
+
+    monkeypatch.setattr(
+        overflow,
+        "spill_overflow",
+        lambda text, **kw: time.sleep(0.2) or Spill("/tmp/x.txt", False),
+    )
+
+    ticks = 0
+
+    async def _tick():
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    ticker = asyncio.create_task(_tick())
+    try:
+        spill = await spill_overflow_async("payload", deps=deps, kind="t")
+    finally:
+        ticker.cancel()
+
+    assert spill.path == "/tmp/x.txt"
+    assert ticks > 5, f"the loop was blocked during the write ({ticks} ticks)"

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -35,6 +35,18 @@ def _deps(tmp_path: Path, *, chat_id: str = "chat-1", sandbox: bool = False):
     )
 
 
+@pytest.fixture(autouse=True)
+def _canonical_root(tmp_path, monkeypatch):
+    """The spill root comes from config, not from whatever /shared maps to.
+
+    A custom volume can retarget /shared, so the writer derives the canonical
+    directory itself; the tests have to point that same config at tmp_path.
+    """
+    from suzent.config import CONFIG
+
+    monkeypatch.setattr(CONFIG, "sandbox_data_path", str(tmp_path), raising=False)
+
+
 @pytest.fixture
 def deps(tmp_path):
     return _deps(tmp_path)
@@ -121,13 +133,51 @@ def test_no_resolver_means_no_spill_rather_than_a_crash():
 
 
 def test_an_unreachable_shared_root_degrades_quietly(tmp_path):
+    """Sandbox mode needs /shared to resolve so it can advertise a path; host
+    mode writes the canonical directory and never asks."""
+
     class _Broken:
         def resolve(self, virtual: str) -> str:
             raise ValueError("no matching custom mount is registered")
 
-    deps = SimpleNamespace(path_resolver=_Broken(), sandbox_enabled=False, chat_id="c")
+    deps = SimpleNamespace(path_resolver=_Broken(), sandbox_enabled=True, chat_id="c")
 
     assert spill_overflow("x" * 100, deps=deps, kind="t") is None
+
+
+def test_a_remapped_shared_mount_is_not_written_to(tmp_path):
+    """A custom volume can target /shared and PathResolver gives it priority.
+    Writing there would put .overflow in the user's own directory, force-chmod
+    it 0755, and leave the files where the sweep never looks."""
+    elsewhere = tmp_path / "someone-elses-folder"
+    elsewhere.mkdir()
+
+    class _Remapped:
+        def resolve(self, virtual: str) -> str:
+            return str(elsewhere)
+
+    deps = SimpleNamespace(path_resolver=_Remapped(), sandbox_enabled=True, chat_id="c")
+
+    assert spill_overflow("x" * 100, deps=deps, kind="t") is None
+    assert list(elsewhere.iterdir()) == [], "wrote into the remapped mount"
+
+
+def test_host_mode_writes_the_canonical_root_regardless(tmp_path):
+    """Host mode advertises a host path, so a remapped /shared is irrelevant to
+    it — but the file still has to land where the sweep looks."""
+
+    class _Remapped:
+        def resolve(self, virtual: str) -> str:
+            return str(tmp_path / "somewhere-else")
+
+    deps = SimpleNamespace(
+        path_resolver=_Remapped(), sandbox_enabled=False, chat_id="c"
+    )
+
+    spill = spill_overflow("x" * 100, deps=deps, kind="t")
+
+    assert spill is not None
+    assert str(tmp_path / "shared" / ".overflow") in spill.path
 
 
 # --- one chat's output is not another chat's to read --------------------------
@@ -862,3 +912,35 @@ def test_the_path_fallback_also_holds_the_root_quota(tmp_path, monkeypatch):
     total = sum(p.stat().st_size for p in root.rglob("*.txt"))
 
     assert total <= 5_000 + 3_100, total
+
+
+def test_abandoned_spill_workers_are_bounded(deps, monkeypatch):
+    """A timed-out spill is abandoned, not cancelled. With permanently wedged
+    storage every oversized result would otherwise park another thread forever,
+    until the process runs out and healthy tool calls start failing."""
+    import threading
+    import time
+
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "SPILL_TIMEOUT_SECONDS", 0.02)
+    monkeypatch.setattr(overflow, "spill_overflow", lambda text, **kw: time.sleep(30))
+
+    before = threading.active_count()
+    for _ in range(20):
+        assert overflow.spill_overflow_bounded("x", deps=deps, kind="t") is None
+    parked = threading.active_count() - before
+
+    assert parked <= overflow._SPILL_THREADS, (
+        f"{parked} threads parked on wedged storage"
+    )
+
+
+def test_a_slot_is_returned_when_the_spill_completes(deps):
+    import suzent.tools.overflow as overflow
+
+    before = overflow._spill_slots._value
+    for _ in range(5):
+        overflow.spill_overflow_bounded("x" * 100, deps=deps, kind="t")
+
+    assert overflow._spill_slots._value == before

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -52,8 +52,11 @@ def deps(tmp_path):
     return _deps(tmp_path)
 
 
-def _chat_dir(tmp_path: Path, chat_id: str = "chat-1") -> Path:
-    return tmp_path / "shared" / ".overflow" / chat_id
+def _chat_dir(
+    tmp_path: Path, chat_id: str = "chat-1", *, sandbox: bool = False
+) -> Path:
+    prefix = "sandbox" if sandbox else "host"
+    return tmp_path / "shared" / ".overflow" / f"{prefix}-{chat_id}"
 
 
 def test_the_whole_output_is_written_not_the_kept_part(deps):
@@ -98,7 +101,7 @@ def test_sandbox_mode_gets_the_virtual_path(tmp_path):
 
     spill = spill_overflow("y" * 100, deps=_deps(tmp_path, sandbox=True), kind="t")
 
-    assert spill.path.startswith(f"{OVERFLOW_VIRTUAL_DIR}/chat-1/")
+    assert spill.path.startswith(f"{OVERFLOW_VIRTUAL_DIR}/sandbox-chat-1/")
 
 
 def test_a_sandbox_spill_is_readable_by_a_different_uid(tmp_path):
@@ -111,7 +114,7 @@ def test_a_sandbox_spill_is_readable_by_a_different_uid(tmp_path):
     """
     spill_overflow("x" * 100, deps=_deps(tmp_path, sandbox=True), kind="t")
 
-    chat_dir = _chat_dir(tmp_path)
+    chat_dir = _chat_dir(tmp_path, sandbox=True)
     written = next(chat_dir.glob("*.txt"))
 
     assert os.stat(written).st_mode & 0o044, "the sandbox cannot read the spill"
@@ -191,9 +194,8 @@ def test_spills_are_scoped_to_their_chat(tmp_path):
     first = spill_overflow("secret alpha", deps=_deps(tmp_path, chat_id="a"), kind="t")
     second = spill_overflow("secret beta", deps=_deps(tmp_path, chat_id="b"), kind="t")
 
-    assert "/a/" in first.path.replace(str(tmp_path), "")
-    assert "/b/" in second.path.replace(str(tmp_path), "")
-    assert list(_chat_dir(tmp_path, "a").glob("*.txt")) != []
+    assert "-a/" in first.path.replace(str(tmp_path), "")
+    assert "-b/" in second.path.replace(str(tmp_path), "")
     assert len(list(_chat_dir(tmp_path, "a").glob("*.txt"))) == 1
 
 
@@ -677,7 +679,7 @@ def test_sandbox_spills_stay_reachable_under_any_umask(tmp_path, umask_value):
         os.umask(previous)
 
     host_file = (
-        tmp_path / "shared" / ".overflow" / f"u{umask_value:o}" / Path(spill.path).name
+        _chat_dir(tmp_path, f"u{umask_value:o}", sandbox=True) / Path(spill.path).name
     )
     assert os.stat(host_file).st_mode & 0o044, "the file is not readable"
     walked = host_file.parent
@@ -729,7 +731,7 @@ def test_the_path_fallback_also_survives_the_umask(tmp_path, monkeypatch):
     finally:
         os.umask(previous)
 
-    host_file = tmp_path / "shared" / ".overflow" / "fallback" / Path(spill.path).name
+    host_file = _chat_dir(tmp_path, "fallback", sandbox=True) / Path(spill.path).name
     assert os.stat(host_file).st_mode & 0o044
     assert os.stat(host_file.parent).st_mode & 0o011
 
@@ -780,9 +782,7 @@ def test_a_host_spill_does_not_lock_out_the_sandbox(tmp_path):
     sandbox_spill = spill_overflow(
         "s", deps=_deps(tmp_path, chat_id="sbx", sandbox=True), kind="t"
     )
-    host_path = (
-        tmp_path / "shared" / ".overflow" / "sbx" / Path(sandbox_spill.path).name
-    )
+    host_path = _chat_dir(tmp_path, "sbx", sandbox=True) / Path(sandbox_spill.path).name
 
     # A host-mode chat spills afterwards, touching the shared ancestors.
     spill_overflow("h", deps=_deps(tmp_path, chat_id="host"), kind="t")
@@ -944,3 +944,66 @@ def test_a_slot_is_returned_when_the_spill_completes(deps):
         overflow.spill_overflow_bounded("x" * 100, deps=deps, kind="t")
 
     assert overflow._spill_slots._value == before
+
+
+def test_switching_execution_mode_does_not_lock_out_earlier_spills(tmp_path):
+    """A chat can move between modes, and the mode decides the directory's
+    permissions. Sharing one directory let a host spill chmod it 0700 and made
+    every sandbox path already advertised from it unreadable — the most recent
+    spill retroactively deciding whether older ones could be opened."""
+    sandbox_spill = spill_overflow(
+        "s", deps=_deps(tmp_path, chat_id="c9", sandbox=True), kind="t"
+    )
+    written = _chat_dir(tmp_path, "c9", sandbox=True) / Path(sandbox_spill.path).name
+
+    # The same chat, now in host mode.
+    spill_overflow("h", deps=_deps(tmp_path, chat_id="c9"), kind="t")
+
+    assert os.stat(written).st_mode & 0o044, "the earlier sandbox spill is unreadable"
+    assert os.stat(written.parent).st_mode & 0o011, "its directory is untraversable"
+
+
+def test_the_two_modes_use_separate_leaves(tmp_path):
+    spill_overflow("s", deps=_deps(tmp_path, chat_id="c9", sandbox=True), kind="t")
+    spill_overflow("h", deps=_deps(tmp_path, chat_id="c9"), kind="t")
+
+    names = sorted(p.name for p in (tmp_path / "shared" / ".overflow").iterdir())
+
+    assert names == ["host-c9", "sandbox-c9"]
+
+
+def test_a_slot_is_returned_when_the_worker_cannot_start(deps, monkeypatch):
+    """The worker's finally is what returns the slot, so a thread that never
+    starts never gives it back — four of those and spilling is off for the life
+    of the process."""
+    import threading
+
+    import suzent.tools.overflow as overflow
+
+    before = overflow._spill_slots._value
+
+    def _no_thread(*args, **kwargs):
+        class _Dead:
+            def start(self):
+                raise RuntimeError("can't start new thread")
+
+        return _Dead()
+
+    monkeypatch.setattr(threading, "Thread", _no_thread)
+
+    assert overflow.spill_overflow_bounded("x", deps=deps, kind="t") is None
+    assert overflow._spill_slots._value == before, "slot leaked"
+
+
+def test_a_platform_without_fchmod_still_writes(tmp_path, monkeypatch):
+    """os.fchmod does not exist on Windows before 3.13, and AttributeError is
+    not an OSError — uncaught, it escaped before fdopen took ownership, so every
+    oversized result leaked a handle and wrote nothing."""
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.delattr(os, "fchmod", raising=False)
+
+    spill = overflow.spill_overflow("x" * 100, deps=_deps(tmp_path), kind="t")
+
+    assert spill is not None
+    assert Path(spill.path).read_text(encoding="utf-8") == "x" * 100

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1772,3 +1772,27 @@ def test_fresh_spills_count_toward_the_root_quota(tmp_path, monkeypatch):
     assert not Path(aged.host_path).exists(), (
         "fresh spills did not consume the deployment budget"
     )
+
+
+def test_future_dated_spills_do_not_hold_grace_open(tmp_path, monkeypatch):
+    """A backward clock step stamps already-published spills in the future. Read
+    as a one-sided ``mtime >= now - 60`` that made them undeletable for the whole
+    rollback interval — hours, not a minute — so a burst caught by it stayed
+    above the ceiling. Grace is a window, and its future side is closed."""
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_TOTAL_BYTES", 1_000)
+
+    rolled_back = spill_overflow("a" * 3_000, deps=_deps(tmp_path), kind="t")
+    ahead = time.time() + 3_600
+    os.utime(rolled_back.host_path, (ahead, ahead))
+    genuinely_fresh = spill_overflow("b" * 3_000, deps=_deps(tmp_path), kind="t")
+
+    overflow.sweep_overflow()
+
+    assert not Path(rolled_back.host_path).exists(), (
+        "a future-dated spill kept its grace and could not be evicted"
+    )
+    assert Path(genuinely_fresh.host_path).exists(), (
+        "grace no longer protects a spill that really is newborn"
+    )

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1202,3 +1202,52 @@ def test_the_sweep_lock_is_released_for_the_next_tick(monkeypatch):
                 break
             time.sleep(0.01)
         assert not overflow._sweep_lock.locked(), "the lock outlived its sweep"
+
+
+def test_a_masked_mount_writes_nothing_at_all(tmp_path):
+    """Validating after the write meant the file was created and both quota
+    passes had run before the answer was thrown away — so a chat with a masked
+    mount produced unreachable orphans on every oversized result, and its
+    pruning could evict spills other chats still pointed at."""
+
+    class _Masked:
+        """Resolves /shared canonically but sends anything below .overflow
+        somewhere else, as a nested custom volume does."""
+
+        def resolve(self, virtual: str) -> str:
+            if virtual.startswith("/shared/.overflow"):
+                return str(tmp_path / "masked" / virtual.split("/")[-1])
+            return str(tmp_path / "shared" / virtual[len("/shared") :].lstrip("/"))
+
+    deps = SimpleNamespace(
+        path_resolver=_Masked(), sandbox_enabled=True, chat_id="masked-chat"
+    )
+
+    assert spill_overflow("x" * 100, deps=deps, kind="t") is None
+    assert not (tmp_path / "shared" / ".overflow").exists(), "an orphan was written"
+
+
+def test_a_masked_mount_cannot_evict_another_chats_spill(tmp_path, monkeypatch):
+    """The eviction half: the rejected chat's pruning ran against the shared
+    root before the rejection."""
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_ROOT_BYTES", 4_000)
+    good = spill_overflow(
+        "y" * 3_000, deps=_deps(tmp_path, chat_id="good", sandbox=True), kind="t"
+    )
+    written = _chat_dir(tmp_path, "good", sandbox=True) / Path(good.path).name
+
+    class _Masked:
+        def resolve(self, virtual: str) -> str:
+            if virtual.startswith("/shared/.overflow"):
+                return str(tmp_path / "masked" / virtual.split("/")[-1])
+            return str(tmp_path / "shared" / virtual[len("/shared") :].lstrip("/"))
+
+    bad = SimpleNamespace(
+        path_resolver=_Masked(), sandbox_enabled=True, chat_id="masked-chat"
+    )
+    for _ in range(5):
+        assert spill_overflow("z" * 3_000, deps=bad, kind="t") is None
+
+    assert written.exists(), "a rejected spill evicted a valid one"

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -11,6 +11,7 @@ chats sharing the same mount.
 """
 
 import os
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -26,9 +27,15 @@ from suzent.tools.overflow import (
 
 def _deps(tmp_path: Path, *, chat_id: str = "chat-1", sandbox: bool = False):
     class _Resolver:
+        """Maps /shared and anything under it, as PathResolver does.
+
+        The spill verifies the *final* virtual path resolves back to the file it
+        wrote, so a resolver that only knows the root is not a stand-in for one.
+        """
+
         def resolve(self, virtual: str) -> str:
-            assert virtual == "/shared"
-            return str(tmp_path / "shared")
+            assert virtual.startswith("/shared")
+            return str(tmp_path / "shared" / virtual[len("/shared") :].lstrip("/"))
 
     return SimpleNamespace(
         path_resolver=_Resolver(), sandbox_enabled=sandbox, chat_id=chat_id
@@ -1061,23 +1068,78 @@ def test_an_abandoned_worker_does_not_hold_the_whole_output(deps, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_a_saturated_executor_does_not_strand_the_caller(deps, monkeypatch):
-    """The bounded pool's join only starts once the coroutine reaches a worker.
-    On a shared default executor saturated by unrelated work it can sit queued
-    instead — routing through the pool is what made the outer deadline
-    necessary, and is exactly when I removed it."""
+async def test_the_async_path_does_not_use_the_shared_executor():
+    """to_thread was wrong twice over: cancelling its future does not remove the
+    work item from the executor queue, so a timed-out submission keeps holding
+    what it captured until some worker dequeues it — and those threads are
+    shared with everything else that offloads."""
+    import inspect
+
+    import suzent.tools.overflow as overflow
+
+    source = inspect.getsource(overflow.spill_overflow_async)
+
+    assert "asyncio.to_thread(" not in source, (
+        "the spill is back on the shared executor"
+    )
+    assert "daemon=True" in source
+
+
+@pytest.mark.asyncio
+async def test_a_wedged_async_spill_still_returns(deps, monkeypatch):
+    import threading
     import time
 
     import suzent.tools.overflow as overflow
 
+    monkeypatch.setattr(
+        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
+    )
     monkeypatch.setattr(overflow, "SPILL_TIMEOUT_SECONDS", 0.05)
     monkeypatch.setattr(
-        overflow, "spill_overflow_bounded", lambda text, **kw: time.sleep(1)
+        overflow, "_spill_payload", lambda payload, clipped, **kw: time.sleep(1)
     )
 
     started = time.monotonic()
     result = await overflow.spill_overflow_async("payload", deps=deps, kind="t")
-    elapsed = time.monotonic() - started
 
     assert result is None
-    assert elapsed < 2.0, f"the caller waited {elapsed:.2f}s on a stuck executor"
+    assert time.monotonic() - started < 1.0
+
+
+def test_the_sweep_runs_on_a_thread_the_process_can_leave():
+    """Cancelling the coroutine does not stop the function, and default-executor
+    threads are joined at interpreter exit — so a sweep on a wedged filesystem
+    would hold up the shutdown the cancellation exists to allow."""
+    import inspect
+
+    import suzent.tools.overflow as overflow
+    from suzent import server
+
+    background = inspect.getsource(overflow.sweep_overflow_in_background)
+
+    assert "asyncio.to_thread(" not in background
+    assert "daemon=True" in background
+    assert "asyncio.to_thread(sweep_overflow" not in inspect.getsource(server.startup)
+
+
+def test_a_failing_sweep_thread_is_not_an_unhandled_exception(monkeypatch, recwarn):
+    """Moving the sweep onto a thread moved its failures out of reach of the
+    loop's handler — they surfaced as unhandled thread errors instead."""
+    import threading
+
+    import suzent.tools.overflow as overflow
+
+    def _boom():
+        raise OSError("disk went away")
+
+    monkeypatch.setattr(overflow, "sweep_overflow", _boom)
+
+    before = threading.active_count()
+    overflow.sweep_overflow_in_background()
+    for _ in range(100):
+        if threading.active_count() <= before:
+            break
+        time.sleep(0.01)
+
+    assert threading.active_count() <= before, "the sweep thread never finished"

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -83,7 +83,7 @@ def test_the_marker_names_the_file(deps):
 
     assert spill.path in out
     assert "full output" in out
-    assert "kept up to 24h" in out
+    assert "kept up to 25h" in out
 
 
 def test_a_marker_without_a_spill_still_reports_the_loss():
@@ -397,12 +397,28 @@ def test_the_sweep_is_harmless_with_no_directory(tmp_path, monkeypatch):
 
 
 def test_the_stated_window_tracks_the_actual_ttl(monkeypatch):
+    """Derived, not written out: the two would drift the first time either
+    number moved — and the sweep interval is part of the bound because deletion
+    happens on a tick, not on an alarm."""
     import suzent.tools.overflow as overflow
     from suzent.tools.overflow import retention_hint
 
     monkeypatch.setattr(overflow, "OVERFLOW_TTL_SECONDS", 3 * 60 * 60)
+    monkeypatch.setattr(overflow, "OVERFLOW_SWEEP_INTERVAL_SECONDS", 60 * 60)
 
-    assert retention_hint() == "kept up to 3h"
+    assert retention_hint() == "kept up to 4h"
+
+
+def test_the_promise_covers_the_polling_interval(monkeypatch):
+    """A spill created just after a sweep is still inside the window at the tick
+    following its expiry, and goes on the one after that."""
+    import suzent.tools.overflow as overflow
+    from suzent.tools.overflow import retention_hint
+
+    monkeypatch.setattr(overflow, "OVERFLOW_TTL_SECONDS", 10 * 60 * 60)
+    monkeypatch.setattr(overflow, "OVERFLOW_SWEEP_INTERVAL_SECONDS", 2 * 60 * 60)
+
+    assert retention_hint() == "kept up to 12h"
 
 
 @pytest.mark.asyncio
@@ -1143,3 +1159,46 @@ def test_a_failing_sweep_thread_is_not_an_unhandled_exception(monkeypatch, recwa
         time.sleep(0.01)
 
     assert threading.active_count() <= before, "the sweep thread never finished"
+
+
+def test_only_one_sweep_runs_at_a_time(monkeypatch):
+    """On storage wedged for longer than the interval, every tick would
+    otherwise start another uncancellable thread — and when storage recovers,
+    an hour of queued sweeps all start at once."""
+    import threading
+
+    import suzent.tools.overflow as overflow
+
+    release = threading.Event()
+    started = threading.Semaphore(0)
+
+    def _blocked():
+        started.release()
+        release.wait(timeout=5)
+
+    monkeypatch.setattr(overflow, "sweep_overflow", _blocked)
+
+    before = threading.active_count()
+    overflow.sweep_overflow_in_background()
+    assert started.acquire(timeout=2), "the first sweep never started"
+    for _ in range(10):
+        overflow.sweep_overflow_in_background()
+
+    running = threading.active_count() - before
+    release.set()
+
+    assert running == 1, f"{running} sweeps running at once"
+
+
+def test_the_sweep_lock_is_released_for_the_next_tick(monkeypatch):
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "sweep_overflow", lambda: None)
+
+    for _ in range(3):
+        overflow.sweep_overflow_in_background()
+        for _ in range(100):
+            if not overflow._sweep_lock.locked():
+                break
+            time.sleep(0.01)
+        assert not overflow._sweep_lock.locked(), "the lock outlived its sweep"

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -111,3 +111,82 @@ def test_an_expired_spill_is_removed(deps):
     spill_overflow("new", deps=deps, kind="t")
 
     assert not Path(stale).exists()
+
+
+# --- the spill must not become a write primitive ------------------------------
+
+
+def test_a_planted_symlink_is_not_followed(deps, tmp_path):
+    """The old name was the output's own hash plus the current second, both of
+    which a sandboxed agent can compute. Pre-place a symlink at that path, emit
+    matching output, and the host process follows it — overwriting a file the
+    agent could never reach through PathResolver, because the write is ours."""
+    import os
+
+    target = tmp_path / "precious.txt"
+    target.write_text("do not clobber", encoding="utf-8")
+
+    directory = Path(deps.path_resolver.resolve(OVERFLOW_VIRTUAL_DIR))
+    directory.mkdir(parents=True, exist_ok=True)
+
+    # Point every plausible spill name at the target.
+    planted = directory / "run_command-deadbeefdeadbeefdeadbeefdeadbeef.txt"
+    os.symlink(target, planted)
+
+    spill_overflow("payload" * 100, deps=deps, kind="run_command")
+
+    assert target.read_text(encoding="utf-8") == "do not clobber"
+
+
+def test_the_name_is_not_derivable_from_the_output(deps):
+    """Two identical outputs must not land on the same path — a predictable name
+    is what makes the symlink race worth attempting."""
+    text = "same output" * 50
+
+    first = spill_overflow(text, deps=deps, kind="t")
+    second = spill_overflow(text, deps=deps, kind="t")
+
+    assert first != second
+
+
+def test_an_existing_regular_file_is_never_overwritten(deps, monkeypatch):
+    """O_EXCL, not just an unlikely collision."""
+    import suzent.tools.overflow as overflow
+
+    directory = Path(deps.path_resolver.resolve(OVERFLOW_VIRTUAL_DIR))
+    directory.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(overflow.secrets, "token_hex", lambda n: "fixed")
+    (directory / "t-fixed.txt").write_text("existing", encoding="utf-8")
+
+    assert spill_overflow("new content", deps=deps, kind="t") is None
+    assert (directory / "t-fixed.txt").read_text(encoding="utf-8") == "existing"
+
+
+# --- disk bounds --------------------------------------------------------------
+
+
+def test_one_spill_cannot_be_arbitrarily_large(deps):
+    """A foreground shell command reads its whole output into memory, and this
+    writes all of it."""
+    from suzent.tools.overflow import OVERFLOW_MAX_FILE_BYTES, SPILL_CLIPPED_NOTE
+
+    path = spill_overflow("x" * (OVERFLOW_MAX_FILE_BYTES * 2), deps=deps, kind="t")
+    written = Path(path).read_bytes()
+
+    assert len(written) <= OVERFLOW_MAX_FILE_BYTES
+    assert written.endswith(SPILL_CLIPPED_NOTE.encode("utf-8"))
+
+
+def test_the_directory_is_bounded_in_bytes_not_only_in_count(deps, monkeypatch):
+    """200 files of any size is not a bound on disk."""
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_TOTAL_BYTES", 20_000)
+
+    for _ in range(30):
+        spill_overflow("y" * 2_000, deps=deps, kind="t")
+
+    directory = Path(deps.path_resolver.resolve(OVERFLOW_VIRTUAL_DIR))
+    total = sum(p.stat().st_size for p in directory.glob("*.txt"))
+
+    assert total <= 20_000 + 2_100, total

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1865,3 +1865,32 @@ def test_the_root_quota_evicts_undatable_spills_before_current_ones(
         "an undatable spill outranked a datable one under root pressure"
     )
     assert Path(aged.host_path).exists()
+
+
+def test_deleted_entries_do_not_consume_the_file_ceiling(tmp_path, monkeypatch):
+    """The count ceiling is a budget for retained files. Charging an entry for
+    the positions above it meant a single expired spill at the head evicted a
+    valid one at the tail, leaving the directory under its own limit and
+    breaking a live pointer for nothing."""
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_FILES", 2)
+
+    expired = spill_overflow("a" * 100, deps=_deps(tmp_path), kind="t")
+    ahead = time.time() + 3_600
+    os.utime(expired.host_path, (ahead, ahead))
+
+    keepers = []
+    for payload in ("b", "c"):
+        kept = spill_overflow(payload * 100, deps=_deps(tmp_path), kind="t")
+        long_ago = time.time() - 3_600 - len(keepers)
+        os.utime(kept.host_path, (long_ago, long_ago))
+        keepers.append(kept)
+
+    overflow.sweep_overflow()
+
+    assert not Path(expired.host_path).exists()
+    for kept in keepers:
+        assert Path(kept.host_path).exists(), (
+            "an entry deleted ahead of this one still consumed the ceiling"
+        )

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -19,7 +19,6 @@ import pytest
 from suzent.tools.base import truncate_tool_output
 from suzent.tools.overflow import (
     OVERFLOW_MAX_FILES,
-    OVERFLOW_VIRTUAL_DIR,
     Spill,
     spill_overflow,
 )
@@ -62,7 +61,7 @@ def test_the_marker_names_the_file(deps):
 
     assert spill.path in out
     assert "full output" in out
-    assert "kept 24h" in out
+    assert "kept up to 24h" in out
 
 
 def test_a_marker_without_a_spill_still_reports_the_loss():
@@ -74,14 +73,23 @@ def test_a_marker_without_a_spill_still_reports_the_loss():
     assert "full output" not in out
 
 
-def test_the_path_is_the_one_this_agent_can_open(tmp_path):
-    """Host mode gets a host path, sandbox mode the virtual one. A path the
-    agent cannot open is worse than none: it invites a read that fails."""
+def test_host_mode_gets_a_host_path(tmp_path):
+    """A path the agent cannot open is worse than none: it invites a read that
+    fails."""
     host = spill_overflow("y" * 100, deps=_deps(tmp_path), kind="t")
-    sandboxed = spill_overflow("y" * 100, deps=_deps(tmp_path, sandbox=True), kind="t")
 
     assert host.path.startswith(str(tmp_path))
-    assert sandboxed.path.startswith(f"{OVERFLOW_VIRTUAL_DIR}/chat-1/")
+
+
+def test_sandbox_mode_does_not_spill_at_all(tmp_path):
+    """Directory naming is not a boundary here: every container bind-mounts the
+    same host `shared` directory read-write and every one runs as uid 1000, so
+    chat B reads chat A's spills whatever the mode bits say. Until there is a
+    per-chat mount, the sandbox gets the plain marker."""
+    assert (
+        spill_overflow("y" * 100, deps=_deps(tmp_path, sandbox=True), kind="t") is None
+    )
+    assert not (tmp_path / "shared" / ".overflow").exists()
 
 
 def test_no_resolver_means_no_spill_rather_than_a_crash():
@@ -311,7 +319,7 @@ def test_the_stated_window_tracks_the_actual_ttl(monkeypatch):
 
     monkeypatch.setattr(overflow, "OVERFLOW_TTL_SECONDS", 3 * 60 * 60)
 
-    assert retention_hint() == "kept 3h"
+    assert retention_hint() == "kept up to 3h"
 
 
 @pytest.mark.asyncio
@@ -351,3 +359,35 @@ async def test_the_async_spill_does_not_hold_the_loop(deps, monkeypatch):
 
     assert spill.path == "/tmp/x.txt"
     assert ticks > 5, f"the loop was blocked during the write ({ticks} ticks)"
+
+
+def test_the_sweep_refuses_a_symlinked_chat_directory(tmp_path, monkeypatch):
+    """The write path was pinned and the sweep was not; the attacker picks the
+    weaker one. _prune_fd unlinks, so a symlink left under .overflow would let
+    the next restart delete *.txt files in a directory of its choosing."""
+    from suzent.config import CONFIG
+    from suzent.tools.overflow import sweep_overflow
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    bystander = elsewhere / "keepme.txt"
+    bystander.write_text("unrelated", encoding="utf-8")
+    old = 1.0
+    os.utime(bystander, (old, old))  # stale enough that a prune would take it
+
+    root = tmp_path / "shared" / ".overflow"
+    root.mkdir(parents=True)
+    os.symlink(elsewhere, root / "pretend-chat")
+
+    monkeypatch.setattr(CONFIG, "sandbox_data_path", str(tmp_path), raising=False)
+    sweep_overflow()
+
+    assert bystander.exists(), "the sweep followed a symlinked chat directory"
+
+
+def test_the_retention_hint_is_an_upper_bound(deps):
+    """The count and byte ceilings evict early — eleven maximum-sized results
+    inside an hour drop the first long before the day is out."""
+    from suzent.tools.overflow import retention_hint
+
+    assert retention_hint().startswith("kept up to")

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1251,3 +1251,72 @@ def test_a_masked_mount_cannot_evict_another_chats_spill(tmp_path, monkeypatch):
         assert spill_overflow("z" * 3_000, deps=bad, kind="t") is None
 
     assert written.exists(), "a rejected spill evicted a valid one"
+
+
+@pytest.mark.asyncio
+async def test_the_async_caller_slices_but_does_not_encode(deps, monkeypatch):
+    """The slice bounds what an abandoned worker retains; the encode allocates
+    up to four bytes per character and belongs off the loop."""
+    import threading
+
+    import suzent.tools.overflow as overflow
+
+    encoded_on: list[str] = []
+    real = overflow._encode_bounded
+
+    def _watch(head, dropped):
+        encoded_on.append(threading.current_thread().name)
+        return real(head, dropped)
+
+    monkeypatch.setattr(overflow, "_encode_bounded", _watch)
+
+    await overflow.spill_overflow_async("é" * 10_000, deps=deps, kind="t")
+
+    assert encoded_on, "the encode never ran"
+    assert all(n.startswith("overflow-spill") for n in encoded_on), (
+        f"encoding ran on {encoded_on}"
+    )
+
+
+def test_the_bounded_prefix_is_a_slice_not_an_encode():
+    """_bound_chars must stay cheap: it is what the event loop runs."""
+    import suzent.tools.overflow as overflow
+
+    head, dropped = overflow._bound_chars("é" * (overflow.OVERFLOW_MAX_FILE_BYTES + 10))
+
+    assert isinstance(head, str)
+    assert len(head) == overflow.OVERFLOW_MAX_FILE_BYTES
+    assert dropped is True
+
+
+def test_a_failed_fallback_write_leaves_no_file(tmp_path, monkeypatch):
+    """A half-written file that was never advertised is pure litter, and this
+    branch skips pruning, so it sits there until the sweep."""
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "_HAVE_DIR_FD", False)
+
+    real_fdopen = os.fdopen
+
+    def _explode(fd, *args, **kwargs):
+        handle = real_fdopen(fd, *args, **kwargs)
+
+        class _Broken:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                handle.close()
+                return False
+
+            def write(self, data):
+                raise OSError("volume disconnected")
+
+        return _Broken()
+
+    monkeypatch.setattr(os, "fdopen", _explode)
+
+    assert overflow.spill_overflow("x" * 100, deps=_deps(tmp_path), kind="t") is None
+
+    chat_dir = _chat_dir(tmp_path)
+    assert not chat_dir.exists() or list(chat_dir.glob("*.txt")) == []

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1816,3 +1816,23 @@ def test_future_dated_spills_expire_within_the_advertised_retention(tmp_path):
         "an undatable spill outlived the advertised retention window"
     )
     assert Path(ordinary.host_path).exists()
+
+
+def test_a_future_dated_staging_file_survives_the_sweep(tmp_path):
+    """Rollback expiry belongs to published spills only. A `.part` with a
+    future-dated mtime is far more likely to be a live writer caught by a clock
+    step than an abandoned file, and unlinking it costs the caller its output:
+    the write lands in the open inode, the rename fails, no pointer comes
+    back."""
+    import suzent.tools.overflow as overflow
+    from suzent.tools.overflow import PARTIAL_SUFFIX
+
+    published = spill_overflow("a" * 100, deps=_deps(tmp_path), kind="t")
+    staged = Path(published.host_path).parent / f"t-live.txt{PARTIAL_SUFFIX}"
+    staged.write_bytes(b"half a payload")
+    ahead = time.time() + 3_600
+    os.utime(staged, (ahead, ahead))
+
+    overflow.sweep_overflow()
+
+    assert staged.exists(), "the sweep deleted a staging file out from under a writer"

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1,0 +1,113 @@
+"""Truncation keeps the tail on disk instead of discarding it.
+
+A cap stops one output swallowing the context window, but the part it removes
+is usually the part someone wanted — the failing assertion at the end of a test
+run, the last of a build log. Truncating to a bare marker tells the model that
+content is missing and gives it no way to read it.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from suzent.tools.base import truncate_tool_output
+from suzent.tools.overflow import (
+    OVERFLOW_MAX_FILES,
+    OVERFLOW_VIRTUAL_DIR,
+    spill_overflow,
+)
+
+
+@pytest.fixture
+def deps(tmp_path):
+    class _Resolver:
+        def resolve(self, virtual: str) -> str:
+            assert virtual == OVERFLOW_VIRTUAL_DIR
+            return str(tmp_path / "overflow")
+
+    return SimpleNamespace(path_resolver=_Resolver(), sandbox_enabled=False)
+
+
+def test_the_whole_output_is_written_not_the_kept_part(deps):
+    text = "\n".join(f"line {i}" for i in range(5000))
+
+    path = spill_overflow(text, deps=deps, kind="run_command")
+
+    assert Path(path).read_text(encoding="utf-8") == text
+
+
+def test_the_marker_names_the_file(deps):
+    text = "x" * 50_000
+
+    path = spill_overflow(text, deps=deps, kind="run_command")
+    out = truncate_tool_output(text, 100, full_output_path=path)
+
+    assert path in out
+    assert "full output" in out
+    assert len(out) < 500
+
+
+def test_a_marker_without_a_spill_still_reports_the_loss(deps):
+    """Spilling is best-effort. Losing the tail beats failing the tool call
+    that produced it, but the model still has to know it happened."""
+    out = truncate_tool_output("x" * 50_000, 100, full_output_path=None)
+
+    assert "truncated" in out
+    assert "full output" not in out
+
+
+def test_the_path_is_the_one_this_agent_can_open(tmp_path):
+    """Host mode gets a host path, sandbox mode the virtual one. A path the
+    agent cannot open is worse than none: it invites a read that fails."""
+
+    class _Resolver:
+        def resolve(self, virtual: str) -> str:
+            return str(tmp_path / "overflow")
+
+    host = SimpleNamespace(path_resolver=_Resolver(), sandbox_enabled=False)
+    sandboxed = SimpleNamespace(path_resolver=_Resolver(), sandbox_enabled=True)
+
+    assert spill_overflow("y" * 100, deps=host, kind="t").startswith(str(tmp_path))
+    assert spill_overflow("y" * 100, deps=sandboxed, kind="t").startswith(
+        OVERFLOW_VIRTUAL_DIR
+    )
+
+
+def test_no_resolver_means_no_spill_rather_than_a_crash():
+    assert spill_overflow("x" * 100, deps=SimpleNamespace(), kind="t") is None
+
+
+def test_an_unwritable_directory_degrades_quietly(tmp_path):
+    class _Broken:
+        def resolve(self, virtual: str) -> str:
+            raise ValueError("no matching custom mount is registered")
+
+    deps = SimpleNamespace(path_resolver=_Broken(), sandbox_enabled=False)
+
+    assert spill_overflow("x" * 100, deps=deps, kind="t") is None
+
+
+def test_spills_do_not_accumulate_without_limit(deps):
+    """A single runaway session can write thousands; the TTL alone would not
+    bound that until tomorrow."""
+    for i in range(OVERFLOW_MAX_FILES + 25):
+        spill_overflow(f"body {i}", deps=deps, kind="t")
+
+    directory = Path(deps.path_resolver.resolve(OVERFLOW_VIRTUAL_DIR))
+    assert len(list(directory.glob("*.txt"))) <= OVERFLOW_MAX_FILES
+
+
+def test_an_expired_spill_is_removed(deps):
+    import os
+    import time
+
+    from suzent.tools.overflow import OVERFLOW_TTL_SECONDS
+
+    stale = spill_overflow("old", deps=deps, kind="t")
+    old_time = time.time() - OVERFLOW_TTL_SECONDS - 60
+    os.utime(stale, (old_time, old_time))
+
+    spill_overflow("new", deps=deps, kind="t")
+
+    assert not Path(stale).exists()

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -116,12 +116,19 @@ def test_an_expired_spill_is_removed(deps):
 # --- the spill must not become a write primitive ------------------------------
 
 
-def test_a_planted_symlink_is_not_followed(deps, tmp_path):
-    """The old name was the output's own hash plus the current second, both of
-    which a sandboxed agent can compute. Pre-place a symlink at that path, emit
-    matching output, and the host process follows it — overwriting a file the
-    agent could never reach through PathResolver, because the write is ours."""
+def test_a_planted_symlink_is_not_followed(deps, tmp_path, monkeypatch):
+    """The write must refuse a symlink sitting at its destination.
+
+    The old name was the output's own hash plus the current second, both of
+    which a sandboxed agent can compute — so it could place a symlink there,
+    emit matching output, and have the host process overwrite a file the agent
+    could never reach through PathResolver, because the write is ours. The name
+    is random now, so this pins the second half of the fix: even aimed exactly
+    at the destination, the open is refused rather than followed.
+    """
     import os
+
+    import suzent.tools.overflow as overflow
 
     target = tmp_path / "precious.txt"
     target.write_text("do not clobber", encoding="utf-8")
@@ -129,12 +136,12 @@ def test_a_planted_symlink_is_not_followed(deps, tmp_path):
     directory = Path(deps.path_resolver.resolve(OVERFLOW_VIRTUAL_DIR))
     directory.mkdir(parents=True, exist_ok=True)
 
-    # Point every plausible spill name at the target.
-    planted = directory / "run_command-deadbeefdeadbeefdeadbeefdeadbeef.txt"
-    os.symlink(target, planted)
+    monkeypatch.setattr(overflow.secrets, "token_hex", lambda n: "aimed")
+    os.symlink(target, directory / "run_command-aimed.txt")
 
-    spill_overflow("payload" * 100, deps=deps, kind="run_command")
+    result = spill_overflow("payload" * 100, deps=deps, kind="run_command")
 
+    assert result is None, "the write should be refused, not redirected"
     assert target.read_text(encoding="utf-8") == "do not clobber"
 
 

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -789,3 +789,76 @@ def test_the_sweeper_survives_an_in_process_restart():
     guard_at = source.index("Social brain already initialized")
 
     assert sweeper_at < guard_at, "the sweeper starts after an early return"
+
+
+def test_the_synchronous_spill_is_bounded_too(deps, monkeypatch):
+    """A sync tool runs on a worker rather than the loop, so a wedged volume
+    does not stall other chats — but it holds a tool call that has *already
+    succeeded*. Bounding only the async path left two halves of one rule
+    disagreeing."""
+    import time
+
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "SPILL_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(
+        overflow,
+        "spill_overflow",
+        lambda text, **kw: time.sleep(2) or Spill("/x", False),
+    )
+
+    started = time.monotonic()
+    result = overflow.spill_overflow_bounded("payload", deps=deps, kind="t")
+    elapsed = time.monotonic() - started
+
+    assert result is None
+    assert elapsed < 1.0, f"the worker waited {elapsed:.2f}s for a wedged volume"
+
+
+def test_both_wrappers_bound_the_spill():
+    """The rule is 'a spill never holds its caller', so it has to hold on both
+    branches of the wrapper, not the one that happened to be reviewed."""
+    import inspect
+
+    from suzent.tools import registry
+
+    source = inspect.getsource(registry)
+
+    assert "spill_overflow_async(" in source
+    assert "spill_overflow_bounded(" in source
+    # The unbounded call must not survive anywhere in the wrapper.
+    assert "= spill_overflow(" not in source
+
+
+def test_the_root_quota_holds_between_sweeps(tmp_path, monkeypatch):
+    """Leaving it to the hourly sweep let a burst of chats sit above the
+    deployment ceiling for an hour — long enough to fill a volume that every
+    directory was individually respecting."""
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_ROOT_BYTES", 5_000)
+
+    for chat in ("a", "b", "c", "d", "e"):
+        spill_overflow("y" * 3_000, deps=_deps(tmp_path, chat_id=chat), kind="t")
+
+    root = tmp_path / "shared" / ".overflow"
+    total = sum(p.stat().st_size for p in root.rglob("*.txt"))
+
+    assert total <= 5_000 + 3_100, f"{total} bytes retained with no sweep run"
+
+
+def test_the_path_fallback_also_holds_the_root_quota(tmp_path, monkeypatch):
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_ROOT_BYTES", 5_000)
+    monkeypatch.setattr(overflow, "_HAVE_DIR_FD", False)
+
+    for chat in ("a", "b", "c", "d", "e"):
+        overflow.spill_overflow(
+            "y" * 3_000, deps=_deps(tmp_path, chat_id=chat), kind="t"
+        )
+
+    root = tmp_path / "shared" / ".overflow"
+    total = sum(p.stat().st_size for p in root.rglob("*.txt"))
+
+    assert total <= 5_000 + 3_100, total

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1430,7 +1430,12 @@ async def test_cancellation_abandons_the_spill_like_a_timeout(
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    time.sleep(0.6)
+    # Awaited, not slept: the worker asks the loop whether its result was taken,
+    # so a blocking sleep here would stop the very callback under test.
+    for _ in range(60):
+        await asyncio.sleep(0.02)
+        if not list(_chat_dir(tmp_path).glob("*.txt")):
+            break
 
     assert list(_chat_dir(tmp_path).glob("*.txt")) == [], (
         "a cancelled spill left an unadvertised file behind"
@@ -1514,3 +1519,76 @@ async def test_a_cancel_racing_delivery_still_discards(deps, tmp_path, monkeypat
     assert list(_chat_dir(tmp_path).glob("*.txt")) == [], (
         "a spill delivered after cancellation was left behind"
     )
+
+
+@pytest.mark.asyncio
+async def test_the_loop_does_no_filesystem_work_for_a_spill(deps, monkeypatch):
+    """_deliver runs on the loop and only answers yes or no. An unlink there
+    would stall every chat on the same wedged volume the caller already gave up
+    waiting for."""
+    import asyncio
+    import inspect
+    import threading
+
+    import suzent.tools.overflow as overflow
+
+    source = inspect.getsource(overflow.spill_overflow_async)
+    deliver = source[source.index("def _deliver") : source.index("def _worker")]
+
+    assert "_discard" not in deliver, "the loop callback deletes files"
+    assert "_prune" not in deliver, "the loop callback prunes"
+
+    ran_on: list[str] = []
+    monkeypatch.setattr(
+        overflow,
+        "_discard",
+        lambda spill: ran_on.append(threading.current_thread().name),
+    )
+    monkeypatch.setattr(
+        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
+    )
+
+    task = asyncio.create_task(
+        overflow.spill_overflow_async("x" * 100, deps=deps, kind="t")
+    )
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    for _ in range(60):
+        await asyncio.sleep(0.02)
+        if ran_on:
+            break
+
+    assert ran_on, "the abandoned spill was never discarded"
+    assert all(n.startswith("overflow-spill") for n in ran_on), (
+        f"cleanup ran on {ran_on}"
+    )
+
+
+def test_a_stored_result_is_accepted_rather_than_abandoned(deps, monkeypatch):
+    """The worker can store its result and still be inside its finally when the
+    join expires. Abandoning then throws away a spill that is already written
+    and already ours."""
+    import threading
+
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(
+        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
+    )
+    monkeypatch.setattr(overflow, "SPILL_TIMEOUT_SECONDS", 0.05)
+
+    real = overflow._prune_after_accept
+
+    def _slow_prune(snapshot):
+        # Stands in for a worker that has stored its result but not yet exited.
+        time.sleep(0.3)
+        return real(snapshot)
+
+    monkeypatch.setattr(overflow, "_prune_after_accept", _slow_prune)
+
+    spill = overflow.spill_overflow_bounded("x" * 100, deps=deps, kind="t")
+
+    assert spill is not None, "a written, stored spill was thrown away"
+    assert Path(spill.host_path).exists()

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -720,3 +720,72 @@ async def test_the_sweeper_is_cancelled_at_shutdown():
 
     assert "overflow_sweeper" in source, "the sweeper outlives the application"
     assert "cancel()" in source
+
+
+def test_a_host_spill_does_not_lock_out_the_sandbox(tmp_path):
+    """The mount root and .overflow are shared between execution modes, so
+    their mode cannot depend on which one is spilling now: a host spill setting
+    them 0700 makes every path already advertised to a sandbox container
+    unreadable until some later sandbox spill happens to set them back."""
+    sandbox_spill = spill_overflow(
+        "s", deps=_deps(tmp_path, chat_id="sbx", sandbox=True), kind="t"
+    )
+    host_path = (
+        tmp_path / "shared" / ".overflow" / "sbx" / Path(sandbox_spill.path).name
+    )
+
+    # A host-mode chat spills afterwards, touching the shared ancestors.
+    spill_overflow("h", deps=_deps(tmp_path, chat_id="host"), kind="t")
+
+    for ancestor in (tmp_path / "shared", tmp_path / "shared" / ".overflow"):
+        mode = os.stat(ancestor).st_mode & 0o777
+        assert mode & 0o011, f"{ancestor} became untraversable ({mode:o})"
+    assert os.stat(host_path).st_mode & 0o044, "the sandbox spill became unreadable"
+
+
+def test_the_host_chat_directory_is_still_private(tmp_path):
+    """Traversable ancestors are not readable contents: the leaf keeps the
+    private mode."""
+    spill = spill_overflow("h", deps=_deps(tmp_path, chat_id="host"), kind="t")
+
+    assert os.stat(Path(spill.path).parent).st_mode & 0o077 == 0
+    assert os.stat(spill.path).st_mode & 0o077 == 0
+
+
+@pytest.mark.asyncio
+async def test_a_wedged_volume_does_not_hold_the_caller(deps, monkeypatch):
+    """to_thread frees the loop and bounds nothing. The caller is either a
+    reminder being built or a tool call that has already done its work — losing
+    the pointer beats losing either."""
+    import time
+
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "SPILL_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(
+        overflow,
+        "spill_overflow",
+        lambda text, **kw: time.sleep(2) or Spill("/x", False),
+    )
+
+    started = time.monotonic()
+    result = await overflow.spill_overflow_async("payload", deps=deps, kind="t")
+    elapsed = time.monotonic() - started
+
+    assert result is None, "a wedged write must fall back to the plain marker"
+    assert elapsed < 1.0, f"the caller waited {elapsed:.2f}s for a wedged volume"
+
+
+def test_the_sweeper_survives_an_in_process_restart():
+    """shutdown() cancels the sweeper but leaves social_brain set, so the next
+    startup() returns at the duplicate-social guard. Starting the sweeper after
+    that guard left a restarted application with no retention at all."""
+    import inspect
+
+    from suzent import server
+
+    source = inspect.getsource(server.startup)
+    sweeper_at = source.index("overflow_sweeper")
+    guard_at = source.index("Social brain already initialized")
+
+    assert sweeper_at < guard_at, "the sweeper starts after an early return"

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1397,3 +1397,41 @@ def test_the_snapshot_carries_what_a_spill_needs():
 
     assert (snap.path_resolver, snap.sandbox_enabled, snap.chat_id) == ("R", True, "c")
     assert not hasattr(snap, "extra")
+
+
+@pytest.mark.asyncio
+async def test_cancellation_abandons_the_spill_like_a_timeout(
+    deps, tmp_path, monkeypatch
+):
+    """A client disconnecting or a superseded social turn cancels the caller,
+    which means the same thing as the deadline: nobody receives this pointer, so
+    the file the worker may still write must not count against the quotas."""
+    import asyncio
+    import threading
+
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(
+        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
+    )
+    real = overflow._spill_payload
+
+    def _slow(payload, clipped, **kw):
+        time.sleep(0.3)
+        return real(payload, clipped, **kw)
+
+    monkeypatch.setattr(overflow, "_spill_payload", _slow)
+
+    task = asyncio.create_task(
+        overflow.spill_overflow_async("x" * 100, deps=deps, kind="t")
+    )
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    time.sleep(0.6)
+
+    assert list(_chat_dir(tmp_path).glob("*.txt")) == [], (
+        "a cancelled spill left an unadvertised file behind"
+    )

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -14,6 +14,7 @@ import os
 import time
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -1320,3 +1321,79 @@ def test_a_failed_fallback_write_leaves_no_file(tmp_path, monkeypatch):
 
     chat_dir = _chat_dir(tmp_path)
     assert not chat_dir.exists() or list(chat_dir.glob("*.txt")) == []
+
+
+def test_a_spill_that_lands_after_the_deadline_is_removed(deps, tmp_path, monkeypatch):
+    """Storage that is slow but recovers writes a file nobody was told about —
+    it consumes the per-chat and root quotas and can evict spills whose paths
+    *were* handed out."""
+    import threading
+
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(
+        overflow, "_spill_slots", threading.Semaphore(overflow._SPILL_THREADS)
+    )
+    monkeypatch.setattr(overflow, "SPILL_TIMEOUT_SECONDS", 0.05)
+
+    real = overflow._spill_payload
+
+    def _slow(payload, clipped, **kw):
+        time.sleep(0.3)
+        return real(payload, clipped, **kw)
+
+    monkeypatch.setattr(overflow, "_spill_payload", _slow)
+
+    assert overflow.spill_overflow_bounded("x" * 100, deps=deps, kind="t") is None
+
+    for _ in range(100):
+        if list(_chat_dir(tmp_path).glob("*.txt")):
+            time.sleep(0.01)
+        else:
+            break
+    time.sleep(0.3)
+
+    assert list(_chat_dir(tmp_path).glob("*.txt")) == [], (
+        "a late spill was left behind, unadvertised"
+    )
+
+
+def test_the_worker_does_not_retain_the_whole_request(deps, monkeypatch):
+    """AgentDeps carries the request's message history, repository context and
+    caches. Four abandoned workers holding those is far more than the bounded
+    payload the slot limit was reasoning about."""
+    import suzent.tools.overflow as overflow
+
+    seen: list[Any] = []
+
+    def _capture(payload, clipped, *, deps, kind):
+        seen.append(deps)
+        return None
+
+    monkeypatch.setattr(overflow, "_spill_payload", _capture)
+
+    bulky = SimpleNamespace(
+        path_resolver=deps.path_resolver,
+        sandbox_enabled=False,
+        chat_id="chat-1",
+        last_messages=["a very long history"] * 1000,
+        repository_context="...",
+    )
+    overflow.spill_overflow_bounded("x" * 100, deps=bulky, kind="t")
+
+    assert seen, "the worker never ran"
+    assert not hasattr(seen[0], "last_messages"), "the worker kept the whole deps"
+    assert seen[0].chat_id == "chat-1"
+
+
+def test_the_snapshot_carries_what_a_spill_needs():
+    import suzent.tools.overflow as overflow
+
+    snap = overflow._deps_snapshot(
+        SimpleNamespace(
+            path_resolver="R", sandbox_enabled=True, chat_id="c", extra="dropped"
+        )
+    )
+
+    assert (snap.path_resolver, snap.sandbox_enabled, snap.chat_id) == ("R", True, "c")
+    assert not hasattr(snap, "extra")

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -63,8 +63,12 @@ def deps(tmp_path):
 def _chat_dir(
     tmp_path: Path, chat_id: str = "chat-1", *, sandbox: bool = False
 ) -> Path:
-    prefix = "sandbox" if sandbox else "host"
-    return tmp_path / "shared" / ".overflow" / f"{prefix}-{chat_id}"
+    """Built through the real segment function — the name carries a digest, and
+    a hand-rolled copy here would drift from it."""
+    from suzent.tools.overflow import _chat_segment
+
+    segment = _chat_segment(SimpleNamespace(chat_id=chat_id, sandbox_enabled=sandbox))
+    return tmp_path / "shared" / ".overflow" / segment
 
 
 def test_the_whole_output_is_written_not_the_kept_part(deps):
@@ -109,7 +113,7 @@ def test_sandbox_mode_gets_the_virtual_path(tmp_path):
 
     spill = spill_overflow("y" * 100, deps=_deps(tmp_path, sandbox=True), kind="t")
 
-    assert spill.path.startswith(f"{OVERFLOW_VIRTUAL_DIR}/sandbox-chat-1/")
+    assert spill.path.startswith(f"{OVERFLOW_VIRTUAL_DIR}/sandbox-chat-1-")
 
 
 def test_a_sandbox_spill_is_readable_by_a_different_uid(tmp_path):
@@ -202,8 +206,9 @@ def test_spills_are_scoped_to_their_chat(tmp_path):
     first = spill_overflow("secret alpha", deps=_deps(tmp_path, chat_id="a"), kind="t")
     second = spill_overflow("secret beta", deps=_deps(tmp_path, chat_id="b"), kind="t")
 
-    assert "-a/" in first.path.replace(str(tmp_path), "")
-    assert "-b/" in second.path.replace(str(tmp_path), "")
+    assert Path(first.path).parent != Path(second.path).parent
+    assert Path(first.path).parent.name.startswith("host-a-")
+    assert Path(second.path).parent.name.startswith("host-b-")
     assert len(list(_chat_dir(tmp_path, "a").glob("*.txt"))) == 1
 
 
@@ -230,7 +235,9 @@ def test_a_symlink_at_the_destination_is_not_followed(deps, tmp_path, monkeypatc
     chat_dir.mkdir(parents=True, exist_ok=True)
 
     monkeypatch.setattr(overflow.secrets, "token_hex", lambda n: "aimed")
-    os.symlink(target, chat_dir / "run_command-aimed.txt")
+    # The staged name is what the open creates, so that is where an attacker
+    # would have to aim.
+    os.symlink(target, chat_dir / ("run_command-aimed.txt" + overflow.PARTIAL_SUFFIX))
 
     assert spill_overflow("payload" * 100, deps=deps, kind="run_command") is None
     assert target.read_text(encoding="utf-8") == "do not clobber"
@@ -1015,7 +1022,8 @@ def test_the_two_modes_use_separate_leaves(tmp_path):
 
     names = sorted(p.name for p in (tmp_path / "shared" / ".overflow").iterdir())
 
-    assert names == ["host-c9", "sandbox-c9"]
+    assert len(names) == 2
+    assert names[0].startswith("host-c9-") and names[1].startswith("sandbox-c9-")
 
 
 def test_a_slot_is_returned_when_the_worker_cannot_start(deps, monkeypatch):
@@ -1515,3 +1523,78 @@ def test_the_new_spill_survives_its_own_prune(tmp_path, monkeypatch):
         assert Path(spill.host_path).exists(), "the advertised file was pruned away"
 
     _ = real_stat
+
+
+def test_sanitising_two_different_ids_keeps_them_apart(tmp_path):
+    """The sanitiser is many-to-one even without truncation: `a2a:local:a/b` and
+    `a2a:local:a?b` both become `a2a-local-a-b`."""
+    first = spill_overflow(
+        "one", deps=_deps(tmp_path, chat_id="a2a:local:a/b"), kind="t"
+    )
+    second = spill_overflow(
+        "two", deps=_deps(tmp_path, chat_id="a2a:local:a?b"), kind="t"
+    )
+
+    assert Path(first.host_path).parent != Path(second.host_path).parent
+    assert Path(first.host_path).read_text(encoding="utf-8") == "one"
+    assert Path(second.host_path).read_text(encoding="utf-8") == "two"
+
+
+def test_a_half_written_spill_is_invisible_to_scans(tmp_path, monkeypatch):
+    """The sweep or another chat's prune must not be able to select a file that
+    is still being written — on POSIX that deletion succeeds against the open
+    inode and leaves an advertised path with nothing behind it."""
+    import suzent.tools.overflow as overflow
+
+    observed: list[str] = []
+    real_write = (
+        overflow._spill_pinned if overflow._HAVE_DIR_FD else overflow._spill_by_path
+    )
+    name = "_spill_pinned" if overflow._HAVE_DIR_FD else "_spill_by_path"
+
+    def _watch(*args, **kwargs):
+        result = real_write(*args, **kwargs)
+        return result
+
+    # Look at the directory from inside the write, before the rename lands.
+    real_force = overflow._force_mode
+
+    def _peek(fd, mode):
+        chat = _chat_dir(tmp_path)
+        if chat.exists():
+            observed.extend(p.name for p in chat.iterdir())
+        return real_force(fd, mode)
+
+    monkeypatch.setattr(overflow, "_force_mode", _peek)
+    monkeypatch.setattr(overflow, name, _watch)
+
+    spill_overflow("x" * 100, deps=_deps(tmp_path), kind="t")
+
+    staged = [n for n in observed if n.endswith(overflow.PARTIAL_SUFFIX)]
+    finished = [n for n in observed if n.endswith(".txt")]
+
+    assert staged, "the write never staged the file"
+    assert not finished, f"a .txt file existed mid-write: {finished}"
+
+
+def test_the_sweep_collects_a_stranded_staged_file(tmp_path, monkeypatch):
+    """Staged files are invisible to every scan by design, so nothing else will
+    ever collect one left by a crash or a failed rename."""
+    from suzent.config import CONFIG
+    from suzent.tools.overflow import (
+        OVERFLOW_TTL_SECONDS,
+        PARTIAL_SUFFIX,
+        sweep_overflow,
+    )
+
+    chat_dir = _chat_dir(tmp_path)
+    chat_dir.mkdir(parents=True)
+    stranded = chat_dir / f"t-abandoned.txt{PARTIAL_SUFFIX}"
+    stranded.write_text("half", encoding="utf-8")
+    old = time.time() - OVERFLOW_TTL_SECONDS - 60
+    os.utime(stranded, (old, old))
+
+    monkeypatch.setattr(CONFIG, "sandbox_data_path", str(tmp_path), raising=False)
+    sweep_overflow()
+
+    assert not stranded.exists(), "a stranded staged file was never collected"

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -1836,3 +1836,32 @@ def test_a_future_dated_staging_file_survives_the_sweep(tmp_path):
     overflow.sweep_overflow()
 
     assert staged.exists(), "the sweep deleted a staging file out from under a writer"
+
+
+def test_the_root_quota_evicts_undatable_spills_before_current_ones(
+    tmp_path, monkeypatch
+):
+    """A file stamped before a backward clock step sorts ahead of everything
+    real, so under root pressure it kept its budget while genuinely current
+    spills — the ones with live pointers in a conversation — were evicted in
+    its place. It sorts oldest now."""
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_ROOT_BYTES", 4_000)
+
+    rolled_back = spill_overflow(
+        "a" * 3_000, deps=_deps(tmp_path, chat_id="old"), kind="t"
+    )
+    ahead = time.time() + 3_600
+    os.utime(rolled_back.host_path, (ahead, ahead))
+
+    aged = spill_overflow("b" * 3_000, deps=_deps(tmp_path, chat_id="mid"), kind="t")
+    long_ago = time.time() - 3_600
+    os.utime(aged.host_path, (long_ago, long_ago))
+
+    overflow._enforce_root_quota_path(overflow._overflow_root())
+
+    assert not Path(rolled_back.host_path).exists(), (
+        "an undatable spill outranked a datable one under root pressure"
+    )
+    assert Path(aged.host_path).exists()

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -309,7 +309,13 @@ def test_a_clipped_spill_is_not_advertised_as_the_full_output(deps):
     assert "full output" not in out
 
 
-def test_spills_do_not_accumulate_without_limit(deps, tmp_path):
+def test_spills_do_not_accumulate_without_limit(deps, tmp_path, monkeypatch):
+    # The grace period is not what this test is about: it protects a freshly
+    # written file from any prune, so a ceiling test has to waive it.
+    import suzent.tools.overflow as _overflow
+
+    monkeypatch.setattr(_overflow, "OVERFLOW_GRACE_SECONDS", 0)
+
     for i in range(OVERFLOW_MAX_FILES + 25):
         spill_overflow(f"body {i}", deps=deps, kind="t")
 
@@ -324,6 +330,12 @@ def test_spills_do_not_accumulate_without_limit(deps, tmp_path):
 def test_the_directory_is_bounded_in_bytes_not_only_in_count(
     deps, tmp_path, monkeypatch
 ):
+    # The grace period is not what this test is about: it protects a freshly
+    # written file from any prune, so a ceiling test has to waive it.
+    import suzent.tools.overflow as _overflow
+
+    monkeypatch.setattr(_overflow, "OVERFLOW_GRACE_SECONDS", 0)
+
     import suzent.tools.overflow as overflow
 
     monkeypatch.setattr(overflow, "OVERFLOW_MAX_TOTAL_BYTES", 20_000)
@@ -545,6 +557,12 @@ def test_the_root_total_is_bounded_across_chats(tmp_path, monkeypatch):
     """Pruning on write only ever sees one chat's directory, so the per-chat
     allowance multiplies by the number of chats — a hundred of them retain
     5 GiB while every directory is individually within bounds."""
+    # The grace period is not what this test is about: it protects a freshly
+    # written file from any prune, so a ceiling test has to waive it.
+    import suzent.tools.overflow as _overflow
+
+    monkeypatch.setattr(_overflow, "OVERFLOW_GRACE_SECONDS", 0)
+
     from suzent.config import CONFIG
     import suzent.tools.overflow as overflow
     from suzent.tools.overflow import sweep_overflow
@@ -604,6 +622,12 @@ def test_the_sweep_has_a_path_based_twin(tmp_path, monkeypatch):
 
 
 def test_the_path_sweep_also_applies_the_root_quota(tmp_path, monkeypatch):
+    # The grace period is not what this test is about: it protects a freshly
+    # written file from any prune, so a ceiling test has to waive it.
+    import suzent.tools.overflow as _overflow
+
+    monkeypatch.setattr(_overflow, "OVERFLOW_GRACE_SECONDS", 0)
+
     from suzent.config import CONFIG
     import suzent.tools.overflow as overflow
     from suzent.tools.overflow import sweep_overflow
@@ -930,6 +954,12 @@ def test_the_root_quota_holds_between_sweeps(tmp_path, monkeypatch):
     """Leaving it to the hourly sweep let a burst of chats sit above the
     deployment ceiling for an hour — long enough to fill a volume that every
     directory was individually respecting."""
+    # The grace period is not what this test is about: it protects a freshly
+    # written file from any prune, so a ceiling test has to waive it.
+    import suzent.tools.overflow as _overflow
+
+    monkeypatch.setattr(_overflow, "OVERFLOW_GRACE_SECONDS", 0)
+
     import suzent.tools.overflow as overflow
 
     monkeypatch.setattr(overflow, "OVERFLOW_MAX_ROOT_BYTES", 5_000)
@@ -944,6 +974,12 @@ def test_the_root_quota_holds_between_sweeps(tmp_path, monkeypatch):
 
 
 def test_the_path_fallback_also_holds_the_root_quota(tmp_path, monkeypatch):
+    # The grace period is not what this test is about: it protects a freshly
+    # written file from any prune, so a ceiling test has to waive it.
+    import suzent.tools.overflow as _overflow
+
+    monkeypatch.setattr(_overflow, "OVERFLOW_GRACE_SECONDS", 0)
+
     import suzent.tools.overflow as overflow
 
     monkeypatch.setattr(overflow, "OVERFLOW_MAX_ROOT_BYTES", 5_000)
@@ -1641,3 +1677,59 @@ def test_every_scan_filters_to_completed_spills():
         assert '".txt"' in source or '"*.txt"' in source, (
             f"{fn.__name__} scans without filtering to completed spills"
         )
+
+
+def test_a_freshly_published_spill_cannot_be_pruned(tmp_path, monkeypatch):
+    """Publication and advertisement are not one step: the file is renamed into
+    place, then the pointer reaches the caller. Another chat's prune or the
+    sweep runs in between, and on coarse mtime the new file need not sort as
+    newest — so quota pressure could delete the path about to be returned."""
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_FILES", 1)
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_TOTAL_BYTES", 10)
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_ROOT_BYTES", 10)
+
+    first = spill_overflow("a" * 100, deps=_deps(tmp_path, chat_id="one"), kind="t")
+
+    # A second chat spills, running both quota passes over a directory far past
+    # its ceilings. The first file is seconds old, so nothing may take it.
+    spill_overflow("b" * 100, deps=_deps(tmp_path, chat_id="two"), kind="t")
+
+    assert Path(first.host_path).exists(), "a just-published spill was pruned"
+
+
+def test_the_grace_period_expires(tmp_path, monkeypatch):
+    """It is a short window, not an exemption: an aged file prunes normally."""
+    import suzent.tools.overflow as overflow
+
+    # By bytes, not by count: with the new file protected there is only one
+    # unprotected entry, so a count ceiling of 1 would evict nothing and the
+    # test would pass for the wrong reason.
+    monkeypatch.setattr(overflow, "OVERFLOW_MAX_TOTAL_BYTES", 10)
+    monkeypatch.setattr(overflow, "OVERFLOW_GRACE_SECONDS", 1)
+
+    old_spill = spill_overflow("a" * 100, deps=_deps(tmp_path), kind="t")
+    aged = time.time() - 120
+    os.utime(old_spill.host_path, (aged, aged))
+
+    spill_overflow("b" * 100, deps=_deps(tmp_path), kind="t")
+
+    assert not Path(old_spill.host_path).exists(), "the grace period never ends"
+
+
+def test_the_shared_root_is_opened_without_following(tmp_path):
+    """mkdir(exist_ok=True) accepts a symlink as an existing directory, so a
+    `shared` replaced by one would be followed and every pinned step below it
+    would be pinned to the wrong tree."""
+    import suzent.tools.overflow as overflow
+
+    if not overflow._HAVE_DIR_FD:
+        pytest.skip("dir_fd unsupported")
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    os.symlink(elsewhere, tmp_path / "shared")
+
+    assert spill_overflow("x" * 100, deps=_deps(tmp_path), kind="t") is None
+    assert list(elsewhere.iterdir()) == [], "the write followed a symlinked root"

--- a/tests/tools/test_overflow_spill.py
+++ b/tests/tools/test_overflow_spill.py
@@ -601,3 +601,39 @@ def test_every_registered_tool_can_reach_its_deps():
             missing.append(cls.name)
 
     assert missing == [], f"these tools cannot spill their output: {missing}"
+
+
+@pytest.mark.parametrize("umask_value", [0o077, 0o022, 0o000])
+def test_the_modes_survive_a_restrictive_umask(tmp_path, umask_value):
+    """Creation modes are masked by the process umask, so a service started with
+    umask 0077 turns 0755/0644 into 0700/0600 — exactly the permissions that
+    make the marker point at a file the sandbox cannot open."""
+    previous = os.umask(umask_value)
+    try:
+        spill = spill_overflow(
+            "x" * 100, deps=_deps(tmp_path, chat_id=f"u{umask_value:o}"), kind="t"
+        )
+    finally:
+        os.umask(previous)
+
+    file_mode = os.stat(spill.path).st_mode & 0o777
+    dir_mode = os.stat(Path(spill.path).parent).st_mode & 0o777
+
+    assert file_mode & 0o044, f"umask {umask_value:o} left the file at {file_mode:o}"
+    assert dir_mode & 0o011, f"umask {umask_value:o} left the dir at {dir_mode:o}"
+
+
+def test_the_path_fallback_also_survives_the_umask(tmp_path, monkeypatch):
+    import suzent.tools.overflow as overflow
+
+    monkeypatch.setattr(overflow, "_HAVE_DIR_FD", False)
+    previous = os.umask(0o077)
+    try:
+        spill = overflow.spill_overflow(
+            "x" * 100, deps=_deps(tmp_path, chat_id="fallback"), kind="t"
+        )
+    finally:
+        os.umask(previous)
+
+    assert os.stat(spill.path).st_mode & 0o044
+    assert os.stat(Path(spill.path).parent).st_mode & 0o011

--- a/tests/tools/test_voice_tool_async.py
+++ b/tests/tools/test_voice_tool_async.py
@@ -15,7 +15,7 @@ async def test_forward_awaits_speech():
     tool._sink = mock_sink
     tool._speech = mock_speech
 
-    result = await tool.forward("hello", prompt="cheerful")
+    result = await tool.forward(None, "hello", prompt="cheerful")
 
     mock_speech.speak.assert_awaited_once_with("hello", prompt="cheerful")
     assert result.success
@@ -26,7 +26,7 @@ async def test_forward_awaits_speech():
 async def test_forward_returns_error_for_empty_text():
     tool = SpeakTool()
 
-    result = await tool.forward("")
+    result = await tool.forward(None, "")
 
     assert not result.success
     assert result.message == "No text to speak."

--- a/tests/verify_voice.py
+++ b/tests/verify_voice.py
@@ -8,7 +8,9 @@ def test_speak():
     tool = SpeakTool()
 
     print("Speaking...")
-    result = asyncio.run(tool.forward("Hello, I am Suzent. I can speak now."))
+    # ctx first, as the registry passes it. SpeakTool does not read it, but the
+    # signature has to match the one the wrapper calls.
+    result = asyncio.run(tool.forward(None, "Hello, I am Suzent. I can speak now."))
     print(f"Result: {result}")
 
 


### PR DESCRIPTION
Closes #180.

## The problem

`truncate_tool_output` caps a result at 30,000 chars and throws the rest away:

```
... [2989 lines truncated]
```

The part a cap removes is usually the part that was wanted — the failing assertion at the end of a test run, the last hundred lines of a build log. The marker told the model content was missing and gave it no way to read it.

## What changed

The full text is written to a file under `/shared/.overflow` and the marker carries the path:

```
... [2989 lines truncated — full output: /Users/suzy/.suzent/sandbox/shared/.overflow/run_command-1788476432-604a4188.txt]
```

Two call sites:

- **Tool results** — centrally in the registry wrapper, so every tool gets it. Deps come from the `RunContext` the tool already receives.
- **Over-budget reminder fragments** — and this is the case that matters more. A tool result can be re-run; a reminder block is gone next turn, so a dropped tail is unrecoverable.

## Mode-native paths

The path handed to the model is the one *this* agent can open — host paths in host mode, `/shared/...` in sandbox — following #183/#184. A path it cannot open is worse than no path: it invites a read that fails.

Verified in both modes:

```
HOST    marker: ... full output: /Users/suzy/.suzent/sandbox/shared/.overflow/run_command-….txt
SANDBOX marker: ... full output: /shared/.overflow/run_command-….txt
both readable: True   bytes=133889
```

## Best-effort by design

No resolver, an unwritable directory, or a tool that takes no `RunContext` all fall back to the plain marker. Losing the tail beats failing the call that produced it — so the spill never turns a working tool into a broken one.

## Lifetime

`/shared/.overflow`, pruned on every write by age (24h) and count (200). The count bound matters independently: one runaway session outpaces a TTL that only expires tomorrow. Under `/shared` rather than the project workspace so spills are not mistaken for the user's files, and so a sub-agent on the same task can read them.

## Not done

The issue also floats truncating the *middle* for output whose summary is at the end. `keep_output_tail = True` already exists for the two tools where that matters (bash, process), so I left the strategy alone rather than adding a third mode speculatively.

## Verification

18 tests — 8 for the spill helper, 2 for the reminder path, plus the existing truncation tests still passing. Verified failing against the parent commit.

Suite 2008 passed, ruff clean.

### One process note

My first attempt at that verification proved nothing. `git stash push <paths>` silently created no stash, so the subsequent `pop` applied an unrelated three-month-old stash into the tree — which is how a `frontend/package-lock.json` conflict appeared in a Python change. The tests "passed while stashed" because nothing had been stashed. Restored the tree, left the old stashes intact, and re-verified with `git checkout HEAD~1 -- <files>`, which actually removes the code and is observable (`grep -c` went 4 → 0 → 4).