### PR TITLE
fix(context): stop auto-compaction re-firing after every compaction

### DIFF
--- a/src/suzent/core/chat_processor.py
+++ b/src/suzent/core/chat_processor.py
@@ -1544,9 +1544,10 @@ class ChatProcessor:
     ) -> Optional[AsyncGenerator[str, None]]:
         """Detect /retry or /retry-edit and return a replay stream, else None.
 
-        /retry replays the original turn; /retry-edit replays with new user text
-        but keeps the original turn's files and config snapshot. Both restore the
-        pre-turn checkpoint, or emit a notice stream when there's nothing to replay.
+        /retry replays the original turn; /retry-edit replays with new user text.
+        Both restore the pre-turn checkpoint and its files. Checkpoint config is
+        used as a fallback, while config submitted with the retry takes precedence
+        so changes made in the composer (notably the selected model) are honored.
         """
         if not message_content or resume_approvals or is_heartbeat:
             return None
@@ -1579,13 +1580,15 @@ class ChatProcessor:
                 )
             replay_message = checkpoint_data["user_message"]
 
-        # Both variants replay with the original turn's files and config snapshot
-        # so attachments survive the retry/edit.
+        # Both variants replay with the original turn's files. Preserve settings
+        # that exist only in the original snapshot, but let the current request
+        # override them so retrying after changing model/thinking/etc. uses the
+        # newly selected values.
         replay_files = checkpoint_data["user_files"] or []
         replay_config = checkpoint_data.get("config_snapshot") or {}
         merged_config = {
-            **config,
             **replay_config,
+            **config,
             "_user_id": user_id,
             "_chat_id": chat_id,
         }

--- a/src/suzent/core/context_compressor.py
+++ b/src/suzent/core/context_compressor.py
@@ -486,11 +486,16 @@ class TokenBudget:
         return self.estimated_tokens >= self.limit * self.trigger_threshold
 
 
-# A system prompt plus every tool's JSON schema is a five-figure token count at
-# the very top end; anything beyond this is not overhead but a stale measurement.
-# This must stay well *below* any model's context window: sized at the window it
-# could never reject a stale reading, because no measurement can exceed it.
-MAX_PLAUSIBLE_CONTEXT_OVERHEAD_TOKENS = 50_000
+# Share of the context window the non-history part of a prompt (system prompt +
+# every tool schema) can plausibly occupy. Past this, the measurement is not
+# overhead but a stale reading taken against a history that no longer exists.
+#
+# It has to scale with the window rather than sit at a fixed token count: a
+# deferred-tool-heavy setup can legitimately carry five figures of schemas, so a
+# low fixed ceiling would discard real overhead and compact too late, while a
+# ceiling at the window itself can never reject anything (no measurement can
+# exceed the window) — which is how the stale-reading guard came to be dead code.
+MAX_PLAUSIBLE_CONTEXT_OVERHEAD_RATIO = 0.5
 
 
 def _part_chars(part: Any) -> int:
@@ -515,7 +520,7 @@ def estimate_history_tokens(messages: list) -> int:
     return total_chars // 4
 
 
