### PR TITLE
fix(chat): measure the worked timer over the whole turn

### DIFF
--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -14,7 +14,7 @@ import { hideStreamingDrafts } from '../lib/streamingDrafts';
 import { reconcileToolCallMessages } from '../lib/toolCallReconciliation';
 import type { Message, FileAttachment } from '../types/api';
 import type { ContentBlock } from '../lib/chatUtils';
-import { buildMessageRenderPlan } from '../lib/messageRenderPlan';
+import { buildMessageRenderPlan, buildTurnWorkedSeconds } from '../lib/messageRenderPlan';
 import {
   capturePrependScrollSnapshot,
   restorePrependScrollSnapshot,
@@ -427,6 +427,8 @@ const MessageList: React.FC<{
   onEditUserMessage?: (newContent: string) => void;
   chatCitationSources?: CitationSourcesMap;
   fallbackModel?: string;
+  /** Turn durations keyed by *absolute* message index; built from the full history. */
+  turnWorkedSeconds?: Map<number, number>;
 }> = ({
   messages,
   streamingForCurrentChat,
@@ -449,9 +451,12 @@ const MessageList: React.FC<{
   onEditUserMessage,
   chatCitationSources,
   fallbackModel,
+  turnWorkedSeconds,
 }) => {
-  const { skipIndices, groupRenders, stepSummaryByMessageIndex, turnWorkedSecondsByMessageIndex } =
-    useMemo(() => buildMessageRenderPlan(messages), [messages]);
+  const { skipIndices, groupRenders, stepSummaryByMessageIndex } = useMemo(
+    () => buildMessageRenderPlan(messages),
+    [messages]
+  );
 
   // A fresh `() => onFork(index)` per row would hand every AssistantMessage a
   // new prop identity on each render and defeat its memo -- which is the whole
@@ -524,7 +529,7 @@ const MessageList: React.FC<{
               <div className="flex justify-start w-full">
                 <AssistantMessage
                   message={groupedMessage}
-                  workedDurationSeconds={turnWorkedSecondsByMessageIndex.get(idx)}
+                  workedDurationSeconds={turnWorkedSeconds?.get(globalIdx)}
                   messageIndex={globalIdx}
                   isStreaming={false}
                   isLastMessage={false}
@@ -619,7 +624,7 @@ const MessageList: React.FC<{
                 ) : (
                   <AssistantMessage
                     message={m}
-                    workedDurationSeconds={turnWorkedSecondsByMessageIndex.get(idx)}
+                    workedDurationSeconds={turnWorkedSeconds?.get(globalIdx)}
                     messageIndex={globalIdx}
                     isStreaming={streamingForCurrentChat}
                     isLastMessage={isLastMessage}
@@ -1434,6 +1439,12 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   const visibleMessages = useMemo(
     () => safeMessages.slice(visibleMessageStartIndex),
     [safeMessages, visibleMessageStartIndex]
+  );
+  // Built from the whole history rather than the rendered window: a turn's
+  // duration must not change as older messages load in.
+  const turnWorkedSecondsByMessageIndex = useMemo(
+    () => buildTurnWorkedSeconds(safeMessages),
+    [safeMessages]
   );
 
   // Chat-wide citation sources: aggregate every message's citation-sources parts
@@ -2658,6 +2669,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
                 {safeMessages.length > 0 && (
                   <MessageListMemo
                     messages={visibleMessages}
+                    turnWorkedSeconds={turnWorkedSecondsByMessageIndex}
                     streamingForCurrentChat={false}
                     chatCitationSources={chatCitationSources}
                     messageIndexOffset={visibleMessageStartIndex}

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -122,13 +122,6 @@ const ForkOriginMarker: React.FC<{
   );
 };
 
-function getLastMessageTimestamp(messages: Message[]): string | undefined {
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    if (messages[i].timestamp) return messages[i].timestamp;
-  }
-  return undefined;
-}
-
 function formatCompactLifecycleNotice(payload: any): string | null {
   if (!payload || payload.event !== 'auto_compaction') return null;
   const source = String(payload.source || 'auto');
@@ -457,10 +450,8 @@ const MessageList: React.FC<{
   chatCitationSources,
   fallbackModel,
 }) => {
-  const { skipIndices, groupRenders, stepSummaryByMessageIndex } = useMemo(
-    () => buildMessageRenderPlan(messages),
-    [messages]
-  );
+  const { skipIndices, groupRenders, stepSummaryByMessageIndex, turnWorkedSecondsByMessageIndex } =
+    useMemo(() => buildMessageRenderPlan(messages), [messages]);
 
   // A fresh `() => onFork(index)` per row would hand every AssistantMessage a
   // new prop identity on each render and defeat its memo -- which is the whole
@@ -502,13 +493,6 @@ const MessageList: React.FC<{
     return -1;
   }, [messages, skipIndices]);
 
-  const getPreviousMessageTimestamp = (index: number): string | undefined => {
-    for (let i = index - 1; i >= 0; i -= 1) {
-      if (messages[i].timestamp) return messages[i].timestamp;
-    }
-    return undefined;
-  };
-
   return (
     <div className="space-y-6">
       {messages.map((m, idx) => {
@@ -540,7 +524,7 @@ const MessageList: React.FC<{
               <div className="flex justify-start w-full">
                 <AssistantMessage
                   message={groupedMessage}
-                  previousMessageTimestamp={getPreviousMessageTimestamp(idx)}
+                  workedDurationSeconds={turnWorkedSecondsByMessageIndex.get(idx)}
                   messageIndex={globalIdx}
                   isStreaming={false}
                   isLastMessage={false}
@@ -635,7 +619,7 @@ const MessageList: React.FC<{
                 ) : (
                   <AssistantMessage
                     message={m}
-                    previousMessageTimestamp={getPreviousMessageTimestamp(idx)}
+                    workedDurationSeconds={turnWorkedSecondsByMessageIndex.get(idx)}
                     messageIndex={globalIdx}
                     isStreaming={streamingForCurrentChat}
                     isLastMessage={isLastMessage}
@@ -2712,7 +2696,6 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
                         ) : (
                           <AssistantMessage
                             message={{ role: 'assistant', content: '' }}
-                            previousMessageTimestamp={getLastMessageTimestamp(safeMessages)}
                             messageIndex={safeMessages.length}
                             isStreaming={streamingForCurrentChat}
                             isLastMessage={true}

--- a/frontend/src/components/chat/ActivityRail.tsx
+++ b/frontend/src/components/chat/ActivityRail.tsx
@@ -239,18 +239,6 @@ export function isActionableAguiApproval(part: AGUIPart): boolean {
   return part.state === 'approval-requested' && !part.output && Boolean(part.approvalId);
 }
 
-export function getTimestampDeltaSeconds(
-  previousTimestamp?: string,
-  currentTimestamp?: string
-): number | undefined {
-  if (!previousTimestamp || !currentTimestamp) return undefined;
-  const previousTime = new Date(previousTimestamp).getTime();
-  const currentTime = new Date(currentTimestamp).getTime();
-  if (!Number.isFinite(previousTime) || !Number.isFinite(currentTime)) return undefined;
-  const deltaSeconds = Math.floor((currentTime - previousTime) / 1000);
-  return deltaSeconds >= 0 ? deltaSeconds : undefined;
-}
-
 export function getAguiActivityLabel(
   chunks: Array<{ chunk: { type: string; items?: AGUIPart[] } }>,
   isStreaming: boolean
@@ -407,6 +395,9 @@ export const ActivityRail: React.FC<{
   useEffect(() => {
     if (startedAtMs && startedAtMs !== startedAtRef.current) {
       startedAtRef.current = startedAtMs;
+      // Re-read now rather than waiting up to a second for the next tick, or
+      // the rail shows a count measured from the wrong origin in between.
+      setElapsedSeconds(Math.max(0, Math.floor((Date.now() - startedAtMs) / 1000)));
     }
   }, [startedAtMs]);
 

--- a/frontend/src/components/chat/AssistantMessage.tsx
+++ b/frontend/src/components/chat/AssistantMessage.tsx
@@ -39,7 +39,6 @@ import {
   getAguiActivityLabel,
   getLegacyActivityLabel,
   getReasoningHeader,
-  getTimestampDeltaSeconds,
   groupActivityChunks,
   hasAguiPendingApproval,
   hasLegacyPendingApproval,
@@ -92,7 +91,8 @@ function findLastActivityGroupIndex(groups: Array<{ type: string }>): number {
 
 interface AssistantMessageProps {
   message: Message;
-  previousMessageTimestamp?: string;
+  /** Wall-clock seconds the agent worked on this message's whole turn. */
+  workedDurationSeconds?: number;
   messageIndex: number;
   isStreaming: boolean;
   isLastMessage: boolean;
@@ -707,7 +707,7 @@ const ModelSignature: React.FC<{ model?: string }> = ({ model }) => {
 
 const AssistantMessageComponent: React.FC<AssistantMessageProps> = ({
   message,
-  previousMessageTimestamp,
+  workedDurationSeconds,
   messageIndex,
   isStreaming,
   isLastMessage,
@@ -740,10 +740,6 @@ const AssistantMessageComponent: React.FC<AssistantMessageProps> = ({
   const isAcp = !!acpAgent;
 
   const isThinking = isStreamingThis && !message.content && !hasStreamedOutput(effectiveParts);
-  const workedDurationSeconds = useMemo(
-    () => getTimestampDeltaSeconds(previousMessageTimestamp, message.timestamp),
-    [previousMessageTimestamp, message.timestamp]
-  );
   const legacyBlocks = useMemo(
     () =>
       effectiveParts === undefined

--- a/frontend/src/hooks/useChatStore.tsx
+++ b/frontend/src/hooks/useChatStore.tsx
@@ -32,6 +32,22 @@ function escapeHtml(s: string): string {
     .replace(/"/g, '&quot;');
 }
 
+/**
+ * Track the newest server row folded into a coalesced assistant bubble.
+ *
+ * A turn's rows collapse into one bubble that keeps the *first* model
+ * response's timestamp, and that timestamp marks when the response began --
+ * every tool result and follow-up response it led to is later. Without this,
+ * nothing downstream can tell how long the turn actually worked.
+ */
+function noteTurnActivity(bubble: Partial<Message>, timestamp?: string): void {
+  if (!timestamp) return;
+  const current = bubble.turn_last_activity_at;
+  if (!current || new Date(timestamp).getTime() > new Date(current).getTime()) {
+    bubble.turn_last_activity_at = timestamp;
+  }
+}
+
 function userMessageFingerprint(message: Message): string {
   const files = (message.files ?? [])
     .map((file) => `${file.filename}:${file.path}:${file.mime_type}:${file.size}`)
@@ -1540,6 +1556,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode; enabled?: boole
                   };
                   awaitingToolContinuation = false;
                 }
+                noteTurnActivity(currentAssistant!, msg.timestamp);
                 if (msg.tool_calls && Array.isArray(msg.tool_calls)) {
                   msg.tool_calls.forEach((tc: any) => {
                     const args = escapeHtml(
@@ -1564,6 +1581,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode; enabled?: boole
                 }
                 currentAssistant.content += `\n<details data-tool-call-id="${escapeHtml(msg.tool_call_id ?? '')}"><summary>📦 ${escapeHtml(msg.name ?? '')}</summary>\n<pre><code class="language-text">${escapeHtml(msg.content ?? '')}</code></pre>\n</details>\n`;
                 currentAssistant.raw_message_end_index = serverMessageIndex + 1;
+                noteTurnActivity(currentAssistant!, msg.timestamp);
                 awaitingToolContinuation = true;
               } else {
                 if (currentAssistant) {

--- a/frontend/src/lib/messageRenderPlan.test.ts
+++ b/frontend/src/lib/messageRenderPlan.test.ts
@@ -173,4 +173,66 @@ describe('buildMessageRenderPlan', () => {
 
     expect(Array.from(plan.groupRenders.keys()).sort((a, b) => a - b)).toEqual([1, 4]);
   });
+
+  describe('turnWorkedSecondsByMessageIndex', () => {
+    function at(message: Message, timestamp: string): Message {
+      return { ...message, timestamp };
+    }
+
+    // Tool results are persisted as their own rows; the display `Message` union
+    // only names the roles that render on their own.
+    function toolResult(content: string, timestamp: string): Message {
+      return { role: 'tool', content, timestamp } as unknown as Message;
+    }
+
+    it('spans the whole turn, not the gap to the first model response', () => {
+      const messages: Message[] = [
+        at(user('do the thing'), '2026-08-31T22:12:43.000Z'),
+        at(assistant('<details><summary>🔧 bash</summary></details>'), '2026-08-31T22:12:52.000Z'),
+        toolResult('ok', '2026-08-31T22:13:54.000Z'),
+        at(assistant('all done'), '2026-08-31T22:14:00.000Z'),
+      ];
+
+      const plan = buildMessageRenderPlan(messages);
+
+      // 22:12:43 -> 22:14:00, not the 9s to the first response.
+      expect(plan.turnWorkedSecondsByMessageIndex.get(1)).toBe(77);
+      expect(plan.turnWorkedSecondsByMessageIndex.get(3)).toBe(77);
+    });
+
+    it('measures each turn from its own user message', () => {
+      const messages: Message[] = [
+        at(user('first'), '2026-08-31T22:00:00.000Z'),
+        at(assistant('one'), '2026-08-31T22:00:10.000Z'),
+        at(user('second'), '2026-08-31T22:05:00.000Z'),
+        at(assistant('two'), '2026-08-31T22:05:30.000Z'),
+      ];
+
+      const plan = buildMessageRenderPlan(messages);
+
+      expect(plan.turnWorkedSecondsByMessageIndex.get(1)).toBe(10);
+      expect(plan.turnWorkedSecondsByMessageIndex.get(3)).toBe(30);
+    });
+
+    it('ignores out-of-order rows and clock skew instead of reporting a negative span', () => {
+      const messages: Message[] = [
+        at(user('go'), '2026-08-31T22:14:00.000Z'),
+        at(assistant('<details><summary>🔧 bash</summary></details>'), '2026-08-31T22:14:05.000Z'),
+        // Concurrent tool results can land out of order.
+        toolResult('b', '2026-08-31T22:14:31.000Z'),
+        toolResult('a', '2026-08-31T22:14:30.000Z'),
+        at(assistant('done'), '2026-08-31T22:14:20.000Z'),
+      ];
+
+      const plan = buildMessageRenderPlan(messages);
+
+      expect(plan.turnWorkedSecondsByMessageIndex.get(1)).toBe(31);
+    });
+
+    it('omits a duration when the turn has no timestamps', () => {
+      const plan = buildMessageRenderPlan([user('go'), assistant('done')]);
+
+      expect(plan.turnWorkedSecondsByMessageIndex.size).toBe(0);
+    });
+  });
 });

--- a/frontend/src/lib/messageRenderPlan.test.ts
+++ b/frontend/src/lib/messageRenderPlan.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Message } from '../types/api';
-import { buildMessageRenderPlan } from './messageRenderPlan';
+import { buildMessageRenderPlan, buildTurnWorkedSeconds } from './messageRenderPlan';
 
 function assistant(content: string, stepInfo?: string): Message {
   return { role: 'assistant', content, stepInfo };
@@ -173,66 +173,104 @@ describe('buildMessageRenderPlan', () => {
 
     expect(Array.from(plan.groupRenders.keys()).sort((a, b) => a - b)).toEqual([1, 4]);
   });
+});
 
-  describe('turnWorkedSecondsByMessageIndex', () => {
-    function at(message: Message, timestamp: string): Message {
-      return { ...message, timestamp };
-    }
+describe('buildTurnWorkedSeconds', () => {
+  function at(message: Message, timestamp: string): Message {
+    return { ...message, timestamp };
+  }
 
-    // Tool results are persisted as their own rows; the display `Message` union
-    // only names the roles that render on their own.
-    function toolResult(content: string, timestamp: string): Message {
-      return { role: 'tool', content, timestamp } as unknown as Message;
-    }
+  // Tool results are persisted as their own rows; the display `Message` union
+  // only names the roles that render on their own.
+  function toolResult(content: string, timestamp: string): Message {
+    return { role: 'tool', content, timestamp } as unknown as Message;
+  }
 
-    it('spans the whole turn, not the gap to the first model response', () => {
-      const messages: Message[] = [
-        at(user('do the thing'), '2026-08-31T22:12:43.000Z'),
-        at(assistant('<details><summary>🔧 bash</summary></details>'), '2026-08-31T22:12:52.000Z'),
-        toolResult('ok', '2026-08-31T22:13:54.000Z'),
-        at(assistant('all done'), '2026-08-31T22:14:00.000Z'),
-      ];
+  it('spans the whole turn, not the gap to the first model response', () => {
+    const messages: Message[] = [
+      at(user('do the thing'), '2026-08-31T22:12:43.000Z'),
+      at(assistant('<details><summary>🔧 bash</summary></details>'), '2026-08-31T22:12:52.000Z'),
+      toolResult('ok', '2026-08-31T22:13:54.000Z'),
+      at(assistant('all done'), '2026-08-31T22:14:00.000Z'),
+    ];
 
-      const plan = buildMessageRenderPlan(messages);
+    const worked = buildTurnWorkedSeconds(messages);
 
-      // 22:12:43 -> 22:14:00, not the 9s to the first response.
-      expect(plan.turnWorkedSecondsByMessageIndex.get(1)).toBe(77);
-      expect(plan.turnWorkedSecondsByMessageIndex.get(3)).toBe(77);
-    });
+    // 22:12:43 -> 22:14:00, not the 9s to the first response.
+    expect(worked.get(1)).toBe(77);
+    expect(worked.get(3)).toBe(77);
+  });
 
-    it('measures each turn from its own user message', () => {
-      const messages: Message[] = [
-        at(user('first'), '2026-08-31T22:00:00.000Z'),
-        at(assistant('one'), '2026-08-31T22:00:10.000Z'),
-        at(user('second'), '2026-08-31T22:05:00.000Z'),
-        at(assistant('two'), '2026-08-31T22:05:30.000Z'),
-      ];
+  it('measures each turn from its own user message', () => {
+    const messages: Message[] = [
+      at(user('first'), '2026-08-31T22:00:00.000Z'),
+      at(assistant('one'), '2026-08-31T22:00:10.000Z'),
+      at(user('second'), '2026-08-31T22:05:00.000Z'),
+      at(assistant('two'), '2026-08-31T22:05:30.000Z'),
+    ];
 
-      const plan = buildMessageRenderPlan(messages);
+    const worked = buildTurnWorkedSeconds(messages);
 
-      expect(plan.turnWorkedSecondsByMessageIndex.get(1)).toBe(10);
-      expect(plan.turnWorkedSecondsByMessageIndex.get(3)).toBe(30);
-    });
+    expect(worked.get(1)).toBe(10);
+    expect(worked.get(3)).toBe(30);
+  });
 
-    it('ignores out-of-order rows and clock skew instead of reporting a negative span', () => {
-      const messages: Message[] = [
-        at(user('go'), '2026-08-31T22:14:00.000Z'),
-        at(assistant('<details><summary>🔧 bash</summary></details>'), '2026-08-31T22:14:05.000Z'),
-        // Concurrent tool results can land out of order.
-        toolResult('b', '2026-08-31T22:14:31.000Z'),
-        toolResult('a', '2026-08-31T22:14:30.000Z'),
-        at(assistant('done'), '2026-08-31T22:14:20.000Z'),
-      ];
+  it('ignores out-of-order rows and clock skew instead of reporting a negative span', () => {
+    const messages: Message[] = [
+      at(user('go'), '2026-08-31T22:14:00.000Z'),
+      at(assistant('<details><summary>🔧 bash</summary></details>'), '2026-08-31T22:14:05.000Z'),
+      // Concurrent tool results can land out of order.
+      toolResult('b', '2026-08-31T22:14:31.000Z'),
+      toolResult('a', '2026-08-31T22:14:30.000Z'),
+      at(assistant('done'), '2026-08-31T22:14:20.000Z'),
+    ];
 
-      const plan = buildMessageRenderPlan(messages);
+    const worked = buildTurnWorkedSeconds(messages);
 
-      expect(plan.turnWorkedSecondsByMessageIndex.get(1)).toBe(31);
-    });
+    expect(worked.get(1)).toBe(31);
+  });
 
-    it('omits a duration when the turn has no timestamps', () => {
-      const plan = buildMessageRenderPlan([user('go'), assistant('done')]);
+  it('omits a duration when the turn has no timestamps', () => {
+    const worked = buildTurnWorkedSeconds([user('go'), assistant('done')]);
 
-      expect(plan.turnWorkedSecondsByMessageIndex.size).toBe(0);
-    });
+    expect(worked.size).toBe(0);
+  });
+
+  it('measures a turn the store coalesced into a single assistant bubble', () => {
+    // The store folds a turn's tool rows and follow-up responses into one
+    // bubble that keeps the first response's timestamp; the rows it absorbed
+    // survive only as turn_last_activity_at.
+    const messages: Message[] = [
+      at(user('do the thing'), '2026-08-31T22:12:43.000Z'),
+      {
+        ...at(assistant('all done'), '2026-08-31T22:12:52.000Z'),
+        turn_last_activity_at: '2026-08-31T22:14:00.000Z',
+      },
+    ];
+
+    const worked = buildTurnWorkedSeconds(messages);
+
+    expect(worked.get(1)).toBe(77);
+  });
+
+  it('omits a duration when the turn boundary is outside the list', () => {
+    // A rendered window can start mid-turn; a duration measured from the first
+    // visible assistant row would change as older messages load.
+    const worked = buildTurnWorkedSeconds([
+      at(assistant('continued'), '2026-08-31T22:12:52.000Z'),
+      at(assistant('all done'), '2026-08-31T22:14:00.000Z'),
+    ]);
+
+    expect(worked.size).toBe(0);
+  });
+
+  it('omits a duration when the boundary clock runs ahead of the turn', () => {
+    // An optimistic user row is stamped by the client; the rest by the backend.
+    const worked = buildTurnWorkedSeconds([
+      at(user('go'), '2026-08-31T22:14:10.000Z'),
+      at(assistant('done'), '2026-08-31T22:14:00.000Z'),
+    ]);
+
+    expect(worked.has(1)).toBe(false);
   });
 });

--- a/frontend/src/lib/messageRenderPlan.ts
+++ b/frontend/src/lib/messageRenderPlan.ts
@@ -15,13 +15,6 @@ export interface MessageRenderPlan {
   skipIndices: Set<number>;
   groupRenders: Map<number, StepGroupRender>;
   stepSummaryByMessageIndex: Map<number, string>;
-  /**
-   * Wall-clock seconds the agent worked on the turn each assistant message
-   * belongs to, keyed by that message's index. Every assistant row in a turn
-   * maps to the same number: they are one stretch of work, and a rail must not
-   * report only the slice between two adjacent rows.
-   */
-  turnWorkedSecondsByMessageIndex: Map<number, number>;
 }
 
 const IGNORED_TOOL_NAMES = ['final_answer', 'final answer'];
@@ -82,23 +75,85 @@ function computeTurnWorkedSeconds(
   turnStart: number,
   turnEnd: number
 ): number | undefined {
-  const startedAt = parseTimestamp(
-    boundaryIndex >= 0 ? messages[boundaryIndex].timestamp : messages[turnStart]?.timestamp
-  );
+  // Without a boundary the turn's start is unknown -- which happens when the
+  // opening user row sits outside the slice being rendered. Falling back to the
+  // first assistant row would report a near-zero span that silently changes as
+  // older messages load, so report nothing instead.
+  if (boundaryIndex < 0) return undefined;
+  const startedAt = parseTimestamp(messages[boundaryIndex].timestamp);
   if (startedAt === undefined) return undefined;
 
   let endedAt: number | undefined;
   for (let idx = turnStart; idx < turnEnd; idx += 1) {
-    const stamp = parseTimestamp(messages[idx].timestamp);
-    if (stamp !== undefined && (endedAt === undefined || stamp > endedAt)) {
-      endedAt = stamp;
+    // `turn_last_activity_at` carries the rows the store folded into a
+    // coalesced assistant bubble; `timestamp` alone is when that bubble's first
+    // model response began.
+    for (const stamp of [
+      parseTimestamp(messages[idx].timestamp),
+      parseTimestamp(messages[idx].turn_last_activity_at),
+    ]) {
+      if (stamp !== undefined && (endedAt === undefined || stamp > endedAt)) {
+        endedAt = stamp;
+      }
     }
   }
   if (endedAt === undefined) return undefined;
 
-  // Clock skew between rows can make a span read negative; show nothing rather
-  // than a bogus count.
-  return Math.max(0, Math.floor((endedAt - startedAt) / 1000));
+  // Clock skew -- an optimistic user row stamped by a client clock running
+  // ahead of the backend -- can make a span read negative. Show nothing rather
+  // than a bogus "Worked for 0s".
+  if (endedAt < startedAt) return undefined;
+  return Math.floor((endedAt - startedAt) / 1000);
+}
+
+/**
+ * Wall-clock seconds the agent worked on the turn each assistant message
+ * belongs to, keyed by that message's index. Every assistant row in a turn maps
+ * to the same number: they are one stretch of work, and a rail must not report
+ * only the slice between two adjacent rows.
+ *
+ * Build this from the *full* message list, not a rendered window: a slice can
+ * start after the user row that opened a turn, and a turn's duration must not
+ * depend on how much history happens to be loaded.
+ */
+export function buildTurnWorkedSeconds(messages: Message[]): Map<number, number> {
+  const workedSecondsByMessageIndex = new Map<number, number>();
+
+  let i = 0;
+  while (i < messages.length) {
+    if (messages[i].role !== 'assistant') {
+      i += 1;
+      continue;
+    }
+
+    let turnEnd = i;
+    while (turnEnd < messages.length && !isTurnBoundary(messages[turnEnd])) {
+      turnEnd += 1;
+    }
+
+    // The row that opened this turn -- scanned back from the first assistant
+    // message, since the scan itself starts at that assistant row.
+    let boundaryIndex = -1;
+    for (let j = i - 1; j >= 0; j -= 1) {
+      if (isTurnBoundary(messages[j])) {
+        boundaryIndex = j;
+        break;
+      }
+    }
+
+    const workedSeconds = computeTurnWorkedSeconds(messages, boundaryIndex, i, turnEnd);
+    if (workedSeconds !== undefined) {
+      for (let idx = i; idx < turnEnd; idx += 1) {
+        if (messages[idx].role === 'assistant') {
+          workedSecondsByMessageIndex.set(idx, workedSeconds);
+        }
+      }
+    }
+
+    i = turnEnd;
+  }
+
+  return workedSecondsByMessageIndex;
 }
 
 function filterIgnoredToolCalls(blocks: ContentBlock[]): ContentBlock[] {
@@ -127,7 +182,6 @@ export function buildMessageRenderPlan(messages: Message[]): MessageRenderPlan {
   const skipIndices = new Set<number>();
   const groupRenders = new Map<number, StepGroupRender>();
   const stepSummaryByMessageIndex = new Map<number, string>();
-  const turnWorkedSecondsByMessageIndex = new Map<number, number>();
 
   // Hide any synthetic compaction summary rows that leaked into the display log.
   for (let k = 0; k < messages.length; k++) {
@@ -185,22 +239,6 @@ export function buildMessageRenderPlan(messages: Message[]): MessageRenderPlan {
     }
     const stepSummary = summarizeStepInfos(allStepInfos);
 
-    // The row that opened this turn -- scanned back from the first assistant
-    // message, since the turn loop itself starts at that assistant row.
-    let boundaryIndex = -1;
-    for (let j = i - 1; j >= 0; j -= 1) {
-      if (isTurnBoundary(messages[j])) {
-        boundaryIndex = j;
-        break;
-      }
-    }
-    const turnWorkedSeconds = computeTurnWorkedSeconds(messages, boundaryIndex, i, turnEnd);
-    if (turnWorkedSeconds !== undefined) {
-      for (const idx of assistantIndicesInTurn) {
-        turnWorkedSecondsByMessageIndex.set(idx, turnWorkedSeconds);
-      }
-    }
-
     if (intermediateIndices.length > 0) {
       const groupStart = intermediateIndices[0];
       const allBlocks: ContentBlock[] = [];
@@ -235,10 +273,5 @@ export function buildMessageRenderPlan(messages: Message[]): MessageRenderPlan {
     i = turnEnd;
   }
 
-  return {
-    skipIndices,
-    groupRenders,
-    stepSummaryByMessageIndex,
-    turnWorkedSecondsByMessageIndex,
-  };
+  return { skipIndices, groupRenders, stepSummaryByMessageIndex };
 }

--- a/frontend/src/lib/messageRenderPlan.ts
+++ b/frontend/src/lib/messageRenderPlan.ts
@@ -15,6 +15,13 @@ export interface MessageRenderPlan {
   skipIndices: Set<number>;
   groupRenders: Map<number, StepGroupRender>;
   stepSummaryByMessageIndex: Map<number, string>;
+  /**
+   * Wall-clock seconds the agent worked on the turn each assistant message
+   * belongs to, keyed by that message's index. Every assistant row in a turn
+   * maps to the same number: they are one stretch of work, and a rail must not
+   * report only the slice between two adjacent rows.
+   */
+  turnWorkedSecondsByMessageIndex: Map<number, number>;
 }
 
 const IGNORED_TOOL_NAMES = ['final_answer', 'final answer'];
@@ -51,6 +58,49 @@ function isTurnBoundary(message: Message): boolean {
   return false;
 }
 
+function parseTimestamp(value?: string): number | undefined {
+  if (!value) return undefined;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Wall-clock span of a turn: from the user message that opened it to the last
+ * thing it produced.
+ *
+ * Both ends need care. The start is the turn boundary, not the previous row --
+ * inside a turn the previous row is a tool result or a tool-resume stub. The
+ * end is the *latest* timestamp anywhere in the turn rather than the last
+ * message's: an assistant row is stamped when its model response *began*, so
+ * the tool results it triggered are later than the response that asked for
+ * them. Rows can also arrive slightly out of order (tool results from
+ * concurrent calls), which a max ignores and a last-row read would not.
+ */
+function computeTurnWorkedSeconds(
+  messages: Message[],
+  boundaryIndex: number,
+  turnStart: number,
+  turnEnd: number
+): number | undefined {
+  const startedAt = parseTimestamp(
+    boundaryIndex >= 0 ? messages[boundaryIndex].timestamp : messages[turnStart]?.timestamp
+  );
+  if (startedAt === undefined) return undefined;
+
+  let endedAt: number | undefined;
+  for (let idx = turnStart; idx < turnEnd; idx += 1) {
+    const stamp = parseTimestamp(messages[idx].timestamp);
+    if (stamp !== undefined && (endedAt === undefined || stamp > endedAt)) {
+      endedAt = stamp;
+    }
+  }
+  if (endedAt === undefined) return undefined;
+
+  // Clock skew between rows can make a span read negative; show nothing rather
+  // than a bogus count.
+  return Math.max(0, Math.floor((endedAt - startedAt) / 1000));
+}
+
 function filterIgnoredToolCalls(blocks: ContentBlock[]): ContentBlock[] {
   return blocks.filter((block) => {
     if (block.type !== 'toolCall') return true;
@@ -77,6 +127,7 @@ export function buildMessageRenderPlan(messages: Message[]): MessageRenderPlan {
   const skipIndices = new Set<number>();
   const groupRenders = new Map<number, StepGroupRender>();
   const stepSummaryByMessageIndex = new Map<number, string>();
+  const turnWorkedSecondsByMessageIndex = new Map<number, number>();
 
   // Hide any synthetic compaction summary rows that leaked into the display log.
   for (let k = 0; k < messages.length; k++) {
@@ -134,6 +185,22 @@ export function buildMessageRenderPlan(messages: Message[]): MessageRenderPlan {
     }
     const stepSummary = summarizeStepInfos(allStepInfos);
 
+    // The row that opened this turn -- scanned back from the first assistant
+    // message, since the turn loop itself starts at that assistant row.
+    let boundaryIndex = -1;
+    for (let j = i - 1; j >= 0; j -= 1) {
+      if (isTurnBoundary(messages[j])) {
+        boundaryIndex = j;
+        break;
+      }
+    }
+    const turnWorkedSeconds = computeTurnWorkedSeconds(messages, boundaryIndex, i, turnEnd);
+    if (turnWorkedSeconds !== undefined) {
+      for (const idx of assistantIndicesInTurn) {
+        turnWorkedSecondsByMessageIndex.set(idx, turnWorkedSeconds);
+      }
+    }
+
     if (intermediateIndices.length > 0) {
       const groupStart = intermediateIndices[0];
       const allBlocks: ContentBlock[] = [];
@@ -168,5 +235,10 @@ export function buildMessageRenderPlan(messages: Message[]): MessageRenderPlan {
     i = turnEnd;
   }
 
-  return { skipIndices, groupRenders, stepSummaryByMessageIndex };
+  return {
+    skipIndices,
+    groupRenders,
+    stepSummaryByMessageIndex,
+    turnWorkedSecondsByMessageIndex,
+  };
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -45,6 +45,10 @@ export interface Message {
   file_changes_undone?: boolean; // Whether this message-scoped snapshot was restored
   file_change_message_index?: number; // Raw backend index used for message-scoped undo
   raw_message_end_index?: number; // End-exclusive backend boundary for this rendered message
+  // Latest timestamp of any server row folded into this bubble (tool results and
+  // merged follow-up responses). `timestamp` marks when the turn's first model
+  // response *began*, so it alone cannot measure how long the turn worked.
+  turn_last_activity_at?: string;
 }
 export interface ChatConfig {
   model: string;


### PR DESCRIPTION
## Description

The "Worked for …" label on a settled activity rail was computed as the delta between the previous message row and the representative assistant row. Both anchors were wrong for any turn with tool calls.

- An assistant row is stamped when its model response **began** (pydantic-ai's `ModelResponse.timestamp`, serialized in `chat_processor.py`), and a turn's rail is represented by the turn's **first** response — so everything after that first response (every tool call, every later step) was excluded.
- The start anchor scanned back to the nearest timestamped row of any role, which inside a turn is a tool result or an empty tool-resume stub, not the user message that opened the turn.

Against real data in `~/.suzent/chats.db`, a turn running `22:12:43 → 22:21:06` (8.5 minutes) rendered as **"Worked for 9s"**. The rail visibly collapsed from an honest live counter to a few seconds the moment the turn finished.

The span is now computed in `buildMessageRenderPlan`: the start is the turn boundary (`isTurnBoundary` — the real user message), the end is the **latest** timestamp anywhere in the turn, tool results included. Max rather than last-row, because responses are stamped before the tool results they trigger, and concurrent tool results genuinely land out of order. Clock skew clamps to zero, and a turn with no parseable timestamps reports nothing, so a bogus count never reaches the rail.

Fixes # (no issue filed)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] 4 new cases in `messageRenderPlan.test.ts`: multi-step turn (the real chat above — 77s where it previously read 9s), per-turn anchoring across two turns, out-of-order tool rows, and a turn with no timestamps
- [x] Full frontend suite: 328 tests / 47 files pass
- [x] `tsc --noEmit` clean
- [x] ESLint error count on the two touched components unchanged at 14 before and after (all pre-existing unused-variable warnings in untouched code)

Not verified visually in a running app — worth a glance at a finished multi-tool turn to confirm the settled number lines up with the live counter it replaces.

## Notes for reviewers

- `AssistantMessage` now takes `workedDurationSeconds` as a prop instead of deriving it; the `previousMessageTimestamp` prop, its two `ChatWindow` helpers (`getPreviousMessageTimestamp`, `getLastMessageTimestamp`), and `getTimestampDeltaSeconds` in `ActivityRail` are all removed with their last callers.
- The streaming placeholder no longer receives a duration at all — the live clock owns the label until the turn persists.
- Separately, the late-`startedAtMs` effect now recomputes immediately rather than leaving up to a second of count measured from the wrong origin.
- Longer term, an explicit per-turn `duration_ms` from the backend would be sounder than any arrangement of response-start timestamps: even the last response's start omits its own token generation, so this remains a small under-count.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
