### PR TITLE
fix(vision): route image analysis through the shared model resolution

### DIFF
--- a/src/suzent/llm.py
+++ b/src/suzent/llm.py
@@ -65,6 +65,23 @@ def _chat_template_kwargs(model: Optional[str]) -> Dict[str, Any]:
     return {"extra_body": {"chat_template_kwargs": {"enable_thinking": False}}}
 
 
+def chat_completion_args(model: Optional[str]) -> tuple[Optional[str], Dict[str, Any]]:
+    """Model id and kwargs for a chat completion issued outside this module.
+
+    One-off ``litellm.acompletion`` calls elsewhere in the codebase were reaching
+    the provider with none of this: no ``api_base`` (so a self-hosted endpoint was
+    simply unreachable), no ``api_key``, and no ``enable_thinking: false`` (so the
+    token budget went to reasoning and the caller got an empty string back). The
+    fix is to route them through the same resolution the rest of the module uses,
+    not to restate it at each call site.
+    """
+    litellm_model, kwargs = _litellm_model_and_kwargs(model)
+    # Keyed off the original id: _litellm_model_and_kwargs may have rewritten the
+    # provider prefix to ``openai/`` for a self-hosted server.
+    kwargs.update(_chat_template_kwargs(model))
+    return litellm_model, kwargs
+
+
 def _litellm_model_and_kwargs(
     model: Optional[str],
 ) -> tuple[Optional[str], Dict[str, Any]]:

--- a/src/suzent/llm.py
+++ b/src/suzent/llm.py
@@ -100,6 +100,13 @@ def _litellm_model_and_kwargs(
 
     kwargs: Dict[str, str] = {}
     api_key = resolve_api_key(provider)
+    if not api_key and provider in _LOCAL_OPENAI_SERVER_PROVIDERS:
+        # A self-hosted server usually wants no credential at all, but the
+        # request is about to be rewritten to ``openai/`` and that adapter
+        # refuses to send anything without one — it fails on the missing key
+        # before it ever looks at api_base. model_factory settles this the same
+        # way (``api_key or "local"``); the server ignores the value.
+        api_key = "local"
     if api_key:
         kwargs["api_key"] = api_key
 

--- a/src/suzent/tools/image_vision_tool.py
+++ b/src/suzent/tools/image_vision_tool.py
@@ -120,14 +120,10 @@ class ImageVisionTool(Tool):
                 **call_kwargs,
             )
 
-            result_text = response.choices[0].message.content
-            if not result_text or not result_text.strip():
-                # A 200 with nothing in it. Reported as itself, because the
-                # alternative is a success result holding an empty string and a
-                # reader with no idea the model never answered.
-                raise EmptyCompletionError(model)
-
-            # Log cost
+            # Billed before it is read: an answerless response is the
+            # expensive case, not the free one — the tokens went to reasoning
+            # that never reached a description. Logging after the content check
+            # would drop exactly those from the ledger.
             try:
                 usage = response.usage
                 if usage:
@@ -142,6 +138,13 @@ class ImageVisionTool(Tool):
                     )
             except Exception:
                 pass
+
+            result_text = response.choices[0].message.content
+            if not result_text or not result_text.strip():
+                # A 200 with nothing in it. Reported as itself, because the
+                # alternative is a success result holding an empty string and a
+                # reader with no idea the model never answered.
+                raise EmptyCompletionError(model)
 
             return ToolResult.success_result(result_text)
 

--- a/src/suzent/tools/image_vision_tool.py
+++ b/src/suzent/tools/image_vision_tool.py
@@ -6,6 +6,7 @@ from pydantic_ai import RunContext
 import litellm
 
 from suzent.core.agent_deps import AgentDeps
+from suzent.llm import EmptyCompletionError, chat_completion_args
 from suzent.tools.base import Tool, ToolErrorCode, ToolGroup, ToolResult
 from suzent.tools.filesystem.file_tool_utils import get_or_create_path_resolver
 from suzent.logger import get_logger
@@ -13,6 +14,10 @@ from suzent.logger import get_logger
 logger = get_logger(__name__)
 
 MAX_IMAGE_SIZE = 20 * 1024 * 1024  # 20MB limit
+
+#: Room for a description, and for the reasoning a self-hosted server may
+#: insist on emitting first despite being asked not to.
+VISION_MAX_TOKENS = 2000
 
 
 class ImageVisionTool(Tool):
@@ -104,13 +109,23 @@ class ImageVisionTool(Tool):
             ]
 
             logger.info(f"Analyzing image {path.name} with model {model}")
