### PR TITLE
ci: SHA-pin GitHub Actions and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Scoped deliberately narrow: GitHub Actions only.
+#
+# The npm (frontend, website, src-tauri, apps/suzent-installer), cargo, and uv
+# manifests are intentionally left out. Six manifests on a weekly cadence
+# produces more PRs than this repo can review, and a bot everyone ignores stops
+# working for the security updates that matter. Vulnerable dependencies in
+# those ecosystems are covered by Dependabot security updates, enabled in repo
+# settings, which only opens a PR when there is an actual advisory with a fix.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -45,12 +45,12 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
 
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ steps.release-tag.outputs.tag }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -148,17 +148,19 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.prepare-release.outputs.tag }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workdir: src-tauri
 
@@ -210,7 +212,7 @@ jobs:
     if: needs.prepare-release.outputs.assets_mode == 'reuse'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: "3.12"
 
@@ -59,10 +59,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '22'
         cache: npm
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         fetch-depth: 0
 
@@ -144,10 +144,12 @@ jobs:
           librsvg2-dev \
           patchelf
 
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
       if: steps.changed.outputs.touched == 'true'
+      with:
+        toolchain: stable
 
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       if: steps.changed.outputs.touched == 'true'
       with:
         workspaces: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,10 +18,10 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: 'npm'
@@ -36,7 +36,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./website/build

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -36,14 +36,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.RELEASE_BOT_TOKEN || github.token }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/refresh-release.yml
+++ b/.github/workflows/refresh-release.yml
@@ -69,14 +69,14 @@ jobs:
           GH_REPO: ${{ github.repository }}
 
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.RELEASE_BOT_TOKEN || github.token }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout merged commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/update-model-capabilities.yml
+++ b/.github/workflows/update-model-capabilities.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -33,7 +33,7 @@ jobs:
         run: uv run python scripts/sync_model_capabilities.py --to-repo
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           branch: automation/model-capabilities
           delete-branch: true


### PR DESCRIPTION
## Description

Pins every GitHub Action to a full commit SHA and adds a narrowly scoped Dependabot config.

**Why:** floating refs are mutable. `@v4`, `@v2` and especially `dtolnay/rust-toolchain@stable` (a branch) can be repointed upstream, and the new code executes in CI on the next run. Eight actions across seven workflows are now pinned to SHAs, with the human-readable version kept in a trailing comment so Dependabot can still recognise and bump them.

`.github/dependabot.yml` covers `github-actions` only, grouped into one weekly PR. The npm (frontend, website, src-tauri, apps/suzent-installer), cargo and uv manifests are deliberately excluded — six manifests on a weekly cadence produces more PRs than this repo can review, and a bot everyone ignores stops working for the updates that matter. Those ecosystems are covered by Dependabot **security** updates instead, which only open a PR on a real advisory with a fix.

Related repo settings enabled outside this PR: Dependabot alerts and Dependabot security updates.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Reviewer notes

**The one non-mechanical change** is `dtolnay/rust-toolchain`. That action picks its Rust toolchain from the *ref name* it is invoked with, so pinning it to a SHA would leave it with no toolchain to install and break both Rust jobs. `toolchain: stable` is now passed explicitly:

```yaml
- uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
  with:
    toolchain: stable
```

Behaviour is unchanged (current stable Rust), but the action code is pinned while the toolchain stays floating. Note that Dependabot **cannot** update this one — it was a branch ref and is now a SHA with no corresponding version tag, so it stays manual.

Trigger audit confirming Dependabot PRs won't misfire:

| Workflow | Trigger | Effect on a `dependabot/*` PR |
|---|---|---|
| `ci.yml` | `pull_request` → main | Runs. Uses no secrets, so the read-only `GITHUB_TOKEN` on Dependabot PRs is fine |
| `release-on-merge.yml` | `pull_request` closed | Skipped — gated on `head.ref` starting with `release/` |
| `refresh-release.yml` | `push` → main | Runs post-merge as intended; `push` event, so `RELEASE_BOT_TOKEN` resolves normally |
| others | tags / paths / dispatch / cron | Never triggered |

## How Has This Been Tested?

- [x] All workflow files and `dependabot.yml` verified to parse as YAML
- [x] Every SHA resolved via the GitHub API from the tag it replaces (annotated tags dereferenced to their commit)
- [x] No floating refs remain (`grep` for `@v[0-9]`/`@stable`/`@main` returns nothing)
- [ ] **Not yet proven by a real run** — CI on this PR is the actual test of the `rust-toolchain` change. Please confirm the Rust job goes green before merging.