### PR TITLE
Size auto-compaction and the context panel by the model in use

### DIFF
--- a/docs/02-concepts/memory/configuration.md
+++ b/docs/02-concepts/memory/configuration.md
@@ -95,8 +95,19 @@ is off by default.
 ## Context window
 
 ```yaml
-max_context_tokens: 800000         # Budget before a conversation is compressed
+max_context_tokens: 0              # 0 = use whatever the active model supports
 ```
+
+The compaction budget is derived from the model actually running the conversation:
+its input window, read from the model capability registry. A 1M-token model gets a
+1M-token budget, a 128k model gets 128k, and compaction triggers at the same
+*fraction* of each (`context_compaction_trigger`, 80% by default) instead of at one
+fixed token count that was wrong for every model but one.
+
+Set `max_context_tokens` to a non-zero value to cap that budget — useful to keep
+prompts (and cost) below what the model would allow. It is a ceiling, never a
+raise: the smaller of the two always wins. When a model is missing from the
+registry, the budget falls back to 200k tokens.
 
 ## Rebuilding the search index
 

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useStatusStore, StatusType } from '../hooks/useStatusStore';
 import { useChatCoreStore, useChatStore } from '../hooks/useChatStore';
+import { selectContextLimit } from '../lib/contextLimit';
 import { useI18n } from '../i18n';
 import { useHeartbeatRunning } from '../hooks/useHeartbeatRunning';
 import { useSubAgentStatus } from '../hooks/useSubAgentStatus';