+            # Through the shared resolution rather than straight to LiteLLM: a
+            # self-hosted vision endpoint needs its api_base and its thinking
+            # switched off, and neither is visible from here.
+            litellm_model, call_kwargs = chat_completion_args(model)
             response = await litellm.acompletion(
-                model=model,
+                model=litellm_model,
                 messages=messages,
-                max_tokens=1000,
+                max_tokens=VISION_MAX_TOKENS,
+                **call_kwargs,
             )
 
             result_text = response.choices[0].message.content
+            if not result_text or not result_text.strip():
+                # A 200 with nothing in it. Reported as itself, because the
+                # alternative is a success result holding an empty string and a
+                # reader with no idea the model never answered.
+                raise EmptyCompletionError(model)
 
             # Log cost
             try:

--- a/tests/tools/test_image_vision_tool.py
+++ b/tests/tools/test_image_vision_tool.py
@@ -140,3 +140,101 @@ async def test_image_vision_too_large(mock_ctx):
 
         assert not result.success
         assert result.error_code == ToolErrorCode.FILE_TOO_LARGE
+
+
+def _staged_image(mock_open):
+    """The mocks every call-path test needs: a readable 1KB png."""
+    mock_stat = MagicMock()
+    mock_stat.st_size = 1024
+
+    mock_path = MagicMock()
+    mock_path.exists.return_value = True
+    mock_path.is_file.return_value = True
+    mock_path.stat.return_value = mock_stat
+    mock_path.suffix = ".png"
+    mock_path.name = "test.png"
+
+    mock_file = MagicMock()
+    mock_file.read.return_value = b"fake_image_data"
+    mock_open.return_value.__enter__.return_value = mock_file
+
+    mock_resolver = MagicMock()
+    mock_resolver.resolve.return_value = mock_path
+    return mock_resolver
+
+
+@pytest.mark.asyncio
+@patch("suzent.tools.image_vision_tool.litellm.acompletion", new_callable=AsyncMock)
+@patch("builtins.open", new_callable=MagicMock)
+async def test_a_self_hosted_vision_model_is_reachable_and_not_thinking(
+    mock_open, mock_acompletion, mock_ctx
+):
+    """This call used to go straight to LiteLLM with nothing but the model id,
+    so a self-hosted endpoint had no api_base to reach and no instruction to
+    stop thinking — the budget went to reasoning and the answer came back
+    empty."""
+    mock_resolver = _staged_image(mock_open)
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "A photo of a server rack."
+    mock_acompletion.return_value = mock_response
+
+    mock_router = MagicMock()
+    mock_router.get_model_id.return_value = "sglang/qwen3-vl"
+
+    with patch(
+        "suzent.tools.image_vision_tool.get_or_create_path_resolver",
+        return_value=mock_resolver,
+    ):
+        with patch("suzent.core.role_router.get_role_router", return_value=mock_router):
+            with patch(
+                "suzent.tools.image_vision_tool.chat_completion_args",
+                return_value=(
+                    "openai/qwen3-vl",
+                    {
+                        "api_base": "http://localhost:30000/v1",
+                        "extra_body": {
+                            "chat_template_kwargs": {"enable_thinking": False}
+                        },
+                    },
+                ),
+            ):
+                result = await ImageVisionTool().forward(mock_ctx, "test.png", "What?")
+
+    assert result.success
+    sent = mock_acompletion.call_args.kwargs
+    assert sent["model"] == "openai/qwen3-vl"
+    assert sent["api_base"] == "http://localhost:30000/v1"
+    assert sent["extra_body"]["chat_template_kwargs"]["enable_thinking"] is False
+
+
+@pytest.mark.asyncio
+@patch("suzent.tools.image_vision_tool.litellm.acompletion", new_callable=AsyncMock)
+@patch("builtins.open", new_callable=MagicMock)
+async def test_an_empty_completion_is_an_error_not_an_empty_description(
+    mock_open, mock_acompletion, mock_ctx
+):
+    """A reasoning model that spends the budget before answering returns a 200
+    with no content. Reported as a success it becomes an empty description the
+    agent has no reason to doubt."""
+    mock_resolver = _staged_image(mock_open)
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = ""
+    mock_acompletion.return_value = mock_response
+
+    mock_router = MagicMock()
+    mock_router.get_model_id.return_value = "sglang/qwen3-vl"
+
+    with patch(
+        "suzent.tools.image_vision_tool.get_or_create_path_resolver",
+        return_value=mock_resolver,
+    ):
+        with patch("suzent.core.role_router.get_role_router", return_value=mock_router):
+            result = await ImageVisionTool().forward(mock_ctx, "test.png", "What?")
+
+    assert not result.success
+    assert result.error_code == ToolErrorCode.EXECUTION_FAILED
+    assert "empty completion" in result.message.lower()