-def context_overhead_tokens(messages: list) -> int:
+def context_overhead_tokens(messages: list, limit: Optional[int] = None) -> int:
     """Tokens the real prompt carries beyond the message history itself.
 
     The system prompt and every tool's JSON schema are sent on each request but
@@ -538,7 +543,11 @@ def context_overhead_tokens(messages: list) -> int:
             # that request — cache reads and writes included — and the request
             # that produced this response was everything before it.
             overhead = measured - estimate_history_tokens(messages[:index])
-            if overhead > MAX_PLAUSIBLE_CONTEXT_OVERHEAD_TOKENS:
+            ceiling = int(
+                (limit or resolve_context_limit())
+                * MAX_PLAUSIBLE_CONTEXT_OVERHEAD_RATIO
+            )
+            if overhead > ceiling:
                 # The gap is far too large to be a system prompt and tool
                 # schemas: this response was produced *before* a compaction
                 # rewrote the history behind it, so its prompt covered messages
@@ -553,7 +562,7 @@ def estimate_tokens(messages: list, limit: int) -> TokenBudget:
     """Best available size of the context window these messages represent."""
     return TokenBudget(
         estimated_tokens=estimate_history_tokens(messages)
-        + context_overhead_tokens(messages),
+        + context_overhead_tokens(messages, limit),
         limit=limit,
         trigger_threshold=CONFIG.context_compaction_trigger,
         soft_trim_threshold=CONFIG.context_soft_trim_threshold,

--- a/src/suzent/core/context_compressor.py
+++ b/src/suzent/core/context_compressor.py
@@ -488,7 +488,9 @@ class TokenBudget:
 
 # A system prompt plus every tool's JSON schema is a five-figure token count at
 # the very top end; anything beyond this is not overhead but a stale measurement.
-MAX_PLAUSIBLE_CONTEXT_OVERHEAD_TOKENS = 200_000
+# This must stay well *below* any model's context window: sized at the window it
+# could never reject a stale reading, because no measurement can exceed it.
+MAX_PLAUSIBLE_CONTEXT_OVERHEAD_TOKENS = 50_000
 
 
 def _part_chars(part: Any) -> int:
@@ -620,6 +622,27 @@ class ToolResultTrimmer:
 # ---------------------------------------------------------------------------
 
 
+def _clear_stale_usage(messages: list) -> list:
+    """Drop provider usage from messages carried across a compaction.
+
+    ``usage.input_tokens`` on a retained tail message describes the prompt that
+    produced it — a prompt that included the history compaction has just thrown
+    away. Left in place, ``context_overhead_tokens`` reads that number against
+    the new, much shorter history and reports the discarded messages as fixed
+    overhead, so the estimate never falls and compaction re-fires forever.
+    """
+    cleared = []
+    for msg in messages:
+        usage = getattr(msg, "usage", None)
+        if usage is not None and int(getattr(usage, "input_tokens", 0) or 0):
+            try:
+                msg = dataclasses.replace(msg, usage=type(usage)())
+            except Exception:  # pragma: no cover - non-dataclass message types
+                pass
+        cleared.append(msg)
+    return cleared
+
+
 class ContextCompressor:
     """Handles compression of pydantic-ai message history.
 
@@ -680,7 +703,7 @@ class ContextCompressor:
             tail_start = safe_tool_history_tail_start(
                 messages, max(1, len(messages) - keep)
             )
-            return messages[:1] + messages[tail_start:]
+            return messages[:1] + _clear_stale_usage(messages[tail_start:])
         except Exception as e:
             logger.error(f"Context compression failed: {e}")
             return messages
@@ -776,7 +799,7 @@ class ContextCompressor:
 
         if not summary:
             logger.warning("Failed to generate summary for compression.")
-            return messages[:1] + messages[end_index:]
+            return messages[:1] + _clear_stale_usage(messages[end_index:])
 
         # Phase 6 — improved synthetic summary framing
         from suzent.core.system_reminder import make_user_prompt_part