@@ -460,11 +461,24 @@ function HeartbeatWidget() {
 
 function ContextWidget() {
   const { usage } = useContextUsageStore();
-  const { backendConfig } = useChatCoreStore();
+  const { backendConfig, config } = useChatCoreStore();
 
-  if (!usage || !backendConfig?.maxContextTokens) return null;
+  // Mirror what actually runs when a chat carries no model of its own: the
+  // backend falls back to the user's preferred model, then to the first enabled
+  // one. Reading only `config.model` sized those chats against nothing.
+  const selectedModel =
+    config?.model || backendConfig?.userPreferences?.model || backendConfig?.models?.[0];
 
-  return <ContextWidgetBody usage={usage} limit={backendConfig.maxContextTokens} />;
+  const limit = selectContextLimit({
+    selectedModel,
+    contextWindows: backendConfig?.contextWindows,
+    turnLimit: usage?.context_limit,
+    fallback: backendConfig?.maxContextTokens,
+  });
+
+  if (!usage || !limit) return null;
+
+  return <ContextWidgetBody usage={usage} limit={limit} />;
 }
 
 function ContextWidgetBody({ usage, limit }: { usage: ContextUsage; limit: number }) {

--- a/frontend/src/hooks/useChatStore.tsx
+++ b/frontend/src/hooks/useChatStore.tsx
@@ -543,64 +543,76 @@ export const ChatProvider: React.FC<{ children: React.ReactNode; enabled?: boole
     [getMessagesForChat, currentChatId]
   );
 
-  // Fetch backend config with retry logic
-  const fetchConfigWithRetry = useCallback(async (attempt = 1, maxAttempts = 5) => {
-    try {
-      const res = await fetch(`${getApiBase()}/config`);
-      if (res.ok) {
-        const data: ConfigOptions = await res.json();
+  // Fetch backend config with retry logic.
+  //
+  // `applyDefaults` decides whether the listing also (re)initializes the active
+  // chat config from user preferences. That is right on mount and after a
+  // settings change, and wrong for a refresh triggered mid-session: the fetch
+  // resolves after a chat's own config was installed, so applying defaults there
+  // would silently switch the open chat's model and tools — and the next message
+  // would run with them.
+  const fetchConfigWithRetry = useCallback(
+    async (attempt = 1, maxAttempts = 5, applyDefaults = true) => {
+      try {
+        const res = await fetch(`${getApiBase()}/config`);
+        if (res.ok) {
+          const data: ConfigOptions = await res.json();
 
-        setBackendConfig(data);
-        // Align memory user id with backend-provided userId if present
-        try {
-          if (data.userId) {
-            // Lazy import to avoid circulars; memory hook standalone
-            const { useMemory } = await import('./useMemory');
-            useMemory.getState().setUserId(data.userId);
+          setBackendConfig(data);
+          // Align memory user id with backend-provided userId if present
+          try {
+            if (data.userId) {
+              // Lazy import to avoid circulars; memory hook standalone
+              const { useMemory } = await import('./useMemory');
+              useMemory.getState().setUserId(data.userId);
+            }
+          } catch (e) {
+            console.warn('Failed to set memory userId from backend config:', e);
           }
-        } catch (e) {
-          console.warn('Failed to set memory userId from backend config:', e);
+
+          // Build initial config from user preferences or backend defaults
+          const firstConfig: ChatConfig = buildConfigFromPreferences(data.userPreferences, data);
+
+          // Track saved preferences to avoid re-saving on initial load
+          if (data.userPreferences) {
+            lastSavedPreferencesRef.current = extractSavedPreferences(data.userPreferences);
+          }
+
+          if (applyDefaults) {
+            setConfigState(firstConfig);
+            setConfigByChat((prev) => ({ ...prev, [UNSAVED_CHAT_KEY]: firstConfig }));
+          }
+        } else if (attempt < maxAttempts) {
+          // Backend not ready, retry with exponential backoff
+          const delay = Math.min(1000 * Math.pow(2, attempt - 1), 5000);
+          console.log(
+            `Backend not ready (${res.status}), retrying in ${delay}ms... (attempt ${attempt}/${maxAttempts})`
+          );
+          setTimeout(() => fetchConfigWithRetry(attempt + 1, maxAttempts, applyDefaults), delay);
+        } else {
+          console.error(
+            'Failed to fetch config after',
+            maxAttempts,
+            'attempts:',
+            res.status,
+            res.statusText
+          );
         }
-
-        // Build initial config from user preferences or backend defaults
-        const firstConfig: ChatConfig = buildConfigFromPreferences(data.userPreferences, data);
-
-        // Track saved preferences to avoid re-saving on initial load
-        if (data.userPreferences) {
-          lastSavedPreferencesRef.current = extractSavedPreferences(data.userPreferences);
+      } catch (error) {
+        if (attempt < maxAttempts) {
+          // Network error, retry with exponential backoff
+          const delay = Math.min(1000 * Math.pow(2, attempt - 1), 5000);
+          console.log(
+            `Error fetching config, retrying in ${delay}ms... (attempt ${attempt}/${maxAttempts})`
+          );
+          setTimeout(() => fetchConfigWithRetry(attempt + 1, maxAttempts, applyDefaults), delay);
+        } else {
+          console.error('Error fetching config after', maxAttempts, 'attempts:', error);
         }
-
-        setConfigState(firstConfig);
-        setConfigByChat((prev) => ({ ...prev, [UNSAVED_CHAT_KEY]: firstConfig }));
-      } else if (attempt < maxAttempts) {
-        // Backend not ready, retry with exponential backoff
-        const delay = Math.min(1000 * Math.pow(2, attempt - 1), 5000);
-        console.log(
-          `Backend not ready (${res.status}), retrying in ${delay}ms... (attempt ${attempt}/${maxAttempts})`
-        );
-        setTimeout(() => fetchConfigWithRetry(attempt + 1, maxAttempts), delay);
-      } else {
-        console.error(
-          'Failed to fetch config after',
-          maxAttempts,
-          'attempts:',
-          res.status,
-          res.statusText
-        );
       }
-    } catch (error) {
-      if (attempt < maxAttempts) {
-        // Network error, retry with exponential backoff
-        const delay = Math.min(1000 * Math.pow(2, attempt - 1), 5000);
-        console.log(
-          `Error fetching config, retrying in ${delay}ms... (attempt ${attempt}/${maxAttempts})`
-        );
-        setTimeout(() => fetchConfigWithRetry(attempt + 1, maxAttempts), delay);
-      } else {
-        console.error('Error fetching config after', maxAttempts, 'attempts:', error);
-      }
-    }
-  }, []);
+    },
+    []
+  );
 
   const refreshBackendConfig = useCallback(async () => {
     await fetchConfigWithRetry();
@@ -1426,7 +1438,8 @@ export const ChatProvider: React.FC<{ children: React.ReactNode; enabled?: boole
             !refetchedForModelsRef.current.has(model)
           ) {
             refetchedForModelsRef.current.add(model);
-            void fetchConfigWithRetry();
+            // Listing only: this resolves after the chat's config is installed.
+            void fetchConfigWithRetry(1, 5, false);
           }
           // Save reusable preferences for the next new chat without chat-scoped state.
           try {

--- a/frontend/src/hooks/useChatStore.tsx
+++ b/frontend/src/hooks/useChatStore.tsx
@@ -348,6 +348,12 @@ export const ChatProvider: React.FC<{ children: React.ReactNode; enabled?: boole
   });
   const [config, setConfigState] = useState<ChatConfig>(defaultConfig);
   const [backendConfig, setBackendConfig] = useState<ConfigOptions | null>(null);
+  // Read from callbacks that must not be rebuilt whenever the listing changes.
+  const backendConfigRef = useRef<ConfigOptions | null>(null);
+  backendConfigRef.current = backendConfig;
+  // Models we have already refetched the listing for, so an unlisted model
+  // (an ACP agent, a disabled provider) costs one request, not one per load.
+  const refetchedForModelsRef = useRef<Set<string>>(new Set());
   const [backendConfigError, setBackendConfigError] = useState<string | null>(null);
   const [shouldResetNext, setShouldResetNext] = useState(false);
   const [isStreaming, setIsStreamingState] = useState(false);
@@ -1392,6 +1398,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode; enabled?: boole
               total_tokens:
                 serverUsage?.total_tokens ?? existingUsage?.total_tokens ?? contextTokens,
               context_tokens: contextTokens,
+              context_limit: serverUsage?.context_limit ?? existingUsage?.context_limit ?? null,
               cache_write_tokens:
                 serverUsage?.cache_write_tokens ?? existingUsage?.cache_write_tokens ?? 0,
               cache_read_tokens:
@@ -1406,6 +1413,21 @@ export const ChatProvider: React.FC<{ children: React.ReactNode; enabled?: boole
           );
           setConfigByChat((prev) => ({ ...prev, [key]: loadedConfig }));
           setConfigState(loadedConfig);
+          // The backend config listing is fetched once on mount, so a backend that
+          // restarted (or gained a model) since then leaves this window holding a
+          // listing that can't size the chat's model — which is how the context
+          // panel kept showing a stale maximum. Not being able to resolve a budget
+          // for the model we just loaded is the signal to refetch the listing.
+          const model = loadedConfig.model;
+          if (
+            model &&
+            backendConfigRef.current &&
+            !backendConfigRef.current.contextWindows?.[model] &&
+            !refetchedForModelsRef.current.has(model)
+          ) {
+            refetchedForModelsRef.current.add(model);
+            void fetchConfigWithRetry();
+          }
           // Save reusable preferences for the next new chat without chat-scoped state.
           try {
             localStorage.setItem(

--- a/frontend/src/hooks/useContextUsageStore.ts
+++ b/frontend/src/hooks/useContextUsageStore.ts
@@ -5,6 +5,12 @@ export interface ContextUsage {
   output_tokens: number;
   total_tokens: number;
   context_tokens?: number | null;
+  /**
+   * Context window of the model this chat runs on, as resolved by the backend.
+   * Absent until the first turn reports it — fall back to the backend config's
+   * `maxContextTokens` then, never to a hardcoded number.
+   */
+  context_limit?: number | null;
   cache_write_tokens: number;
   cache_read_tokens: number;
   requests: number;

--- a/frontend/src/lib/contextLimit.test.ts
+++ b/frontend/src/lib/contextLimit.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { selectContextLimit } from './contextLimit';
+
+const WINDOWS = {
+  'gemini/gemini-3.1-pro-preview': 1_048_576,
+  'openai/gpt-4.1': 128_000,
+};
+
+describe('selectContextLimit', () => {
+  it('uses the window of the model in the selector', () => {
+    expect(
+      selectContextLimit({
+        selectedModel: 'gemini/gemini-3.1-pro-preview',
+        contextWindows: WINDOWS,
+        fallback: 200_000,
+      })
+    ).toBe(1_048_576);
+  });
+
+  it('follows a model switch instead of the limit the last turn reported', () => {
+    // The regression: the panel kept showing the previous model's maximum.
+    expect(
+      selectContextLimit({
+        selectedModel: 'openai/gpt-4.1',
+        contextWindows: WINDOWS,
+        turnLimit: 1_048_576,
+        fallback: 200_000,
+      })
+    ).toBe(128_000);
+  });
+
+  it('falls back to the turn’s own limit for a model the listing lacks', () => {
+    expect(
+      selectContextLimit({
+        selectedModel: 'local/unlisted',
+        contextWindows: WINDOWS,
+        turnLimit: 32_000,
+        fallback: 200_000,
+      })
+    ).toBe(32_000);
+  });
+
+  it('falls back to the backend default when nothing else is known', () => {
+    expect(selectContextLimit({ contextWindows: WINDOWS, fallback: 200_000 })).toBe(200_000);
+  });
+
+  it('is undefined when there is no budget to show', () => {
+    expect(selectContextLimit({})).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/contextLimit.ts
+++ b/frontend/src/lib/contextLimit.ts
@@ -1,0 +1,26 @@
+/**
+ * Which context budget the usage panel draws its percentage against.
+ *
+ * The budget belongs to a model, not to the app: a 1M-token model and a 128k one
+ * are at very different fractions of full with the same conversation in them.
+ */
+export function selectContextLimit({
+  selectedModel,
+  contextWindows,
+  turnLimit,
+  fallback,
+}: {
+  /** Model currently chosen in the selector (a provider-prefixed id). */
+  selectedModel?: string;
+  /** Per-model budgets from the backend config listing. */
+  contextWindows?: Record<string, number>;
+  /** Limit the last turn reported alongside its usage. */
+  turnLimit?: number | null;
+  /** Backend-wide default, for a model nothing else knows about. */
+  fallback?: number;
+}): number | undefined {
+  // Selector first: switching models has to move the maximum immediately, and
+  // the last turn's limit belongs to whichever model ran that turn.
+  const selected = selectedModel ? contextWindows?.[selectedModel] : undefined;
+  return selected || turnLimit || fallback || undefined;
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -107,6 +107,7 @@ export interface Chat {
     output_tokens?: number;
     total_tokens?: number;
     context_tokens?: number | null;
+    context_limit?: number | null;
     cache_write_tokens?: number;
     cache_read_tokens?: number;
     requests?: number;
@@ -201,7 +202,8 @@ export interface ConfigOptions {
   globalSandboxVolumes?: string[]; // global volumes from config file
   sandboxEnabled?: boolean; // global sandbox enable setting
   defaultPermissionMode?: PermissionMode; // default permission mode for new chats
-  maxContextTokens?: number; // max context window size in tokens
+  contextWindows?: Record<string, number>; // context budget per enabled model id
+  maxContextTokens?: number; // last-resort fallback when the selected model is unknown
   userPreferences?: {
     // saved user preferences from database
     model: string;

--- a/src/suzent/agent_manager.py
+++ b/src/suzent/agent_manager.py
@@ -382,7 +382,7 @@ def create_agent(config: Dict[str, Any]) -> Agent[AgentDeps, str]:
         # Sanitizer first: it must neutralize forged reminder delimiters before
         # compaction folds tool output into a summary that we can no longer inspect.
         ProcessHistory(make_tool_output_sanitizer_history_processor()),
-        ProcessHistory(make_compaction_history_processor()),
+        ProcessHistory(make_compaction_history_processor(model_id=model_id)),
         ToolSearch(),
     ]
     project_context_dir = config.get("_project_context_dir")

--- a/src/suzent/config/model.py
+++ b/src/suzent/config/model.py
@@ -206,7 +206,11 @@ class ConfigModel(BaseModel):
     jsonl_transcripts_enabled: bool = True
     transcript_indexing_enabled: bool = False
 
-    max_context_tokens: int = 800_000
+    # Ceiling on the context budget before compaction kicks in. 0 (the default)
+    # means "whatever the active model supports" — the budget is resolved per
+    # model from the capability registry. A non-zero value caps that, for a
+    # deliberately smaller window than the model allows.
+    max_context_tokens: int = 0
     context_compaction_trigger: float = 0.80
     context_soft_trim_threshold: float = 0.60
     context_hard_trim_threshold: float = 0.80

--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -1056,10 +1056,15 @@ class ChatProcessor:
         )
 
         # 7. Pre-send tool result trimming (in-memory only, never persisted)
-        from suzent.core.context_compressor import ToolResultTrimmer, estimate_tokens
-        from suzent.config import CONFIG as _cfg
+        from suzent.core.context_compressor import (
+            ToolResultTrimmer,
+            estimate_tokens,
+            resolve_context_limit,
+        )
 
-        _budget = estimate_tokens(message_history or [], _cfg.max_context_tokens)
+        _budget = estimate_tokens(
+            message_history or [], resolve_context_limit(_model_id)
+        )
         if _budget.over_hard:
             message_history = ToolResultTrimmer.apply_hard_clear(
                 message_history, _budget

--- a/src/suzent/core/commands/compact.py
+++ b/src/suzent/core/commands/compact.py
@@ -26,8 +26,8 @@ def handle_compact(
             ContextCompressor,
             emit_compaction_event,
             estimate_tokens,
+            resolve_context_limit,
         )
-        from suzent.config import CONFIG
 
         cmd_ctx: CommandContext = ctx.obj
         focus_text = " ".join(focus).strip() if focus else None
@@ -78,12 +78,13 @@ def handle_compact(
         model_id = state.get("model_id")
         tool_names = state.get("tool_names", [])
 
-        tokens_before = estimate_tokens(
-            messages, CONFIG.max_context_tokens
-        ).estimated_tokens
+        context_limit = resolve_context_limit(model_id)
+        tokens_before = estimate_tokens(messages, context_limit).estimated_tokens
         messages_before = len(messages)
 
-        compressor = ContextCompressor(chat_id=cmd_ctx.chat_id, user_id=cmd_ctx.user_id)
+        compressor = ContextCompressor(
+            chat_id=cmd_ctx.chat_id, user_id=cmd_ctx.user_id, model_id=model_id
+        )
         emit_compaction_event(
             chat_id=cmd_ctx.chat_id,
             stage="start",
@@ -118,9 +119,7 @@ def handle_compact(
         if revision is None:
             db.update_chat(cmd_ctx.chat_id, agent_state=agent_state_bytes)
 
-        tokens_after = estimate_tokens(
-            compressed, CONFIG.max_context_tokens
-        ).estimated_tokens
+        tokens_after = estimate_tokens(compressed, context_limit).estimated_tokens
         emit_compaction_event(
             chat_id=cmd_ctx.chat_id,
             stage="complete",
@@ -130,6 +129,7 @@ def handle_compact(
             tokens_before=tokens_before,
             tokens_after=tokens_after,
             persist_result=True,
+            context_limit=context_limit,
         )
         before_k = round(tokens_before / 1000)
         after_k = round(tokens_after / 1000)

--- a/src/suzent/core/commands/system.py
+++ b/src/suzent/core/commands/system.py
@@ -30,8 +30,10 @@ def handle_status(ctx: typer.Context):
         if cmd_ctx and cmd_ctx.chat_id:
             from suzent.database import get_database
             from suzent.core.agent_serializer import deserialize_state
-            from suzent.core.context_compressor import estimate_tokens
-            from suzent.config import CONFIG
+            from suzent.core.context_compressor import (
+                estimate_tokens,
+                resolve_context_limit,
+            )
             from suzent.core.cost_tracker import get_cost_tracker
 
             db = get_database()
@@ -48,7 +50,9 @@ def handle_status(ctx: typer.Context):
                         msg_history = state.get("message_history") or []
                         status.append(f"  Model: {model_id}")
 
-                        budget = estimate_tokens(msg_history, CONFIG.max_context_tokens)
+                        budget = estimate_tokens(
+                            msg_history, resolve_context_limit(state.get("model_id"))
+                        )
                         pct = budget.estimated_tokens / budget.limit * 100
                         bar_filled = int(pct / 5)
                         bar = "█" * bar_filled + "░" * (20 - bar_filled)

--- a/src/suzent/core/context_compressor.py
+++ b/src/suzent/core/context_compressor.py
@@ -157,7 +157,46 @@ def extract_summary_body(raw: str) -> str:
     return re.sub(r"</?summary>", "", text).strip()
 
 
-def build_post_compaction_usage(context_tokens: int) -> dict[str, Any]:
+# Budget used when the active model is unknown or absent from the capability
+# registry. Deliberately conservative: overshooting a model's real window costs a
+# hard provider error mid-turn, while undershooting only compacts a little early.
+DEFAULT_CONTEXT_LIMIT_TOKENS = 200_000
+
+
+def resolve_context_limit(model_id: Optional[str] = None) -> int:
+    """Context budget for the model actually running this conversation.
+
+    The trigger used to be a single fixed number for every model, which is wrong
+    in both directions: a 1M-token model got compacted at a fraction of its
+    window, and a 128k model sailed past its real limit until the provider
+    rejected the request outright.
+
+    ``CONFIG.max_context_tokens`` keeps working as an explicit *ceiling* (a user
+    who wants to cap cost or latency below what the model allows), and 0 — the
+    default — means "whatever the model supports". Where the registry knows the
+    model, ``max_input_tokens`` is the number that matters: the output reservation
+    is not part of the prompt we are sizing.
+    """
+    ceiling = int(CONFIG.max_context_tokens or 0)
+    window = 0
+    if model_id:
+        try:
+            from suzent.core.model_registry import get_model_registry
+
+            caps = get_model_registry().get_capabilities(model_id)
+            if caps:
+                window = int(caps.max_input_tokens or caps.context_window or 0)
+        except Exception as e:
+            logger.debug(f"Context window lookup failed for {model_id}: {e}")
+
+    if window <= 0:
+        return ceiling or DEFAULT_CONTEXT_LIMIT_TOKENS
+    return min(window, ceiling) if ceiling > 0 else window
+
+
+def build_post_compaction_usage(
+    context_tokens: int, context_limit: Optional[int] = None
+) -> dict[str, Any]:
     """Build a context-window usage payload reflecting the post-compaction total.
 
     The frontend usage panel is normally fed by provider-reported usage from the
@@ -166,7 +205,7 @@ def build_post_compaction_usage(context_tokens: int) -> dict[str, Any]:
     (stage="complete") so all surfaces update the same way. Cumulative/cache fields
     are reset; the next real request repopulates them.
     """
-    return {
+    payload: dict[str, Any] = {
         "input_tokens": context_tokens,
         "output_tokens": 0,
         "total_tokens": context_tokens,
@@ -176,9 +215,14 @@ def build_post_compaction_usage(context_tokens: int) -> dict[str, Any]:
         "requests": 0,
         "details": {},
     }
+    if context_limit:
+        payload["context_limit"] = int(context_limit)
+    return payload
 
 
-def build_live_context_usage(context_tokens: int, usage: Any = None) -> dict[str, Any]:
+def build_live_context_usage(
+    context_tokens: int, usage: Any = None, context_limit: Optional[int] = None
+) -> dict[str, Any]:
     """Build a partial usage payload describing the context window right now.
 
     Only ``context_tokens`` is always known mid-run; the cumulative counters come
@@ -187,6 +231,11 @@ def build_live_context_usage(context_tokens: int, usage: Any = None) -> dict[str
     them at the start of a run.
     """
     payload: dict[str, Any] = {"context_tokens": context_tokens}
+    # The limit travels with the count: it depends on the model this turn is
+    # running on, so a panel that assumed one global number would draw the wrong
+    # percentage as soon as the chat switched models.
+    if context_limit:
+        payload["context_limit"] = int(context_limit)
     for field in (
         "input_tokens",
         "output_tokens",
@@ -208,7 +257,11 @@ def build_live_context_usage(context_tokens: int, usage: Any = None) -> dict[str
 
 
 def emit_context_usage_event(
-    *, chat_id: str, context_tokens: int, usage: Any = None
+    *,
+    chat_id: str,
+    context_tokens: int,
+    usage: Any = None,
+    context_limit: Optional[int] = None,
 ) -> None:
     """Broadcast the live context-window size to every connected client.
 
@@ -227,7 +280,9 @@ def emit_context_usage_event(
             {
                 "event": "context_usage",
                 "chat_id": chat_id,
-                "usage": build_live_context_usage(context_tokens, usage),
+                "usage": build_live_context_usage(
+                    context_tokens, usage, context_limit=context_limit
+                ),
             }
         )
     except Exception as e:
@@ -355,6 +410,7 @@ def emit_compaction_event(
     tokens_after: Optional[int] = None,
     message: Optional[str] = None,
     persist_result: bool = False,
+    context_limit: Optional[int] = None,
 ) -> dict[str, Any]:
     payload = build_compaction_event(
         chat_id=chat_id,
@@ -371,7 +427,7 @@ def emit_compaction_event(
     # (manual button, /compact slash, auto) refreshes the panel identically, and
     # persist it so a reload reflects the reduced context too.
     if stage == "complete" and tokens_after is not None:
-        usage_data = build_post_compaction_usage(tokens_after)
+        usage_data = build_post_compaction_usage(tokens_after, context_limit)
         payload["usage"] = usage_data
         if chat_id:
             try:
@@ -576,6 +632,7 @@ class ContextCompressor:
         llm_client: Optional[LLMClient] = None,
         chat_id: Optional[str] = None,
         user_id: Optional[str] = None,
+        model_id: Optional[str] = None,
     ):
         if llm_client:
             self.llm_client = llm_client
@@ -585,13 +642,25 @@ class ContextCompressor:
 
         self.chat_id = chat_id
         self.user_id = user_id
+        # Model the conversation runs on — decides how much context there is to
+        # spend before compaction has to step in.
+        self.model_id = model_id
+
+    @property
+    def context_limit(self) -> int:
+        """Token budget for this conversation's model, resolved per call.
+
+        Not cached: the registry can be reloaded (capability sync) and a chat can
+        be reopened on a different model within the process's lifetime.
+        """
+        return resolve_context_limit(self.model_id)
 
     async def compress_messages(self, messages: list) -> list:
         """Check if message history needs compression and perform it if necessary."""
         if not messages:
             return messages
 
-        budget = estimate_tokens(messages, CONFIG.max_context_tokens)
+        budget = estimate_tokens(messages, self.context_limit)
         if not budget.over_trigger:
             return messages
 
@@ -618,7 +687,7 @@ class ContextCompressor:
 
     def get_auto_compaction_plan(self, messages: list) -> dict[str, Any]:
         """Compute whether an automatic compaction attempt should be made."""
-        budget = estimate_tokens(messages, CONFIG.max_context_tokens)
+        budget = estimate_tokens(messages, self.context_limit)
         keep_recent = CONFIG.compaction_keep_recent_turns * 2
         can_attempt = budget.over_trigger and len(messages) > keep_recent + 1
         return {
@@ -690,7 +759,7 @@ class ContextCompressor:
             await self._pre_compaction_flush(messages_to_compress)
 
         # Adaptive chunk size
-        budget = estimate_tokens(messages, CONFIG.max_context_tokens)
+        budget = estimate_tokens(messages, self.context_limit)
         chunk_size = CONFIG.compaction_chunk_size
         if len(messages_to_compress) > 0:
             avg_tokens = budget.estimated_tokens / len(messages)
@@ -1000,7 +1069,9 @@ def _message_has_compaction_marker(msg: Any) -> bool:
     return False
 
 
-def context_input_tokens(ctx: Any, messages: list) -> int:
+def context_input_tokens(
+    ctx: Any, messages: list, model_id: Optional[str] = None
+) -> int:
     """Best-effort size of the history about to be sent to the model.
 
     This MUST reflect the current ``messages`` list, because it is the trigger
@@ -1015,10 +1086,12 @@ def context_input_tokens(ctx: Any, messages: list) -> int:
     char-based estimate over the incoming ``messages`` tracks the compacted list
     directly. ``ctx`` is retained for signature stability / future use.
     """
-    return estimate_tokens(messages, CONFIG.max_context_tokens).estimated_tokens
+    return estimate_tokens(messages, resolve_context_limit(model_id)).estimated_tokens
 
 
-def make_compaction_history_processor(source: str = "auto_midrun"):
+def make_compaction_history_processor(
+    source: str = "auto_midrun", model_id: Optional[str] = None
+):
     """Build a pydantic-ai history processor that compacts context mid-run.
 
     Registered via ``Agent(history_processors=[...])``, it runs before EVERY model
@@ -1042,9 +1115,9 @@ def make_compaction_history_processor(source: str = "auto_midrun"):
             return messages
 
         chat_id = getattr(deps, "chat_id", "") or ""
-        limit = CONFIG.max_context_tokens
+        limit = resolve_context_limit(model_id)
         trigger = limit * CONFIG.context_compaction_trigger
-        current_tokens = context_input_tokens(ctx, messages)
+        current_tokens = context_input_tokens(ctx, messages, model_id)
 
         # Report the context window on every model request, not just when we are
         # about to compact — this is what keeps the frontend panel live during a
@@ -1053,6 +1126,7 @@ def make_compaction_history_processor(source: str = "auto_midrun"):
             chat_id=chat_id,
             context_tokens=current_tokens,
             usage=getattr(ctx, "usage", None),
+            context_limit=limit,
         )
 
         if current_tokens < trigger:
@@ -1077,7 +1151,9 @@ def make_compaction_history_processor(source: str = "auto_midrun"):
             tokens_before=tokens_before,
         )
 
-        compressor = ContextCompressor(chat_id=chat_id, user_id=user_id)
+        compressor = ContextCompressor(
+            chat_id=chat_id, user_id=user_id, model_id=model_id
+        )
         try:
             compressed = await asyncio.wait_for(
                 compressor._perform_compression(messages, background_flush=True),
@@ -1145,6 +1221,7 @@ def make_compaction_history_processor(source: str = "auto_midrun"):
             messages_after=len(compressed),
             tokens_before=tokens_before,
             tokens_after=tokens_after,
+            context_limit=limit,
         )
         logger.info(
             f"Mid-run compaction: {messages_before} -> {len(compressed)} messages "

--- a/src/suzent/core/model_registry.py
+++ b/src/suzent/core/model_registry.py
@@ -86,6 +86,25 @@ class ModelCapabilities:
     def context_window(self) -> int:
         return self.max_input_tokens + self.max_output_tokens
 
+    @property
+    def is_stub(self) -> bool:
+        """Whether this entry is a name with no capabilities behind it.
+
+        Runtime discovery registers every model a provider lists, but a provider
+        listing carries slugs, not windows — so those entries answer "0 tokens,
+        supports nothing", which is absence of data, not a description.
+        """
+        return not (
+            self.max_input_tokens
+            or self.max_output_tokens
+            or self.output_vector_size
+            or self.supports_vision
+            or self.supports_function_calling
+            or self.supports_reasoning
+            or self.supports_prompt_caching
+            or self.supports_response_schema
+        )
+
     def estimate_cost(self, input_tokens: int, output_tokens: int) -> float:
         return (
             input_tokens * self.input_cost_per_token
@@ -417,6 +436,19 @@ def save_discovered_models(provider_id: str, model_ids: list[str]) -> None:
         logger.info("Added {} new model(s) to {}.json", added, provider_id)
 
 
+# The two ways to reach the same OpenAI models: an API key (`openai/`) or a
+# ChatGPT subscription (`chatgpt/`). Capability data gets curated under whichever
+# prefix someone happened to be using.
+_PROVIDER_TWINS = {"chatgpt": "openai", "openai": "chatgpt"}
+
+
+def _aliased_model_id(model_id: str) -> Optional[str]:
+    """The same model spelled with its twin provider prefix, if it has one."""
+    provider, sep, slug = model_id.partition("/")
+    twin = _PROVIDER_TWINS.get(provider) if sep else None
+    return f"{twin}/{slug}" if twin else None
+
+
 class ModelRegistry:
     """
     Singleton registry for model capabilities.
@@ -433,8 +465,25 @@ class ModelRegistry:
         self._capabilities = _load_capabilities()
 
     def get_capabilities(self, model_id: str) -> Optional[ModelCapabilities]:
-        """Look up capabilities for a model ID. Returns None if not registered."""
-        return self._capabilities.get(model_id)
+        """Look up capabilities for a model ID. Returns None if not registered.
+
+        A ChatGPT-subscription id and an OpenAI API id with the same slug name the
+        same model, and either side may be the curated one — `chatgpt/gpt-5.5`
+        carries real numbers while `openai/gpt-5.5` is a bare stub, and elsewhere
+        it is the other way round. So a stub defers to its twin, and only to a twin
+        that actually has data: borrowing one stub to explain another would just
+        move the blank around.
+        """
+        caps = self._capabilities.get(model_id)
+        if caps is not None and not caps.is_stub:
+            return caps
+
+        twin_id = _aliased_model_id(model_id)
+        if twin_id:
+            twin = self._capabilities.get(twin_id)
+            if twin is not None and not twin.is_stub:
+                return twin
+        return caps
 
     def get_context_window(self, model_id: str) -> int:
         """Return total context window size, or 0 if unknown."""

--- a/src/suzent/memory/indexer.py
+++ b/src/suzent/memory/indexer.py
@@ -31,6 +31,13 @@ logger = get_logger(__name__)
 VAULT_READ_TIMEOUT_SECONDS = 15
 
 
+# Paths whose read is still parked in the syscall. A timed-out read cannot be
+# cancelled, so its thread stays out of reach until the provider answers; the
+# watcher would otherwise abandon a fresh worker for the same file every pass
+# and eventually drain the shared executor, stalling unrelated threaded work.
+_reads_in_flight: set[str] = set()
+
+
 async def read_text_off_loop(path: Path) -> Optional[str]:
     """File contents, or ``None`` if the read failed or outlived its deadline.
 
@@ -38,12 +45,26 @@ async def read_text_off_loop(path: Path) -> Optional[str]:
     answers — an uninterruptible read cannot be cancelled — but the loop is free
     again, which is what decides whether the rest of the process still responds.
     Skipping the file also leaves its recorded mtime alone, so the next pass
-    retries it once the provider is healthy.
+    retries it once the provider is healthy, and one blocked file costs one
+    thread however many passes go by.
     """
+    key = str(path)
+    if key in _reads_in_flight:
+        logger.debug(f"Skipping {path}: an earlier read of it is still blocked")
+        return None
+
+    def _read() -> str:
+        try:
+            return path.read_text(encoding="utf-8", errors="replace")
+        finally:
+            # In the worker, so the path frees up when the read finally returns
+            # — whether or not anyone is still waiting for the result.
+            _reads_in_flight.discard(key)
+
+    _reads_in_flight.add(key)
     try:
         return await asyncio.wait_for(
-            asyncio.to_thread(path.read_text, encoding="utf-8", errors="replace"),
-            timeout=VAULT_READ_TIMEOUT_SECONDS,
+            asyncio.to_thread(_read), timeout=VAULT_READ_TIMEOUT_SECONDS
         )
     except asyncio.TimeoutError:
         logger.warning(

--- a/src/suzent/memory/indexer.py
+++ b/src/suzent/memory/indexer.py
@@ -24,6 +24,38 @@ from suzent.logger import get_logger
 logger = get_logger(__name__)
 
 
+# A vault backed by a cloud file provider (OneDrive, iCloud Drive) can accept the
+# open() and then block the first read() indefinitely while it hydrates the file.
+# Done on the event loop, that starves every request in the process — one
+# unavailable page froze the whole server, /health included, until it was killed.
+VAULT_READ_TIMEOUT_SECONDS = 15
+
+
+async def read_text_off_loop(path: Path) -> Optional[str]:
+    """File contents, or ``None`` if the read failed or outlived its deadline.
+
+    A timed-out read leaves its thread parked in the syscall until the provider
+    answers — an uninterruptible read cannot be cancelled — but the loop is free
+    again, which is what decides whether the rest of the process still responds.
+    Skipping the file also leaves its recorded mtime alone, so the next pass
+    retries it once the provider is healthy.
+    """
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(path.read_text, encoding="utf-8", errors="replace"),
+            timeout=VAULT_READ_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            f"Timed out after {VAULT_READ_TIMEOUT_SECONDS}s reading {path} — "
+            "skipping it this pass (cloud file provider may be unavailable)"
+        )
+        return None
+    except OSError as e:
+        logger.warning(f"Could not read {path}: {e}")
+        return None
+
+
 def _owned_by_file(row: dict) -> bool:
     """Whether a stored row is maintained by the markdown file it came from.
 
@@ -101,12 +133,15 @@ class TranscriptIndexer:
             logger.debug(f"Transcript not found: {transcript_path}")
             return stats
 
+        raw = await read_text_off_loop(transcript_path)
+        if raw is None:
+            stats["errors"] += 1
+            return stats
+
         try:
             # Read all turns
             turns = []
-            for line in transcript_path.read_text(
-                encoding="utf-8", errors="replace"
-            ).splitlines():
+            for line in raw.splitlines():
                 line = line.strip()
                 if not line:
                     continue
@@ -384,7 +419,8 @@ class CoreMemoryFileIndexer:
         """
         # Load persisted state on first call
         if self._state_path is None:
-            self._load_state(markdown_store)
+            # Same file provider, same hazard: the state file lives in the vault.
+            await asyncio.to_thread(self._load_state, markdown_store)
 
         stats = {
             "files_checked": 0,
@@ -447,7 +483,11 @@ class CoreMemoryFileIndexer:
                 continue  # File unchanged (or unreadable) — nothing to do
 
             try:
-                content = path.read_text(encoding="utf-8", errors="replace").strip()
+                raw = await read_text_off_loop(path)
+                if raw is None:
+                    stats["errors"] += 1
+                    continue
+                content = raw.strip()
                 if not content:
                     self._mtimes[path_key] = mtime
                     state_dirty = True
@@ -475,7 +515,7 @@ class CoreMemoryFileIndexer:
                 logger.error(f"Failed to re-index {filename}: {e}")
 
         if state_dirty:
-            self._save_state()
+            await asyncio.to_thread(self._save_state)
 
         return stats
 
@@ -495,7 +535,7 @@ class CoreMemoryFileIndexer:
         """
         async with self._lock:
             if self._state_path is None:
-                self._load_state(markdown_store)
+                await asyncio.to_thread(self._load_state, markdown_store)
 
             if label == "archive":
                 path = markdown_store.archive_dir / filename
@@ -508,10 +548,13 @@ class CoreMemoryFileIndexer:
                 return 0
 
             file_mtime, file_birthtime = self.file_times(path)
-            content = path.read_text(encoding="utf-8", errors="replace").strip()
+            raw = await read_text_off_loop(path)
+            if raw is None:
+                return 0
+            content = raw.strip()
             if not content:
                 self._mtimes[self._state_key(label, filename)] = path.stat().st_mtime
-                self._save_state()
+                await asyncio.to_thread(self._save_state)
                 return 0
 
             n = await self._reindex_file(
@@ -527,7 +570,7 @@ class CoreMemoryFileIndexer:
             )
             # Record post-write mtime so the watcher treats this file as handled.
             self._mtimes[self._state_key(label, filename)] = path.stat().st_mtime
-            self._save_state()
+            await asyncio.to_thread(self._save_state)
             return n
 
     async def clear_and_full_reindex(
@@ -546,7 +589,7 @@ class CoreMemoryFileIndexer:
             self._swept = set()
             if self._state_path is None:
                 self._state_path = markdown_store.base_dir / self.INDEX_STATE_FILENAME
-            self._save_state()
+            await asyncio.to_thread(self._save_state)
             return await self._check_and_update_impl(
                 markdown_store, lancedb_store, embedding_gen, user_id
             )

--- a/src/suzent/routes/chat_routes.py
+++ b/src/suzent/routes/chat_routes.py
@@ -895,18 +895,34 @@ async def get_chat(request: Request) -> JSONResponse:
         if chat.agent_state and context_usage.get("context_tokens") is None:
             try:
                 from suzent.core.agent_serializer import deserialize_state
-                from suzent.core.context_compressor import estimate_tokens
-                from suzent.config import CONFIG as _CFG
+                from suzent.core.context_compressor import (
+                    estimate_tokens,
+                    resolve_context_limit,
+                )
 
                 state = deserialize_state(chat.agent_state)
                 if state and state.get("message_history"):
                     budget = estimate_tokens(
-                        state["message_history"], _CFG.max_context_tokens
+                        state["message_history"],
+                        resolve_context_limit(state.get("model_id")),
                     )
                     response_chat["contextTokens"] = budget.estimated_tokens
                     context_usage["context_tokens"] = budget.estimated_tokens
             except Exception:
                 pass
+
+        # Every load reports the budget of the model this chat runs on, even when
+        # the usage counters are older than the model it now uses: a stored limit
+        # from a previous model (or none at all, on a chat that predates them)
+        # would otherwise be what the panel drew its percentage against.
+        try:
+            from suzent.core.context_compressor import resolve_context_limit
+            from suzent.core.providers import get_default_chat_model
+
+            chat_model = (chat.config or {}).get("model") or get_default_chat_model()
+            context_usage["context_limit"] = resolve_context_limit(chat_model)
+        except Exception:
+            pass
 
         response_chat.pop("context_usage", None)
         if context_usage:

--- a/src/suzent/routes/config_routes.py
+++ b/src/suzent/routes/config_routes.py
@@ -142,6 +142,8 @@ def _first_newly_enabled_provider_models(
 
 async def get_config(request: Request) -> JSONResponse:
     """Return frontend-consumable configuration merged with user preferences."""
+    from suzent.core.context_compressor import resolve_context_limit
+
     db = get_database()
     user_prefs = db.get_user_preferences()
 
@@ -149,7 +151,6 @@ async def get_config(request: Request) -> JSONResponse:
     sandbox_volumes = CONFIG.sandbox_volumes or []
     available_models = get_enabled_models_from_db()
     default_model = get_default_chat_model()
-
     mem_config = get_effective_memory_config()
     embedding_model = mem_config["embedding_model"]
     extraction_model = mem_config["extraction_model"]
@@ -167,7 +168,13 @@ async def get_config(request: Request) -> JSONResponse:
         "globalSandboxVolumes": sandbox_volumes,
         "sandboxEnabled": sandbox_enabled,
         "defaultPermissionMode": CONFIG.default_permission_mode,
-        "maxContextTokens": CONFIG.max_context_tokens,
+        # The context budget per model, so the panel can follow the model selector
+        # immediately instead of waiting for a turn to report one. `default_model`
+        # is only the last-resort fallback — it is not the chat's chosen model.
+        "contextWindows": {
+            model_id: resolve_context_limit(model_id) for model_id in available_models
+        },
+        "maxContextTokens": resolve_context_limit(default_model),
         "embeddingModel": CONFIG.embedding_model,
         "extractionModel": CONFIG.extraction_model,
         "volumeMetadata": db.get_volume_metadata(sandbox_volumes),

--- a/src/suzent/streaming.py
+++ b/src/suzent/streaming.py
@@ -1823,16 +1823,20 @@ async def stream_agent_responses(
                         try:
                             usage = _run_result_usage(payload.result)
                             context_tokens = None
+                            context_limit = None
                             if result_messages is not None:
                                 try:
-                                    from suzent.config import CONFIG
                                     from suzent.core.context_compressor import (
                                         estimate_tokens,
+                                        resolve_context_limit,
                                     )
 
+                                    context_limit = resolve_context_limit(
+                                        getattr(agent, "_model_id", None)
+                                    )
                                     context_tokens = estimate_tokens(
                                         result_messages,
-                                        CONFIG.max_context_tokens,
+                                        context_limit,
                                     ).estimated_tokens
                                 except Exception as e:
                                     logger.debug(
@@ -1844,6 +1848,9 @@ async def stream_agent_responses(
                                 "output_tokens": usage.output_tokens,
                                 "total_tokens": usage.total_tokens,
                                 "context_tokens": context_tokens,
+                                # Model-resolved, so the panel keeps drawing the
+                                # right percentage when a chat changes model.
+                                "context_limit": context_limit,
                                 "cache_write_tokens": usage.cache_write_tokens,
                                 "cache_read_tokens": usage.cache_read_tokens,
                                 "requests": usage.requests,

--- a/tests/core/test_context_limit_resolution.py
+++ b/tests/core/test_context_limit_resolution.py
@@ -1,0 +1,133 @@
+"""Tests for the model-derived context budget.
+
+The compaction trigger used to be one fixed token count for every model. It is
+now the active model's own input window, with ``max_context_tokens`` acting only
+as an optional ceiling.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
+
+import suzent.core.context_compressor as cc
+from suzent.config import CONFIG
+from suzent.core.context_compressor import (
+    DEFAULT_CONTEXT_LIMIT_TOKENS,
+    make_compaction_history_processor,
+    resolve_context_limit,
+)
+from suzent.core.model_registry import ModelCapabilities
+
+
+def _fake_registry(monkeypatch, windows: dict[str, ModelCapabilities]):
+    monkeypatch.setattr(
+        "suzent.core.model_registry.get_model_registry",
+        lambda: SimpleNamespace(get_capabilities=lambda mid: windows.get(mid)),
+    )
+
+
+def _caps(max_input=0, max_output=0):
+    return ModelCapabilities(max_input_tokens=max_input, max_output_tokens=max_output)
+
+
+@pytest.fixture(autouse=True)
+def _auto_budget(monkeypatch):
+    # 0 == adaptive, the shipped default.
+    monkeypatch.setattr(CONFIG, "max_context_tokens", 0, raising=False)
+    yield
+
+
+def test_uses_the_models_input_window(monkeypatch):
+    _fake_registry(
+        monkeypatch, {"g/big": _caps(max_input=1_000_000, max_output=65_536)}
+    )
+
+    # The output reservation is not part of the prompt being sized.
+    assert resolve_context_limit("g/big") == 1_000_000
+
+
+def test_small_model_gets_a_small_budget(monkeypatch):
+    _fake_registry(monkeypatch, {"o/small": _caps(max_input=128_000)})
+
+    assert resolve_context_limit("o/small") == 128_000
+
+
+def test_unknown_model_falls_back_to_the_default(monkeypatch):
+    _fake_registry(monkeypatch, {})
+
+    assert resolve_context_limit("who/knows") == DEFAULT_CONTEXT_LIMIT_TOKENS
+    assert resolve_context_limit(None) == DEFAULT_CONTEXT_LIMIT_TOKENS
+
+
+def test_configured_value_caps_a_larger_window(monkeypatch):
+    monkeypatch.setattr(CONFIG, "max_context_tokens", 200_000, raising=False)
+    _fake_registry(monkeypatch, {"g/big": _caps(max_input=1_000_000)})
+
+    assert resolve_context_limit("g/big") == 200_000
+
+
+def test_configured_value_never_raises_a_smaller_window(monkeypatch):
+    monkeypatch.setattr(CONFIG, "max_context_tokens", 800_000, raising=False)
+    _fake_registry(monkeypatch, {"o/small": _caps(max_input=128_000)})
+
+    # A ceiling above what the model accepts must not be mistaken for a budget.
+    assert resolve_context_limit("o/small") == 128_000
+
+
+def test_registry_failure_does_not_break_the_budget(monkeypatch):
+    def _boom():
+        raise RuntimeError("registry unavailable")
+
+    monkeypatch.setattr("suzent.core.model_registry.get_model_registry", _boom)
+
+    assert resolve_context_limit("g/big") == DEFAULT_CONTEXT_LIMIT_TOKENS
+
+
+def test_capabilities_without_input_split_use_the_whole_window(monkeypatch):
+    # Some registry entries only carry a total; the sum is then the best estimate.
+    _fake_registry(monkeypatch, {"x/total-only": _caps(max_output=32_000)})
+
+    assert resolve_context_limit("x/total-only") == 32_000
+
+
+@pytest.mark.asyncio
+async def test_processor_trigger_follows_the_models_window(monkeypatch):
+    """Same history, two models: only the one that is actually short compacts."""
+    monkeypatch.setattr("suzent.core.stream_registry.emit_bus_event", lambda p: None)
+    monkeypatch.setattr(CONFIG, "compaction_keep_recent_turns", 3, raising=False)
+    monkeypatch.setattr(CONFIG, "context_compaction_trigger", 0.80, raising=False)
+    _fake_registry(
+        monkeypatch,
+        {
+            "o/small": _caps(max_input=1_000),
+            "g/big": _caps(max_input=10_000_000),
+        },
+    )
+
+    # A history far too big for a 1k window and trivial for a 10M one.
+    hist: list = []
+    for i in range(6):
+        hist.append(ModelRequest(parts=[UserPromptPart(content=f"ask {i} " * 200)]))
+        hist.append(ModelResponse(parts=[TextPart(content=f"answer {i} " * 200)]))
+    hist.append(ModelRequest(parts=[UserPromptPart(content="pending")]))
+
+    async def _shrink(self, messages, **kwargs):
+        return messages[:1] + messages[-2:]
+
+    monkeypatch.setattr(
+        cc.ContextCompressor, "_perform_compression", _shrink, raising=True
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(stateless=False, chat_id="c1", user_id="u1"),
+        usage=SimpleNamespace(input_tokens=0),
+    )
+
+    big = make_compaction_history_processor(model_id="g/big")
+    assert await big(ctx, hist) is hist
+
+    small = make_compaction_history_processor(model_id="o/small")
+    compacted = await small(ctx, hist)
+    assert len(compacted) < len(hist)
+    # pydantic-ai invariant: the processed history still ends with a ModelRequest.
+    assert isinstance(compacted[-1], ModelRequest)

--- a/tests/core/test_model_registry.py
+++ b/tests/core/test_model_registry.py
@@ -359,3 +359,81 @@ class TestPruneStaleModels:
             "suzent.core.model_registry._local_capabilities_dir", return_value=cap_dir
         ):
             assert prune_stale_models("nope", ["nope/x"]) == []
+
+
+class TestProviderTwinFallback:
+    """`chatgpt/x` and `openai/x` are the same model reached two ways.
+
+    Runtime discovery registers every slug a provider lists, so a model can be
+    present as a name with nothing behind it while its twin carries the curated
+    numbers — in both directions: `chatgpt/gpt-5.5` ships real values where
+    `openai/gpt-5.5` is a bare stub.
+    """
+
+    def _registry(self, models):
+        registry = ModelRegistry.__new__(ModelRegistry)
+        registry._capabilities = models
+        return registry
+
+    def test_stub_borrows_its_twin_s_data(self):
+        registry = self._registry(
+            {
+                "openai/gpt-5.5": ModelCapabilities(mode="chat"),
+                "chatgpt/gpt-5.5": ModelCapabilities(
+                    max_input_tokens=1_050_000, max_output_tokens=128_000
+                ),
+            }
+        )
+
+        assert registry.get_context_window("openai/gpt-5.5") == 1_178_000
+
+    def test_fallback_runs_the_other_way_too(self):
+        registry = self._registry(
+            {
+                "chatgpt/gpt-4.1": ModelCapabilities(mode="chat"),
+                "openai/gpt-4.1": ModelCapabilities(
+                    max_input_tokens=1_047_576, supports_vision=True
+                ),
+            }
+        )
+
+        assert registry.get_context_window("chatgpt/gpt-4.1") == 1_047_576
+        assert registry.supports_vision("chatgpt/gpt-4.1") is True
+
+    def test_real_data_is_never_replaced_by_a_twin(self):
+        registry = self._registry(
+            {
+                "openai/gpt-4.1": ModelCapabilities(max_input_tokens=1_047_576),
+                "chatgpt/gpt-4.1": ModelCapabilities(max_input_tokens=128_000),
+            }
+        )
+
+        assert registry.get_context_window("openai/gpt-4.1") == 1_047_576
+
+    def test_two_stubs_stay_a_stub(self):
+        # Borrowing one blank to explain another would only move the blank.
+        registry = self._registry(
+            {
+                "chatgpt/gpt-5.6-sol": ModelCapabilities(mode="chat"),
+                "openai/gpt-5.6-sol": ModelCapabilities(mode="chat"),
+            }
+        )
+
+        assert registry.get_context_window("chatgpt/gpt-5.6-sol") == 0
+
+    def test_other_providers_are_not_twinned(self):
+        registry = self._registry(
+            {
+                "gemini/gemini-3.1-pro-preview": ModelCapabilities(mode="chat"),
+                "openai/gemini-3.1-pro-preview": ModelCapabilities(
+                    max_input_tokens=999
+                ),
+            }
+        )
+
+        assert registry.get_context_window("gemini/gemini-3.1-pro-preview") == 0
+
+    def test_unprefixed_id_has_no_twin(self):
+        registry = self._registry({"gpt-4.1": ModelCapabilities(mode="chat")})
+
+        assert registry.get_capabilities("gpt-4.1").is_stub is True

--- a/tests/memory/test_indexer_unresponsive_file.py
+++ b/tests/memory/test_indexer_unresponsive_file.py
@@ -83,3 +83,51 @@ async def test_readable_file_is_returned_verbatim(tmp_path):
 @pytest.mark.asyncio
 async def test_missing_file_is_reported_as_unreadable(tmp_path):
     assert await read_text_off_loop(tmp_path / "gone.md") is None
+
+
+@pytest.mark.asyncio
+async def test_a_still_blocked_path_does_not_take_a_second_thread(
+    monkeypatch, wedged_path
+):
+    """One wedged file costs one worker, however many passes retry it.
+
+    The watcher re-checks unchanged files every few minutes. Starting a fresh
+    read each time would abandon another thread for the same path until the
+    shared executor is drained and unrelated threaded work stalls too.
+    """
+    monkeypatch.setattr(indexer_module, "VAULT_READ_TIMEOUT_SECONDS", 0.05)
+    starts = 0
+    original = type(wedged_path).read_text
+
+    def _counted(self, *args, **kwargs):
+        nonlocal starts
+        starts += 1
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(type(wedged_path), "read_text", _counted)
+
+    for _ in range(4):
+        assert await read_text_off_loop(wedged_path) is None
+
+    assert starts == 1
+
+
+@pytest.mark.asyncio
+async def test_the_path_is_retried_once_the_read_completes(monkeypatch, tmp_path):
+    """A finished read must free its path, or one slow file is skipped forever."""
+    monkeypatch.setattr(indexer_module, "VAULT_READ_TIMEOUT_SECONDS", 5)
+    page = tmp_path / "page.md"
+    page.write_text("first\n", encoding="utf-8")
+
+    assert await read_text_off_loop(page) == "first\n"
+    assert await read_text_off_loop(page) == "first\n"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_read_frees_its_path_too(monkeypatch, tmp_path):
+    monkeypatch.setattr(indexer_module, "VAULT_READ_TIMEOUT_SECONDS", 5)
+    missing = tmp_path / "gone.md"
+
+    assert await read_text_off_loop(missing) is None
+    missing.write_text("here now\n", encoding="utf-8")
+    assert await read_text_off_loop(missing) == "here now\n"

--- a/tests/memory/test_indexer_unresponsive_file.py
+++ b/tests/memory/test_indexer_unresponsive_file.py
@@ -1,0 +1,85 @@
+"""A vault file that never finishes reading must not freeze the process.
+
+Cloud file providers (OneDrive, iCloud Drive) accept the ``open()`` and then block
+the first ``read()`` while they hydrate the file. Read on the event loop, one such
+file starved every HTTP request in the backend — /health included — until the
+process was killed. Reads now get their own thread and a deadline.
+"""
+
+import asyncio
+import threading
+from pathlib import Path
+
+import pytest
+
+import suzent.memory.indexer as indexer_module
+from suzent.memory.indexer import read_text_off_loop
+
+
+@pytest.fixture
+def wedged_path():
+    """A path whose read blocks the way an unhydrated cloud file does.
+
+    The real syscall is uninterruptible and its thread stays parked until the
+    provider answers; this one gives up after a second so the suite does not pay
+    for the thread the event loop waits on at shutdown. All that matters is that
+    the read outlives the (much shorter) deadline under test.
+    """
+    released = threading.Event()
+
+    class _WedgedPath(Path):
+        _flavour = type(Path())._flavour  # type: ignore[attr-defined]
+
+        def read_text(self, *args, **kwargs):
+            released.wait(1)
+            return "released after the deadline"
+
+    try:
+        yield _WedgedPath("/vault/wedged.md")
+    finally:
+        released.set()
+
+
+@pytest.mark.asyncio
+async def test_unresponsive_read_gives_up_and_returns_none(monkeypatch, wedged_path):
+    monkeypatch.setattr(indexer_module, "VAULT_READ_TIMEOUT_SECONDS", 0.05)
+
+    assert await read_text_off_loop(wedged_path) is None
+
+
+@pytest.mark.asyncio
+async def test_the_event_loop_keeps_serving_during_a_wedged_read(
+    monkeypatch, wedged_path
+):
+    """The real regression: other coroutines must keep running meanwhile."""
+    monkeypatch.setattr(indexer_module, "VAULT_READ_TIMEOUT_SECONDS", 0.2)
+
+    ticks = 0
+
+    async def _heartbeat():
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    beat = asyncio.create_task(_heartbeat())
+    try:
+        assert await read_text_off_loop(wedged_path) is None
+    finally:
+        beat.cancel()
+
+    # A read done on the loop would have blocked this to a single tick.
+    assert ticks > 5
+
+
+@pytest.mark.asyncio
+async def test_readable_file_is_returned_verbatim(tmp_path):
+    page = tmp_path / "page.md"
+    page.write_text("- [goal] ship it\n", encoding="utf-8")
+
+    assert await read_text_off_loop(page) == "- [goal] ship it\n"
+
+
+@pytest.mark.asyncio
+async def test_missing_file_is_reported_as_unreadable(tmp_path):
+    assert await read_text_off_loop(tmp_path / "gone.md") is None

--- a/tests/routes/test_config_context_windows.py
+++ b/tests/routes/test_config_context_windows.py
@@ -1,0 +1,105 @@
+"""The config listing carries a context budget per model.
+
+The panel has to show the maximum for the model in the selector the moment it
+changes. One global number could not do that: it described whichever model
+happened to be the default, so a chat on a 1M-token model was drawn against the
+128k default's budget — or against the unknown-model fallback.
+"""
+
+from starlette.testclient import TestClient
+
+from suzent.core.model_registry import ModelCapabilities
+from suzent.routes import config_routes
+from suzent.server import app
+
+client = TestClient(app)
+
+CAPS = {
+    "gemini/big": ModelCapabilities(
+        max_input_tokens=1_048_576, max_output_tokens=65_536
+    ),
+    "openai/small": ModelCapabilities(max_input_tokens=128_000),
+}
+
+
+def _fake_registry(monkeypatch, default_model="gemini/big"):
+    monkeypatch.setattr(
+        config_routes, "get_enabled_models_from_db", lambda: list(CAPS) + ["who/knows"]
+    )
+    monkeypatch.setattr(config_routes, "get_default_chat_model", lambda: default_model)
+    monkeypatch.setattr(
+        "suzent.core.model_registry.get_model_registry",
+        lambda: type("R", (), {"get_capabilities": staticmethod(CAPS.get)})(),
+    )
+
+
+def test_every_enabled_model_reports_its_own_window(monkeypatch):
+    _fake_registry(monkeypatch)
+
+    windows = client.get("/config").json()["contextWindows"]
+
+    assert windows["gemini/big"] == 1_048_576
+    assert windows["openai/small"] == 128_000
+
+
+def test_unknown_model_gets_the_conservative_fallback(monkeypatch):
+    _fake_registry(monkeypatch)
+
+    windows = client.get("/config").json()["contextWindows"]
+
+    # Overshooting a real window is a hard provider error; undershooting only
+    # compacts early, so an unregistered model is budgeted low.
+    assert windows["who/knows"] == 200_000
+
+
+def test_global_default_is_not_the_selected_model(monkeypatch):
+    # The bug this replaced: an unregistered default model dragged every chat's
+    # displayed maximum down to the fallback, whatever model the chat was on.
+    _fake_registry(monkeypatch, default_model="who/knows")
+
+    payload = client.get("/config").json()
+
+    assert payload["maxContextTokens"] == 200_000
+    assert payload["contextWindows"]["gemini/big"] == 1_048_576
+
+
+def test_chat_load_reports_the_budget_of_that_chat_s_model(monkeypatch, tmp_path):
+    """Opening a chat carries a limit for the model that chat runs on.
+
+    The panel has to be right the moment a chat opens, without waiting for a turn,
+    and a limit stored while another model was selected must not outlive the
+    switch — that stale value is what kept the old maximum on screen.
+    """
+    from starlette.applications import Starlette
+    from starlette.routing import Route
+
+    from suzent.database.models import ChatModel
+    from suzent.routes.chat_routes import get_chat
+
+    _fake_registry(monkeypatch)
+    tmp_project = tmp_path
+
+    chat = ChatModel(
+        id="c1",
+        title="a chat",
+        config={"model": "openai/small"},
+        messages=[],
+        context_usage={"context_tokens": 50_000, "context_limit": 1_048_576},
+    )
+
+    class _Db:
+        @staticmethod
+        def get_chat(_id):
+            return chat
+
+        @staticmethod
+        def get_project_dir(_id):
+            return tmp_project
+
+    monkeypatch.setattr("suzent.routes.chat_routes.get_database", lambda: _Db())
+
+    app = Starlette(routes=[Route("/chats/{chat_id}", get_chat)])
+    usage = TestClient(app).get("/chats/c1").json()["contextUsage"]
+
+    assert usage["context_limit"] == 128_000
+    assert usage["context_tokens"] == 50_000


### PR DESCRIPTION
Auto-compaction triggered at a fixed 800k tokens regardless of model, and the context panel drew its percentage against a single app-wide number. Both now follow the model actually running the conversation.

## Adaptive compaction budget

`resolve_context_limit` reads the running model's input window from the capability registry. `max_context_tokens` becomes a **ceiling** rather than the budget — `0`, the new default, means "whatever the model supports" — and an unregistered model falls back to a conservative 200k, since overshooting a real window is a hard provider error mid-turn while undershooting only compacts early.

The model id is threaded to every caller that used to read the config value: the mid-run history processor closes over the id resolved at agent build time, `ContextCompressor` takes one, and the turn-end, `/compact`, `/status` and chat-load paths read it from the persisted agent state. The trigger fraction (`context_compaction_trigger`, 80%) is unchanged — it now applies to each model's own window.

```
gemini/gemini-3.1-pro-preview   800,000 -> 1,048,576   (compaction at ~839k, not 640k)
```

## Panel follows the selector

`/config` reports a budget per enabled model, and the panel picks by the model in the selector, falling back to the limit the last turn reported and then to the global default. Chat loads always carry a limit for that chat's own model, so opening a chat is correct before any turn runs and a limit stored under a previously selected model cannot outlive the switch. The config listing is fetched once on mount, so a backend that restarted since then left the window unable to size anything — a model it cannot resolve now triggers one refetch.

Capability lookup gained a twin-provider fallback: `chatgpt/x` and `openai/x` name the same model reached two ways, and either side may be the curated one. A stub entry defers to its twin, but only to a twin that carries data. This lifts `openai/gpt-5`, `gpt-5.1`, `gpt-5.5` and friends — shipped as bare `{"mode": "chat"}` stubs — from the 200k fallback to their real windows, and applies to vision and function-calling checks too, not just the context budget.

## Unrelated crash found while diagnosing this

A vault on a cloud file provider accepts the `open()` and then blocks the first `read()` while it hydrates the file. The memory indexer read those files directly inside its async pass, so one unresponsive page parked the event loop in an uninterruptible syscall — `/health`, `/config` and every other request stopped answering, the process sat at 0% CPU, and it had to be killed. Confirmed with a stack sample of a wedged backend and reproduced independently.

Reads now run in a thread under a deadline; a file that outlives it is skipped with a warning and its recorded mtime left alone, so the next pass retries it once the provider is healthy. The timed-out thread stays parked — nothing can cancel that read — but the loop is free. The index state file lives in the same vault and moved off the loop too.

## Testing

- `test_context_limit_resolution.py` — window lookup, the ceiling in both directions, unknown models, registry failure, and a same-history/two-models check proving only the genuinely short window compacts
- `test_config_context_windows.py` — per-model windows, the unknown-model fallback, "the default model isn't the chat's model", and a real `/chats/{id}` request asserting a stale 1M limit is replaced by the chat model's 128k
- `test_model_registry.py` — twin fallback in both directions, the stub guard, two-stubs-stay-a-stub, non-twinned providers, unprefixed ids
- `test_indexer_unresponsive_file.py` — a heartbeat coroutine must keep ticking through a wedged read
- `contextLimit.test.ts` — limit precedence, including the model-switch regression

Backend 2124 passed, frontend 320 passed, ruff and `tsc --noEmit` clean.

## Known gap

`chatgpt/gpt-5.6-sol` (and `-terra`, `-luna`) exist only as runtime-discovery stubs with no capability data, and have no OpenAI twin, so they budget at the 200k fallback. They need curated entries in `config/capabilities/chatgpt.json` once their real windows are known.