--- a/tests/tools/test_image_vision_tool.py
+++ b/tests/tools/test_image_vision_tool.py
@@ -238,3 +238,58 @@ async def test_an_empty_completion_is_an_error_not_an_empty_description(
     assert not result.success
     assert result.error_code == ToolErrorCode.EXECUTION_FAILED
     assert "empty completion" in result.message.lower()
+
+
+def test_a_keyless_local_server_still_gets_a_credential():
+    """The request is rewritten to `openai/`, and that adapter refuses to send
+    anything without a key — it fails on the missing credential before it looks
+    at api_base, so a keyless self-hosted server would be unreachable."""
+    from suzent.llm import chat_completion_args
+
+    with patch("suzent.llm.resolve_api_key", return_value=None):
+        for model in ("vllm/qwen3-vl", "sglang/qwen3-vl"):
+            _, kwargs = chat_completion_args(model)
+            assert kwargs.get("api_key"), f"{model} would be sent without a credential"
+
+
+@pytest.mark.asyncio
+@patch("suzent.tools.image_vision_tool.litellm.acompletion", new_callable=AsyncMock)
+@patch("builtins.open", new_callable=MagicMock)
+async def test_an_empty_completion_is_still_billed(
+    mock_open, mock_acompletion, mock_ctx
+):
+    """The answerless response is the expensive one — the tokens went to
+    reasoning that never produced a description. Rejecting it before the ledger
+    saw it understated the cost of exactly the calls that waste the most."""
+    mock_resolver = _staged_image(mock_open)
+
+    usage = MagicMock()
+    usage.prompt_tokens = 1200
+    usage.completion_tokens = 2000
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = ""
+    mock_response.usage = usage
+    mock_acompletion.return_value = mock_response
+
+    mock_router = MagicMock()
+    mock_router.get_model_id.return_value = "sglang/qwen3-vl"
+
+    tracker = MagicMock()
+    tracker.log_cost = AsyncMock()
+
+    with patch(
+        "suzent.tools.image_vision_tool.get_or_create_path_resolver",
+        return_value=mock_resolver,
+    ):
+        with patch("suzent.core.role_router.get_role_router", return_value=mock_router):
+            with patch(
+                "suzent.core.cost_tracker.get_cost_tracker", return_value=tracker
+            ):
+                result = await ImageVisionTool().forward(mock_ctx, "test.png", "What?")
+
+    assert not result.success
+    tracker.log_cost.assert_awaited_once()
+    billed = tracker.log_cost.await_args.kwargs
+    assert billed["input_tokens"] == 1200
+    assert billed["output_tokens"] == 2000


### PR DESCRIPTION
Follow-up to #181. That PR fixed the self-hosted-server assumptions in `llm.py`; `analyze_image` never went through `llm.py` at all, so it kept every one of them.

## The gap

`ImageVisionTool.forward()` called `litellm.acompletion(model=model, messages=..., max_tokens=1000)` with nothing else. Against a self-hosted vision endpoint that means:

- **no `api_base`** — the provider registry holds the endpoint URL, and the call never asked for it, so the request went nowhere near the server
- **no `api_key`**
- **no `enable_thinking: false`** — the chat template's default is thinking on, so the budget is spent reasoning before any description exists
- **no empty-completion guard** — the result is a 200 with `content == ""`, which the tool returned as `ToolResult.success_result("")`: an empty description the agent has no reason to distrust

## The change

- `llm.py` gains `chat_completion_args(model)`, which composes the two existing private helpers (`_litellm_model_and_kwargs` + `_chat_template_kwargs`). Restating the resolution at each call site is what produced this bug in the first place; any future one-off completion should use this.
- `analyze_image` calls it, and raises `EmptyCompletionError` rather than returning an empty success.
- `max_tokens` 1000 → 2000 (`VISION_MAX_TOKENS`), leaving room for a description plus whatever reasoning a server emits despite being asked not to.

## Verification

Two tests, both failing against the parent commit:
- `test_a_self_hosted_vision_model_is_reachable_and_not_thinking` — asserts the rewritten model id, `api_base` and `extra_body` actually reach LiteLLM
- `test_an_empty_completion_is_an_error_not_an_empty_description`

Resolution checked directly for each provider: `sglang/*` and `vllm/*` get `api_base` + `enable_thinking: false`, hosted providers get neither. Full suite 2100 passed.

**Not verified end-to-end:** the configured vision role is `gemini/gemini-3.1-pro-preview` and the reachable self-hosted server runs a text model, so there was no live self-hosted vision endpoint to call. The #181 fix it mirrors *was* measured live.

Closes nothing; found while sweeping for other call paths carrying #181's assumptions. No other completion call exists outside `llm.py`.