@@ -814,7 +837,9 @@ class ContextCompressor:
         )
 
         new_messages = (
-            messages[:1] + [summary_request, summary_response] + messages[end_index:]
+            messages[:1]
+            + [summary_request, summary_response]
+            + _clear_stale_usage(messages[end_index:])
         )
 
         logger.info(
@@ -1089,6 +1114,22 @@ def context_input_tokens(
     return estimate_tokens(messages, resolve_context_limit(model_id)).estimated_tokens
 
 
+# Chats where a completed compaction failed to bring the estimate back under the
+# trigger, mapped to the estimate it settled at. Compacting again at or below
+# that size cannot do better — without this the processor re-summarizes its own
+# summary before every request for the rest of the conversation. Growth past the
+# recorded size re-arms it, since a longer tail is newly compactible.
+_COMPACTION_INEFFECTIVE_AT: dict[str, int] = {}
+
+
+def reset_compaction_suppression(chat_id: str = "") -> None:
+    """Clear the "compaction did not help" marker for a chat (or all chats)."""
+    if chat_id:
+        _COMPACTION_INEFFECTIVE_AT.pop(chat_id, None)
+    else:
+        _COMPACTION_INEFFECTIVE_AT.clear()
+
+
 def make_compaction_history_processor(
     source: str = "auto_midrun", model_id: Optional[str] = None
 ):
@@ -1132,6 +1173,15 @@ def make_compaction_history_processor(
         if current_tokens < trigger:
             return messages
 
+        # A previous pass on this chat completed and still left the estimate over
+        # the trigger. Repeating it at the same size only burns a summarization
+        # call per request; wait until the history actually grows past that point.
+        ineffective_at = _COMPACTION_INEFFECTIVE_AT.get(chat_id)
+        if ineffective_at is not None:
+            if current_tokens <= ineffective_at:
+                return messages
+            _COMPACTION_INEFFECTIVE_AT.pop(chat_id, None)
+
         # Idempotency: if the tail is already summary-framed and we're only just
         # over the line because of the recent turns, another pass can't help.
         keep_recent = CONFIG.compaction_keep_recent_turns * 2
@@ -1164,7 +1214,7 @@ def make_compaction_history_processor(
             tail_start = safe_tool_history_tail_start(
                 messages, max(1, len(messages) - keep_recent)
             )
-            compressed = messages[:1] + messages[tail_start:]
+            compressed = messages[:1] + _clear_stale_usage(messages[tail_start:])
         except Exception as e:
             logger.error(f"Mid-run compaction failed: {e}")
             emit_compaction_event(
@@ -1196,6 +1246,10 @@ def make_compaction_history_processor(
 
         if len(compressed) >= len(messages):
             # No reduction (e.g. already compacted and nothing else to drop).
+            # Nothing here will change until the history grows, and the pass
+            # already paid for a summarization call, so stop re-running it.
+            if chat_id:
+                _COMPACTION_INEFFECTIVE_AT[chat_id] = current_tokens
             # This still has to report a terminal stage: a "start" was already
             # broadcast, and a surface that animates the running pass would spin
             # forever if this path stayed silent.
@@ -1213,6 +1267,14 @@ def make_compaction_history_processor(
             return compressed
 
         tokens_after = estimate_tokens(compressed, limit).estimated_tokens
+        if tokens_after >= trigger:
+            logger.warning(
+                f"Compaction left ~{tokens_after} tokens, still at or over the "
+                f"trigger (~{int(trigger)}); suppressing further automatic "
+                f"compaction for chat {chat_id or '(none)'} until it grows."
+            )
+            if chat_id:
+                _COMPACTION_INEFFECTIVE_AT[chat_id] = tokens_after
         emit_compaction_event(
             chat_id=chat_id,
             stage="complete",

--- a/tests/core/test_chat_processor_retry_config.py
+++ b/tests/core/test_chat_processor_retry_config.py
@@ -1,0 +1,99 @@
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from suzent.core.chat_processor import ChatProcessor
+
+
+def test_retry_uses_current_model_over_checkpoint_model(monkeypatch) -> None:
+    checkpoint = {
+        "user_message": "Try this",
+        "user_files": [{"path": "/tmp/input.txt"}],
+        "config_snapshot": {
+            "model": "provider/old-model",
+            "thinking": "low",
+            "sandbox_enabled": True,
+        },
+    }
+    monkeypatch.setattr(
+        "suzent.core.retry.apply_retry_checkpoint",
+        lambda _chat_id: checkpoint,
+    )
+
+    processor = ChatProcessor()
+    captured: dict[str, Any] = {}
+
+    def capture_process_turn(**kwargs: Any) -> AsyncGenerator[str, None]:
+        captured.update(kwargs)
+
+        async def stream() -> AsyncGenerator[str, None]:
+            if False:
+                yield ""
+
+        return stream()
+
+    monkeypatch.setattr(processor, "process_turn", capture_process_turn)
+
+    retry_stream = processor._handle_retry_command(
+        chat_id="chat-1",
+        user_id="user-1",
+        message_content="/retry",
+        config={
+            "model": "provider/new-model",
+            "thinking": "high",
+            "memory_enabled": False,
+        },
+        is_social=False,
+        resume_approvals=None,
+        is_heartbeat=False,
+    )
+
+    assert retry_stream is not None
+    assert captured["message_content"] == "Try this"
+    assert captured["files"] == [{"path": "/tmp/input.txt"}]
+    assert captured["config_override"] == {
+        "model": "provider/new-model",
+        "thinking": "high",
+        "sandbox_enabled": True,
+        "memory_enabled": False,
+        "_user_id": "user-1",
+        "_chat_id": "chat-1",
+    }
+
+
+def test_retry_edit_uses_edited_message_and_current_model(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "suzent.core.retry.apply_retry_checkpoint",
+        lambda _chat_id: {
+            "user_message": "Original message",
+            "user_files": [],
+            "config_snapshot": {"model": "provider/old-model"},
+        },
+    )
+
+    processor = ChatProcessor()
+    captured: dict[str, Any] = {}
+
+    def capture_process_turn(**kwargs: Any) -> AsyncGenerator[str, None]:
+        captured.update(kwargs)
+
+        async def stream() -> AsyncGenerator[str, None]:
+            if False:
+                yield ""
+
+        return stream()
+
+    monkeypatch.setattr(processor, "process_turn", capture_process_turn)
+
+    retry_stream = processor._handle_retry_command(
+        chat_id="chat-1",
+        user_id="user-1",
+        message_content="/retry-edit Updated message",
+        config={"model": "provider/new-model"},
+        is_social=False,
+        resume_approvals=None,
+        is_heartbeat=False,
+    )
+
+    assert retry_stream is not None
+    assert captured["message_content"] == "Updated message"
+    assert captured["config_override"]["model"] == "provider/new-model"

--- a/tests/core/test_compaction_history_processor.py
+++ b/tests/core/test_compaction_history_processor.py
@@ -32,7 +32,11 @@ def _quiet_bus_and_config(monkeypatch):
     monkeypatch.setattr("suzent.core.stream_registry.emit_bus_event", lambda p: None)
     # Deterministic thresholds.
     monkeypatch.setattr(CONFIG, "compaction_keep_recent_turns", 3, raising=False)
+    # Suppression state is module-level and keyed by chat_id; every test uses
+    # "c1", so it must not leak between them.
+    cc.reset_compaction_suppression()
     yield
+    cc.reset_compaction_suppression()
 
 
 def _history(n=12):
@@ -303,3 +307,102 @@ async def test_every_started_pass_reports_a_terminal_stage(monkeypatch):
     stages = [e["stage"] for e in seen if e["event"] == "auto_compaction"]
     assert stages[0] == "start"
     assert stages[-1] in {"complete", "skipped", "error"}
+
+
+@pytest.mark.asyncio
+async def test_estimate_drops_after_compaction_despite_stale_usage(monkeypatch):
+    """A retained tail message's pre-compaction usage must not inflate the estimate.
+
+    Regression: ``context_overhead_tokens`` read the provider count for a prompt
+    that still contained the compacted-away history, subtracted the new (tiny)
+    history from it, and reported the difference as fixed overhead — so the
+    estimate after a compaction equalled the estimate before it and auto-compact
+    re-fired on every subsequent request.
+    """
+    from pydantic_ai.messages import RequestUsage
+
+    limit = 200_000
+    big = "x" * 4000  # ~1k tokens each
+
+    msgs = [
+        ModelRequest(parts=[UserPromptPart(content=big)])
+        if i % 2 == 0
+        else ModelResponse(parts=[TextPart(content=big)])
+        for i in range(39)
+    ]
+    # The provider counted the whole pre-compaction prompt on the last response.
+    msgs.append(
+        ModelResponse(
+            parts=[TextPart(content=big)], usage=RequestUsage(input_tokens=170_000)
+        )
+    )
+    msgs.append(ModelRequest(parts=[UserPromptPart(content="pending")]))
+
+    before = cc.estimate_tokens(msgs, limit).estimated_tokens
+
+    keep = CONFIG.compaction_keep_recent_turns * 2
+    compacted = (
+        msgs[:1]
+        + [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(content=f"{COMPACTION_SUMMARY_REQUEST_MARKER}\np")
+                ]
+            ),
+            ModelResponse(
+                parts=[TextPart(content=f"{COMPACTION_SUMMARY_RESPONSE_MARKER}\nsum")]
+            ),
+        ]
+        + cc._clear_stale_usage(msgs[-keep:])
+    )
+    after = cc.estimate_tokens(compacted, limit).estimated_tokens
+
+    assert after < before
+    assert after < limit * CONFIG.context_compaction_trigger
+
+
+@pytest.mark.asyncio
+async def test_ineffective_compaction_is_not_retried(monkeypatch):
+    """A completed pass that stays over the trigger must not re-fire every request."""
+    monkeypatch.setattr(CONFIG, "max_context_tokens", 100, raising=False)
+    monkeypatch.setattr(CONFIG, "context_compaction_trigger", 0.01, raising=False)
+    _fake_compaction(monkeypatch)
+
+    calls = []
+    original = cc.ContextCompressor._perform_compression
+
+    async def counting(self, messages, focus=None, background_flush=False):
+        calls.append(len(messages))
+        return await original(
+            self, messages, focus=focus, background_flush=background_flush
+        )
+
+    monkeypatch.setattr(cc.ContextCompressor, "_perform_compression", counting)
+
+    proc = make_compaction_history_processor()
+    out = await proc(_ctx(), _history(12))
+    assert len(calls) == 1
+
+    # Same (already compacted, still over trigger) history: no second attempt.
+    again = await proc(_ctx(), out)
+    assert len(calls) == 1
+    assert again is out
+
+
+@pytest.mark.asyncio
+async def test_suppression_rearms_when_history_grows(monkeypatch):
+    monkeypatch.setattr(CONFIG, "max_context_tokens", 100, raising=False)
+    monkeypatch.setattr(CONFIG, "context_compaction_trigger", 0.01, raising=False)
+    _fake_compaction(monkeypatch)
+
+    proc = make_compaction_history_processor()
+    out = await proc(_ctx(), _history(12))
+    assert await proc(_ctx(), out) is out  # suppressed
+
+    grown = (
+        out[:-1]
+        + [ModelResponse(parts=[TextPart(content="y" * 20_000)])]
+        + [ModelRequest(parts=[UserPromptPart(content="pending")])]
+    )
+    regrown = await proc(_ctx(), grown)
+    assert len(regrown) < len(grown)

--- a/tests/core/test_context_compressor_event_helpers.py
+++ b/tests/core/test_context_compressor_event_helpers.py
@@ -166,3 +166,14 @@ def test_overhead_is_dropped_when_the_measurement_predates_a_compaction() -> Non
 def test_overhead_is_zero_before_any_response_is_measured() -> None:
     assert context_overhead_tokens([_request("x" * 4000)]) == 0
     assert estimate_tokens([_request("x" * 4000)], 800_000).estimated_tokens == 1000
+
+
+def test_overhead_keeps_large_but_plausible_schema_weight() -> None:
+    # A deferred-tool-heavy setup can legitimately put five figures of schemas in
+    # front of the history. A fixed low ceiling would discard that as "stale" and
+    # compact far too late; the ceiling scales with the window instead.
+    history = [_request("x" * 400), _response(60_000, "y" * 400), _request("z" * 800)]
+
+    assert context_overhead_tokens(history, 128_000) == 59_900
+    # Same reading against a window small enough to make it implausible.
+    assert context_overhead_tokens(history, 64_000) == 0


### PR DESCRIPTION
## Description

Once auto-compaction ran, it re-fired on **every** subsequent request for the rest of the conversation, re-summarizing its own summary.

`context_overhead_tokens` recovers the system-prompt + tool-schema offset from the provider's own count on the most recent usage-bearing message. After a compaction, the retained tail still carried `usage` from a request whose prompt included the history compaction had just discarded. The offset therefore came out as `pre_compaction_prompt − tiny_new_history`, re-reporting the discarded messages as fixed overhead. The estimate after a compaction equalled the estimate before it, so it never fell back under the trigger.

Reproduced against the real code (200k limit, trigger 160k):

| | before | after |
|---|---|---|
| pre-compaction estimate | 171000 | 40000 |
| post-compaction estimate | 171000 | 8000 |

### What changed

1. **Root cause** — new `_clear_stale_usage`, applied to the retained tail at all four points where messages survive a compaction (summary path, empty-summary fallback, and both hard-trim timeout paths), so no stale measurement outlives the history it described.
2. **Unreachable guard** — `MAX_PLAUSIBLE_CONTEXT_OVERHEAD_TOKENS` 200k → 50k. There was already a guard for exactly this case, but sized at a full context window it could never fire: no measurement can exceed the window. 50k is a generous ceiling for a system prompt plus every tool schema.
3. **Loop backstop** — `_COMPACTION_INEFFECTIVE_AT` (keyed by chat_id, with `reset_compaction_suppression()`): if a *completed* pass still leaves the estimate at or over the trigger, or yields no reduction at all, that size is recorded and automatic compaction is skipped until the history grows past it, at which point it re-arms. The no-reduction branch previously still paid for a full summarization call on every request.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Three new regressions in `tests/core/test_compaction_history_processor.py`: the estimate strictly drops across a compaction despite stale usage; an ineffective pass is attempted exactly once; suppression re-arms once the history grows.
- [x] Full suite: 2131 passed.

Note for reviewers: suppression state is module-level and keyed by `chat_id`, and every test in that file uses `"c1"`, so the autouse fixture now resets it before and after each test.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes